### PR TITLE
feat(proxy): add dispatcher/agent proxy support for ws and media

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,36 +11,47 @@
             "devDependencies": {
                 "@changesets/cli": "^2.30.0",
                 "@types/node": "^22.13.14",
+                "@types/ws": "^8.18.1",
                 "@typescript-eslint/parser": "^8.56.1",
                 "@vinikjkkj/eslint-config": "^1.0.0",
                 "better-sqlite3": "^12.6.2",
                 "c8": "^11.0.0",
                 "eslint": "^9.39.4",
                 "eslint-plugin-import": "^2.32.0",
+                "got": "14.6.4",
                 "pino": "^10.3.1",
                 "pino-pretty": "^13.1.3",
                 "prettier": "^3.8.1",
                 "tsc-alias": "^1.8.16",
                 "tsx": "^4.20.6",
                 "typescript": "^5.7.3",
-                "typescript-eslint": "^8.56.1"
+                "typescript-eslint": "^8.56.1",
+                "ws": "^8.18.3"
             },
             "engines": {
                 "node": ">=20.9.0"
             },
             "peerDependencies": {
                 "better-sqlite3": "^11.9.1",
+                "got": "14.6.4",
                 "pino": "^9.0.0",
-                "pino-pretty": "^13.0.0"
+                "pino-pretty": "^13.0.0",
+                "ws": "^8.18.3"
             },
             "peerDependenciesMeta": {
                 "better-sqlite3": {
+                    "optional": true
+                },
+                "got": {
                     "optional": true
                 },
                 "pino": {
                     "optional": true
                 },
                 "pino-pretty": {
+                    "optional": true
+                },
+                "ws": {
                     "optional": true
                 }
             }
@@ -1119,6 +1130,13 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@keyv/serialize": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+            "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@manypkg/find-root": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
@@ -1299,10 +1317,37 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@sec-ant/readable-stream": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@sindresorhus/is": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+            "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/http-cache-semantics": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -1336,6 +1381,16 @@
             "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
+            }
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2006,6 +2061,19 @@
                 "ieee754": "^1.1.13"
             }
         },
