### PR TITLE
feat!: add batch usync pn-to-lid lookup with exists flag...

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -38,7 +38,8 @@ import type {
 import type { WaMessageClient } from '@message/WaMessageClient'
 import { proto, type Proto } from '@proto'
 import { WA_APP_STATE_COLLECTION_STATES, WA_DEFAULTS, WA_MESSAGE_TAGS } from '@protocol/constants'
-import { normalizeDeviceJid, toUserJid } from '@protocol/jid'
+import { normalizeDeviceJid, parsePhoneJid, toUserJid } from '@protocol/jid'
+import type { SignalDeviceSyncApi, SignalLidSyncResult } from '@signal/api/SignalDeviceSyncApi'
 import type { WaAppStateStore } from '@store/contracts/appstate.store'
 import type { WaContactStore } from '@store/contracts/contact.store'
 import type { WaDeviceListStore } from '@store/contracts/device-list.store'
@@ -84,6 +85,7 @@ export class WaClient extends EventEmitter {
     private readonly nodeOrchestrator!: WaNodeOrchestrator
     private readonly keepAlive!: WaKeepAlive
     private readonly nodeTransport!: WaNodeTransport
+    private readonly signalDeviceSync!: SignalDeviceSyncApi
     public readonly appStateSync!: WaAppStateSyncClient
     private readonly incomingNode!: WaIncomingNodeCoordinator
     private readonly passiveTasks!: WaPassiveTasksCoordinator
@@ -655,6 +657,23 @@ export class WaClient extends EventEmitter {
         }
         this.logger.trace('wa client fetch pairing country code iso')
         return this.authClient.fetchPairingCountryCodeIso()
+    }
+
+    public async getLidsByPhoneNumbers(
+        phoneNumbers: readonly string[]
+    ): Promise<readonly SignalLidSyncResult[]> {
+        if (!this.comms || !this.authClient.getCurrentCredentials()) {
+            throw new Error('client is not connected')
+        }
+        const normalizedPhoneJids = phoneNumbers.map((phoneNumber) => {
+            const atIndex = phoneNumber.indexOf('@')
+            const phonePart = atIndex === -1 ? phoneNumber : phoneNumber.slice(0, atIndex)
+            return parsePhoneJid(phonePart)
+        })
+        this.logger.trace('wa client query lids by phone numbers', {
+            phones: normalizedPhoneJids.length
+        })
+        return this.signalDeviceSync.queryLidsByPhoneJids(normalizedPhoneJids)
     }
 
     public async sendMessage(

--- a/src/protocol/nodes.ts
+++ b/src/protocol/nodes.ts
@@ -23,6 +23,8 @@ export const WA_NODE_TAGS = Object.freeze({
     KEY_FETCH: 'key_fetch',
     LIST: 'list',
     USER: 'user',
+    CONTACT: 'contact',
+    LID: 'lid',
     PICTURE: 'picture',
     PRIVACY: 'privacy',
     PARTICIPATING: 'participating',

--- a/src/signal/api/SignalDeviceSyncApi.ts
+++ b/src/signal/api/SignalDeviceSyncApi.ts
@@ -17,6 +17,12 @@ interface SignalDeviceSyncApiOptions {
     readonly generateSid?: WaUsyncSidGenerator
 }
 
+export interface SignalLidSyncResult {
+    readonly phoneJid: string
+    readonly lidJid: string | null
+    readonly exists: boolean
+}
+
 export class SignalDeviceSyncApi {
     private readonly logger: SignalDeviceSyncApiOptions['logger']
     private readonly query: SignalDeviceSyncApiOptions['query']
@@ -94,6 +100,47 @@ export class SignalDeviceSyncApi {
         return merged
     }
 
+    public async queryLidsByPhoneJids(
+        phoneJids: readonly string[],
+        timeoutMs = this.defaultTimeoutMs
+    ): Promise<readonly SignalLidSyncResult[]> {
+        const normalizedPhoneJids = this.normalizeUsers(phoneJids)
+        if (normalizedPhoneJids.length === 0) {
+            return []
+        }
+        const sid = await this.generateSid()
+        const request = this.makeLidSyncRequest(normalizedPhoneJids, sid)
+        this.logger.debug('signal lid sync request', {
+            users: normalizedPhoneJids.length,
+            timeoutMs
+        })
+        const response = await this.query(request, timeoutMs)
+        const parsed = this.parseLidSyncResponse(response, normalizedPhoneJids)
+        const parsedByPhoneJid = new Map<string, SignalLidSyncResult>(
+            parsed.map((entry) => [
+                entry.phoneJid ?? entry.jid,
+                {
+                    phoneJid: entry.phoneJid ?? entry.jid,
+                    lidJid: entry.lidJid,
+                    exists: entry.exists
+                }
+            ])
+        )
+        const result = normalizedPhoneJids.map(
+            (phoneJid) =>
+                parsedByPhoneJid.get(phoneJid) ?? {
+                    phoneJid,
+                    lidJid: null,
+                    exists: false
+                }
+        )
+        this.logger.debug('signal lid sync success', {
+            users: result.length,
+            found: result.reduce((total, entry) => total + (entry.exists ? 1 : 0), 0)
+        })
+        return result
+    }
+
     private async collectUsersToQuery(
         normalizedUsers: readonly string[],
         nowMs: number,
@@ -133,6 +180,34 @@ export class SignalDeviceSyncApi {
         })
     }
 
+    private makeLidSyncRequest(userJids: readonly string[], sid: string): BinaryNode {
+        return buildUsyncIq({
+            sid,
+            hostDomain: this.hostDomain,
+            context: WA_USYNC_CONTEXTS.INTERACTIVE,
+            queryProtocolNodes: [
+                {
+                    tag: WA_NODE_TAGS.CONTACT,
+                    attrs: {}
+                },
+                {
+                    tag: WA_NODE_TAGS.LID,
+                    attrs: {}
+                }
+            ],
+            users: userJids.map((jid) => ({
+                jid,
+                content: [
+                    {
+                        tag: WA_NODE_TAGS.CONTACT,
+                        attrs: {},
+                        content: splitJid(jid).user
+                    }
+                ]
+            }))
+        })
+    }
+
     private parseDeviceSyncResponse(
         node: BinaryNode,
         requestedUsers: readonly string[]
@@ -165,6 +240,116 @@ export class SignalDeviceSyncApi {
                 }
             ]
         })
+    }
+
+    private parseLidSyncResponse(
+        node: BinaryNode,
+        requestedUsers: readonly string[]
+    ): readonly {
+        readonly jid: string
+        readonly lidJid: string | null
+        readonly phoneJid: string | null
+        readonly exists: boolean
+    }[] {
+        assertIqResult(node, 'signal lid sync')
+        const usyncNode = findNodeChild(node, WA_NODE_TAGS.USYNC)
+        if (!usyncNode) {
+            throw new Error('signal lid sync response missing usync node')
+        }
+        const listNode = findNodeChild(usyncNode, WA_NODE_TAGS.LIST)
+        if (!listNode) {
+            throw new Error('signal lid sync response missing list node')
+        }
+
+        const requestedSet = new Set(requestedUsers)
+        const userNodes = getNodeChildrenByTag(listNode, WA_NODE_TAGS.USER)
+        return userNodes.flatMap((userNode) => {
+            const userJid = userNode.attrs.jid
+            if (!userJid) {
+                return []
+            }
+
+            const normalizedUserJid = this.normalizeUserJid(userJid)
+            const normalizedPhoneJid = userNode.attrs.pn_jid
+                ? this.normalizeUserJid(userNode.attrs.pn_jid)
+                : null
+            const wasRequested =
+                requestedSet.has(normalizedUserJid) ||
+                (normalizedPhoneJid !== null && requestedSet.has(normalizedPhoneJid))
+            if (!wasRequested) {
+                return []
+            }
+
+            const lidNode = findNodeChild(userNode, WA_NODE_TAGS.LID)
+            const contactNode = findNodeChild(userNode, WA_NODE_TAGS.CONTACT)
+            if (!lidNode) {
+                return [
+                    {
+                        jid: normalizedUserJid,
+                        lidJid: null,
+                        phoneJid: normalizedPhoneJid,
+                        exists: this.parseLidSyncContactExists(
+                            contactNode,
+                            normalizedUserJid,
+                            false
+                        )
+                    }
+                ]
+            }
+            const errorNode = findNodeChild(lidNode, WA_NODE_TAGS.ERROR)
+            if (errorNode) {
+                this.logger.warn('signal lid sync user error', {
+                    jid: normalizedUserJid,
+                    code: errorNode.attrs.code,
+                    text: errorNode.attrs.text
+                })
+                return [
+                    {
+                        jid: normalizedUserJid,
+                        lidJid: null,
+                        phoneJid: normalizedPhoneJid,
+                        exists: this.parseLidSyncContactExists(
+                            contactNode,
+                            normalizedUserJid,
+                            false
+                        )
+                    }
+                ]
+            }
+            const lidJid = lidNode.attrs.val ? this.normalizeUserJid(lidNode.attrs.val) : null
+            return [
+                {
+                    jid: normalizedUserJid,
+                    lidJid,
+                    phoneJid: normalizedPhoneJid,
+                    exists: this.parseLidSyncContactExists(
+                        contactNode,
+                        normalizedUserJid,
+                        lidJid !== null
+                    )
+                }
+            ]
+        })
+    }
+
+    private parseLidSyncContactExists(
+        contactNode: BinaryNode | undefined,
+        userJid: string,
+        defaultExists: boolean
+    ): boolean {
+        if (!contactNode) {
+            return defaultExists
+        }
+        const errorNode = findNodeChild(contactNode, WA_NODE_TAGS.ERROR)
+        if (errorNode) {
+            this.logger.warn('signal lid sync contact error', {
+                jid: userJid,
+                code: errorNode.attrs.code,
+                text: errorNode.attrs.text
+            })
+            return false
+        }
+        return contactNode.attrs.type === 'in'
     }
 
     private parseUserDeviceJids(userNode: BinaryNode, userJid: string): readonly string[] {

--- a/src/signal/api/__tests__/api.test.ts
+++ b/src/signal/api/__tests__/api.test.ts
@@ -303,6 +303,317 @@ test('signal device sync api preserves requested users omitted by usync response
     ])
 })
 
+test('signal device sync api resolves lids by phone jids via usync and returns exists', async () => {
+    let capturedRequest: BinaryNode | null = null
+    const api = new SignalDeviceSyncApi({
+        logger: createLogger(),
+        query: async (node) => {
+            capturedRequest = node
+            return iqResult([
+                {
+                    tag: WA_NODE_TAGS.USYNC,
+                    attrs: {},
+                    content: [
+                        {
+                            tag: WA_NODE_TAGS.LIST,
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: WA_NODE_TAGS.USER,
+                                    attrs: { jid: '5511999999999@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: WA_NODE_TAGS.CONTACT,
+                                            attrs: {
+                                                type: 'in'
+                                            }
+                                        },
+                                        {
+                                            tag: WA_NODE_TAGS.LID,
+                                            attrs: {
+                                                val: '123456789@lid'
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+        }
+    })
+
+    const result = await api.queryLidsByPhoneJids([
+        '5511999999999@s.whatsapp.net',
+        '5511888888888@s.whatsapp.net'
+    ])
+    assert.deepEqual(result, [
+        {
+            phoneJid: '5511999999999@s.whatsapp.net',
+            lidJid: '123456789@lid',
+            exists: true
+        },
+        {
+            phoneJid: '5511888888888@s.whatsapp.net',
+            lidJid: null,
+            exists: false
+        }
+    ])
+
+    if (!capturedRequest) {
+        throw new Error('expected captured lid sync request content')
+    }
+    const request = capturedRequest as BinaryNode
+    if (!Array.isArray(request.content)) {
+        throw new Error('expected captured lid sync request content')
+    }
+    const requestContent = request.content as readonly BinaryNode[]
+    const usyncNode = requestContent[0]
+    assert.equal(usyncNode.tag, WA_NODE_TAGS.USYNC)
+    if (!Array.isArray(usyncNode.content)) {
+        throw new Error('expected usync node content')
+    }
+    const queryNode = usyncNode.content.find(
+        (entry: BinaryNode) => entry.tag === WA_NODE_TAGS.QUERY
+    )
+    if (!queryNode || !Array.isArray(queryNode.content)) {
+        throw new Error('expected usync query node content')
+    }
+    assert.equal(queryNode.content[0].tag, WA_NODE_TAGS.CONTACT)
+    assert.equal(queryNode.content[1].tag, WA_NODE_TAGS.LID)
+
+    const listNode = usyncNode.content.find((entry: BinaryNode) => entry.tag === WA_NODE_TAGS.LIST)
+    if (!listNode || !Array.isArray(listNode.content)) {
+        throw new Error('expected usync list node content')
+    }
+    assert.equal(listNode.content.length, 2)
+    assert.ok(Array.isArray(listNode.content[0].content))
+    assert.equal(
+        (listNode.content[0].content as readonly BinaryNode[])[0].tag,
+        WA_NODE_TAGS.CONTACT
+    )
+})
+
+test('signal device sync api marks exists=false when contact type is out', async () => {
+    const api = new SignalDeviceSyncApi({
+        logger: createLogger(),
+        query: async () =>
+            iqResult([
+                {
+                    tag: WA_NODE_TAGS.USYNC,
+                    attrs: {},
+                    content: [
+                        {
+                            tag: WA_NODE_TAGS.LIST,
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: WA_NODE_TAGS.USER,
+                                    attrs: { jid: '5511888888888@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: WA_NODE_TAGS.CONTACT,
+                                            attrs: {
+                                                type: 'out'
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+    })
+
+    const result = await api.queryLidsByPhoneJids(['5511888888888@s.whatsapp.net'])
+    assert.deepEqual(result, [
+        {
+            phoneJid: '5511888888888@s.whatsapp.net',
+            lidJid: null,
+            exists: false
+        }
+    ])
+})
+
+test('signal device sync api handles lid node user error and preserves contact existence', async () => {
+    const warnings: {
+        readonly message: string
+        readonly context: Readonly<Record<string, unknown>>
+    }[] = []
+    const api = new SignalDeviceSyncApi({
+        logger: {
+            ...createLogger(),
+            warn: (message, context = {}) => {
+                warnings.push({ message, context })
+            }
+        },
+        query: async () =>
+            iqResult([
+                {
+                    tag: WA_NODE_TAGS.USYNC,
+                    attrs: {},
+                    content: [
+                        {
+                            tag: WA_NODE_TAGS.LIST,
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: WA_NODE_TAGS.USER,
+                                    attrs: { jid: '5511999999999@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: WA_NODE_TAGS.CONTACT,
+                                            attrs: {
+                                                type: 'in'
+                                            }
+                                        },
+                                        {
+                                            tag: WA_NODE_TAGS.LID,
+                                            attrs: {},
+                                            content: [
+                                                {
+                                                    tag: WA_NODE_TAGS.ERROR,
+                                                    attrs: { code: '404', text: 'not-found' }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+    })
+
+    const result = await api.queryLidsByPhoneJids(['5511999999999@s.whatsapp.net'])
+    assert.deepEqual(result, [
+        {
+            phoneJid: '5511999999999@s.whatsapp.net',
+            lidJid: null,
+            exists: true
+        }
+    ])
+    assert.equal(warnings.length, 1)
+    assert.equal(warnings[0].message, 'signal lid sync user error')
+})
+
+test('signal device sync api forces exists=false when contact node has error', async () => {
+    const warnings: {
+        readonly message: string
+        readonly context: Readonly<Record<string, unknown>>
+    }[] = []
+    const api = new SignalDeviceSyncApi({
+        logger: {
+            ...createLogger(),
+            warn: (message, context = {}) => {
+                warnings.push({ message, context })
+            }
+        },
+        query: async () =>
+            iqResult([
+                {
+                    tag: WA_NODE_TAGS.USYNC,
+                    attrs: {},
+                    content: [
+                        {
+                            tag: WA_NODE_TAGS.LIST,
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: WA_NODE_TAGS.USER,
+                                    attrs: { jid: '5511999999999@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: WA_NODE_TAGS.CONTACT,
+                                            attrs: {},
+                                            content: [
+                                                {
+                                                    tag: WA_NODE_TAGS.ERROR,
+                                                    attrs: { code: '500', text: 'lookup-failed' }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            tag: WA_NODE_TAGS.LID,
+                                            attrs: {
+                                                val: '123456789@lid'
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+    })
+
+    const result = await api.queryLidsByPhoneJids(['5511999999999@s.whatsapp.net'])
+    assert.deepEqual(result, [
+        {
+            phoneJid: '5511999999999@s.whatsapp.net',
+            lidJid: '123456789@lid',
+            exists: false
+        }
+    ])
+    assert.equal(warnings.length, 1)
+    assert.equal(warnings[0].message, 'signal lid sync contact error')
+})
+
+test('signal device sync api maps user response by pn_jid when jid differs', async () => {
+    const api = new SignalDeviceSyncApi({
+        logger: createLogger(),
+        query: async () =>
+            iqResult([
+                {
+                    tag: WA_NODE_TAGS.USYNC,
+                    attrs: {},
+                    content: [
+                        {
+                            tag: WA_NODE_TAGS.LIST,
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: WA_NODE_TAGS.USER,
+                                    attrs: {
+                                        jid: '123456789@lid',
+                                        pn_jid: '5511999999999@s.whatsapp.net'
+                                    },
+                                    content: [
+                                        {
+                                            tag: WA_NODE_TAGS.CONTACT,
+                                            attrs: {
+                                                type: 'in'
+                                            }
+                                        },
+                                        {
+                                            tag: WA_NODE_TAGS.LID,
+                                            attrs: {
+                                                val: '123456789@lid'
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+    })
+
+    const result = await api.queryLidsByPhoneJids(['5511999999999@s.whatsapp.net'])
+    assert.deepEqual(result, [
+        {
+            phoneJid: '5511999999999@s.whatsapp.net',
+            lidJid: '123456789@lid',
+            exists: true
+        }
+    ])
+})
+
 test('signal identity sync api parses result list and stores remote identities', async () => {
     const signalStore = new WaSignalMemoryStore()
     const api = new SignalIdentitySyncApi({


### PR DESCRIPTION
...expose getLidsByPhoneNumbers/queryLidsByPhoneJids and remove single-item lookup API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phone-number-based user-identifier lookup to resolve accounts by phone and return per-phone results including presence/existence status.
  * Enhanced device-sync lookup that returns mapped identifiers (when available) for matched phone numbers.

* **Tests**
  * Added unit tests covering phone-based lookup, sync request/response handling, error scenarios, and existence mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->