+        "node_modules/byte-counter": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
+            "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/c8": {
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/c8/-/c8-11.0.0.tgz",
@@ -2038,6 +2106,58 @@
                 "monocart-coverage-reports": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/cacheable-lookup": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+            "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
+        "node_modules/cacheable-request": {
+            "version": "13.0.18",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.18.tgz",
+            "integrity": "sha512-rFWadDRKJs3s2eYdXlGggnBZKG7MTblkFBB0YllFds+UYnfogDp2wcR6JN97FhRkHTvq59n2vhNoHNZn29dh/Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-cache-semantics": "^4.0.4",
+                "get-stream": "^9.0.1",
+                "http-cache-semantics": "^4.2.0",
+                "keyv": "^5.5.5",
+                "mimic-response": "^4.0.0",
+                "normalize-url": "^8.1.1",
+                "responselike": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/cacheable-request/node_modules/keyv": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+            "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@keyv/serialize": "^1.1.1"
+            }
+        },
+        "node_modules/cacheable-request/node_modules/mimic-response": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/call-bind": {
@@ -3283,6 +3403,16 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/form-data-encoder": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
+            "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
         "node_modules/fs-constants": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -3420,6 +3550,23 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-symbol-description": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -3553,6 +3700,72 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/got": {
+            "version": "14.6.4",
+            "resolved": "https://registry.npmjs.org/got/-/got-14.6.4.tgz",
+            "integrity": "sha512-DjsLab39NUMf5iYlK9asVCkHMhaA2hEhrlmf+qXRhjEivuuBHWYbjmty9DA3OORUwZgENTB+6vSmY2ZW8gFHVw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/is": "^7.0.1",
+                "byte-counter": "^0.1.0",
+                "cacheable-lookup": "^7.0.0",
+                "cacheable-request": "^13.0.12",
+                "decompress-response": "^10.0.0",
+                "form-data-encoder": "^4.0.2",
+                "http2-wrapper": "^2.2.1",
+                "keyv": "^5.5.3",
+                "lowercase-keys": "^3.0.0",
+                "p-cancelable": "^4.0.1",
+                "responselike": "^4.0.2",
+                "type-fest": "^4.26.1"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/got?sponsor=1"
+            }
+        },
+        "node_modules/got/node_modules/decompress-response": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
+            "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-response": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/got/node_modules/keyv": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+            "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@keyv/serialize": "^1.1.1"
+            }
+        },
+        "node_modules/got/node_modules/mimic-response": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3667,6 +3880,27 @@
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/http-cache-semantics": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/http2-wrapper": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+            "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "quick-lru": "^5.1.1",
+                "resolve-alpn": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=10.19.0"
+            }
         },
         "node_modules/human-id": {
             "version": "4.1.3",
@@ -4100,6 +4334,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-string": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -4394,6 +4641,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/lowercase-keys": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+            "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/lru-cache": {
             "version": "11.2.7",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
@@ -4591,6 +4851,19 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/normalize-url": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+            "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -4749,6 +5022,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/p-cancelable": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
+            "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
             }
         },
         "node_modules/p-filter": {
@@ -5172,6 +5455,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/quick-lru": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/rc": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -5364,6 +5660,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/resolve-alpn": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5382,6 +5685,22 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
+        "node_modules/responselike": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
+            "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lowercase-keys": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/reusify": {
@@ -6153,6 +6472,19 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/typed-array-buffer": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -6478,6 +6810,28 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/ws": {
+            "version": "8.19.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+            "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/y18n": {
             "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -119,11 +119,16 @@
     "dependencies": {},
     "peerDependencies": {
         "better-sqlite3": "^11.9.1",
+        "got": "14.6.4",
         "pino": "^9.0.0",
-        "pino-pretty": "^13.0.0"
+        "pino-pretty": "^13.0.0",
+        "ws": "^8.18.3"
     },
     "peerDependenciesMeta": {
         "better-sqlite3": {
+            "optional": true
+        },
+        "got": {
             "optional": true
         },
         "pino": {
@@ -131,23 +136,29 @@
         },
         "pino-pretty": {
             "optional": true
+        },
+        "ws": {
+            "optional": true
         }
     },
     "devDependencies": {
         "@changesets/cli": "^2.30.0",
         "@types/node": "^22.13.14",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/parser": "^8.56.1",
         "@vinikjkkj/eslint-config": "^1.0.0",
         "better-sqlite3": "^12.6.2",
         "c8": "^11.0.0",
         "eslint": "^9.39.4",
         "eslint-plugin-import": "^2.32.0",
+        "got": "14.6.4",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "prettier": "^3.8.1",
         "tsc-alias": "^1.8.16",
         "tsx": "^4.20.6",
         "typescript": "^5.7.3",
-        "typescript-eslint": "^8.56.1"
+        "typescript-eslint": "^8.56.1",
+        "ws": "^8.18.3"
     }
 }

--- a/src/auth/flow/WaAuthCredentialsFlow.ts
+++ b/src/auth/flow/WaAuthCredentialsFlow.ts
@@ -8,6 +8,7 @@ import { verifySignalSignature } from '@signal/crypto/WaAdvSignature'
 import { createAndStoreInitialKeys } from '@signal/registration/utils'
 import type { WaAuthStore } from '@store/contracts/auth.store'
 import type { WaSignalStore } from '@store/contracts/signal.store'
+import { toProxyAgent, toProxyDispatcher } from '@transport/proxy'
 import type { WaCommsConfig } from '@transport/types'
 import { toError } from '@util/primitives'
 
@@ -66,6 +67,7 @@ export function buildCommsConfig(
 ): WaCommsConfig {
     const registered = credentials.meJid !== null && credentials.meJid !== undefined
     const loginIdentity = registered ? getLoginIdentity(credentials.meJid) : null
+    const wsProxy = socketOptions.proxy?.ws
     logger.debug('building comms config from credentials', {
         registered,
         hasServerStaticKey:
@@ -76,6 +78,8 @@ export function buildCommsConfig(
         url: socketOptions.url,
         urls: socketOptions.urls,
         protocols: socketOptions.protocols,
+        dispatcher: toProxyDispatcher(wsProxy),
+        agent: toProxyAgent(wsProxy),
         connectTimeoutMs: socketOptions.connectTimeoutMs,
         reconnectIntervalMs: socketOptions.reconnectIntervalMs,
         timeoutIntervalMs: socketOptions.timeoutIntervalMs,

--- a/src/auth/flow/__tests__/credentials-flow.test.ts
+++ b/src/auth/flow/__tests__/credentials-flow.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import http from 'node:http'
 import test from 'node:test'
 
 import {
@@ -9,6 +10,7 @@ import {
 import type { WaAuthCredentials } from '@auth/types'
 import type { Logger } from '@infra/log/types'
 import { WaSignalMemoryStore } from '@store/providers/memory/signal.store'
+import type { WaProxyDispatcher } from '@transport/types'
 
 function createLogger(): Logger {
     return {
@@ -84,6 +86,9 @@ test('auth flow persists and restores existing credentials', async () => {
 test('buildCommsConfig switches between login and registration payloads', () => {
     const logger = createLogger()
     const credentials = createCredentials()
+    const wsDispatcher: WaProxyDispatcher = {
+        dispatch: () => undefined
+    }
 
     const loginConfig = buildCommsConfig(
         logger,
@@ -94,7 +99,10 @@ test('buildCommsConfig switches between login and registration payloads', () => 
             connectTimeoutMs: 10,
             reconnectIntervalMs: 20,
             timeoutIntervalMs: 30,
-            maxReconnectAttempts: 40
+            maxReconnectAttempts: 40,
+            proxy: {
+                ws: wsDispatcher
+            }
         },
         {
             deviceBrowser: 'Chrome',
@@ -106,6 +114,8 @@ test('buildCommsConfig switches between login and registration payloads', () => 
     assert.equal(loginConfig.noise.isRegistered, true)
     assert.ok(loginConfig.noise.loginPayloadConfig)
     assert.equal(loginConfig.noise.registrationPayloadConfig, undefined)
+    assert.equal(loginConfig.dispatcher, wsDispatcher)
+    assert.equal(loginConfig.agent, undefined)
 
     const registrationConfig = buildCommsConfig(
         logger,
@@ -122,4 +132,27 @@ test('buildCommsConfig switches between login and registration payloads', () => 
 
     assert.equal(registrationConfig.noise.isRegistered, false)
     assert.ok(registrationConfig.noise.registrationPayloadConfig)
+})
+
+test('buildCommsConfig maps ws proxy agent when provided', () => {
+    const wsAgent = new http.Agent({ keepAlive: true })
+    const config = buildCommsConfig(
+        createLogger(),
+        createCredentials(),
+        {
+            url: 'wss://web.whatsapp.com/ws/chat',
+            proxy: {
+                ws: wsAgent
+            }
+        },
+        {
+            deviceBrowser: 'Chrome',
+            deviceOsDisplayName: 'Windows',
+            requireFullSync: false
+        }
+    )
+
+    assert.equal(config.dispatcher, undefined)
+    assert.equal(config.agent, wsAgent)
+    wsAgent.destroy()
 })

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -1,6 +1,7 @@
 import type { SignalKeyPair } from '@crypto/curves/types'
 import type { Proto } from '@proto'
 import type { RegistrationInfo, SignedPreKeyRecord } from '@signal/types'
+import type { WaProxyTransport } from '@transport/types'
 
 export interface WaAuthCredentials {
     readonly noiseKeyPair: SignalKeyPair
@@ -31,6 +32,9 @@ export interface WaAuthSocketOptions {
     readonly reconnectIntervalMs?: number
     readonly timeoutIntervalMs?: number
     readonly maxReconnectAttempts?: number
+    readonly proxy?: {
+        readonly ws?: WaProxyTransport
+    }
 }
 
 export interface WaAuthClientOptions {

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -40,6 +40,7 @@ import { WaKeepAlive } from '@transport/keepalive/WaKeepAlive'
 import { createUsyncSidGenerator, type WaUsyncSidGenerator } from '@transport/node/usync'
 import { WaNodeOrchestrator } from '@transport/node/WaNodeOrchestrator'
 import { WaNodeTransport } from '@transport/node/WaNodeTransport'
+import { isProxyTransport, toProxyAgent, toProxyDispatcher } from '@transport/proxy'
 import type { BinaryNode } from '@transport/types'
 import type { WaComms } from '@transport/WaComms'
 import { toError } from '@util/primitives'
@@ -78,6 +79,35 @@ interface WaClientDependencies {
     readonly groupCoordinator: WaGroupCoordinator
 }
 
+function assertProxyTransport(value: unknown, path: string): void {
+    if (value === undefined) {
+        return
+    }
+    if (!isProxyTransport(value)) {
+        throw new Error(
+            `${path} must be a proxy transport instance (dispatcher with dispatch(...) or agent with addRequest(...))`
+        )
+    }
+}
+
+function validateProxyOptions(options: WaClientOptions): void {
+    const rawProxy = options.proxy as unknown
+    if (rawProxy === undefined) {
+        return
+    }
+    if (typeof rawProxy !== 'object' || rawProxy === null || Array.isArray(rawProxy)) {
+        throw new Error('proxy must be an object with optional ws/mediaUpload/mediaDownload')
+    }
+    const proxy = rawProxy as {
+        readonly ws?: unknown
+        readonly mediaUpload?: unknown
+        readonly mediaDownload?: unknown
+    }
+    assertProxyTransport(proxy?.ws, 'proxy.ws')
+    assertProxyTransport(proxy?.mediaUpload, 'proxy.mediaUpload')
+    assertProxyTransport(proxy?.mediaDownload, 'proxy.mediaDownload')
+}
+
 export interface WaClientDependencyHost {
     readonly sendNode: (node: BinaryNode) => Promise<void>
     readonly query: (node: BinaryNode, timeoutMs?: number) => Promise<BinaryNode>
@@ -108,6 +138,8 @@ export interface WaClientDependencyHost {
 }
 
 export function resolveWaClientBase(options: WaClientOptions, logger: Logger): WaClientBase {
+    validateProxyOptions(options)
+
     const deviceBrowser = options.deviceBrowser ?? WA_DEFAULTS.DEVICE_BROWSER
     const sessionId = options.sessionId.trim()
     if (sessionId.length === 0) {
@@ -368,7 +400,11 @@ export function buildWaClientDependencies(input: {
 
     const mediaTransfer = new WaMediaTransferClient({
         logger,
-        defaultTimeoutMs: options.mediaTimeoutMs
+        defaultTimeoutMs: options.mediaTimeoutMs,
+        defaultUploadDispatcher: toProxyDispatcher(options.proxy?.mediaUpload),
+        defaultDownloadDispatcher: toProxyDispatcher(options.proxy?.mediaDownload),
+        defaultUploadAgent: toProxyAgent(options.proxy?.mediaUpload),
+        defaultDownloadAgent: toProxyAgent(options.proxy?.mediaDownload)
     })
     const mediaMessageBuildOptions: WaMediaMessageBuildOptions = {
         logger,

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -4,6 +4,8 @@ import { gzipSync } from 'node:zlib'
 
 import { parseDirtyBits } from '@client/dirty'
 import { processHistorySyncNotification } from '@client/history-sync'
+import type { WaClientOptions } from '@client/types'
+import { resolveWaClientBase } from '@client/WaClientFactory'
 import type { Logger } from '@infra/log/types'
 import { proto } from '@proto'
 
@@ -115,4 +117,78 @@ test('history sync processor persists conversations and emits chunk event', asyn
     assert.equal(contacts.length, 1)
     assert.equal(emitted.length, 1)
     assert.equal((emitted[0] as { messagesCount: number }).messagesCount, 1)
+})
+
+test('resolveWaClientBase rejects invalid proxy transport shapes', () => {
+    const minimalStore = {
+        session: () => ({})
+    }
+    const invalidWs = {
+        store: minimalStore,
+        sessionId: 'session',
+        proxy: {
+            ws: {} as never
+        }
+    } as unknown as WaClientOptions
+    const invalidMediaUpload = {
+        store: minimalStore,
+        sessionId: 'session',
+        proxy: {
+            mediaUpload: {} as never
+        }
+    } as unknown as WaClientOptions
+
+    assert.throws(() => resolveWaClientBase(invalidWs, createLogger()), /proxy\.ws/)
+    assert.throws(
+        () => resolveWaClientBase(invalidMediaUpload, createLogger()),
+        /proxy\.mediaUpload/
+    )
+})
+
+test('resolveWaClientBase rejects invalid proxy root shapes', () => {
+    const minimalStore = {
+        session: () => ({})
+    }
+    const invalidProxyPrimitive = {
+        store: minimalStore,
+        sessionId: 'session',
+        proxy: true as never
+    } as unknown as WaClientOptions
+    const invalidProxyArray = {
+        store: minimalStore,
+        sessionId: 'session',
+        proxy: ['http://proxy'] as never
+    } as unknown as WaClientOptions
+
+    assert.throws(
+        () => resolveWaClientBase(invalidProxyPrimitive, createLogger()),
+        /proxy must be an object/
+    )
+    assert.throws(
+        () => resolveWaClientBase(invalidProxyArray, createLogger()),
+        /proxy must be an object/
+    )
+})
+
+test('resolveWaClientBase accepts proxy agent shapes', () => {
+    const minimalStore = {
+        session: () => ({})
+    }
+    const options = {
+        store: minimalStore,
+        sessionId: 'session',
+        proxy: {
+            ws: {
+                addRequest: () => undefined
+            },
+            mediaUpload: {
+                addRequest: () => undefined
+            },
+            mediaDownload: {
+                addRequest: () => undefined
+            }
+        }
+    } as unknown as WaClientOptions
+
+    assert.doesNotThrow(() => resolveWaClientBase(options, createLogger()))
 })

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,6 @@
 export { WaClient } from '@client/WaClient'
 export type {
+    WaClientProxyOptions,
     WaChatEvent,
     WaChatEventAction,
     WaChatEventSource,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -3,11 +3,18 @@ import type { WaAuthClientOptions, WaAuthCredentials, WaAuthSocketOptions } from
 import type { WaMessagePublishOptions } from '@message/types'
 import type { Proto } from '@proto'
 import type { WaStore } from '@store/types'
-import type { BinaryNode } from '@transport/types'
+import type { BinaryNode, WaProxyTransport } from '@transport/types'
+
+export interface WaClientProxyOptions {
+    readonly ws?: WaProxyTransport
+    readonly mediaUpload?: WaProxyTransport
+    readonly mediaDownload?: WaProxyTransport
+}
 
 export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOptions {
     readonly store: WaStore
     readonly sessionId: string
+    readonly proxy?: WaClientProxyOptions
     readonly chatSocketUrls?: readonly string[]
     readonly iqTimeoutMs?: number
     readonly nodeQueryTimeoutMs?: number

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { WaClient } from '@client'
 export type {
     WaClientEventMap,
     WaClientOptions,
+    WaClientProxyOptions,
     WaHistorySyncChunkEvent,
     WaHistorySyncOptions
 } from '@client'

--- a/src/media/WaMediaTransferClient.ts
+++ b/src/media/WaMediaTransferClient.ts
@@ -5,14 +5,19 @@ import { DEFAULT_MEDIA_HOSTS } from '@media/constants'
 import type { MediaCryptoType, WaMediaTransferClientOptions } from '@media/types'
 import { WaMediaCrypto } from '@media/WaMediaCrypto'
 import { WA_DEFAULTS } from '@protocol/constants'
+import type { WaProxyAgent, WaProxyDispatcher } from '@transport/types'
 import { EMPTY_BYTES, readAllBytes } from '@util/bytes'
 import { toError } from '@util/primitives'
+
+const GOT_OPTIONAL_MODULE = 'got'
 
 interface StreamDownloadRequest {
     readonly url?: string
     readonly directPath?: string
     readonly hosts?: readonly string[]
     readonly headers?: Readonly<Record<string, string>>
+    readonly dispatcher?: WaMediaTransferClientOptions['defaultDownloadDispatcher']
+    readonly agent?: WaMediaTransferClientOptions['defaultDownloadAgent']
     readonly timeoutMs?: number
     readonly signal?: AbortSignal
     readonly maxBytes?: number
@@ -31,6 +36,14 @@ interface StreamTransferResponse {
     readonly ok: boolean
     readonly headers: Readonly<Record<string, string>>
     readonly body: Readable | null
+}
+
+interface InternalTransferResponse {
+    readonly status: number
+    readonly ok: boolean
+    readonly headers: Readonly<Record<string, string>>
+    readonly body: Readable | null
+    cancel(): Promise<void>
 }
 
 interface EncryptedUploadRequest extends StreamDownloadRequest {
@@ -70,6 +83,15 @@ interface ResolvedTransferRequest {
     readonly timeoutMs: number
 }
 
+interface ResolvedProxyTransport {
+    readonly dispatcher?: WaProxyDispatcher
+    readonly agent?: WaProxyAgent
+}
+
+interface OptionalGotModule {
+    readonly stream: (url: string, options?: Readonly<Record<string, unknown>>) => Readable
+}
+
 interface PreparedEncryptedUpload {
     readonly body: Uint8Array | Readable
     readonly contentLength: number | undefined
@@ -85,12 +107,71 @@ interface AbortContext {
     cleanup(): void
 }
 
+function asOptionalGotModule(loaded: unknown): OptionalGotModule | null {
+    if (loaded && typeof loaded === 'object') {
+        const direct = (loaded as { readonly stream?: unknown }).stream
+        if (typeof direct === 'function') {
+            return loaded as OptionalGotModule
+        }
+        const fallback = (loaded as { readonly default?: unknown }).default
+        if (
+            fallback &&
+            typeof fallback === 'object' &&
+            'stream' in fallback &&
+            typeof (fallback as { readonly stream?: unknown }).stream === 'function'
+        ) {
+            return fallback as OptionalGotModule
+        }
+        if (typeof fallback === 'function' && 'stream' in fallback) {
+            const maybeStream = (fallback as { readonly stream?: unknown }).stream
+            if (typeof maybeStream === 'function') {
+                return fallback as unknown as OptionalGotModule
+            }
+        }
+    }
+    if (typeof loaded === 'function' && 'stream' in loaded) {
+        const maybeStream = (loaded as { readonly stream?: unknown }).stream
+        if (typeof maybeStream === 'function') {
+            return loaded as unknown as OptionalGotModule
+        }
+    }
+    return null
+}
+
+async function loadOptionalGotModule(): Promise<OptionalGotModule> {
+    try {
+        const loaded = await import(GOT_OPTIONAL_MODULE)
+        const module = asOptionalGotModule(loaded)
+        if (module) {
+            return module
+        }
+        throw new Error('invalid got module export')
+    } catch (error) {
+        const normalized = toError(error)
+        const code = (normalized as NodeJS.ErrnoException).code
+        const message = normalized.message ?? ''
+        const isModuleNotFound =
+            (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') &&
+            (message.includes(`'${GOT_OPTIONAL_MODULE}'`) ||
+                message.includes(`"${GOT_OPTIONAL_MODULE}"`))
+        if (isModuleNotFound) {
+            throw new Error('optional dependency "got" is not installed. Install with: npm i got')
+        }
+        throw normalized
+    }
+}
+
 export class WaMediaTransferClient {
     private readonly logger?: Logger
     private readonly defaultHosts: readonly string[]
     private readonly defaultTimeoutMs: number
     private readonly defaultMaxReadBytes: number | undefined
     private readonly defaultHeaders: Readonly<Record<string, string>>
+    private readonly defaultUploadDispatcher: WaMediaTransferClientOptions['defaultUploadDispatcher']
+    private readonly defaultDownloadDispatcher: WaMediaTransferClientOptions['defaultDownloadDispatcher']
+    private readonly defaultUploadAgent: WaMediaTransferClientOptions['defaultUploadAgent']
+    private readonly defaultDownloadAgent: WaMediaTransferClientOptions['defaultDownloadAgent']
+    private gotModulePromise: Promise<OptionalGotModule> | null
 
     public constructor(options: WaMediaTransferClientOptions = {}) {
         this.logger = options.logger
@@ -98,10 +179,19 @@ export class WaMediaTransferClient {
         this.defaultTimeoutMs = options.defaultTimeoutMs ?? WA_DEFAULTS.MEDIA_TIMEOUT_MS
         this.defaultMaxReadBytes = options.defaultMaxReadBytes
         this.defaultHeaders = options.defaultHeaders ?? {}
+        this.defaultUploadDispatcher = options.defaultUploadDispatcher
+        this.defaultDownloadDispatcher = options.defaultDownloadDispatcher
+        this.defaultUploadAgent = options.defaultUploadAgent
+        this.defaultDownloadAgent = options.defaultDownloadAgent
+        this.gotModulePromise = null
     }
 
     public async downloadStream(request: StreamDownloadRequest): Promise<StreamTransferResponse> {
         const { urls, headers, timeoutMs } = this.resolveTransferRequest(request)
+        const proxy = this.resolveProxyTransport({
+            dispatcher: request.dispatcher ?? this.defaultDownloadDispatcher,
+            agent: request.agent ?? this.defaultDownloadAgent
+        })
         this.logger?.debug('media download stream start', {
             urls: urls.length,
             timeoutMs
@@ -109,11 +199,15 @@ export class WaMediaTransferClient {
         return this.executeTransfer(urls, timeoutMs, request.signal, {
             responseLog: 'media download stream response',
             send: (url, signal) =>
-                fetch(url, {
-                    method: 'GET',
-                    headers,
-                    signal
-                })
+                this.transferRequest(
+                    url,
+                    {
+                        method: 'GET',
+                        headers,
+                        signal
+                    },
+                    proxy
+                )
         })
     }
 
@@ -135,6 +229,10 @@ export class WaMediaTransferClient {
                     ? String(request.contentLength)
                     : undefined
         })
+        const proxy = this.resolveProxyTransport({
+            dispatcher: request.dispatcher ?? this.defaultUploadDispatcher,
+            agent: request.agent ?? this.defaultUploadAgent
+        })
         const uploadUrls = bodyIsBytes ? urls : urls.slice(0, 1)
         if (!bodyIsBytes && urls.length > 1) {
             this.logger?.warn('upload stream fallback disabled for non-replayable body', {
@@ -152,21 +250,29 @@ export class WaMediaTransferClient {
             responseLog: 'media upload stream response',
             send: async (url, signal) => {
                 if (bodyIsBytes) {
-                    return fetch(url, {
+                    return this.transferRequest(
+                        url,
+                        {
+                            method,
+                            headers,
+                            signal,
+                            body: request.body
+                        },
+                        proxy
+                    )
+                }
+
+                return this.transferRequest(
+                    url,
+                    {
                         method,
                         headers,
                         signal,
-                        body: request.body
-                    })
-                }
-
-                return fetch(url, {
-                    method,
-                    headers,
-                    signal,
-                    body: request.body as unknown as never,
-                    duplex: 'half'
-                } as RequestInit)
+                        body: request.body as unknown as never,
+                        duplex: 'half'
+                    } as RequestInit,
+                    proxy
+                )
             }
         })
     }
@@ -185,6 +291,8 @@ export class WaMediaTransferClient {
                 directPath: request.directPath,
                 hosts: request.hosts,
                 headers: request.headers,
+                dispatcher: request.dispatcher,
+                agent: request.agent,
                 timeoutMs: request.timeoutMs,
                 signal: request.signal,
                 method: request.method,
@@ -262,6 +370,183 @@ export class WaMediaTransferClient {
         return this.readAllBytesWithLimit(response.body, maxBytes)
     }
 
+    private resolveProxyTransport(proxy: ResolvedProxyTransport): ResolvedProxyTransport {
+        if (proxy.agent) {
+            return { agent: proxy.agent }
+        }
+        return { dispatcher: proxy.dispatcher }
+    }
+
+    private async transferRequest(
+        url: string,
+        init: RequestInit,
+        proxy: ResolvedProxyTransport
+    ): Promise<InternalTransferResponse> {
+        if (proxy.agent) {
+            return this.gotWithAgent(url, init, proxy.agent)
+        }
+        return this.fetchWithDispatcher(url, init, proxy.dispatcher)
+    }
+
+    private async fetchWithDispatcher(
+        url: string,
+        init: RequestInit,
+        dispatcher: WaProxyDispatcher | undefined
+    ): Promise<InternalTransferResponse> {
+        const response = !dispatcher
+            ? await fetch(url, init)
+            : await fetch(url, {
+                  ...init,
+                  dispatcher
+              } as RequestInit)
+        return this.toFetchTransferResponse(response)
+    }
+
+    private toFetchTransferResponse(response: Response): InternalTransferResponse {
+        return {
+            status: response.status,
+            ok: response.ok,
+            headers: this.headersToRecord(response.headers),
+            body: response.body
+                ? Readable.fromWeb(response.body as globalThis.ReadableStream<Uint8Array>)
+                : null,
+            cancel: async () => {
+                if (!response.body) {
+                    return
+                }
+                try {
+                    await response.body.cancel()
+                } catch {
+                    // ignore cancel errors from remote resets
+                }
+            }
+        }
+    }
+
+    private async gotWithAgent(
+        url: string,
+        init: RequestInit,
+        agent: WaProxyAgent
+    ): Promise<InternalTransferResponse> {
+        const got = await this.loadGotModule()
+        const gotHeaders = this.normalizeHeadersInit(init.headers)
+        const urlObj = new URL(url)
+        const gotAgent =
+            urlObj.protocol === 'http:'
+                ? { http: agent }
+                : urlObj.protocol === 'https:'
+                  ? { https: agent }
+                  : { http: agent, https: agent }
+        return new Promise<InternalTransferResponse>((resolve, reject) => {
+            const request = got.stream(url, {
+                method: init.method,
+                headers: gotHeaders,
+                body: init.body as unknown,
+                signal: init.signal,
+                throwHttpErrors: false,
+                retry: { limit: 0 },
+                agent: gotAgent
+            })
+            const onError = (error: unknown): void => {
+                request.off('response', onResponse)
+                reject(toError(error))
+            }
+            const onResponse = (incoming: unknown): void => {
+                request.off('error', onError)
+                resolve(this.toGotTransferResponse(incoming))
+            }
+            request.once('error', onError)
+            request.once('response', onResponse)
+        })
+    }
+
+    private async loadGotModule(): Promise<OptionalGotModule> {
+        if (!this.gotModulePromise) {
+            this.gotModulePromise = loadOptionalGotModule().catch((error) => {
+                this.gotModulePromise = null
+                throw error
+            })
+        }
+        return this.gotModulePromise
+    }
+
+    private normalizeHeadersInit(
+        headers: RequestInit['headers'] | undefined
+    ): Record<string, string> {
+        if (!headers) {
+            return {}
+        }
+        if (headers instanceof Headers) {
+            const output: Record<string, string> = {}
+            for (const [key, value] of headers.entries()) {
+                output[key] = value
+            }
+            return output
+        }
+        if (Array.isArray(headers)) {
+            const output: Record<string, string> = {}
+            for (const [key, value] of headers) {
+                output[key] = Array.isArray(value) ? value.join(', ') : value
+            }
+            return output
+        }
+        const output: Record<string, string> = {}
+        for (const [key, value] of Object.entries(
+            headers as Readonly<Record<string, string | readonly string[]>>
+        )) {
+            if (Array.isArray(value)) {
+                output[key] = value.join(', ')
+            } else {
+                output[key] = String(value)
+            }
+        }
+        return output
+    }
+
+    private toGotTransferResponse(incoming: unknown): InternalTransferResponse {
+        if (!incoming || typeof incoming !== 'object') {
+            throw new Error('invalid got response object')
+        }
+        const stream = incoming as Readable & {
+            readonly statusCode?: unknown
+            readonly headers?: unknown
+        }
+        const status =
+            typeof stream.statusCode === 'number' &&
+            Number.isFinite(stream.statusCode) &&
+            stream.statusCode >= 100 &&
+            stream.statusCode <= 599
+                ? stream.statusCode
+                : 500
+        const headers: Record<string, string> = {}
+        if (stream.headers && typeof stream.headers === 'object') {
+            for (const [key, value] of Object.entries(
+                stream.headers as Readonly<Record<string, unknown>>
+            )) {
+                if (typeof value === 'string') {
+                    headers[key] = value
+                    continue
+                }
+                if (Array.isArray(value)) {
+                    headers[key] = value.map((entry) => String(entry)).join(', ')
+                    continue
+                }
+                if (value !== undefined && value !== null) {
+                    headers[key] = String(value)
+                }
+            }
+        }
+        return {
+            status,
+            ok: status >= 200 && status < 300,
+            headers,
+            body: stream,
+            cancel: async () => {
+                stream.destroy()
+            }
+        }
+    }
+
     private resolveTransferRequest(
         request: Pick<
             StreamDownloadRequest,
@@ -289,7 +574,7 @@ export class WaMediaTransferClient {
         signal: AbortSignal | undefined,
         options: {
             readonly responseLog: string
-            readonly send: (url: string, signal: AbortSignal) => Promise<Response>
+            readonly send: (url: string, signal: AbortSignal) => Promise<InternalTransferResponse>
         }
     ): Promise<StreamTransferResponse> {
         const result = await this.fetchWithFallback(urls, timeoutMs, signal, options.send)
@@ -407,8 +692,8 @@ export class WaMediaTransferClient {
         urls: readonly string[],
         timeoutMs: number,
         signal: AbortSignal | undefined,
-        send: (url: string, signal: AbortSignal) => Promise<Response>
-    ): Promise<{ readonly url: string; readonly response: Response }> {
+        send: (url: string, signal: AbortSignal) => Promise<InternalTransferResponse>
+    ): Promise<{ readonly url: string; readonly response: InternalTransferResponse }> {
         let lastError: Error | null = null
 
         for (let index = 0; index < urls.length; index += 1) {
@@ -420,7 +705,7 @@ export class WaMediaTransferClient {
                 if (!shouldFallback) {
                     return { url, response }
                 }
-                await this.cancelWebBody(response.body)
+                await response.cancel()
                 this.logger?.warn('transfer fallback to next host', {
                     url,
                     status: response.status
@@ -477,15 +762,13 @@ export class WaMediaTransferClient {
         }
     }
 
-    private toResponse(url: string, response: Response): StreamTransferResponse {
+    private toResponse(url: string, response: InternalTransferResponse): StreamTransferResponse {
         return {
             url,
             status: response.status,
             ok: response.ok,
-            headers: this.headersToRecord(response.headers),
+            headers: response.headers,
             body: response.body
-                ? Readable.fromWeb(response.body as globalThis.ReadableStream<Uint8Array>)
-                : null
         }
     }
 
@@ -495,17 +778,6 @@ export class WaMediaTransferClient {
             output[key] = value
         }
         return output
-    }
-
-    private async cancelWebBody(body: ReadableStream<Uint8Array> | null): Promise<void> {
-        if (!body) {
-            return
-        }
-        try {
-            await body.cancel()
-        } catch {
-            // ignore cancel errors from remote resets
-        }
     }
 
     private async drainBody(body: Readable | null): Promise<void> {

--- a/src/media/__tests__/media.test.ts
+++ b/src/media/__tests__/media.test.ts
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict'
+import http from 'node:http'
+import { Readable } from 'node:stream'
 import test from 'node:test'
 
 import { buildMediaMessageContent, getMediaConn } from '@client/messages'
 import type { Logger } from '@infra/log/types'
 import { parseMediaConnResponse } from '@media/conn'
 import { WaMediaCrypto } from '@media/WaMediaCrypto'
-import type { BinaryNode } from '@transport/types'
+import { WaMediaTransferClient } from '@media/WaMediaTransferClient'
+import type { BinaryNode, WaProxyDispatcher } from '@transport/types'
 
 function createLogger(): Logger {
     return {
@@ -148,4 +151,159 @@ test('media message builder supports text passthrough and conn caching', async (
 
     assert.equal(cached.auth, 'token')
     assert.equal(queryCount, 1)
+})
+
+test('media transfer client applies separate upload/download dispatchers', async () => {
+    const downloadDispatcher: WaProxyDispatcher = {
+        dispatch: () => undefined
+    }
+    const uploadDispatcher: WaProxyDispatcher = {
+        dispatch: () => undefined
+    }
+    const seenDispatchers: unknown[] = []
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+        const withDispatcher = init as RequestInit & { readonly dispatcher?: unknown }
+        seenDispatchers.push(withDispatcher.dispatcher)
+        return new Response('ok', { status: 200 })
+    }) as typeof fetch
+
+    try {
+        const mediaTransfer = new WaMediaTransferClient({
+            defaultUploadDispatcher: uploadDispatcher,
+            defaultDownloadDispatcher: downloadDispatcher
+        })
+        await mediaTransfer.downloadStream({
+            url: 'https://example.com/download'
+        })
+        await mediaTransfer.uploadStream({
+            url: 'https://example.com/upload',
+            body: new Uint8Array([1, 2, 3])
+        })
+    } finally {
+        globalThis.fetch = originalFetch
+    }
+
+    assert.equal(seenDispatchers.length, 2)
+    assert.equal(seenDispatchers[0], downloadDispatcher)
+    assert.equal(seenDispatchers[1], uploadDispatcher)
+})
+
+test('media transfer client routes through optional got when proxy agent is set', async () => {
+    const server = http.createServer((_request, response) => {
+        response.writeHead(200, { 'content-type': 'text/plain' })
+        response.end('ok-agent')
+    })
+    await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', () => {
+            server.off('error', reject)
+            resolve()
+        })
+    })
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+        throw new Error('failed to resolve media test server address')
+    }
+    const proxyAgent = new http.Agent({ keepAlive: true })
+    const mediaTransfer = new WaMediaTransferClient({
+        defaultDownloadAgent: proxyAgent
+    })
+
+    const originalFetch = globalThis.fetch
+    let fetchCalled = false
+    globalThis.fetch = (async () => {
+        fetchCalled = true
+        throw new Error('fetch should not be called when agent path is enabled')
+    }) as typeof fetch
+
+    try {
+        const bytes = await mediaTransfer.downloadBytes({
+            url: `http://127.0.0.1:${address.port}/agent-proxy`
+        })
+        assert.equal(new TextDecoder().decode(bytes), 'ok-agent')
+        assert.equal(fetchCalled, false)
+    } finally {
+        globalThis.fetch = originalFetch
+        proxyAgent.destroy()
+        await new Promise<void>((resolve) => {
+            server.close(() => resolve())
+        })
+    }
+})
+
+test('media transfer client uploads readable stream through optional got agent', async () => {
+    const receivedBodies: string[] = []
+    const receivedMethods: string[] = []
+    const receivedContentTypes: string[] = []
+
+    const server = http.createServer(async (request, response) => {
+        receivedMethods.push(request.method ?? '')
+        const contentType = request.headers['content-type']
+        if (typeof contentType === 'string') {
+            receivedContentTypes.push(contentType)
+        }
+
+        request.setEncoding('utf8')
+        let body = ''
+        for await (const chunk of request) {
+            body += chunk
+        }
+        receivedBodies.push(body)
+
+        response.writeHead(201, { 'content-type': 'text/plain' })
+        response.end('upload-ok')
+    })
+
+    await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', () => {
+            server.off('error', reject)
+            resolve()
+        })
+    })
+
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+        throw new Error('failed to resolve media upload test server address')
+    }
+
+    const proxyAgent = new http.Agent({ keepAlive: true })
+    const mediaTransfer = new WaMediaTransferClient({
+        defaultUploadAgent: proxyAgent
+    })
+
+    const originalFetch = globalThis.fetch
+    let fetchCalled = false
+    globalThis.fetch = (async () => {
+        fetchCalled = true
+        throw new Error('fetch should not be called when upload agent path is enabled')
+    }) as typeof fetch
+
+    try {
+        const uploadBody = Readable.from(['hello-', 'stream'])
+        const response = await mediaTransfer.uploadStream({
+            url: `http://127.0.0.1:${address.port}/upload-agent-proxy`,
+            method: 'POST',
+            contentType: 'text/plain',
+            body: uploadBody
+        })
+
+        assert.equal(response.status, 201)
+        assert.equal(response.ok, true)
+        assert.equal(fetchCalled, false)
+        assert.equal(receivedMethods[0], 'POST')
+        assert.equal(receivedContentTypes[0], 'text/plain')
+        assert.equal(receivedBodies[0], 'hello-stream')
+
+        const ack = await mediaTransfer.readResponseBytes(response)
+        assert.equal(new TextDecoder().decode(ack), 'upload-ok')
+    } finally {
+        globalThis.fetch = originalFetch
+        proxyAgent.destroy()
+        await new Promise<void>((resolve) => {
+            server.close(() => resolve())
+        })
+    }
 })

--- a/src/media/types.ts
+++ b/src/media/types.ts
@@ -1,6 +1,7 @@
 import type { Readable } from 'node:stream'
 
 import type { Logger } from '@infra/log/types'
+import type { WaProxyAgent, WaProxyDispatcher } from '@transport/types'
 
 export type MediaKind = 'image' | 'video' | 'audio' | 'document' | 'sticker'
 export type MediaCryptoType = MediaKind | 'ptt' | 'gif' | 'ptv' | 'history' | 'md-app-state'
@@ -22,6 +23,10 @@ export interface WaMediaTransferClientOptions {
     readonly defaultTimeoutMs?: number
     readonly defaultMaxReadBytes?: number
     readonly defaultHeaders?: Readonly<Record<string, string>>
+    readonly defaultUploadDispatcher?: WaProxyDispatcher
+    readonly defaultDownloadDispatcher?: WaProxyDispatcher
+    readonly defaultUploadAgent?: WaProxyAgent
+    readonly defaultDownloadAgent?: WaProxyAgent
 }
 
 export interface WaMediaDerivedKeys {

--- a/src/transport/WaComms.ts
+++ b/src/transport/WaComms.ts
@@ -71,6 +71,8 @@ export class WaComms {
                 url: this.config.url,
                 urls: this.config.urls,
                 protocols: this.config.protocols,
+                dispatcher: this.config.dispatcher,
+                agent: this.config.agent,
                 timeoutIntervalMs: this.config.timeoutIntervalMs
             },
             logger

--- a/src/transport/WaWebSocket.ts
+++ b/src/transport/WaWebSocket.ts
@@ -4,6 +4,7 @@ import { WA_DEFAULTS, WA_READY_STATES } from '@protocol/constants'
 import type {
     RawWebSocket,
     RawWebSocketConstructor,
+    WaRawWebSocketInit,
     SocketCloseInfo,
     SocketOpenInfo,
     WebSocketEventLike,
@@ -21,6 +22,47 @@ interface PendingSocket {
 }
 
 type SocketRuntime = 'browser' | 'node'
+const WS_OPTIONAL_MODULE = 'ws'
+
+function asOptionalNodeWsConstructor(loaded: unknown): RawWebSocketConstructor | null {
+    if (loaded && typeof loaded === 'object') {
+        const direct = (loaded as { readonly WebSocket?: unknown }).WebSocket
+        if (typeof direct === 'function') {
+            return direct as RawWebSocketConstructor
+        }
+        const fallback = (loaded as { readonly default?: unknown }).default
+        if (typeof fallback === 'function') {
+            return fallback as RawWebSocketConstructor
+        }
+    }
+    if (typeof loaded === 'function') {
+        return loaded as RawWebSocketConstructor
+    }
+    return null
+}
+
+async function loadOptionalNodeWsConstructor(): Promise<RawWebSocketConstructor> {
+    try {
+        const loaded = await import(WS_OPTIONAL_MODULE)
+        const constructor = asOptionalNodeWsConstructor(loaded)
+        if (constructor) {
+            return constructor
+        }
+        throw new Error('invalid ws module export')
+    } catch (error) {
+        const normalized = toError(error)
+        const code = (normalized as NodeJS.ErrnoException).code
+        const message = normalized.message ?? ''
+        const isModuleNotFound =
+            (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') &&
+            (message.includes(`'${WS_OPTIONAL_MODULE}'`) ||
+                message.includes(`"${WS_OPTIONAL_MODULE}"`))
+        if (isModuleNotFound) {
+            throw new Error('optional dependency "ws" is not installed. Install with: npm i ws')
+        }
+        throw normalized
+    }
+}
 
 function resolveWebSocketConstructor(): RawWebSocketConstructor {
     const ctor = (globalThis as typeof globalThis & { WebSocket?: RawWebSocketConstructor })
@@ -71,6 +113,7 @@ export class WaWebSocket {
     private handlers: WaSocketHandlers
     private socket: RawWebSocket | null
     private closeWaiter: ((info: SocketCloseInfo) => void) | null
+    private nodeWsCtorPromise: Promise<RawWebSocketConstructor> | null
 
     public constructor(config: WaSocketConfig, logger: Logger = new ConsoleLogger('info')) {
         this.config = Object.freeze({
@@ -85,6 +128,7 @@ export class WaWebSocket {
         this.handlers = {}
         this.socket = null
         this.closeWaiter = null
+        this.nodeWsCtorPromise = null
     }
 
     public setHandlers(handlers: WaSocketHandlers): void {
@@ -201,7 +245,7 @@ export class WaWebSocket {
     }
 
     private async openSingle(url: string): Promise<SocketOpenInfo> {
-        const pending = this.createPendingSocket(url)
+        const pending = await this.createPendingSocket(url)
 
         return new Promise<SocketOpenInfo>((resolve, reject) => {
             this.bindPendingSocket(pending, {
@@ -225,7 +269,22 @@ export class WaWebSocket {
     }
 
     private async openConcurrently(urls: readonly string[]): Promise<SocketOpenInfo> {
-        const pendingSockets = urls.map((url) => this.createPendingSocket(url))
+        const setupResults = await Promise.allSettled(
+            urls.map((url) => this.createPendingSocket(url))
+        )
+        const pendingSockets: PendingSocket[] = []
+        let setupError: Error | null = null
+        for (const result of setupResults) {
+            if (result.status === 'fulfilled') {
+                pendingSockets.push(result.value)
+                continue
+            }
+            setupError = setupError ?? toError(result.reason)
+        }
+        if (setupError) {
+            this.releasePendingSocketsAfterSetupFailure(pendingSockets)
+            throw setupError
+        }
 
         return new Promise<SocketOpenInfo>((resolve, reject) => {
             let done = false
@@ -274,6 +333,15 @@ export class WaWebSocket {
                 })
             }
         })
+    }
+
+    private releasePendingSocketsAfterSetupFailure(entries: readonly PendingSocket[]): void {
+        for (const entry of entries) {
+            if (!this.settlePendingSocket(entry)) {
+                continue
+            }
+            this.closeSocketSafe(entry.socket, 1000, 'connect_setup_failed')
+        }
     }
 
     private bindRuntimeHandlers(socket: RawWebSocket): void {
@@ -325,8 +393,8 @@ export class WaWebSocket {
         return null
     }
 
-    private createPendingSocket(url: string): PendingSocket {
-        const socket = this.createRawSocket(url)
+    private async createPendingSocket(url: string): Promise<PendingSocket> {
+        const socket = await this.createRawSocket(url)
         socket.binaryType = 'arraybuffer'
         this.connectingSockets.add(socket)
         return {
@@ -438,11 +506,52 @@ export class WaWebSocket {
         }
     }
 
-    private createRawSocket(url: string): RawWebSocket {
+    private async createRawSocket(url: string): Promise<RawWebSocket> {
         const headers = this.config.headers
-        if (this.socketRuntime === 'node' && headers && Object.keys(headers).length > 0) {
-            return new this.webSocketCtor(url, this.config.protocols, { headers })
+        const dispatcher = this.config.dispatcher
+        const agent = this.config.agent
+
+        if (this.socketRuntime === 'node' && agent) {
+            const nodeWsCtor = await this.resolveNodeWsConstructor()
+            return new nodeWsCtor(url, this.config.protocols, {
+                headers,
+                agent
+            })
+        }
+
+        if (
+            this.socketRuntime === 'node' &&
+            ((headers && Object.keys(headers).length > 0) || dispatcher || agent)
+        ) {
+            const globalWebSocketCtor = (
+                globalThis as typeof globalThis & { WebSocket?: RawWebSocketConstructor }
+            ).WebSocket
+            if (globalWebSocketCtor && this.webSocketCtor === globalWebSocketCtor) {
+                const init: WaRawWebSocketInit = {
+                    protocols: this.config.protocols,
+                    headers,
+                    dispatcher,
+                    agent
+                }
+                return new this.webSocketCtor(url, init)
+            }
+
+            return new this.webSocketCtor(url, this.config.protocols, {
+                headers,
+                dispatcher,
+                agent
+            })
         }
         return new this.webSocketCtor(url, this.config.protocols)
+    }
+
+    private async resolveNodeWsConstructor(): Promise<RawWebSocketConstructor> {
+        if (!this.nodeWsCtorPromise) {
+            this.nodeWsCtorPromise = loadOptionalNodeWsConstructor().catch((error) => {
+                this.nodeWsCtorPromise = null
+                throw error
+            })
+        }
+        return this.nodeWsCtorPromise
     }
 }

--- a/src/transport/__tests__/proxy-dispatcher.test.ts
+++ b/src/transport/__tests__/proxy-dispatcher.test.ts
@@ -1,0 +1,291 @@
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import net from 'node:net'
+import type { Socket } from 'node:net'
+import test from 'node:test'
+
+import type { Logger } from '@infra/log/types'
+import type { WaProxyDispatcher } from '@transport/types'
+import { WaWebSocket } from '@transport/WaWebSocket'
+
+interface ProxyObservations {
+    fetchRequests: number
+    wsUpgradeRequests: number
+    wsConnectRequests: number
+    fetchConnectRequests: number
+}
+
+interface ProxyServerHandle {
+    readonly server: http.Server
+    readonly url: string
+    readonly observations: ProxyObservations
+}
+
+interface UpstreamServerHandle {
+    readonly server: http.Server
+    readonly url: string
+}
+
+interface OptionalUndiciModule {
+    readonly ProxyAgent: new (uri: string) => WaProxyDispatcher & { close?: () => Promise<void> }
+}
+
+function createLogger(): Logger {
+    return {
+        level: 'trace',
+        trace: () => undefined,
+        debug: () => undefined,
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined
+    }
+}
+
+async function loadOptionalUndiciModule(): Promise<OptionalUndiciModule | null> {
+    let moduleName = 'undici'
+    try {
+        const loaded = (await import(moduleName)) as { readonly ProxyAgent?: unknown }
+        if (typeof loaded.ProxyAgent !== 'function') {
+            return null
+        }
+        return {
+            ProxyAgent: loaded.ProxyAgent as OptionalUndiciModule['ProxyAgent']
+        }
+    } catch {
+        return null
+    }
+}
+
+async function startUpstreamServer(): Promise<UpstreamServerHandle> {
+    const server = http.createServer((request, response) => {
+        if (request.url === '/proxy-fetch') {
+            response.writeHead(200, { 'content-type': 'text/plain' })
+            response.end('ok-proxy-fetch')
+            return
+        }
+        response.writeHead(404)
+        response.end('not-found')
+    })
+    await listen(server)
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+        throw new Error('failed to resolve upstream server address')
+    }
+    return {
+        server,
+        url: `http://127.0.0.1:${address.port}`
+    }
+}
+
+async function startProxyServer(): Promise<ProxyServerHandle> {
+    const observations: ProxyObservations = {
+        fetchRequests: 0,
+        wsUpgradeRequests: 0,
+        wsConnectRequests: 0,
+        fetchConnectRequests: 0
+    }
+    const server = http.createServer((request, response) => {
+        observations.fetchRequests += 1
+
+        let target: URL
+        try {
+            target = resolveProxyRequestTarget(request)
+        } catch (error) {
+            response.writeHead(400)
+            response.end(
+                `invalid proxy request target: ${
+                    error instanceof Error ? error.message : 'unknown'
+                }`
+            )
+            return
+        }
+
+        const upstreamRequest = http.request(
+            {
+                hostname: target.hostname,
+                port: Number(target.port || '80'),
+                method: request.method,
+                path: `${target.pathname}${target.search}`,
+                headers: stripProxyHeaders(request.headers)
+            },
+            (upstreamResponse) => {
+                response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers)
+                upstreamResponse.pipe(response)
+            }
+        )
+
+        upstreamRequest.on('error', (error) => {
+            response.writeHead(502)
+            response.end(`proxy upstream failure: ${error.message}`)
+        })
+
+        request.pipe(upstreamRequest)
+    })
+
+    server.on('upgrade', (_request, socket) => {
+        observations.wsUpgradeRequests += 1
+        socket.write('HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\nContent-Length: 0\r\n\r\n')
+        socket.destroy()
+    })
+
+    server.on('connect', (request, socket: Socket, head) => {
+        const { host, port } = parseConnectTarget(request.url)
+        if (host === 'proxy-ws.localtest') {
+            observations.wsConnectRequests += 1
+            socket.write('HTTP/1.1 502 Bad Gateway\r\n\r\n')
+            socket.destroy()
+            return
+        }
+        if (host === 'proxy-fetch.localtest') {
+            observations.fetchConnectRequests += 1
+        }
+
+        const targetHost = host === 'proxy-fetch.localtest' ? '127.0.0.1' : host
+        const upstreamSocket = net.connect(port, targetHost)
+        upstreamSocket.once('connect', () => {
+            socket.write('HTTP/1.1 200 Connection Established\r\n\r\n')
+            if (head.byteLength > 0) {
+                upstreamSocket.write(head)
+            }
+            upstreamSocket.pipe(socket)
+            socket.pipe(upstreamSocket)
+        })
+        upstreamSocket.once('error', () => {
+            socket.write('HTTP/1.1 502 Bad Gateway\r\n\r\n')
+            socket.destroy()
+        })
+    })
+
+    await listen(server)
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+        throw new Error('failed to resolve proxy server address')
+    }
+    return {
+        server,
+        url: `http://127.0.0.1:${address.port}`,
+        observations
+    }
+}
+
+function resolveProxyRequestTarget(request: http.IncomingMessage): URL {
+    const rawUrl = request.url ?? ''
+    if (rawUrl.startsWith('http://') || rawUrl.startsWith('https://')) {
+        return new URL(rawUrl)
+    }
+    const host = request.headers.host
+    if (!host) {
+        throw new Error('missing host header')
+    }
+    return new URL(`http://${host}${rawUrl}`)
+}
+
+function stripProxyHeaders(headers: http.IncomingHttpHeaders): http.OutgoingHttpHeaders {
+    const output: http.OutgoingHttpHeaders = {}
+    for (const [key, value] of Object.entries(headers)) {
+        if (value === undefined) {
+            continue
+        }
+        if (key.toLowerCase() === 'proxy-connection') {
+            continue
+        }
+        output[key] = value
+    }
+    return output
+}
+
+function parseConnectTarget(rawTarget: string | undefined): {
+    readonly host: string
+    readonly port: number
+} {
+    if (!rawTarget) {
+        return {
+            host: '127.0.0.1',
+            port: 80
+        }
+    }
+    const separatorIndex = rawTarget.lastIndexOf(':')
+    if (separatorIndex <= 0 || separatorIndex === rawTarget.length - 1) {
+        return {
+            host: rawTarget,
+            port: 80
+        }
+    }
+    const host = rawTarget.slice(0, separatorIndex)
+    const parsedPort = Number.parseInt(rawTarget.slice(separatorIndex + 1), 10)
+    return {
+        host,
+        port: Number.isFinite(parsedPort) ? parsedPort : 80
+    }
+}
+
+async function listen(server: http.Server): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', () => {
+            server.off('error', reject)
+            resolve()
+        })
+    })
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+    if (!server.listening) {
+        return
+    }
+    await new Promise<void>((resolve) => {
+        server.close(() => resolve())
+    })
+}
+
+test('proxy dispatcher routes fetch and ws handshake through local proxy', async (context) => {
+    const undici = await loadOptionalUndiciModule()
+    if (!undici) {
+        context.skip('undici module unavailable in test runtime')
+        return
+    }
+
+    const upstream = await startUpstreamServer()
+    const proxy = await startProxyServer()
+    const dispatcher = new undici.ProxyAgent(proxy.url)
+
+    context.after(async () => {
+        await dispatcher.close?.().catch(() => undefined)
+        await closeServer(proxy.server)
+        await closeServer(upstream.server)
+    })
+
+    const upstreamAddress = upstream.server.address()
+    if (!upstreamAddress || typeof upstreamAddress === 'string') {
+        throw new Error('failed to resolve upstream server address for proxy connect test')
+    }
+    const fetchResponse = await fetch(
+        `http://proxy-fetch.localtest:${upstreamAddress.port}/proxy-fetch`,
+        {
+            dispatcher
+        } as RequestInit
+    )
+    assert.equal(fetchResponse.status, 200)
+    assert.equal(await fetchResponse.text(), 'ok-proxy-fetch')
+    assert.ok(
+        proxy.observations.fetchRequests >= 1 || proxy.observations.fetchConnectRequests >= 1,
+        'expected fetch request to reach proxy server'
+    )
+
+    const ws = new WaWebSocket(
+        {
+            url: 'ws://proxy-ws.localtest/proxy-ws-test',
+            timeoutIntervalMs: 1_000,
+            dispatcher
+        },
+        createLogger()
+    )
+
+    await assert.rejects(() => ws.open(), /websocket connect/)
+    await ws.close().catch(() => undefined)
+
+    assert.ok(
+        proxy.observations.wsUpgradeRequests > 0 || proxy.observations.wsConnectRequests > 0,
+        'expected websocket handshake to reach proxy server'
+    )
+})

--- a/src/transport/__tests__/websocket-agent.test.ts
+++ b/src/transport/__tests__/websocket-agent.test.ts
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import test from 'node:test'
+
+import type { Logger } from '@infra/log/types'
+import type { RawWebSocket, WebSocketEventLike } from '@transport/types'
+import { WaWebSocket } from '@transport/WaWebSocket'
+
+interface WsServerLike {
+    close(callback?: (error?: Error) => void): void
+    on(event: 'connection', listener: (socket: { send(data: string): void }) => void): this
+}
+
+interface OptionalWsModule {
+    readonly WebSocketServer: new (options: { readonly server: http.Server }) => WsServerLike
+}
+
+function createLogger(): Logger {
+    return {
+        level: 'trace',
+        trace: () => undefined,
+        debug: () => undefined,
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined
+    }
+}
+
+async function loadOptionalWsModule(): Promise<OptionalWsModule | null> {
+    try {
+        const loaded = await import('ws')
+        const constructor = (
+            loaded as {
+                readonly WebSocketServer?: unknown
+            }
+        ).WebSocketServer
+        if (typeof constructor !== 'function') {
+            return null
+        }
+        return {
+            WebSocketServer: constructor as OptionalWsModule['WebSocketServer']
+        }
+    } catch {
+        return null
+    }
+}
+
+async function listen(server: http.Server): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', () => {
+            server.off('error', reject)
+            resolve()
+        })
+    })
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+    if (!server.listening) {
+        return
+    }
+    await new Promise<void>((resolve) => {
+        server.close(() => resolve())
+    })
+}
+
+async function closeWsServer(server: WsServerLike): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+            if (error) {
+                reject(error)
+                return
+            }
+            resolve()
+        })
+    })
+}
+
+test(
+    'websocket uses optional ws package when proxy agent is configured',
+    { concurrency: false },
+    async (context) => {
+        const optionalWs = await loadOptionalWsModule()
+        if (!optionalWs) {
+            context.skip('optional dependency ws is unavailable in test runtime')
+            return
+        }
+
+        const server = http.createServer()
+        await listen(server)
+        const address = server.address()
+        if (!address || typeof address === 'string') {
+            throw new Error('failed to resolve websocket server address')
+        }
+
+        const wsServer = new optionalWs.WebSocketServer({ server })
+        wsServer.on('connection', (socket) => {
+            socket.send('hello-ws-agent')
+        })
+
+        const globalWithWebSocket = globalThis as unknown as { WebSocket?: unknown }
+        const originalGlobalWs = globalWithWebSocket.WebSocket
+        class ThrowingGlobalWebSocket {
+            public constructor() {
+                throw new Error('global websocket constructor should not be used with proxy agent')
+            }
+        }
+        globalWithWebSocket.WebSocket = ThrowingGlobalWebSocket
+
+        const proxyAgent = new http.Agent({ keepAlive: true })
+        const client = new WaWebSocket(
+            {
+                url: `ws://127.0.0.1:${address.port}/agent-test`,
+                timeoutIntervalMs: 3_000,
+                agent: proxyAgent
+            },
+            createLogger()
+        )
+
+        const messagePromise = new Promise<Uint8Array>((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                reject(new Error('timeout waiting websocket message'))
+            }, 5_000)
+            client.setHandlers({
+                onMessage: (payload) => {
+                    clearTimeout(timeout)
+                    resolve(payload)
+                },
+                onError: (error) => {
+                    clearTimeout(timeout)
+                    reject(error)
+                }
+            })
+        })
+
+        context.after(async () => {
+            proxyAgent.destroy()
+            globalWithWebSocket.WebSocket = originalGlobalWs
+            await client.close().catch(() => undefined)
+            await closeWsServer(wsServer).catch(() => undefined)
+            await closeServer(server)
+        })
+
+        await client.open()
+        const payload = await messagePromise
+        assert.equal(new TextDecoder().decode(payload), 'hello-ws-agent')
+    }
+)
+
+test(
+    'websocket concurrent open releases created sockets when setup fails',
+    { concurrency: false },
+    async (context) => {
+        const globalWithWebSocket = globalThis as unknown as { WebSocket?: unknown }
+        const originalGlobalWs = globalWithWebSocket.WebSocket
+
+        class MockWebSocket implements RawWebSocket {
+            public binaryType = 'arraybuffer'
+            public readyState = 0
+            public onopen: ((event: WebSocketEventLike) => void) | null = null
+            public onclose: ((event: WebSocketEventLike) => void) | null = null
+            public onerror: ((event: WebSocketEventLike) => void) | null = null
+            public onmessage: ((event: WebSocketEventLike) => void) | null = null
+
+            public constructor(url: string) {
+                if (url.includes('bad-url')) {
+                    throw new Error('setup failure')
+                }
+            }
+
+            public close(): void {
+                this.readyState = 3
+            }
+
+            public send(_data: string | ArrayBuffer | Uint8Array): void {
+                return
+            }
+        }
+        globalWithWebSocket.WebSocket = MockWebSocket
+
+        const client = new WaWebSocket(
+            {
+                urls: ['ws://good.localtest/socket', 'ws://bad-url/socket'],
+                timeoutIntervalMs: 500
+            },
+            createLogger()
+        )
+
+        context.after(async () => {
+            globalWithWebSocket.WebSocket = originalGlobalWs
+            await client.close().catch(() => undefined)
+        })
+
+        await assert.rejects(() => client.open(), /setup failure/)
+        assert.equal(client.isConnecting(), false)
+    }
+)

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -2,14 +2,25 @@ export type {
     BinaryNode,
     RawWebSocket,
     RawWebSocketConstructor,
+    WaRawWebSocketInit,
     SocketCloseInfo,
     SocketOpenInfo,
     WaCommsConfig,
     WaCommsState,
     WaNoiseConfig,
+    WaProxyAgent,
+    WaProxyDispatcher,
+    WaProxyTransport,
     WaSocketConfig,
     WaSocketHandlers
 } from '@transport/types'
+export {
+    isProxyAgent,
+    isProxyDispatcher,
+    isProxyTransport,
+    toProxyAgent,
+    toProxyDispatcher
+} from '@transport/proxy'
 export { WaComms } from '@transport/WaComms'
 export { WaWebSocket } from '@transport/WaWebSocket'
 export { WaKeepAlive } from '@transport/keepalive/WaKeepAlive'

--- a/src/transport/proxy.ts
+++ b/src/transport/proxy.ts
@@ -1,0 +1,39 @@
+import type { WaProxyAgent, WaProxyDispatcher, WaProxyTransport } from '@transport/types'
+
+export function isProxyDispatcher(value: unknown): value is WaProxyDispatcher {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'dispatch' in value &&
+        typeof (value as { readonly dispatch?: unknown }).dispatch === 'function'
+    )
+}
+
+export function isProxyAgent(value: unknown): value is WaProxyAgent {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'addRequest' in value &&
+        typeof (value as { readonly addRequest?: unknown }).addRequest === 'function'
+    )
+}
+
+export function isProxyTransport(value: unknown): value is WaProxyTransport {
+    return isProxyDispatcher(value) || isProxyAgent(value)
+}
+
+export function toProxyDispatcher(
+    proxy: WaProxyTransport | undefined
+): WaProxyDispatcher | undefined {
+    if (!proxy || !isProxyDispatcher(proxy)) {
+        return undefined
+    }
+    return proxy
+}
+
+export function toProxyAgent(proxy: WaProxyTransport | undefined): WaProxyAgent | undefined {
+    if (!proxy || !isProxyAgent(proxy)) {
+        return undefined
+    }
+    return proxy
+}

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -1,5 +1,16 @@
+import type { Agent as HttpAgent } from 'node:http'
+import type { Agent as HttpsAgent } from 'node:https'
+
 import type { SignalKeyPair } from '@crypto/curves/types'
 import type { WaLoginPayloadConfig, WaRegistrationPayloadConfig } from '@transport/noise/types'
+
+export interface WaProxyDispatcher {
+    dispatch(...args: readonly unknown[]): unknown
+}
+
+export type WaProxyAgent = HttpAgent | HttpsAgent
+
+export type WaProxyTransport = WaProxyDispatcher | WaProxyAgent
 
 export interface BinaryNode {
     readonly tag: string
@@ -22,6 +33,8 @@ export interface WaSocketConfig {
     readonly urls?: readonly string[]
     readonly protocols?: readonly string[]
     readonly headers?: Readonly<Record<string, string>>
+    readonly dispatcher?: WaProxyDispatcher
+    readonly agent?: WaProxyAgent
     readonly timeoutIntervalMs?: number
 }
 
@@ -77,8 +90,19 @@ export interface RawWebSocket {
     send(data: string | ArrayBuffer | Uint8Array): void
 }
 
+export interface WaRawWebSocketInit {
+    readonly protocols?: string | readonly string[]
+    readonly headers?: Readonly<Record<string, string>>
+    readonly dispatcher?: WaProxyDispatcher
+    readonly agent?: WaProxyAgent
+}
+
 export type RawWebSocketConstructor = new (
     url: string,
-    protocols?: string | readonly string[],
-    options?: { headers?: Readonly<Record<string, string>> }
+    protocols?: string | readonly string[] | WaRawWebSocketInit,
+    options?: {
+        headers?: Readonly<Record<string, string>>
+        dispatcher?: WaProxyDispatcher
+        agent?: WaProxyAgent
+    }
 ) => RawWebSocket


### PR DESCRIPTION
Accept WaProxyTransport (dispatcher or http/https Agent) in client/auth config; route ws/media paths accordingly; use optional got/ws when Agent is provided; add deterministic tests for proxy dispatcher, ws agent, and got streaming upload/download; update optional peer/dev deps (got, ws, @types/ws).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end proxy support for WebSocket and media transfers, including per-request and default proxy options.
  * Optional runtime loading of alternate WebSocket and HTTP client implementations for Node.js.
  * New public types to configure proxy transports and proxy-aware client options.

* **Chores**
  * Added optional/peer and dev dependencies for optional ws and HTTP client libraries.

* **Tests**
  * Expanded test coverage for proxy routing, validation, and media transfer paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->