### PR TITLE
feat: add write-behind persistence and store concurrency guards

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -16,6 +16,8 @@ import type { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTa
 import { parseChatEventFromAppStateMutation } from '@client/events/chat'
 import { processHistorySyncNotification } from '@client/history-sync'
 import { persistIncomingMailboxEntities } from '@client/mailbox'
+import type { WriteBehindDrainResult } from '@client/persistence/WriteBehindPersistence'
+import { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
 import type {
     WaAppStateMessageKey,
     WaClearChatOptions,
@@ -98,7 +100,11 @@ export class WaClient extends EventEmitter {
     private readonly receiptQueue!: WaReceiptQueue
     private readonly keyShareCoordinator!: WaKeyShareCoordinator
     private readonly connectionManager!: WaConnectionManager
+    private readonly writeBehind!: WriteBehindPersistence
     private connectPromise: Promise<void> | null = null
+    private acceptingIncomingEvents = true
+    private activeIncomingHandlers = 0
+    private readonly incomingHandlersDrainedWaiters: Array<() => void> = []
 
     public constructor(options: WaClientOptions, logger: Logger = new ConsoleLogger('info')) {
         super()
@@ -115,6 +121,15 @@ export class WaClient extends EventEmitter {
         this.signalStore = base.sessionStore.signal
         this.senderKeyStore = base.sessionStore.senderKey
         this.threadStore = base.sessionStore.threads
+        this.writeBehind = new WriteBehindPersistence(
+            {
+                messageStore: this.messageStore,
+                threadStore: this.threadStore,
+                contactStore: this.contactStore
+            },
+            this.logger,
+            this.options.writeBehind
+        )
 
         const dependencies = buildWaClientDependencies({
             base,
@@ -235,72 +250,79 @@ export class WaClient extends EventEmitter {
 
     private getMailboxPersistenceDeps(): {
         readonly logger: Logger
-        readonly contactStore: WaContactStore
-        readonly messageStore: WaMessageStore
+        readonly writeBehind: WriteBehindPersistence
     } {
         return {
             logger: this.logger,
-            contactStore: this.contactStore,
-            messageStore: this.messageStore
+            writeBehind: this.writeBehind
         }
     }
 
     private async handleIncomingMessageEvent(event: WaIncomingMessageEvent): Promise<void> {
-        this.emit('message', event)
-        void persistIncomingMailboxEntities({
-            ...this.getMailboxPersistenceDeps(),
-            event
-        })
-        const protocolMessage = event.message?.protocolMessage
-        if (!protocolMessage) {
+        if (!this.tryEnterIncomingHandler()) {
             return
         }
-        const protocolEvent: WaIncomingProtocolMessageEvent = {
-            ...event,
-            protocolMessage
-        }
-        this.emit('message_protocol', protocolEvent)
-
-        const protocolType = protocolMessage.type
-        if (protocolType === null || protocolType === undefined) {
-            this.logger.debug('incoming protocol message without type', {
-                id: event.stanzaId,
-                from: event.chatJid
+        try {
+            this.emit('message', event)
+            void persistIncomingMailboxEntities({
+                ...this.getMailboxPersistenceDeps(),
+                event
             })
-            return
-        }
-
-        if (protocolType === proto.Message.ProtocolMessage.Type.APP_STATE_SYNC_KEY_REQUEST) {
-            await this.handleIncomingAppStateSyncKeyRequest(event, protocolMessage)
-            return
-        }
-
-        if (protocolType === proto.Message.ProtocolMessage.Type.APP_STATE_SYNC_KEY_SHARE) {
-            await this.handleIncomingAppStateSyncKeyShare(event, protocolMessage)
-            return
-        }
-
-        if (protocolType === proto.Message.ProtocolMessage.Type.HISTORY_SYNC_NOTIFICATION) {
-            if (this.options.history?.enabled && protocolMessage.historySyncNotification) {
-                await this.handleHistorySyncNotification(protocolMessage.historySyncNotification)
+            const protocolMessage = event.message?.protocolMessage
+            if (!protocolMessage) {
+                return
             }
-            return
-        }
+            const protocolEvent: WaIncomingProtocolMessageEvent = {
+                ...event,
+                protocolMessage
+            }
+            this.emit('message_protocol', protocolEvent)
 
-        if (SYNC_RELATED_PROTOCOL_TYPES.has(protocolType)) {
-            this.logger.info('incoming sync-related protocol message', {
+            const protocolType = protocolMessage.type
+            if (protocolType === null || protocolType === undefined) {
+                this.logger.debug('incoming protocol message without type', {
+                    id: event.stanzaId,
+                    from: event.chatJid
+                })
+                return
+            }
+
+            if (protocolType === proto.Message.ProtocolMessage.Type.APP_STATE_SYNC_KEY_REQUEST) {
+                await this.handleIncomingAppStateSyncKeyRequest(event, protocolMessage)
+                return
+            }
+
+            if (protocolType === proto.Message.ProtocolMessage.Type.APP_STATE_SYNC_KEY_SHARE) {
+                await this.handleIncomingAppStateSyncKeyShare(event, protocolMessage)
+                return
+            }
+
+            if (protocolType === proto.Message.ProtocolMessage.Type.HISTORY_SYNC_NOTIFICATION) {
+                if (this.options.history?.enabled && protocolMessage.historySyncNotification) {
+                    await this.handleHistorySyncNotification(
+                        protocolMessage.historySyncNotification
+                    )
+                }
+                return
+            }
+
+            if (SYNC_RELATED_PROTOCOL_TYPES.has(protocolType)) {
+                this.logger.info('incoming sync-related protocol message', {
+                    id: event.stanzaId,
+                    from: event.chatJid,
+                    protocolType
+                })
+                return
+            }
+
+            this.logger.debug('incoming protocol message received', {
                 id: event.stanzaId,
                 from: event.chatJid,
                 protocolType
             })
-            return
+        } finally {
+            this.leaveIncomingHandler()
         }
-
-        this.logger.debug('incoming protocol message received', {
-            id: event.stanzaId,
-            from: event.chatJid,
-            protocolType
-        })
     }
 
     private async handleIncomingAppStateSyncKeyShare(
@@ -474,9 +496,9 @@ export class WaClient extends EventEmitter {
         try {
             await processHistorySyncNotification(
                 {
-                    ...this.getMailboxPersistenceDeps(),
+                    logger: this.logger,
                     mediaTransfer: this.mediaTransfer,
-                    threadStore: this.threadStore,
+                    writeBehind: this.writeBehind,
                     emitEvent: this.emit.bind(this) as Parameters<
                         typeof processHistorySyncNotification
                     >[0]['emitEvent']
@@ -524,6 +546,7 @@ export class WaClient extends EventEmitter {
             return this.connectPromise
         }
 
+        this.acceptingIncomingEvents = true
         this.connectPromise = this.connectionManager
             .connect((frame) => this.handleIncomingFrame(frame))
             .then(() => {
@@ -536,6 +559,15 @@ export class WaClient extends EventEmitter {
     }
 
     public async disconnect(): Promise<void> {
+        await this.pauseIncomingEventsAndWaitDrain()
+        const writeBehindFlush = await this.writeBehind.flush(
+            this.options.writeBehind?.flushTimeoutMs
+        )
+        if (writeBehindFlush.remaining > 0) {
+            this.logger.warn('disconnect continuing with pending write-behind entries', {
+                remaining: writeBehindFlush.remaining
+            })
+        }
         this.keyShareCoordinator.notifyDisconnected()
         await this.connectionManager.disconnect()
         this.emit('connection_close', {})
@@ -634,6 +666,10 @@ export class WaClient extends EventEmitter {
 
     public flushAppStateMutations(): Promise<void> {
         return this.appStateMutations.flushMutations()
+    }
+
+    public flushWriteBehind(timeoutMs?: number): Promise<WriteBehindDrainResult> {
+        return this.writeBehind.flush(timeoutMs)
     }
 
     public async exportAppState(): Promise<WaAppStateStoreData> {
@@ -776,6 +812,15 @@ export class WaClient extends EventEmitter {
     }
 
     private async clearStoredState(): Promise<void> {
+        await this.pauseIncomingEventsAndWaitDrain()
+        const writeBehindDestroy = await this.writeBehind.destroy(
+            this.options.writeBehind?.flushTimeoutMs
+        )
+        if (writeBehindDestroy.remaining > 0) {
+            throw new Error(
+                `clear stored state aborted: write-behind did not fully drain (remaining=${writeBehindDestroy.remaining})`
+            )
+        }
         const danglingReceipts = this.receiptQueue.take()
         if (danglingReceipts.length > 0) {
             this.logger.debug('cleared dangling receipts while clearing stored state', {
@@ -792,6 +837,50 @@ export class WaClient extends EventEmitter {
         await this.signalStore.clear()
         await this.senderKeyStore.clear()
         await this.threadStore.clear()
+    }
+
+    private tryEnterIncomingHandler(): boolean {
+        if (!this.acceptingIncomingEvents) {
+            return false
+        }
+        this.activeIncomingHandlers += 1
+        if (this.acceptingIncomingEvents) {
+            return true
+        }
+        this.leaveIncomingHandler()
+        return false
+    }
+
+    private leaveIncomingHandler(): void {
+        if (this.activeIncomingHandlers <= 0) {
+            return
+        }
+        this.activeIncomingHandlers -= 1
+        if (this.activeIncomingHandlers === 0) {
+            this.notifyIncomingHandlersDrained()
+        }
+    }
+
+    private async pauseIncomingEventsAndWaitDrain(): Promise<void> {
+        this.acceptingIncomingEvents = false
+        if (this.activeIncomingHandlers === 0) {
+            return
+        }
+        await new Promise<void>((resolve) => {
+            this.incomingHandlersDrainedWaiters[this.incomingHandlersDrainedWaiters.length] =
+                resolve
+        })
+    }
+
+    private notifyIncomingHandlersDrained(): void {
+        if (this.incomingHandlersDrainedWaiters.length === 0) {
+            return
+        }
+        const waitersLength = this.incomingHandlersDrainedWaiters.length
+        for (let index = 0; index < waitersLength; index += 1) {
+            this.incomingHandlersDrainedWaiters[index]()
+        }
+        this.incomingHandlersDrainedWaiters.length = 0
     }
 
     private handleError(error: Error): void {

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -78,9 +78,9 @@ test('history sync processor persists conversations and emits chunk event', asyn
     const threads: unknown[] = []
     const contacts: unknown[] = []
     const emitted: unknown[] = []
-    let messageBatchCalls = 0
-    let threadBatchCalls = 0
-    let contactBatchCalls = 0
+    let messageCalls = 0
+    let threadCalls = 0
+    let contactCalls = 0
 
     await processHistorySyncNotification(
         {
@@ -90,22 +90,18 @@ test('history sync processor persists conversations and emits chunk event', asyn
                     throw new Error('should not be called for inline payload')
                 }
             } as never,
-            messageStore: {
-                upsertBatch: async (records: readonly unknown[]) => {
-                    messageBatchCalls += 1
-                    messages.push(...records)
-                }
-            } as never,
-            threadStore: {
-                upsertBatch: async (records: readonly unknown[]) => {
-                    threadBatchCalls += 1
-                    threads.push(...records)
-                }
-            } as never,
-            contactStore: {
-                upsertBatch: async (records: readonly unknown[]) => {
-                    contactBatchCalls += 1
-                    contacts.push(...records)
+            writeBehind: {
+                persistMessageAsync: async (record: unknown) => {
+                    messageCalls += 1
+                    messages.push(record)
+                },
+                persistThreadAsync: async (record: unknown) => {
+                    threadCalls += 1
+                    threads.push(record)
+                },
+                persistContactAsync: async (record: unknown) => {
+                    contactCalls += 1
+                    contacts.push(record)
                 }
             } as never,
             emitEvent: (_event, payload) => {
@@ -121,11 +117,69 @@ test('history sync processor persists conversations and emits chunk event', asyn
     assert.equal(messages.length, 1)
     assert.equal(threads.length, 1)
     assert.equal(contacts.length, 1)
-    assert.equal(messageBatchCalls, 1)
-    assert.equal(threadBatchCalls, 1)
-    assert.equal(contactBatchCalls, 1)
+    assert.equal(messageCalls, 1)
+    assert.equal(threadCalls, 1)
+    assert.equal(contactCalls, 1)
     assert.equal(emitted.length, 1)
     assert.equal((emitted[0] as { messagesCount: number }).messagesCount, 1)
+})
+
+test('history sync processor does not emit chunk event when chunk persistence fails', async () => {
+    const historySyncBytes = proto.HistorySync.encode({
+        chunkOrder: 2,
+        progress: 10,
+        conversations: [
+            {
+                id: 'thread@s.whatsapp.net',
+                messages: [
+                    {
+                        message: {
+                            key: {
+                                id: 'm-error',
+                                fromMe: false
+                            },
+                            message: {
+                                conversation: 'hello'
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+    }).finish()
+    const zipped = gzipSync(historySyncBytes)
+    const emitted: unknown[] = []
+
+    await assert.rejects(
+        () =>
+            processHistorySyncNotification(
+                {
+                    logger: createLogger(),
+                    mediaTransfer: {
+                        downloadAndDecrypt: async () => {
+                            throw new Error('should not be called for inline payload')
+                        }
+                    } as never,
+                    writeBehind: {
+                        persistMessageAsync: async () => {
+                            throw new Error('persist failed')
+                        },
+                        persistThreadAsync: async () => undefined,
+                        persistContactAsync: async () => undefined
+                    } as never,
+                    emitEvent: (_event, payload) => {
+                        emitted.push(payload)
+                    }
+                },
+                {
+                    syncType: proto.Message.HistorySyncType.RECENT,
+                    initialHistBootstrapInlinePayload: zipped
+                }
+            ),
+        /persist failed/
+    )
+
+    assert.equal(emitted.length, 0)
 })
 
 test('resolveWaClientBase rejects invalid proxy transport shapes', () => {

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -434,34 +434,41 @@ export class WaRetryCoordinator {
             return
         }
 
-        const current = await this.retryStore.getOutboundMessage(messageId)
-        if (!current) {
-            return
-        }
-        const nowMs = Date.now()
-        const expiresAtMs = nowMs + this.retryTtlMs
-        const merged = pickRetryStateMax(current.state, nextState)
-        if (merged !== current.state) {
-            await this.retryStore.updateOutboundMessageState(messageId, merged, nowMs, expiresAtMs)
-        }
-        const requesterJid = receiptNode.attrs.participant ?? receiptNode.attrs.from
-        if (!requesterJid) {
-            return
-        }
-        try {
-            await this.retryStore.markOutboundRequesterDelivered(
-                messageId,
-                normalizeDeviceJid(requesterJid),
-                nowMs,
-                expiresAtMs
-            )
-        } catch (error) {
-            this.logger.warn('failed to update outbound requester delivery state', {
-                id: messageId,
-                requester: requesterJid,
-                message: toError(error).message
-            })
-        }
+        await this.runRetryTaskSerialized(messageId, async () => {
+            const current = await this.retryStore.getOutboundMessage(messageId)
+            if (!current) {
+                return
+            }
+            const nowMs = Date.now()
+            const expiresAtMs = nowMs + this.retryTtlMs
+            const merged = pickRetryStateMax(current.state, nextState)
+            if (merged !== current.state) {
+                await this.retryStore.updateOutboundMessageState(
+                    messageId,
+                    merged,
+                    nowMs,
+                    expiresAtMs
+                )
+            }
+            const requesterJid = receiptNode.attrs.participant ?? receiptNode.attrs.from
+            if (!requesterJid) {
+                return
+            }
+            try {
+                await this.retryStore.markOutboundRequesterDelivered(
+                    messageId,
+                    normalizeDeviceJid(requesterJid),
+                    nowMs,
+                    expiresAtMs
+                )
+            } catch (error) {
+                this.logger.warn('failed to update outbound requester delivery state', {
+                    id: messageId,
+                    requester: requesterJid,
+                    message: toError(error).message
+                })
+            }
+        })
     }
 
     private async runRetryTaskSerialized(
@@ -469,7 +476,7 @@ export class WaRetryCoordinator {
         task: () => Promise<void>
     ): Promise<void> {
         const previous = this.retryProcessingByMessageId.get(messageId) ?? Promise.resolve()
-        const current = previous.then(task, task)
+        const current = previous.then(task)
         const tracker = current.then(
             () => undefined,
             () => undefined

--- a/src/client/coordinators/__tests__/retry-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/retry-coordinator.test.ts
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { WaRetryCoordinator } from '@client/coordinators/WaRetryCoordinator'
+import type { Logger } from '@infra/log/types'
+import type { WaRetryOutboundMessageRecord, WaRetryOutboundState } from '@retry/types'
+import type { WaRetryStore } from '@store/contracts/retry.store'
+import type { BinaryNode } from '@transport/types'
+
+function createLogger(): Logger {
+    return {
+        level: 'trace',
+        trace: () => undefined,
+        debug: () => undefined,
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined
+    }
+}
+
+class ControlledRetryStore implements WaRetryStore {
+    private record: WaRetryOutboundMessageRecord | null
+    private blockFirstGet = true
+    private readonly firstGetStartedPromise: Promise<void>
+    private resolveFirstGetStarted: (() => void) | null = null
+    private readonly releaseFirstGetPromise: Promise<void>
+    private resolveReleaseFirstGet: (() => void) | null = null
+    private readonly stateTransitions: WaRetryOutboundState[] = []
+
+    public constructor(initialRecord: WaRetryOutboundMessageRecord) {
+        this.record = initialRecord
+        this.firstGetStartedPromise = new Promise<void>((resolve) => {
+            this.resolveFirstGetStarted = resolve
+        })
+        this.releaseFirstGetPromise = new Promise<void>((resolve) => {
+            this.resolveReleaseFirstGet = resolve
+        })
+    }
+
+    public waitFirstGetStarted(): Promise<void> {
+        return this.firstGetStartedPromise
+    }
+
+    public releaseFirstGet(): void {
+        this.resolveReleaseFirstGet?.()
+        this.resolveReleaseFirstGet = null
+    }
+
+    public getCurrentState(): WaRetryOutboundState {
+        if (!this.record) {
+            throw new Error('missing outbound record')
+        }
+        return this.record.state
+    }
+
+    public getTransitions(): readonly WaRetryOutboundState[] {
+        return this.stateTransitions
+    }
+
+    public async getOutboundRequesterStatus(
+        _messageId: string,
+        _requesterDeviceJid: string
+    ): Promise<{
+        readonly eligible: boolean
+        readonly delivered: boolean
+    } | null> {
+        return null
+    }
+
+    public getTtlMs(): number {
+        return 60_000
+    }
+
+    public async upsertOutboundMessage(record: WaRetryOutboundMessageRecord): Promise<void> {
+        this.record = record
+    }
+
+    public async deleteOutboundMessage(messageId: string): Promise<number> {
+        if (!this.record || this.record.messageId !== messageId) {
+            return 0
+        }
+        this.record = null
+        return 1
+    }
+
+    public async getOutboundMessage(
+        messageId: string
+    ): Promise<WaRetryOutboundMessageRecord | null> {
+        if (!this.record || this.record.messageId !== messageId) {
+            return null
+        }
+        if (this.blockFirstGet) {
+            this.blockFirstGet = false
+            this.resolveFirstGetStarted?.()
+            this.resolveFirstGetStarted = null
+            await this.releaseFirstGetPromise
+        }
+        return { ...this.record }
+    }
+
+    public async updateOutboundMessageState(
+        messageId: string,
+        state: WaRetryOutboundState,
+        updatedAtMs: number,
+        expiresAtMs: number
+    ): Promise<void> {
+        if (!this.record || this.record.messageId !== messageId) {
+            return
+        }
+        this.record = {
+            ...this.record,
+            state,
+            updatedAtMs,
+            expiresAtMs
+        }
+        this.stateTransitions.push(state)
+    }
+
+    public async markOutboundRequesterDelivered(
+        _messageId: string,
+        _requesterDeviceJid: string,
+        _updatedAtMs: number,
+        _expiresAtMs: number
+    ): Promise<void> {
+        return
+    }
+
+    public async incrementInboundCounter(
+        _messageId: string,
+        _requesterJid: string,
+        _updatedAtMs: number,
+        _expiresAtMs: number
+    ): Promise<number> {
+        return 0
+    }
+
+    public async cleanupExpired(_nowMs: number): Promise<number> {
+        return 0
+    }
+
+    public async clear(): Promise<void> {
+        this.record = null
+    }
+}
+
+function buildReceiptNode(messageId: string, type: string): BinaryNode {
+    return {
+        tag: 'receipt',
+        attrs: {
+            id: messageId,
+            type,
+            from: '551100000000@s.whatsapp.net'
+        },
+        content: []
+    }
+}
+
+test('retry coordinator serializes outbound receipt tracking per message id', async () => {
+    const nowMs = Date.now()
+    const retryStore = new ControlledRetryStore({
+        messageId: 'msg-1',
+        toJid: '551100000000@s.whatsapp.net',
+        messageType: 'text',
+        replayMode: 'plaintext',
+        replayPayload: {
+            mode: 'plaintext',
+            to: '551100000000@s.whatsapp.net',
+            type: 'text',
+            plaintext: new Uint8Array([1, 2, 3])
+        },
+        state: 'pending',
+        createdAtMs: nowMs,
+        updatedAtMs: nowMs,
+        expiresAtMs: nowMs + 60_000
+    })
+
+    const coordinator = new WaRetryCoordinator({
+        logger: createLogger(),
+        retryStore,
+        signalStore: {} as never,
+        senderKeyStore: {} as never,
+        signalProtocol: {} as never,
+        signalDeviceSync: {} as never,
+        signalMissingPreKeysSync: {} as never,
+        messageClient: {} as never,
+        sendNode: async () => undefined,
+        getCurrentMeJid: () => null,
+        getCurrentMeLid: () => null,
+        getCurrentSignedIdentity: () => null
+    })
+
+    const deliveryTracking = coordinator.trackOutboundReceipt(buildReceiptNode('msg-1', 'delivery'))
+    await retryStore.waitFirstGetStarted()
+
+    const readTracking = coordinator.trackOutboundReceipt(buildReceiptNode('msg-1', 'read'))
+    retryStore.releaseFirstGet()
+
+    await Promise.all([deliveryTracking, readTracking])
+
+    assert.equal(retryStore.getCurrentState(), 'read')
+    assert.deepEqual(retryStore.getTransitions(), ['delivered', 'read'])
+})

--- a/src/client/history-sync.ts
+++ b/src/client/history-sync.ts
@@ -1,13 +1,11 @@
 import { promisify } from 'node:util'
 import { unzip } from 'node:zlib'
 
+import type { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
 import type { WaClientEventMap, WaHistorySyncChunkEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
 import { proto, type Proto } from '@proto'
-import type { WaContactStore, WaStoredContactRecord } from '@store/contracts/contact.store'
-import type { WaMessageStore, WaStoredMessageRecord } from '@store/contracts/message.store'
-import type { WaStoredThreadRecord, WaThreadStore } from '@store/contracts/thread.store'
 import { decodeProtoBytes, toBytesView } from '@util/bytes'
 import { longToNumber } from '@util/primitives'
 
@@ -19,13 +17,12 @@ const HANDLED_SYNC_TYPES = new Set([
     proto.Message.HistorySyncType.FULL,
     proto.Message.HistorySyncType.PUSH_NAME
 ])
+const HISTORY_SYNC_MAX_PENDING_WRITES = 1_024
 
 interface WaHistorySyncDeps {
     readonly logger: Logger
     readonly mediaTransfer: WaMediaTransferClient
-    readonly contactStore: WaContactStore
-    readonly messageStore: WaMessageStore
-    readonly threadStore: WaThreadStore
+    readonly writeBehind: WriteBehindPersistence
     readonly emitEvent: <K extends keyof WaClientEventMap>(
         event: K,
         ...args: Parameters<WaClientEventMap[K]>
@@ -55,20 +52,21 @@ export async function processHistorySyncNotification(
     })
 
     const nowMs = Date.now()
-    const contacts: WaStoredContactRecord[] = []
+    const pendingWrites: Promise<void>[] = []
     for (const pn of historySync.pushnames) {
         if (!pn.id) {
             continue
         }
-        contacts.push({
+        pendingWrites[pendingWrites.length] = deps.writeBehind.persistContactAsync({
             jid: pn.id,
             pushName: pn.pushname ?? undefined,
             lastUpdatedMs: nowMs
         })
+        if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
+            await flushPendingWrites(pendingWrites)
+        }
     }
 
-    const threads: WaStoredThreadRecord[] = []
-    const messages: WaStoredMessageRecord[] = []
     let messagesCount = 0
     for (const conversation of historySync.conversations) {
         const threadJid = conversation.id
@@ -77,7 +75,7 @@ export async function processHistorySyncNotification(
             continue
         }
 
-        threads.push({
+        pendingWrites[pendingWrites.length] = deps.writeBehind.persistThreadAsync({
             jid: threadJid,
             name: conversation.name ?? undefined,
             unreadCount: conversation.unreadCount ?? undefined,
@@ -87,13 +85,16 @@ export async function processHistorySyncNotification(
             markedAsUnread: conversation.markedAsUnread ?? undefined,
             ephemeralExpiration: conversation.ephemeralExpiration ?? undefined
         })
+        if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
+            await flushPendingWrites(pendingWrites)
+        }
         for (const histMsg of conversation.messages ?? []) {
             const webMsg = histMsg.message
             if (!webMsg?.key?.id) {
                 continue
             }
             const timestampMs = longToNumber(webMsg.messageTimestamp) * 1000
-            messages.push({
+            pendingWrites[pendingWrites.length] = deps.writeBehind.persistMessageAsync({
                 id: webMsg.key.id,
                 threadJid,
                 senderJid: webMsg.key.participant ?? undefined,
@@ -103,15 +104,12 @@ export async function processHistorySyncNotification(
                     ? proto.Message.encode(webMsg.message).finish()
                     : undefined
             })
+            if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
+                await flushPendingWrites(pendingWrites)
+            }
             messagesCount += 1
         }
     }
-
-    await Promise.all([
-        deps.contactStore.upsertBatch(contacts),
-        deps.threadStore.upsertBatch(threads),
-        deps.messageStore.upsertBatch(messages)
-    ])
 
     const event: WaHistorySyncChunkEvent = {
         syncType,
@@ -121,7 +119,21 @@ export async function processHistorySyncNotification(
         chunkOrder: historySync.chunkOrder ?? undefined,
         progress: historySync.progress ?? undefined
     }
+    await flushPendingWrites(pendingWrites)
     deps.emitEvent('history_sync_chunk', event)
+}
+
+async function flushPendingWrites(pendingWrites: Promise<void>[]): Promise<void> {
+    if (pendingWrites.length === 0) {
+        return
+    }
+    const pendingCount = pendingWrites.length
+    const batch = new Array<Promise<void>>(pendingCount)
+    for (let index = 0; index < pendingCount; index += 1) {
+        batch[index] = pendingWrites[index]
+    }
+    pendingWrites.length = 0
+    await Promise.all(batch)
 }
 
 async function downloadHistorySyncBlob(

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -11,5 +11,6 @@ export type {
     WaDeleteChatOptions,
     WaDeleteMessageForMeOptions,
     WaHistorySyncChunkEvent,
-    WaHistorySyncOptions
+    WaHistorySyncOptions,
+    WaWriteBehindOptions
 } from '@client/types'

--- a/src/client/mailbox.ts
+++ b/src/client/mailbox.ts
@@ -1,22 +1,20 @@
+import type { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
 import type { WaIncomingMessageEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import { proto } from '@proto'
-import type { WaContactStore } from '@store/contracts/contact.store'
-import type { WaMessageStore } from '@store/contracts/message.store'
 import { toError } from '@util/primitives'
 
 interface WaPersistIncomingMailboxOptions {
     readonly logger: Logger
-    readonly contactStore: WaContactStore
-    readonly messageStore: WaMessageStore
+    readonly writeBehind: WriteBehindPersistence
     readonly event: WaIncomingMessageEvent
 }
 
-async function persistContacts(
-    contactStore: WaContactStore,
+function persistContacts(
+    writeBehind: WriteBehindPersistence,
     event: WaIncomingMessageEvent,
     nowMs: number
-): Promise<void> {
+): void {
     const candidateJids = [event.senderJid, event.rawNode.attrs.participant].filter(
         (jid): jid is string => !!jid
     )
@@ -24,14 +22,13 @@ async function persistContacts(
         return
     }
 
-    const contacts = [...new Set(candidateJids)].map((jid) => ({ jid, lastUpdatedMs: nowMs }))
-    await contactStore.upsertBatch(contacts)
+    for (const jid of [...new Set(candidateJids)]) {
+        writeBehind.persistContact({ jid, lastUpdatedMs: nowMs })
+    }
 }
 
-export async function persistIncomingMailboxEntities(
-    options: WaPersistIncomingMailboxOptions
-): Promise<void> {
-    const { logger, contactStore, messageStore, event } = options
+export function persistIncomingMailboxEntities(options: WaPersistIncomingMailboxOptions): void {
+    const { logger, writeBehind, event } = options
     const { stanzaId, chatJid } = event
     if (!stanzaId || !chatJid) {
         return
@@ -42,23 +39,19 @@ export async function persistIncomingMailboxEntities(
         const messageBytes = event.message
             ? proto.Message.encode(event.message).finish()
             : undefined
-        await Promise.all([
-            messageStore.upsert({
-                id: stanzaId,
-                threadJid: chatJid,
-                senderJid: event.senderJid,
-                participantJid: event.rawNode.attrs.participant,
-                fromMe: false,
-                timestampMs:
-                    event.timestampSeconds === undefined
-                        ? undefined
-                        : event.timestampSeconds * 1_000,
-                encType: event.encryptionType,
-                plaintext: event.plaintext,
-                messageBytes
-            }),
-            persistContacts(contactStore, event, nowMs)
-        ])
+        writeBehind.persistMessage({
+            id: stanzaId,
+            threadJid: chatJid,
+            senderJid: event.senderJid,
+            participantJid: event.rawNode.attrs.participant,
+            fromMe: false,
+            timestampMs:
+                event.timestampSeconds === undefined ? undefined : event.timestampSeconds * 1_000,
+            encType: event.encryptionType,
+            plaintext: event.plaintext,
+            messageBytes
+        })
+        persistContacts(writeBehind, event, nowMs)
     } catch (error) {
         logger.warn('failed to persist incoming mailbox entities', {
             id: stanzaId,

--- a/src/client/persistence/WriteBehindPersistence.ts
+++ b/src/client/persistence/WriteBehindPersistence.ts
@@ -1,0 +1,181 @@
+import type { WaWriteBehindOptions } from '@client/types'
+import type { Logger } from '@infra/log/types'
+import type { BackgroundQueueFlushResult } from '@infra/perf/BackgroundQueue'
+import { BackgroundQueue } from '@infra/perf/BackgroundQueue'
+import type { WaContactStore, WaStoredContactRecord } from '@store/contracts/contact.store'
+import type { WaMessageStore, WaStoredMessageRecord } from '@store/contracts/message.store'
+import type { WaStoredThreadRecord, WaThreadStore } from '@store/contracts/thread.store'
+import { toError } from '@util/primitives'
+
+interface WriteBehindStores {
+    readonly messageStore: WaMessageStore
+    readonly threadStore: WaThreadStore
+    readonly contactStore: WaContactStore
+}
+
+export interface WriteBehindDrainResult {
+    readonly messages: BackgroundQueueFlushResult
+    readonly threads: BackgroundQueueFlushResult
+    readonly contacts: BackgroundQueueFlushResult
+    readonly flushed: number
+    readonly remaining: number
+}
+
+function mergeThread(
+    previous: WaStoredThreadRecord,
+    incoming: WaStoredThreadRecord
+): WaStoredThreadRecord {
+    return {
+        jid: incoming.jid,
+        name: incoming.name ?? previous.name,
+        unreadCount: incoming.unreadCount ?? previous.unreadCount,
+        archived: incoming.archived ?? previous.archived,
+        pinned: incoming.pinned ?? previous.pinned,
+        muteEndMs: incoming.muteEndMs ?? previous.muteEndMs,
+        markedAsUnread: incoming.markedAsUnread ?? previous.markedAsUnread,
+        ephemeralExpiration: incoming.ephemeralExpiration ?? previous.ephemeralExpiration
+    }
+}
+
+function mergeContact(
+    previous: WaStoredContactRecord,
+    incoming: WaStoredContactRecord
+): WaStoredContactRecord {
+    return {
+        jid: incoming.jid,
+        displayName: incoming.displayName ?? previous.displayName,
+        pushName: incoming.pushName ?? previous.pushName,
+        lid: incoming.lid ?? previous.lid,
+        phoneNumber: incoming.phoneNumber ?? previous.phoneNumber,
+        lastUpdatedMs: Math.max(previous.lastUpdatedMs, incoming.lastUpdatedMs)
+    }
+}
+
+export class WriteBehindPersistence {
+    private readonly logger: Logger
+    private readonly queues: {
+        readonly messages: BackgroundQueue<string, WaStoredMessageRecord>
+        readonly threads: BackgroundQueue<string, WaStoredThreadRecord>
+        readonly contacts: BackgroundQueue<string, WaStoredContactRecord>
+    }
+    private readonly flushTimeoutMs: number
+
+    public constructor(
+        stores: WriteBehindStores,
+        logger: Logger,
+        options: WaWriteBehindOptions = {}
+    ) {
+        this.logger = logger
+        this.flushTimeoutMs = options.flushTimeoutMs ?? 5_000
+        const queueOptions = (domain: string) => ({
+            maxPendingKeys: options.maxPendingKeys ?? 4_096,
+            flushTimeoutMs: this.flushTimeoutMs,
+            onError: (key: string, error: unknown, attempt: number) => {
+                this.logger.warn('write-behind error', {
+                    domain,
+                    key,
+                    attempt,
+                    message: toError(error).message
+                })
+            },
+            onPressure: (pendingKeys: number) => {
+                this.logger.warn('write-behind pressure', {
+                    domain,
+                    pendingKeys
+                })
+            },
+            onDiscard: (key: string) => {
+                this.logger.warn('write-behind discarded pending write', {
+                    domain,
+                    key
+                })
+            }
+        })
+        this.queues = {
+            messages: new BackgroundQueue(
+                (_key, value) => stores.messageStore.upsert(value),
+                queueOptions('messages')
+            ),
+            threads: new BackgroundQueue((_key, value) => stores.threadStore.upsert(value), {
+                ...queueOptions('threads'),
+                coalesce: (previous, incoming) => mergeThread(previous, incoming)
+            }),
+            contacts: new BackgroundQueue((_key, value) => stores.contactStore.upsert(value), {
+                ...queueOptions('contacts'),
+                coalesce: (previous, incoming) => mergeContact(previous, incoming)
+            })
+        }
+    }
+
+    public persistMessage(record: WaStoredMessageRecord): void {
+        this.queues.messages.enqueue(`msg:${record.id}`, record)
+    }
+
+    public persistMessageAsync(record: WaStoredMessageRecord): Promise<void> {
+        return this.queues.messages.enqueueAsync(`msg:${record.id}`, record)
+    }
+
+    public persistThread(record: WaStoredThreadRecord): void {
+        this.queues.threads.enqueue(`thread:${record.jid}`, record)
+    }
+
+    public persistThreadAsync(record: WaStoredThreadRecord): Promise<void> {
+        return this.queues.threads.enqueueAsync(`thread:${record.jid}`, record)
+    }
+
+    public persistContact(record: WaStoredContactRecord): void {
+        this.queues.contacts.enqueue(`contact:${record.jid}`, record)
+    }
+
+    public persistContactAsync(record: WaStoredContactRecord): Promise<void> {
+        return this.queues.contacts.enqueueAsync(`contact:${record.jid}`, record)
+    }
+
+    public async flush(timeoutMs: number = this.flushTimeoutMs): Promise<WriteBehindDrainResult> {
+        const [messages, threads, contacts] = await Promise.all([
+            this.queues.messages.flush(timeoutMs),
+            this.queues.threads.flush(timeoutMs),
+            this.queues.contacts.flush(timeoutMs)
+        ])
+        const result = this.toDrainResult(messages, threads, contacts)
+        if (result.remaining > 0) {
+            this.logger.warn('write-behind flush finished with pending writes', {
+                messagesRemaining: messages.remaining,
+                threadsRemaining: threads.remaining,
+                contactsRemaining: contacts.remaining
+            })
+        }
+        return result
+    }
+
+    public async destroy(timeoutMs: number = this.flushTimeoutMs): Promise<WriteBehindDrainResult> {
+        const [messages, threads, contacts] = await Promise.all([
+            this.queues.messages.destroy(timeoutMs),
+            this.queues.threads.destroy(timeoutMs),
+            this.queues.contacts.destroy(timeoutMs)
+        ])
+        const result = this.toDrainResult(messages, threads, contacts)
+        if (result.remaining > 0) {
+            this.logger.warn('write-behind destroy finished with pending writes', {
+                messagesRemaining: messages.remaining,
+                threadsRemaining: threads.remaining,
+                contactsRemaining: contacts.remaining
+            })
+        }
+        return result
+    }
+
+    private toDrainResult(
+        messages: BackgroundQueueFlushResult,
+        threads: BackgroundQueueFlushResult,
+        contacts: BackgroundQueueFlushResult
+    ): WriteBehindDrainResult {
+        return {
+            messages,
+            threads,
+            contacts,
+            flushed: messages.flushed + threads.flushed + contacts.flushed,
+            remaining: messages.remaining + threads.remaining + contacts.remaining
+        }
+    }
+}

--- a/src/client/persistence/__tests__/WriteBehindPersistence.test.ts
+++ b/src/client/persistence/__tests__/WriteBehindPersistence.test.ts
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
+import type { Logger } from '@infra/log/types'
+import type { WaStoredContactRecord } from '@store/contracts/contact.store'
+import type { WaStoredThreadRecord } from '@store/contracts/thread.store'
+
+function createLogger(): Logger {
+    return {
+        level: 'trace',
+        trace: () => undefined,
+        debug: () => undefined,
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined
+    }
+}
+
+test('write-behind merges partial contact upserts for the same jid', async () => {
+    let releaseBlock: () => void = () => undefined
+    const blocked = new Promise<void>((resolve) => {
+        releaseBlock = resolve
+    })
+    const contactWrites: WaStoredContactRecord[] = []
+
+    const writeBehind = new WriteBehindPersistence(
+        {
+            messageStore: {
+                upsert: async () => undefined
+            } as never,
+            threadStore: {
+                upsert: async () => undefined
+            } as never,
+            contactStore: {
+                upsert: async (record: WaStoredContactRecord) => {
+                    if (record.jid === 'block@s.whatsapp.net') {
+                        await blocked
+                    }
+                    contactWrites.push(record)
+                }
+            } as never
+        },
+        createLogger()
+    )
+
+    writeBehind.persistContact({
+        jid: 'block@s.whatsapp.net',
+        lastUpdatedMs: 1
+    })
+    writeBehind.persistContact({
+        jid: '5511999999999@s.whatsapp.net',
+        pushName: 'Alice',
+        lastUpdatedMs: 100
+    })
+    writeBehind.persistContact({
+        jid: '5511999999999@s.whatsapp.net',
+        lastUpdatedMs: 200
+    })
+
+    releaseBlock()
+    await writeBehind.flush(2_000)
+
+    const targetWrites = contactWrites.filter(
+        (record) => record.jid === '5511999999999@s.whatsapp.net'
+    )
+    assert.equal(targetWrites.length, 1)
+    assert.equal(targetWrites[0].pushName, 'Alice')
+    assert.equal(targetWrites[0].lastUpdatedMs, 200)
+})
+
+test('write-behind merges partial thread upserts for the same jid', async () => {
+    let releaseBlock: () => void = () => undefined
+    const blocked = new Promise<void>((resolve) => {
+        releaseBlock = resolve
+    })
+    const threadWrites: WaStoredThreadRecord[] = []
+
+    const writeBehind = new WriteBehindPersistence(
+        {
+            messageStore: {
+                upsert: async () => undefined
+            } as never,
+            threadStore: {
+                upsert: async (record: WaStoredThreadRecord) => {
+                    if (record.jid === 'block-thread@s.whatsapp.net') {
+                        await blocked
+                    }
+                    threadWrites.push(record)
+                }
+            } as never,
+            contactStore: {
+                upsert: async () => undefined
+            } as never
+        },
+        createLogger()
+    )
+
+    writeBehind.persistThread({
+        jid: 'block-thread@s.whatsapp.net'
+    })
+    writeBehind.persistThread({
+        jid: 'thread@s.whatsapp.net',
+        name: 'Project',
+        unreadCount: 2
+    })
+    writeBehind.persistThread({
+        jid: 'thread@s.whatsapp.net',
+        archived: true
+    })
+
+    releaseBlock()
+    await writeBehind.flush(2_000)
+
+    const targetWrites = threadWrites.filter((record) => record.jid === 'thread@s.whatsapp.net')
+    assert.equal(targetWrites.length, 1)
+    assert.equal(targetWrites[0].name, 'Project')
+    assert.equal(targetWrites[0].unreadCount, 2)
+    assert.equal(targetWrites[0].archived, true)
+})
+
+test('write-behind flush and destroy expose remaining pending entries', async () => {
+    let releaseBlock: () => void = () => undefined
+    const blocked = new Promise<void>((resolve) => {
+        releaseBlock = resolve
+    })
+
+    const writeBehind = new WriteBehindPersistence(
+        {
+            messageStore: {
+                upsert: async (record: { readonly id: string }) => {
+                    if (record.id === 'blocked') {
+                        await blocked
+                    }
+                }
+            } as never,
+            threadStore: {
+                upsert: async () => undefined
+            } as never,
+            contactStore: {
+                upsert: async () => undefined
+            } as never
+        },
+        createLogger()
+    )
+
+    writeBehind.persistMessage({
+        id: 'blocked',
+        threadJid: 'thread@s.whatsapp.net',
+        fromMe: false
+    })
+
+    const flushResult = await writeBehind.flush(10)
+    assert.equal(flushResult.remaining > 0, true)
+
+    const destroyResult = await writeBehind.destroy(10)
+    assert.equal(destroyResult.remaining > 0, true)
+
+    releaseBlock()
+    const finalFlush = await writeBehind.flush(2_000)
+    assert.equal(finalFlush.remaining, 0)
+})

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -26,10 +26,16 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
     readonly messageAckTimeoutMs?: number
     readonly messageMaxAttempts?: number
     readonly messageRetryDelayMs?: number
+    readonly writeBehind?: WaWriteBehindOptions
     readonly history?: WaHistorySyncOptions
     readonly chatEvents?: {
         readonly emitSnapshotMutations?: boolean
     }
+}
+
+export interface WaWriteBehindOptions {
+    readonly maxPendingKeys?: number
+    readonly flushTimeoutMs?: number
 }
 
 export interface WaHistorySyncOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,8 @@ export type {
     WaClientOptions,
     WaClientProxyOptions,
     WaHistorySyncChunkEvent,
-    WaHistorySyncOptions
+    WaHistorySyncOptions,
+    WaWriteBehindOptions
 } from '@client'
 export { ConsoleLogger } from '@infra/log/ConsoleLogger'
 export { PinoLogger, createPinoLogger } from '@infra/log/PinoLogger'

--- a/src/infra/perf/BackgroundQueue.ts
+++ b/src/infra/perf/BackgroundQueue.ts
@@ -1,0 +1,561 @@
+interface QueueWaiter {
+    readonly resolve: () => void
+    readonly reject: (error: Error) => void
+}
+
+interface QueueEntry<V> {
+    value: V
+    waiters: QueueWaiter[]
+    attempt: number
+}
+
+interface RetryTimerEntry<V> {
+    readonly entry: QueueEntry<V>
+    readonly timer: NodeJS.Timeout
+}
+
+interface StateWaiterEntry {
+    done: () => void
+    index: number
+}
+
+export interface BackgroundQueueOptions<K extends string, V> {
+    readonly coalesce?: (previous: V, incoming: V, key: K) => V
+    readonly maxPendingKeys?: number
+    readonly flushTimeoutMs?: number
+    readonly onError?: (key: K, error: unknown, attempt: number) => void
+    readonly onPressure?: (pendingKeys: number) => void
+    readonly onDiscard?: (key: K, value: V) => void
+}
+
+export interface BackgroundQueueFlushResult {
+    readonly flushed: number
+    readonly remaining: number
+}
+
+const DEFAULT_MAX_PENDING_KEYS = 4_096
+const DEFAULT_FLUSH_TIMEOUT_MS = 5_000
+const RETRY_BACKOFF_BASE_MS = 100
+const RETRY_BACKOFF_MAX_MS = 2_000
+
+function defaultCoalesce<V>(_previous: V, incoming: V): V {
+    return incoming
+}
+
+function toQueueError(error: unknown, fallbackMessage: string): Error {
+    return error instanceof Error ? error : new Error(fallbackMessage)
+}
+
+function validateMaxPendingKeys(value: number): number {
+    if (!Number.isSafeInteger(value) || value < 1) {
+        throw new Error('BackgroundQueue maxPendingKeys must be a positive integer')
+    }
+    return value
+}
+
+function validateFlushTimeoutMs(value: number): number {
+    if (!Number.isFinite(value) || value < 1) {
+        throw new Error('BackgroundQueue flushTimeoutMs must be a positive finite number')
+    }
+    return value
+}
+
+function normalizePublicTimeoutMs(value: number, fallback: number): number {
+    if (!Number.isFinite(value)) {
+        return fallback
+    }
+    if (value < 0) {
+        return 0
+    }
+    return value
+}
+
+export class BackgroundQueue<K extends string, V> {
+    private readonly writer: (key: K, value: V) => Promise<void>
+    private readonly coalesce: (previous: V, incoming: V, key: K) => V
+    private readonly maxPendingKeys: number
+    private readonly flushTimeoutMs: number
+    private readonly onError?: (key: K, error: unknown, attempt: number) => void
+    private readonly onPressure?: (pendingKeys: number) => void
+    private readonly onDiscard?: (key: K, value: V) => void
+    private readonly pendingByKey: Map<K, QueueEntry<V>>
+    private readonly retryTimersByKey: Map<K, RetryTimerEntry<V>>
+    private readonly stateWaiters: StateWaiterEntry[]
+    private drainingPromise: Promise<void> | null
+    private inFlight: number
+    private flushedCount: number
+    private shutdownRequested: boolean
+    private retryDisabled: boolean
+
+    public constructor(
+        writer: (key: K, value: V) => Promise<void>,
+        options: BackgroundQueueOptions<K, V> = {}
+    ) {
+        this.writer = writer
+        this.coalesce = options.coalesce ?? defaultCoalesce
+        this.maxPendingKeys = validateMaxPendingKeys(
+            options.maxPendingKeys ?? DEFAULT_MAX_PENDING_KEYS
+        )
+        this.flushTimeoutMs = validateFlushTimeoutMs(
+            options.flushTimeoutMs ?? DEFAULT_FLUSH_TIMEOUT_MS
+        )
+        this.onError = options.onError
+        this.onPressure = options.onPressure
+        this.onDiscard = options.onDiscard
+        this.pendingByKey = new Map()
+        this.retryTimersByKey = new Map()
+        this.stateWaiters = []
+        this.drainingPromise = null
+        this.inFlight = 0
+        this.flushedCount = 0
+        this.shutdownRequested = false
+        this.retryDisabled = false
+    }
+
+    public enqueue(key: K, value: V): void {
+        if (this.shutdownRequested) {
+            this.invokeOnDiscard(key, value)
+            return
+        }
+        if (this.pendingByKey.has(key) || this.retryTimersByKey.has(key)) {
+            this.addPendingEntry(key, value)
+            this.notifyStateChange()
+            this.ensureDrain()
+            return
+        }
+        if (this.trackedKeys() < this.maxPendingKeys) {
+            this.addPendingEntry(key, value)
+            this.notifyStateChange()
+            this.ensureDrain()
+            return
+        }
+        this.invokeOnPressure(this.trackedKeys())
+        this.invokeOnDiscard(key, value)
+    }
+
+    public async enqueueAsync(key: K, value: V): Promise<void> {
+        if (this.shutdownRequested) {
+            this.invokeOnDiscard(key, value)
+            throw new Error('background queue is destroyed')
+        }
+
+        await this.waitForCapacity(key, value)
+
+        return new Promise<void>((resolve, reject) => {
+            const waiter: QueueWaiter = { resolve, reject }
+            this.addPendingEntry(key, value, waiter)
+            this.notifyStateChange()
+            this.ensureDrain()
+        })
+    }
+
+    private async waitForCapacity(key: K, value: V): Promise<void> {
+        while (
+            !this.pendingByKey.has(key) &&
+            !this.retryTimersByKey.has(key) &&
+            this.trackedKeys() >= this.maxPendingKeys
+        ) {
+            this.invokeOnPressure(this.trackedKeys())
+            await this.waitForStateChange(this.flushTimeoutMs)
+            if (this.shutdownRequested) {
+                this.invokeOnDiscard(key, value)
+                throw new Error('background queue is destroyed')
+            }
+        }
+    }
+
+    private addPendingEntry(key: K, value: V, waiter?: QueueWaiter): void {
+        const scheduledRetryTimer = this.retryTimersByKey.get(key) ?? null
+        const scheduledRetry = scheduledRetryTimer?.entry ?? null
+        const existing = this.pendingByKey.get(key)
+        if (existing) {
+            let coalescedValue = existing.value
+            let coalescedAttempt = existing.attempt
+            try {
+                if (scheduledRetry) {
+                    coalescedValue = this.coalesce(scheduledRetry.value, coalescedValue, key)
+                    coalescedAttempt = Math.max(coalescedAttempt, scheduledRetry.attempt)
+                }
+                coalescedValue = this.coalesce(coalescedValue, value, key)
+            } catch (error) {
+                this.invokeOnError(
+                    key,
+                    error,
+                    Math.max(coalescedAttempt + 1, scheduledRetry?.attempt ?? 0)
+                )
+                if (waiter) {
+                    waiter.reject(toQueueError(error, 'background queue coalesce failed'))
+                } else {
+                    this.invokeOnDiscard(key, value)
+                }
+                return
+            }
+            if (scheduledRetry) {
+                this.detachRetryEntry(key, scheduledRetryTimer)
+                if (scheduledRetry.waiters.length > 0) {
+                    const mergedWaiters = new Array<QueueWaiter>(
+                        scheduledRetry.waiters.length + existing.waiters.length
+                    )
+                    let writeIndex = 0
+                    for (let index = 0; index < scheduledRetry.waiters.length; index += 1) {
+                        mergedWaiters[writeIndex] = scheduledRetry.waiters[index]
+                        writeIndex += 1
+                    }
+                    for (let index = 0; index < existing.waiters.length; index += 1) {
+                        mergedWaiters[writeIndex] = existing.waiters[index]
+                        writeIndex += 1
+                    }
+                    existing.waiters = mergedWaiters
+                }
+                existing.attempt = Math.max(coalescedAttempt, scheduledRetry.attempt)
+            }
+            existing.value = coalescedValue
+            existing.attempt = coalescedAttempt
+            if (waiter) {
+                existing.waiters[existing.waiters.length] = waiter
+            }
+            return
+        }
+        if (scheduledRetry) {
+            let coalescedValue: V
+            try {
+                coalescedValue = this.coalesce(scheduledRetry.value, value, key)
+            } catch (error) {
+                this.invokeOnError(key, error, scheduledRetry.attempt + 1)
+                if (waiter) {
+                    waiter.reject(toQueueError(error, 'background queue coalesce failed'))
+                } else {
+                    this.invokeOnDiscard(key, value)
+                }
+                return
+            }
+            this.detachRetryEntry(key, scheduledRetryTimer)
+            const scheduledWaiterCount = scheduledRetry.waiters.length
+            const waiters = new Array<QueueWaiter>(scheduledWaiterCount + (waiter ? 1 : 0))
+            for (let index = 0; index < scheduledWaiterCount; index += 1) {
+                waiters[index] = scheduledRetry.waiters[index]
+            }
+            if (waiter) {
+                waiters[scheduledWaiterCount] = waiter
+            }
+            this.pendingByKey.set(key, {
+                value: coalescedValue,
+                waiters,
+                attempt: scheduledRetry.attempt
+            })
+            return
+        }
+        this.pendingByKey.set(key, {
+            value,
+            waiters: waiter ? [waiter] : [],
+            attempt: 0
+        })
+    }
+
+    private detachRetryEntry(key: K, retry: RetryTimerEntry<V> | null): void {
+        if (!retry) {
+            return
+        }
+        const current = this.retryTimersByKey.get(key)
+        if (!current || current !== retry) {
+            return
+        }
+        this.retryTimersByKey.delete(key)
+        clearTimeout(retry.timer)
+    }
+
+    public async flush(
+        timeoutMs: number = this.flushTimeoutMs
+    ): Promise<BackgroundQueueFlushResult> {
+        const normalizedTimeoutMs = normalizePublicTimeoutMs(timeoutMs, this.flushTimeoutMs)
+        const startFlushed = this.flushedCount
+        const deadline = Date.now() + normalizedTimeoutMs
+        while (true) {
+            const remaining = this.remaining()
+            if (remaining === 0) {
+                return {
+                    flushed: this.flushedCount - startFlushed,
+                    remaining: 0
+                }
+            }
+            const remainingMs = deadline - Date.now()
+            if (remainingMs <= 0) {
+                return {
+                    flushed: this.flushedCount - startFlushed,
+                    remaining
+                }
+            }
+            await this.waitForStateChange(remainingMs, true)
+        }
+    }
+
+    public async destroy(
+        timeoutMs: number = this.flushTimeoutMs
+    ): Promise<BackgroundQueueFlushResult> {
+        const normalizedTimeoutMs = normalizePublicTimeoutMs(timeoutMs, this.flushTimeoutMs)
+        this.shutdownRequested = true
+        this.notifyStateChange()
+        const flushed = await this.flush(normalizedTimeoutMs)
+        if (flushed.remaining > 0) {
+            this.retryDisabled = true
+            this.discardPending()
+        }
+        return {
+            flushed: flushed.flushed,
+            remaining: this.remaining()
+        }
+    }
+
+    private ensureDrain(): void {
+        if (this.drainingPromise) {
+            return
+        }
+        this.drainingPromise = this.drainLoop().finally(() => {
+            this.drainingPromise = null
+            this.notifyStateChange()
+            if (this.pendingByKey.size > 0) {
+                this.ensureDrain()
+            }
+        })
+    }
+
+    private async drainLoop(): Promise<void> {
+        while (true) {
+            const next = this.takeNext()
+            if (!next) {
+                return
+            }
+            const { key, entry } = next
+            this.inFlight += 1
+            try {
+                await this.writer(key, entry.value)
+                this.flushedCount += 1
+                this.resolveEntry(entry)
+            } catch (error) {
+                if (this.retryDisabled) {
+                    this.discardEntry(key, entry)
+                } else {
+                    const merged = this.mergeForRetry(key, entry)
+                    const attempt = merged.attempt + 1
+                    merged.attempt = attempt
+                    this.invokeOnError(key, error, attempt)
+                    this.scheduleRetry(key, merged, this.retryDelayMs(attempt))
+                }
+            } finally {
+                this.inFlight -= 1
+                this.notifyStateChange()
+            }
+        }
+    }
+
+    private takeNext(): { readonly key: K; readonly entry: QueueEntry<V> } | null {
+        const next = this.pendingByKey.entries().next().value
+        if (!next) {
+            return null
+        }
+        const [key, entry] = next
+        this.pendingByKey.delete(key)
+        return { key, entry }
+    }
+
+    private mergeForRetry(key: K, failedEntry: QueueEntry<V>): QueueEntry<V> {
+        const pending = this.pendingByKey.get(key)
+        if (!pending) {
+            return failedEntry
+        }
+        const mergedWaiters = new Array<QueueWaiter>(
+            failedEntry.waiters.length + pending.waiters.length
+        )
+        let mergedWaitersIndex = 0
+        for (let index = 0; index < failedEntry.waiters.length; index += 1) {
+            mergedWaiters[mergedWaitersIndex] = failedEntry.waiters[index]
+            mergedWaitersIndex += 1
+        }
+        for (let index = 0; index < pending.waiters.length; index += 1) {
+            mergedWaiters[mergedWaitersIndex] = pending.waiters[index]
+            mergedWaitersIndex += 1
+        }
+        let mergedValue: V
+        try {
+            mergedValue = this.coalesce(failedEntry.value, pending.value, key)
+        } catch (error) {
+            const fallbackAttempt = Math.max(failedEntry.attempt, pending.attempt)
+            this.invokeOnError(key, error, fallbackAttempt + 1)
+            this.pendingByKey.delete(key)
+            this.invokeOnDiscard(key, pending.value)
+            if (pending.waiters.length > 0) {
+                const queueError = toQueueError(error, 'background queue coalesce failed')
+                for (let index = 0; index < pending.waiters.length; index += 1) {
+                    pending.waiters[index].reject(queueError)
+                }
+            }
+            return failedEntry
+        }
+        this.pendingByKey.delete(key)
+        return {
+            value: mergedValue,
+            waiters: mergedWaiters,
+            attempt: Math.max(failedEntry.attempt, pending.attempt)
+        }
+    }
+
+    private retryDelayMs(attempt: number): number {
+        if (attempt <= 1) {
+            return RETRY_BACKOFF_BASE_MS
+        }
+        const unbounded = RETRY_BACKOFF_BASE_MS * 2 ** Math.min(6, attempt - 1)
+        return Math.min(RETRY_BACKOFF_MAX_MS, unbounded)
+    }
+
+    private scheduleRetry(key: K, entry: QueueEntry<V>, retryMs: number): void {
+        const existing = this.retryTimersByKey.get(key)
+        if (existing) {
+            clearTimeout(existing.timer)
+        }
+        const timer = setTimeout(() => {
+            this.retryTimersByKey.delete(key)
+            if (this.retryDisabled) {
+                this.discardEntry(key, entry)
+                this.notifyStateChange()
+                return
+            }
+            const latest = this.mergeForRetry(key, entry)
+            this.pendingByKey.set(key, latest)
+            this.notifyStateChange()
+            this.ensureDrain()
+        }, retryMs)
+        timer.unref?.()
+        this.retryTimersByKey.set(key, { entry, timer })
+        this.notifyStateChange()
+    }
+
+    private resolveEntry(entry: QueueEntry<V>): void {
+        if (entry.waiters.length === 0) {
+            return
+        }
+        for (const waiter of entry.waiters) {
+            waiter.resolve()
+        }
+    }
+
+    private discardEntry(key: K, entry: QueueEntry<V>): void {
+        this.invokeOnDiscard(key, entry.value)
+        if (entry.waiters.length === 0) {
+            return
+        }
+        const error = toQueueError(undefined, 'background queue destroyed before write was flushed')
+        for (const waiter of entry.waiters) {
+            waiter.reject(error)
+        }
+    }
+
+    private discardPending(): void {
+        if (this.pendingByKey.size > 0) {
+            for (const [key, entry] of this.pendingByKey) {
+                this.pendingByKey.delete(key)
+                this.discardEntry(key, entry)
+            }
+        }
+        if (this.retryTimersByKey.size > 0) {
+            for (const [key, retry] of this.retryTimersByKey) {
+                this.retryTimersByKey.delete(key)
+                clearTimeout(retry.timer)
+                this.discardEntry(key, retry.entry)
+            }
+        }
+        this.notifyStateChange()
+    }
+
+    private remaining(): number {
+        return this.pendingByKey.size + this.retryTimersByKey.size + this.inFlight
+    }
+
+    private trackedKeys(): number {
+        return this.pendingByKey.size + this.retryTimersByKey.size
+    }
+
+    private notifyStateChange(): void {
+        if (this.stateWaiters.length === 0) {
+            return
+        }
+        const waiterCount = this.stateWaiters.length
+        for (let index = 0; index < waiterCount; index += 1) {
+            const waiter = this.stateWaiters[index]
+            waiter.index = -1
+            waiter.done()
+        }
+        this.stateWaiters.length = 0
+    }
+
+    private waitForStateChange(timeoutMs: number, ref = false): Promise<void> {
+        return new Promise<void>((resolve) => {
+            let active = true
+            const waiter: StateWaiterEntry = {
+                done: () => {
+                    if (!active) {
+                        return
+                    }
+                    active = false
+                    clearTimeout(timer)
+                    this.removeStateWaiter(waiter)
+                    resolve()
+                },
+                index: -1
+            }
+            const timer = setTimeout(waiter.done, timeoutMs)
+            if (!ref) {
+                timer.unref?.()
+            }
+            waiter.index = this.stateWaiters.length
+            this.stateWaiters[waiter.index] = waiter
+        })
+    }
+
+    private removeStateWaiter(waiter: StateWaiterEntry): void {
+        const index = waiter.index
+        if (index < 0) {
+            return
+        }
+        const lastIndex = this.stateWaiters.length - 1
+        if (index !== lastIndex) {
+            const last = this.stateWaiters[lastIndex]
+            this.stateWaiters[index] = last
+            last.index = index
+        }
+        this.stateWaiters.length = lastIndex
+        waiter.index = -1
+    }
+
+    private invokeOnError(key: K, error: unknown, attempt: number): void {
+        if (!this.onError) {
+            return
+        }
+        try {
+            this.onError(key, error, attempt)
+        } catch {
+            return
+        }
+    }
+
+    private invokeOnPressure(pendingKeys: number): void {
+        if (!this.onPressure) {
+            return
+        }
+        try {
+            this.onPressure(pendingKeys)
+        } catch {
+            return
+        }
+    }
+
+    private invokeOnDiscard(key: K, value: V): void {
+        if (!this.onDiscard) {
+            return
+        }
+        try {
+            this.onDiscard(key, value)
+        } catch {
+            return
+        }
+    }
+}

--- a/src/infra/perf/PromiseDedup.ts
+++ b/src/infra/perf/PromiseDedup.ts
@@ -1,0 +1,19 @@
+export class PromiseDedup {
+    private readonly inFlight = new Map<string, Promise<unknown>>()
+
+    public run<T>(key: string, task: () => Promise<T>): Promise<T> {
+        const existing = this.inFlight.get(key)
+        if (existing) {
+            return existing as Promise<T>
+        }
+        const created = Promise.resolve()
+            .then(() => task())
+            .finally(() => {
+                if (this.inFlight.get(key) === created) {
+                    this.inFlight.delete(key)
+                }
+            })
+        this.inFlight.set(key, created)
+        return created
+    }
+}

--- a/src/infra/perf/SharedExclusiveGate.ts
+++ b/src/infra/perf/SharedExclusiveGate.ts
@@ -1,0 +1,113 @@
+type SharedExclusiveTask<T> = () => Promise<T>
+
+export class SharedExclusiveGate {
+    private activeShared = 0
+    private pendingExclusive = 0
+    private exclusiveActive = false
+    private closed = false
+    private readonly waiters: Array<() => void> = []
+
+    public runShared<T>(task: SharedExclusiveTask<T>): Promise<T> {
+        if (this.closed) {
+            return Promise.reject(new Error('shared-exclusive gate is closed'))
+        }
+        if (!this.exclusiveActive && this.pendingExclusive === 0) {
+            this.activeShared += 1
+            let current: Promise<T>
+            try {
+                current = task()
+            } catch (error) {
+                current = Promise.reject(error)
+            }
+            return current.finally(() => {
+                this.activeShared -= 1
+                this.notifyStateChange()
+            })
+        }
+        return this.runSharedSlow(task)
+    }
+
+    private async runSharedSlow<T>(task: SharedExclusiveTask<T>): Promise<T> {
+        await this.acquireShared()
+        try {
+            return await task()
+        } finally {
+            this.activeShared -= 1
+            this.notifyStateChange()
+        }
+    }
+
+    public async runExclusive<T>(task: SharedExclusiveTask<T>): Promise<T> {
+        await this.acquireExclusive()
+        try {
+            return await task()
+        } finally {
+            this.exclusiveActive = false
+            this.notifyStateChange()
+        }
+    }
+
+    public async close(): Promise<void> {
+        if (this.closed) {
+            while (this.activeShared > 0 || this.exclusiveActive || this.pendingExclusive > 0) {
+                await this.waitForStateChange()
+            }
+            return
+        }
+        this.closed = true
+        this.notifyStateChange()
+        while (this.activeShared > 0 || this.exclusiveActive || this.pendingExclusive > 0) {
+            await this.waitForStateChange()
+        }
+    }
+
+    private async acquireShared(): Promise<void> {
+        if (this.closed) {
+            throw new Error('shared-exclusive gate is closed')
+        }
+        while (this.exclusiveActive || this.pendingExclusive > 0) {
+            await this.waitForStateChange()
+            if (this.closed) {
+                throw new Error('shared-exclusive gate is closed')
+            }
+        }
+        this.activeShared += 1
+    }
+
+    private async acquireExclusive(): Promise<void> {
+        if (this.closed) {
+            throw new Error('shared-exclusive gate is closed')
+        }
+        this.pendingExclusive += 1
+        this.notifyStateChange()
+        try {
+            while (this.exclusiveActive || this.activeShared > 0) {
+                await this.waitForStateChange()
+                if (this.closed) {
+                    throw new Error('shared-exclusive gate is closed')
+                }
+            }
+            this.exclusiveActive = true
+        } finally {
+            this.pendingExclusive -= 1
+            this.notifyStateChange()
+        }
+    }
+
+    private notifyStateChange(): void {
+        if (this.waiters.length === 0) {
+            return
+        }
+        const waiterCount = this.waiters.length
+        for (let index = 0; index < waiterCount; index += 1) {
+            this.waiters[index]()
+        }
+        this.waiters.length = 0
+    }
+
+    private waitForStateChange(): Promise<void> {
+        return new Promise<void>((resolve) => {
+            this.waiters[this.waiters.length] = resolve
+        })
+    }
+}

--- a/src/infra/perf/StoreLock.ts
+++ b/src/infra/perf/StoreLock.ts
@@ -1,0 +1,87 @@
+type StoreTask<T> = () => Promise<T>
+
+export class StoreLock {
+    private readonly chains = new Map<string, Promise<void>>()
+    private closed = false
+
+    public run<T>(key: string, task: StoreTask<T>): Promise<T> {
+        return this.runInternal(key, task, true)
+    }
+
+    private runInternal<T>(key: string, task: StoreTask<T>, rejectWhenClosed: boolean): Promise<T> {
+        if (this.closed) {
+            if (rejectWhenClosed) {
+                throw new Error('store lock is closed')
+            }
+        }
+        const previous = this.chains.get(key)
+        let current: Promise<T>
+        if (previous) {
+            current = previous.then(task)
+        } else {
+            try {
+                current = task()
+            } catch (error) {
+                current = Promise.reject(error)
+            }
+        }
+        const tracker = current.then(
+            () => undefined,
+            () => undefined
+        )
+        this.chains.set(key, tracker)
+        void tracker.finally(() => {
+            if (this.chains.get(key) === tracker) {
+                this.chains.delete(key)
+            }
+        })
+        return current
+    }
+
+    public runMany<T>(keys: readonly string[], task: StoreTask<T>): Promise<T> {
+        if (this.closed) {
+            throw new Error('store lock is closed')
+        }
+        if (keys.length <= 1) {
+            return keys.length === 0 ? task() : this.runInternal(keys[0], task, false)
+        }
+        const ordered = new Array<string>(keys.length)
+        for (let index = 0; index < keys.length; index += 1) {
+            ordered[index] = keys[index]
+        }
+        ordered.sort()
+        let uniqueCount = 1
+        let previousKey = ordered[0]
+        for (let index = 1; index < ordered.length; index += 1) {
+            const key = ordered[index]
+            if (key === previousKey) {
+                continue
+            }
+            ordered[uniqueCount] = key
+            uniqueCount += 1
+            previousKey = key
+        }
+        const acquire = (index: number): Promise<T> =>
+            index >= uniqueCount
+                ? task()
+                : this.runInternal(
+                      ordered[index],
+                      () => Promise.resolve().then(() => acquire(index + 1)),
+                      false
+                  )
+        return acquire(0)
+    }
+
+    public async shutdown(): Promise<void> {
+        this.closed = true
+        while (this.chains.size > 0) {
+            const pending = new Array<Promise<void>>(this.chains.size)
+            let pendingIndex = 0
+            for (const chain of this.chains.values()) {
+                pending[pendingIndex] = chain
+                pendingIndex += 1
+            }
+            await Promise.allSettled(pending)
+        }
+    }
+}

--- a/src/infra/perf/__tests__/concurrency-primitives.test.ts
+++ b/src/infra/perf/__tests__/concurrency-primitives.test.ts
@@ -1,0 +1,462 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { BackgroundQueue } from '@infra/perf/BackgroundQueue'
+import { PromiseDedup } from '@infra/perf/PromiseDedup'
+import { SharedExclusiveGate } from '@infra/perf/SharedExclusiveGate'
+import { StoreLock } from '@infra/perf/StoreLock'
+import { delay } from '@util/async'
+
+async function flushMicrotasks(turns = 3): Promise<void> {
+    for (let index = 0; index < turns; index += 1) {
+        await Promise.resolve()
+    }
+}
+
+async function settleWithMockTimers(
+    t: { readonly mock: { readonly timers: { tick: (ms: number) => void } } },
+    target: Promise<unknown>,
+    stepMs = 10,
+    maxSteps = 100
+): Promise<void> {
+    let settled = false
+    let rejected: unknown = null
+    let didReject = false
+    void target.then(
+        () => {
+            settled = true
+        },
+        (error) => {
+            rejected = error
+            didReject = true
+            settled = true
+        }
+    )
+    for (let step = 0; step < maxSteps && !settled; step += 1) {
+        t.mock.timers.tick(stepMs)
+        await flushMicrotasks(8)
+        await new Promise<void>((resolve) => setImmediate(resolve))
+    }
+    if (!settled) {
+        throw new Error('mock timer steps exhausted before promise settled')
+    }
+    if (didReject) {
+        throw rejected
+    }
+}
+
+test('store lock serializes writes for the same key in fifo order', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    const lock = new StoreLock()
+    const order: string[] = []
+    let running = 0
+    let maxRunning = 0
+
+    const run = (label: string, waitMs: number) =>
+        lock.run('k', async () => {
+            running += 1
+            maxRunning = Math.max(maxRunning, running)
+            order.push(`${label}:start`)
+            await delay(waitMs)
+            order.push(`${label}:end`)
+            running -= 1
+        })
+
+    const done = Promise.all([run('a', 15), run('b', 5), run('c', 1)])
+    await settleWithMockTimers(t, done, 5, 30)
+    await done
+    assert.equal(maxRunning, 1)
+    assert.deepEqual(order, ['a:start', 'a:end', 'b:start', 'b:end', 'c:start', 'c:end'])
+})
+
+test('store lock allows parallel writes for different keys', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    const lock = new StoreLock()
+    let running = 0
+    let maxRunning = 0
+
+    const done = Promise.all([
+        lock.run('a', async () => {
+            running += 1
+            maxRunning = Math.max(maxRunning, running)
+            await delay(20)
+            running -= 1
+        }),
+        lock.run('b', async () => {
+            running += 1
+            maxRunning = Math.max(maxRunning, running)
+            await delay(20)
+            running -= 1
+        })
+    ])
+    await settleWithMockTimers(t, done, 10, 10)
+    await done
+
+    assert.equal(maxRunning, 2)
+})
+
+test('store lock runMany avoids deadlock for inverted key ordering', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    const lock = new StoreLock()
+    const completed: string[] = []
+
+    const done = Promise.all([
+        lock.runMany(['b', 'a'], async () => {
+            await delay(10)
+            completed.push('first')
+        }),
+        lock.runMany(['a', 'b'], async () => {
+            await delay(10)
+            completed.push('second')
+        })
+    ])
+    await settleWithMockTimers(t, done, 10, 20)
+    await done
+
+    assert.equal(completed.length, 2)
+})
+
+test('store lock runMany handles large key sets without stack overflow', async () => {
+    const lock = new StoreLock()
+    const keyCount = 8_000
+    const keys = new Array<string>(keyCount)
+    for (let index = 0; index < keyCount; index += 1) {
+        keys[index] = `k-${index}`
+    }
+
+    let ran = false
+    await lock.runMany(keys, async () => {
+        ran = true
+    })
+
+    assert.equal(ran, true)
+})
+
+test('store lock continues after task failure', async () => {
+    const lock = new StoreLock()
+
+    await assert.rejects(
+        () =>
+            lock.run('k', async () => {
+                throw new Error('boom')
+            }),
+        /boom/
+    )
+
+    const value = await lock.run('k', async () => 42)
+    assert.equal(value, 42)
+})
+
+test('store lock shutdown rejects new operations after draining', async () => {
+    const lock = new StoreLock()
+    await lock.shutdown()
+    assert.throws(
+        () =>
+            lock.run('k', async () => {
+                return 1
+            }),
+        /store lock is closed/
+    )
+})
+
+test('shared-exclusive gate allows concurrent shared operations', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    const gate = new SharedExclusiveGate()
+    let running = 0
+    let maxRunning = 0
+
+    const done = Promise.all([
+        gate.runShared(async () => {
+            running += 1
+            maxRunning = Math.max(maxRunning, running)
+            await delay(20)
+            running -= 1
+        }),
+        gate.runShared(async () => {
+            running += 1
+            maxRunning = Math.max(maxRunning, running)
+            await delay(20)
+            running -= 1
+        })
+    ])
+    await settleWithMockTimers(t, done, 10, 10)
+    await done
+
+    assert.equal(maxRunning, 2)
+})
+
+test('shared-exclusive gate blocks shared operations while exclusive is pending', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    const gate = new SharedExclusiveGate()
+    const order: string[] = []
+
+    const firstShared = gate.runShared(async () => {
+        order.push('shared-1:start')
+        await delay(20)
+        order.push('shared-1:end')
+    })
+    await flushMicrotasks(4)
+    const exclusive = gate.runExclusive(async () => {
+        order.push('exclusive')
+    })
+    await flushMicrotasks(4)
+    const secondShared = gate.runShared(async () => {
+        order.push('shared-2')
+    })
+
+    const done = Promise.all([firstShared, exclusive, secondShared])
+    await settleWithMockTimers(t, done, 10, 20)
+    await done
+
+    assert.deepEqual(order, ['shared-1:start', 'shared-1:end', 'exclusive', 'shared-2'])
+})
+
+test('promise dedup shares one in-flight task per key', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    const dedup = new PromiseDedup()
+    let calls = 0
+
+    const run = () =>
+        dedup.run('same', async () => {
+            calls += 1
+            await delay(10)
+            return 7
+        })
+
+    const done = Promise.all([run(), run(), run()])
+    await settleWithMockTimers(t, done, 10, 10)
+    const [a, b, c] = await done
+    assert.equal(a, 7)
+    assert.equal(b, 7)
+    assert.equal(c, 7)
+    assert.equal(calls, 1)
+})
+
+test('promise dedup retries after a rejected task', async () => {
+    const dedup = new PromiseDedup()
+    let attempts = 0
+
+    await assert.rejects(
+        () =>
+            dedup.run('same', async () => {
+                attempts += 1
+                throw new Error('failed')
+            }),
+        /failed/
+    )
+
+    const value = await dedup.run('same', async () => {
+        attempts += 1
+        return 9
+    })
+    assert.equal(value, 9)
+    assert.equal(attempts, 2)
+})
+
+test('promise dedup deduplicates re-entrant calls for the same key', async () => {
+    const dedup = new PromiseDedup()
+    let calls = 0
+    let nested: Promise<number> | null = null
+
+    const outer = dedup.run('same', async () => {
+        calls += 1
+        nested = dedup.run('same', async () => {
+            calls += 1
+            return 2
+        })
+        return 1
+    })
+
+    const outerValue = await outer
+    assert.equal(outerValue, 1)
+    assert.equal(calls, 1)
+    assert.ok(nested)
+    const nestedValue = await nested
+    assert.equal(nestedValue, 1)
+})
+
+test('background queue coalesces pending writes for the same key', async () => {
+    let releaseBlockedKey: () => void = () => undefined
+    const blocked = new Promise<void>((resolve) => {
+        releaseBlockedKey = resolve
+    })
+    const writes: Array<{ readonly key: string; readonly value: number }> = []
+
+    const queue = new BackgroundQueue<string, { readonly value: number }>(async (key, value) => {
+        if (key === 'block') {
+            await blocked
+        }
+        writes.push({ key, value: value.value })
+    })
+
+    const blockWrite = queue.enqueueAsync('block', { value: 0 })
+    const first = queue.enqueueAsync('same', { value: 1 })
+    const second = queue.enqueueAsync('same', { value: 2 })
+
+    releaseBlockedKey()
+    await Promise.all([blockWrite, first, second])
+
+    assert.deepEqual(writes, [
+        { key: 'block', value: 0 },
+        { key: 'same', value: 2 }
+    ])
+})
+
+test('background queue retries using the latest pending value', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    const attempts: number[] = []
+    let resolveErrorSignal: (() => void) | null = null
+    const errorSignal = new Promise<void>((resolve) => {
+        resolveErrorSignal = resolve
+    })
+
+    const queue = new BackgroundQueue<string, { readonly version: number }>(
+        async (_key, value) => {
+            attempts.push(value.version)
+            if (attempts.length === 1) {
+                throw new Error('transient')
+            }
+        },
+        {
+            onError: () => {
+                resolveErrorSignal?.()
+            }
+        }
+    )
+
+    const first = queue.enqueueAsync('k', { version: 1 })
+    await errorSignal
+    const second = queue.enqueueAsync('k', { version: 2 })
+
+    const done = Promise.all([first, second])
+    await settleWithMockTimers(t, done, 20, 20)
+    await done
+    assert.deepEqual(attempts, [1, 2])
+})
+
+test('background queue keeps failed retry payload and rejects incompatible pending value', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    let releaseFirstAttempt: () => void = () => undefined
+    const firstAttemptGate = new Promise<void>((resolve) => {
+        releaseFirstAttempt = () => resolve()
+    })
+    const attempts: string[] = []
+
+    const queue = new BackgroundQueue<string, { readonly kind: string }>(
+        async (_key, value) => {
+            attempts.push(value.kind)
+            if (attempts.length === 1) {
+                await firstAttemptGate
+                throw new Error('transient')
+            }
+        },
+        {
+            coalesce: (previous, incoming) => {
+                if (previous.kind !== incoming.kind) {
+                    throw new Error('incompatible coalesce payload')
+                }
+                return incoming
+            }
+        }
+    )
+
+    const first = queue.enqueueAsync('k', { kind: 'first' })
+    await flushMicrotasks(8)
+    const second = queue.enqueueAsync('k', { kind: 'second' })
+
+    releaseFirstAttempt()
+    await flushMicrotasks(8)
+    await assert.rejects(() => second, /incompatible coalesce payload/)
+
+    t.mock.timers.tick(100)
+    await flushMicrotasks(8)
+    await first
+
+    assert.deepEqual(attempts, ['first', 'first'])
+})
+
+test('background queue capacity accounts for keys waiting on retry timers', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    const writes: string[] = []
+    let shouldFailFirstAttempt = true
+    const queue = new BackgroundQueue<string, { readonly value: number }>(
+        async (key) => {
+            if (key === 'a' && shouldFailFirstAttempt) {
+                shouldFailFirstAttempt = false
+                throw new Error('transient')
+            }
+            writes.push(key)
+        },
+        { maxPendingKeys: 1 }
+    )
+
+    const first = queue.enqueueAsync('a', { value: 1 })
+    await flushMicrotasks(8)
+
+    let secondSettled = false
+    const second = queue.enqueueAsync('b', { value: 1 })
+    void second.then(
+        () => {
+            secondSettled = true
+        },
+        () => {
+            secondSettled = true
+        }
+    )
+    await flushMicrotasks(8)
+    assert.equal(secondSettled, false)
+
+    const done = Promise.all([first, second])
+    await settleWithMockTimers(t, done, 10, 40)
+    await done
+
+    assert.deepEqual(writes, ['a', 'b'])
+})
+
+test('background queue retries do not block unrelated keys', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    let badAttempts = 0
+    const writes: string[] = []
+    const queue = new BackgroundQueue<string, { readonly version: number }>(async (key) => {
+        if (key === 'bad' && badAttempts === 0) {
+            badAttempts += 1
+            throw new Error('transient')
+        }
+        writes.push(key)
+    })
+
+    const bad = queue.enqueueAsync('bad', { version: 1 })
+    await flushMicrotasks(4)
+    const good = queue.enqueueAsync('good', { version: 1 })
+    await flushMicrotasks(8)
+    await good
+
+    assert.deepEqual(writes, ['good'])
+
+    t.mock.timers.tick(100)
+    await flushMicrotasks(8)
+    await bad
+
+    assert.deepEqual(writes, ['good', 'bad'])
+})
+
+test('background queue validates constructor limits', () => {
+    assert.throws(
+        () => new BackgroundQueue(async () => undefined, { maxPendingKeys: 0 }),
+        /maxPendingKeys/
+    )
+    assert.throws(
+        () => new BackgroundQueue(async () => undefined, { flushTimeoutMs: 0 }),
+        /flushTimeoutMs/
+    )
+})

--- a/src/signal/group/SenderKeyManager.ts
+++ b/src/signal/group/SenderKeyManager.ts
@@ -8,8 +8,10 @@ import {
     randomIntAsync,
     X25519
 } from '@crypto'
+import { StoreLock } from '@infra/perf/StoreLock'
 import type { Proto } from '@proto'
 import { proto } from '@proto'
+import { signalAddressKey } from '@protocol/jid'
 import { SIGNAL_GROUP_VERSION, SIGNATURE_SIZE } from '@signal/constants'
 import { signSignalMessage, verifySignalSignature } from '@signal/crypto/WaAdvSignature'
 import { deriveSenderKeyMsgKey, selectMessageKey } from '@signal/group/SenderKeyChain'
@@ -55,6 +57,7 @@ async function aesCbcDecryptFromSeed(
 
 export class SenderKeyManager {
     private readonly store: WaSenderKeyStore
+    private readonly senderLock = new StoreLock()
 
     public constructor(store: WaSenderKeyStore) {
         this.store = store
@@ -69,63 +72,65 @@ export class SenderKeyManager {
         readonly ciphertext: GroupSenderKeyCiphertext
         readonly keyId: number
     }> {
-        const senderKey = await this.ensureSenderKey(groupId, sender)
-        const distributionProto = proto.SenderKeyDistributionMessage.encode({
-            id: senderKey.keyId,
-            iteration: senderKey.iteration,
-            chainKey: senderKey.chainKey,
-            signingKey: senderKey.signingPublicKey
-        }).finish()
-        const distributionMessage = {
-            groupId,
-            axolotlSenderKeyDistributionMessage: prependVersion(
-                distributionProto,
-                SIGNAL_GROUP_VERSION
-            )
-        }
-        if (!senderKey.signingPrivateKey) {
-            throw new Error('sender private signing key is missing')
-        }
+        return this.runWithSenderLock(groupId, sender, async () => {
+            const senderKey = await this.ensureSenderKeyInternal(groupId, sender)
+            const distributionProto = proto.SenderKeyDistributionMessage.encode({
+                id: senderKey.keyId,
+                iteration: senderKey.iteration,
+                chainKey: senderKey.chainKey,
+                signingKey: senderKey.signingPublicKey
+            }).finish()
+            const distributionMessage = {
+                groupId,
+                axolotlSenderKeyDistributionMessage: prependVersion(
+                    distributionProto,
+                    SIGNAL_GROUP_VERSION
+                )
+            }
+            if (!senderKey.signingPrivateKey) {
+                throw new Error('sender private signing key is missing')
+            }
 
-        const derived = await deriveSenderKeyMsgKey(senderKey.iteration, senderKey.chainKey)
-        const messagePayload = await aesCbcEncryptFromSeed(derived.messageKey.seed, plaintext)
-        const senderKeyMessage = proto.SenderKeyMessage.encode({
-            id: senderKey.keyId,
-            iteration: derived.messageKey.iteration,
-            ciphertext: messagePayload
-        }).finish()
-        const versionedContent = prependVersion(senderKeyMessage, SIGNAL_GROUP_VERSION)
-        const signature = await signSignalMessage(senderKey.signingPrivateKey, versionedContent)
-        if (signature.length !== SIGNATURE_SIZE) {
-            throw new Error(`invalid sender key signature length ${signature.length}`)
-        }
-        const ciphertext: GroupSenderKeyCiphertext = {
-            groupId,
-            sender,
-            keyId: senderKey.keyId,
-            iteration: derived.messageKey.iteration,
-            ciphertext: concatBytes([versionedContent, signature])
-        }
-
-        await Promise.all([
-            this.store.upsertSenderKeyDistribution({
+            const derived = await deriveSenderKeyMsgKey(senderKey.iteration, senderKey.chainKey)
+            const messagePayload = await aesCbcEncryptFromSeed(derived.messageKey.seed, plaintext)
+            const senderKeyMessage = proto.SenderKeyMessage.encode({
+                id: senderKey.keyId,
+                iteration: derived.messageKey.iteration,
+                ciphertext: messagePayload
+            }).finish()
+            const versionedContent = prependVersion(senderKeyMessage, SIGNAL_GROUP_VERSION)
+            const signature = await signSignalMessage(senderKey.signingPrivateKey, versionedContent)
+            if (signature.length !== SIGNATURE_SIZE) {
+                throw new Error(`invalid sender key signature length ${signature.length}`)
+            }
+            const ciphertext: GroupSenderKeyCiphertext = {
                 groupId,
                 sender,
                 keyId: senderKey.keyId,
-                timestampMs: Date.now()
-            }),
-            this.store.upsertSenderKey({
-                ...senderKey,
-                chainKey: derived.nextChainKey,
-                iteration: derived.messageKey.iteration + 1
-            })
-        ])
+                iteration: derived.messageKey.iteration,
+                ciphertext: concatBytes([versionedContent, signature])
+            }
 
-        return {
-            distributionMessage,
-            ciphertext,
-            keyId: senderKey.keyId
-        }
+            await Promise.all([
+                this.store.upsertSenderKeyDistribution({
+                    groupId,
+                    sender,
+                    keyId: senderKey.keyId,
+                    timestampMs: Date.now()
+                }),
+                this.store.upsertSenderKey({
+                    ...senderKey,
+                    chainKey: derived.nextChainKey,
+                    iteration: derived.messageKey.iteration + 1
+                })
+            ])
+
+            return {
+                distributionMessage,
+                ciphertext,
+                keyId: senderKey.keyId
+            }
+        })
     }
 
     public async filterParticipantsNeedingDistribution(
@@ -176,82 +181,89 @@ export class SenderKeyManager {
         sender: SignalAddress,
         payload: Uint8Array
     ): Promise<SenderKeyRecord> {
-        if (groupId.length === 0) {
-            throw new Error('sender key distribution missing groupId')
-        }
+        return this.runWithSenderLock(groupId, sender, async () => {
+            if (groupId.length === 0) {
+                throw new Error('sender key distribution missing groupId')
+            }
 
-        const parsed = parseDistributionPayload(payload)
-        const record: SenderKeyRecord = {
-            groupId,
-            sender,
-            keyId: parsed.keyId,
-            iteration: parsed.iteration,
-            chainKey: parsed.chainKey,
-            signingPublicKey: parsed.signingPublicKey,
-            unusedMessageKeys: []
-        }
-        await Promise.all([
-            this.store.upsertSenderKey(record),
-            this.store.upsertSenderKeyDistribution({
+            const parsed = parseDistributionPayload(payload)
+            const record: SenderKeyRecord = {
                 groupId,
                 sender,
                 keyId: parsed.keyId,
-                timestampMs: Date.now()
-            })
-        ])
-        return record
+                iteration: parsed.iteration,
+                chainKey: parsed.chainKey,
+                signingPublicKey: parsed.signingPublicKey,
+                unusedMessageKeys: []
+            }
+            await Promise.all([
+                this.store.upsertSenderKey(record),
+                this.store.upsertSenderKeyDistribution({
+                    groupId,
+                    sender,
+                    keyId: parsed.keyId,
+                    timestampMs: Date.now()
+                })
+            ])
+            return record
+        })
     }
 
     public async decryptGroupMessage(payload: GroupSenderKeyCiphertext): Promise<Uint8Array> {
-        const parsed = parseSenderKeyMessage(payload.ciphertext)
+        return this.runWithSenderLock(payload.groupId, payload.sender, async () => {
+            const parsed = parseSenderKeyMessage(payload.ciphertext)
 
-        const senderKey = await this.store.getDeviceSenderKey(payload.groupId, payload.sender)
-        if (!senderKey) {
-            throw new Error('missing sender key')
-        }
-        if (senderKey.keyId !== parsed.keyId) {
-            throw new Error('sender key id mismatch')
-        }
+            const senderKey = await this.store.getDeviceSenderKey(payload.groupId, payload.sender)
+            if (!senderKey) {
+                throw new Error('missing sender key')
+            }
+            if (senderKey.keyId !== parsed.keyId) {
+                throw new Error('sender key id mismatch')
+            }
 
-        if (
-            payload.keyId !== undefined &&
-            payload.keyId !== null &&
-            parsed.keyId !== payload.keyId
-        ) {
-            throw new Error('sender key id mismatch')
-        }
-        if (
-            payload.iteration !== undefined &&
-            payload.iteration !== null &&
-            parsed.iteration !== payload.iteration
-        ) {
-            throw new Error('sender key iteration mismatch')
-        }
+            if (
+                payload.keyId !== undefined &&
+                payload.keyId !== null &&
+                parsed.keyId !== payload.keyId
+            ) {
+                throw new Error('sender key id mismatch')
+            }
+            if (
+                payload.iteration !== undefined &&
+                payload.iteration !== null &&
+                parsed.iteration !== payload.iteration
+            ) {
+                throw new Error('sender key iteration mismatch')
+            }
 
-        const signedContent = parsed.versionContentMac.subarray(
-            0,
-            parsed.versionContentMac.length - SIGNATURE_SIZE
-        )
-        const signature = parsed.versionContentMac.subarray(
-            parsed.versionContentMac.length - SIGNATURE_SIZE
-        )
-        const validSignature = await verifySignalSignature(
-            senderKey.signingPublicKey,
-            signedContent,
-            signature
-        )
-        if (!validSignature) {
-            throw new Error('invalid sender key signature')
-        }
+            const signedContent = parsed.versionContentMac.subarray(
+                0,
+                parsed.versionContentMac.length - SIGNATURE_SIZE
+            )
+            const signature = parsed.versionContentMac.subarray(
+                parsed.versionContentMac.length - SIGNATURE_SIZE
+            )
+            const validSignature = await verifySignalSignature(
+                senderKey.signingPublicKey,
+                signedContent,
+                signature
+            )
+            if (!validSignature) {
+                throw new Error('invalid sender key signature')
+            }
 
-        const selected = await selectMessageKey(senderKey, parsed.iteration)
-        // Keep decrypt + persist ordered: failed decrypt must not advance sender-key state.
-        const plaintext = await aesCbcDecryptFromSeed(selected.messageKey.seed, parsed.ciphertext)
-        await this.store.upsertSenderKey(selected.updatedRecord)
-        return plaintext
+            const selected = await selectMessageKey(senderKey, parsed.iteration)
+            // Keep decrypt + persist ordered: failed decrypt must not advance sender-key state.
+            const plaintext = await aesCbcDecryptFromSeed(
+                selected.messageKey.seed,
+                parsed.ciphertext
+            )
+            await this.store.upsertSenderKey(selected.updatedRecord)
+            return plaintext
+        })
     }
 
-    private async ensureSenderKey(
+    private async ensureSenderKeyInternal(
         groupId: string,
         sender: SignalAddress
     ): Promise<SenderKeyRecord> {
@@ -277,5 +289,13 @@ export class SenderKeyManager {
         }
         await this.store.upsertSenderKey(created)
         return created
+    }
+
+    private runWithSenderLock<T>(
+        groupId: string,
+        sender: SignalAddress,
+        task: () => Promise<T>
+    ): Promise<T> {
+        return this.senderLock.run(`senderKey:${groupId}:${signalAddressKey(sender)}`, task)
     }
 }

--- a/src/signal/session/SignalProtocol.ts
+++ b/src/signal/session/SignalProtocol.ts
@@ -1,6 +1,7 @@
 import { toSerializedPubKey } from '@crypto'
 import { ConsoleLogger } from '@infra/log/ConsoleLogger'
 import type { Logger } from '@infra/log/types'
+import { StoreLock } from '@infra/perf/StoreLock'
 import { MAX_PREV_SESSIONS } from '@signal/constants'
 import { decryptMsg, decryptMsgFromSession, encryptMsg } from '@signal/session/SignalRatchet'
 import type { DecryptOutcome } from '@signal/session/SignalRatchet'
@@ -33,13 +34,23 @@ function signalAddressMapKey(address: SignalAddress): string {
     return `${address.user}\u0001${address.server ?? ''}\u0001${address.device}`
 }
 
+function signalAddressLockKey(address: SignalAddress): string {
+    return `signal:${signalAddressMapKey(address)}`
+}
+
+interface EstablishOutgoingSessionOptions {
+    readonly reuseExisting?: boolean
+}
+
 export class SignalProtocol {
     private readonly store: WaSignalStore
     private readonly logger: Logger
+    private readonly sessionMutationLock: StoreLock
 
     public constructor(store: WaSignalStore, logger: Logger = new ConsoleLogger('info')) {
         this.store = store
         this.logger = logger
+        this.sessionMutationLock = new StoreLock()
     }
 
     public async hasSession(address: SignalAddress): Promise<boolean> {
@@ -52,17 +63,30 @@ export class SignalProtocol {
 
     public async establishOutgoingSession(
         address: SignalAddress,
-        remoteBundle: SignalPreKeyBundle
+        remoteBundle: SignalPreKeyBundle,
+        options: EstablishOutgoingSessionOptions = {}
     ): Promise<SignalSessionRecord> {
-        const [local, localOneTimeBase] = await Promise.all([
-            requireLocalIdentity(this.store),
-            generateSerializedKeyPair()
-        ])
-        const session = await initiateSessionOutgoing(local, remoteBundle, localOneTimeBase)
-        // Keep writes ordered: a stored session without matching remote identity causes false mismatch checks.
-        await this.store.setRemoteIdentity(address, session.remote.pubKey)
-        await this.store.setSession(address, session)
-        return session
+        return this.runWithAddressLock(address, async () => {
+            if (options.reuseExisting) {
+                const existing = await this.store.getSession(address)
+                if (existing) {
+                    const remoteIdentity = toSerializedPubKey(remoteBundle.identity)
+                    if (!uint8Equal(existing.remote.pubKey, remoteIdentity)) {
+                        throw new Error('identity mismatch')
+                    }
+                    return existing
+                }
+            }
+            const [local, localOneTimeBase] = await Promise.all([
+                requireLocalIdentity(this.store),
+                generateSerializedKeyPair()
+            ])
+            const session = await initiateSessionOutgoing(local, remoteBundle, localOneTimeBase)
+            // Keep writes ordered: a stored session without matching remote identity causes false mismatch checks.
+            await this.store.setRemoteIdentity(address, session.remote.pubKey)
+            await this.store.setSession(address, session)
+            return session
+        })
     }
 
     public async encryptMessage(
@@ -100,109 +124,127 @@ export class SignalProtocol {
         if (requests.length === 0) {
             return []
         }
+        const lockKeys = [
+            ...new Set(requests.map((request) => signalAddressLockKey(request.address)))
+        ]
+        return this.sessionMutationLock.runMany(lockKeys, async () => {
+            const prefetchedByAddress = new Map<string, SignalSessionRecord>()
+            if (prefetchedSessions && prefetchedSessions.length > 0) {
+                for (let index = 0; index < prefetchedSessions.length; index += 1) {
+                    const entry = prefetchedSessions[index]
+                    prefetchedByAddress.set(signalAddressMapKey(entry.address), entry.session)
+                }
+            }
 
-        const latestSessionByAddress = new Map<string, SignalSessionRecord>()
-        if (prefetchedSessions && prefetchedSessions.length > 0) {
-            for (let index = 0; index < prefetchedSessions.length; index += 1) {
-                const entry = prefetchedSessions[index]
-                latestSessionByAddress.set(signalAddressMapKey(entry.address), entry.session)
-            }
-        }
-        const seenMissingAddressKeys = new Set<string>()
-        const missingAddresses: SignalAddress[] = []
-        for (let index = 0; index < requests.length; index += 1) {
-            const address = requests[index].address
-            const addressKey = signalAddressMapKey(address)
-            if (latestSessionByAddress.has(addressKey)) {
-                continue
-            }
-            if (seenMissingAddressKeys.has(addressKey)) {
-                continue
-            }
-            seenMissingAddressKeys.add(addressKey)
-            missingAddresses.push(address)
-        }
-        if (missingAddresses.length > 0) {
-            const missingSessions = await this.store.getSessionsBatch(missingAddresses)
-            for (let index = 0; index < missingAddresses.length; index += 1) {
-                const session = missingSessions[index]
-                if (!session) {
+            const uniqueAddressKeys = new Array<string>(requests.length)
+            const uniqueAddresses = new Array<SignalAddress>(requests.length)
+            let uniqueAddressCount = 0
+            for (let index = 0; index < requests.length; index += 1) {
+                const address = requests[index].address
+                const addressKey = signalAddressMapKey(address)
+                let isDuplicate = false
+                for (let dedupIndex = 0; dedupIndex < uniqueAddressCount; dedupIndex += 1) {
+                    if (uniqueAddressKeys[dedupIndex] === addressKey) {
+                        isDuplicate = true
+                        break
+                    }
+                }
+                if (isDuplicate) {
                     continue
                 }
-                latestSessionByAddress.set(signalAddressMapKey(missingAddresses[index]), session)
+                uniqueAddressKeys[uniqueAddressCount] = addressKey
+                uniqueAddresses[uniqueAddressCount] = address
+                uniqueAddressCount += 1
             }
-        }
-        const sessionUpdatesByAddress = new Map<
-            string,
-            { readonly address: SignalAddress; readonly session: SignalSessionRecord }
-        >()
-        const identityUpdatesByAddress = new Map<
-            string,
-            { readonly address: SignalAddress; readonly identityKey: Uint8Array }
-        >()
-        const results = new Array<{
-            readonly type: 'msg' | 'pkmsg'
-            readonly ciphertext: Uint8Array
-            readonly baseKey: Uint8Array | null
-        }>(requests.length)
+            uniqueAddressKeys.length = uniqueAddressCount
+            uniqueAddresses.length = uniqueAddressCount
 
-        for (let index = 0; index < requests.length; index += 1) {
-            const request = requests[index]
-            const address = request.address
-            const addressKey = signalAddressMapKey(address)
-            const session = latestSessionByAddress.get(addressKey)
-            if (!session) {
-                throw new Error('signal session not found')
+            const currentSessions = await this.store.getSessionsBatch(uniqueAddresses)
+            const latestSessionByAddress = new Map<string, SignalSessionRecord>()
+            for (let index = 0; index < uniqueAddressCount; index += 1) {
+                const addressKey = uniqueAddressKeys[index]
+                const current = currentSessions[index]
+                if (current) {
+                    latestSessionByAddress.set(addressKey, current)
+                    continue
+                }
+                const prefetched = prefetchedByAddress.get(addressKey)
+                if (prefetched) {
+                    latestSessionByAddress.set(addressKey, prefetched)
+                }
             }
-            if (
-                request.expectedIdentity &&
-                !uint8Equal(toSerializedPubKey(request.expectedIdentity), session.remote.pubKey)
-            ) {
-                throw new Error('identity mismatch')
-            }
+            const sessionUpdatesByAddress = new Map<
+                string,
+                { readonly address: SignalAddress; readonly session: SignalSessionRecord }
+            >()
+            const identityUpdatesByAddress = new Map<
+                string,
+                { readonly address: SignalAddress; readonly identityKey: Uint8Array }
+            >()
+            const results = new Array<{
+                readonly type: 'msg' | 'pkmsg'
+                readonly ciphertext: Uint8Array
+                readonly baseKey: Uint8Array | null
+            }>(requests.length)
 
-            const [updatedSession, encrypted] = await encryptMsg(session, request.plaintext)
-            latestSessionByAddress.set(addressKey, updatedSession)
-            sessionUpdatesByAddress.set(addressKey, {
-                address,
-                session: updatedSession
-            })
-            if (!uint8Equal(updatedSession.remote.pubKey, session.remote.pubKey)) {
-                identityUpdatesByAddress.set(addressKey, {
+            for (let index = 0; index < requests.length; index += 1) {
+                const request = requests[index]
+                const address = request.address
+                const addressKey = signalAddressMapKey(address)
+                const session = latestSessionByAddress.get(addressKey)
+                if (!session) {
+                    throw new Error('signal session not found')
+                }
+                if (
+                    request.expectedIdentity &&
+                    !uint8Equal(toSerializedPubKey(request.expectedIdentity), session.remote.pubKey)
+                ) {
+                    throw new Error('identity mismatch')
+                }
+
+                const [updatedSession, encrypted] = await encryptMsg(session, request.plaintext)
+                latestSessionByAddress.set(addressKey, updatedSession)
+                sessionUpdatesByAddress.set(addressKey, {
                     address,
-                    identityKey: updatedSession.remote.pubKey
+                    session: updatedSession
                 })
+                if (!uint8Equal(updatedSession.remote.pubKey, session.remote.pubKey)) {
+                    identityUpdatesByAddress.set(addressKey, {
+                        address,
+                        identityKey: updatedSession.remote.pubKey
+                    })
+                }
+                results[index] = {
+                    ...encrypted,
+                    baseKey: updatedSession.aliceBaseKey
+                }
             }
-            results[index] = {
-                ...encrypted,
-                baseKey: updatedSession.aliceBaseKey
-            }
-        }
 
-        // Persist remote identities first when needed so session writes never commit ahead of identity data.
-        if (identityUpdatesByAddress.size > 0) {
-            const identityUpdates = new Array<{
-                readonly address: SignalAddress
-                readonly identityKey: Uint8Array
-            }>(identityUpdatesByAddress.size)
-            let identityIndex = 0
-            for (const update of identityUpdatesByAddress.values()) {
-                identityUpdates[identityIndex] = update
-                identityIndex += 1
+            // Persist remote identities first when needed so session writes never commit ahead of identity data.
+            if (identityUpdatesByAddress.size > 0) {
+                const identityUpdates = new Array<{
+                    readonly address: SignalAddress
+                    readonly identityKey: Uint8Array
+                }>(identityUpdatesByAddress.size)
+                let identityIndex = 0
+                for (const update of identityUpdatesByAddress.values()) {
+                    identityUpdates[identityIndex] = update
+                    identityIndex += 1
+                }
+                await this.store.setRemoteIdentities(identityUpdates)
             }
-            await this.store.setRemoteIdentities(identityUpdates)
-        }
-        const sessionUpdates = new Array<{
-            readonly address: SignalAddress
-            readonly session: SignalSessionRecord
-        }>(sessionUpdatesByAddress.size)
-        let sessionIndex = 0
-        for (const update of sessionUpdatesByAddress.values()) {
-            sessionUpdates[sessionIndex] = update
-            sessionIndex += 1
-        }
-        await this.store.setSessionsBatch(sessionUpdates)
-        return results
+            const sessionUpdates = new Array<{
+                readonly address: SignalAddress
+                readonly session: SignalSessionRecord
+            }>(sessionUpdatesByAddress.size)
+            let sessionIndex = 0
+            for (const update of sessionUpdatesByAddress.values()) {
+                sessionUpdates[sessionIndex] = update
+                sessionIndex += 1
+            }
+            await this.store.setSessionsBatch(sessionUpdates)
+            return results
+        })
     }
 
     public async decryptMessage(
@@ -212,27 +254,33 @@ export class SignalProtocol {
             readonly ciphertext: Uint8Array
         }
     ): Promise<Uint8Array> {
-        const currentSession = await this.store.getSession(address)
+        return this.runWithAddressLock(address, async () => {
+            const currentSession = await this.store.getSession(address)
 
-        let outcome: DecryptOutcome
-        if (envelope.type === 'pkmsg') {
-            const parsedPk = deserializePkMsg(envelope.ciphertext)
-            outcome = await this.decryptPkMsg(currentSession, parsedPk)
-        } else {
-            const parsed = deserializeMsg(envelope.ciphertext)
-            outcome = await this.decryptMsgInternal(currentSession, parsed)
-        }
+            let outcome: DecryptOutcome
+            if (envelope.type === 'pkmsg') {
+                const parsedPk = deserializePkMsg(envelope.ciphertext)
+                outcome = await this.decryptPkMsg(currentSession, parsedPk)
+            } else {
+                const parsed = deserializeMsg(envelope.ciphertext)
+                outcome = await this.decryptMsgInternal(currentSession, parsed)
+            }
 
-        const nextRemoteIdentity =
-            outcome.newSessionInfo?.newIdentity ?? outcome.updatedSession.remote.pubKey
-        const identityChanged =
-            !currentSession || !uint8Equal(currentSession.remote.pubKey, nextRemoteIdentity)
-        // Keep writes ordered for consistency with resolver identity checks.
-        if (identityChanged) {
-            await this.store.setRemoteIdentity(address, nextRemoteIdentity)
-        }
-        await this.store.setSession(address, outcome.updatedSession)
-        return outcome.plaintext
+            const nextRemoteIdentity =
+                outcome.newSessionInfo?.newIdentity ?? outcome.updatedSession.remote.pubKey
+            const identityChanged =
+                !currentSession || !uint8Equal(currentSession.remote.pubKey, nextRemoteIdentity)
+            // Keep writes ordered for consistency with resolver identity checks.
+            if (identityChanged) {
+                await this.store.setRemoteIdentity(address, nextRemoteIdentity)
+            }
+            await this.store.setSession(address, outcome.updatedSession)
+            return outcome.plaintext
+        })
+    }
+
+    private runWithAddressLock<T>(address: SignalAddress, task: () => Promise<T>): Promise<T> {
+        return this.sessionMutationLock.run(signalAddressLockKey(address), task)
     }
 
     private async decryptMsgInternal(

--- a/src/signal/session/__tests__/resolver.test.ts
+++ b/src/signal/session/__tests__/resolver.test.ts
@@ -4,6 +4,13 @@ import test from 'node:test'
 import type { Logger } from '@infra/log/types'
 import { createSignalSessionResolver } from '@signal/session/resolver'
 import type { SignalPreKeyBundle } from '@signal/types'
+import { delay } from '@util/async'
+
+async function flushMicrotasks(turns = 3): Promise<void> {
+    for (let index = 0; index < turns; index += 1) {
+        await Promise.resolve()
+    }
+}
 
 function createLogger(): Logger {
     return {
@@ -74,42 +81,65 @@ test('signal session resolver rejects identity mismatch on reasonIdentity sync',
     assert.equal(syncedIdentityKeys, 1)
 })
 
-test('signal session resolver batch falls back to single fetch for partial failures', async () => {
+test('signal session resolver batch does not fallback to single fetch for partial failures', async () => {
     const established: string[] = []
+    const sessionsByAddress = new Map<string, unknown>()
+    let batchFetchCalls = 0
+    let singleFetchCalls = 0
+    const toKey = (address: { readonly user: string; readonly device: number }): string =>
+        `${address.user}:${address.device}`
 
     const resolver = createSignalSessionResolver({
         signalProtocol: {
-            hasSession: async () => false,
+            hasSession: async (address: { readonly user: string; readonly device: number }) =>
+                sessionsByAddress.has(toKey(address)),
             establishOutgoingSession: async (address: {
                 readonly user: string
                 readonly device: number
             }) => {
-                established.push(`${address.user}:${address.device}`)
-                return {} as never
+                const key = toKey(address)
+                established.push(key)
+                const session = {} as never
+                sessionsByAddress.set(key, session)
+                return session
             }
         } as never,
         signalStore: {
-            getSessionsBatch: async () => [null, null],
+            getSessionsBatch: async (
+                addresses: readonly { readonly user: string; readonly device: number }[]
+            ) => {
+                const out = new Array<unknown>(addresses.length)
+                for (let index = 0; index < addresses.length; index += 1) {
+                    out[index] = sessionsByAddress.get(toKey(addresses[index])) ?? null
+                }
+                return out
+            },
             getRemoteIdentity: async () => null
         } as never,
         signalIdentitySync: {
             syncIdentityKeys: async () => undefined
         } as never,
         signalSessionSync: {
-            fetchKeyBundles: async () => [
-                {
-                    jid: '5511888888888:1@s.whatsapp.net',
-                    bundle: buildBundle(2)
-                },
-                {
+            fetchKeyBundles: async () => {
+                batchFetchCalls += 1
+                return [
+                    {
+                        jid: '5511888888888:1@s.whatsapp.net',
+                        bundle: buildBundle(2)
+                    },
+                    {
+                        jid: '5511777777777:2@s.whatsapp.net',
+                        errorText: 'not found'
+                    }
+                ]
+            },
+            fetchKeyBundle: async () => {
+                singleFetchCalls += 1
+                return {
                     jid: '5511777777777:2@s.whatsapp.net',
-                    errorText: 'not found'
+                    bundle: buildBundle(3)
                 }
-            ],
-            fetchKeyBundle: async (target: { readonly jid: string }) => ({
-                jid: target.jid,
-                bundle: buildBundle(3)
-            })
+            }
         } as never,
         logger: createLogger()
     })
@@ -119,9 +149,178 @@ test('signal session resolver batch falls back to single fetch for partial failu
         '5511777777777:2@s.whatsapp.net'
     ])
 
-    assert.deepEqual(established.sort(), ['5511777777777:2', '5511888888888:1'])
-    assert.deepEqual([...resolvedTargets.map((target) => target.jid)].sort(), [
-        '5511777777777:2@s.whatsapp.net',
-        '5511888888888:1@s.whatsapp.net'
+    assert.equal(batchFetchCalls, 1)
+    assert.equal(singleFetchCalls, 0)
+    assert.deepEqual(established, ['5511888888888:1'])
+    assert.deepEqual(
+        [...resolvedTargets.map((target) => target.jid)],
+        ['5511888888888:1@s.whatsapp.net']
+    )
+})
+
+test('signal session resolver deduplicates concurrent ensureSession for same address', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    let fetchCalls = 0
+    let establishCalls = 0
+
+    const resolver = createSignalSessionResolver({
+        signalProtocol: {
+            hasSession: async () => false,
+            establishOutgoingSession: async () => {
+                establishCalls += 1
+            }
+        } as never,
+        signalStore: {
+            getRemoteIdentity: async () => null
+        } as never,
+        signalIdentitySync: {
+            syncIdentityKeys: async () => undefined
+        } as never,
+        signalSessionSync: {
+            fetchKeyBundle: async () => {
+                fetchCalls += 1
+                await delay(20)
+                return {
+                    jid: '5511999999999:2@s.whatsapp.net',
+                    bundle: buildBundle(7)
+                }
+            }
+        } as never,
+        logger: createLogger()
+    })
+
+    const address = {
+        user: '5511999999999',
+        device: 2,
+        server: 's.whatsapp.net'
+    } as const
+    const done = Promise.all([
+        resolver.ensureSession(address, '5511999999999:2@s.whatsapp.net'),
+        resolver.ensureSession(address, '5511999999999:2@s.whatsapp.net')
     ])
+    await flushMicrotasks(4)
+    t.mock.timers.tick(20)
+    await flushMicrotasks(4)
+    await done
+
+    assert.equal(fetchCalls, 1)
+    assert.equal(establishCalls, 1)
+})
+
+test('signal session resolver shares dedup between ensureSession and ensureSessionsBatch', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    let fetchCalls = 0
+    let fetchBatchCalls = 0
+    let establishCalls = 0
+    let hasSession = false
+    const sessionRecord = {} as never
+    const jid = '5511999999999:2@s.whatsapp.net'
+    const address = {
+        user: '5511999999999',
+        device: 2,
+        server: 's.whatsapp.net'
+    } as const
+
+    const resolver = createSignalSessionResolver({
+        signalProtocol: {
+            hasSession: async () => hasSession,
+            establishOutgoingSession: async () => {
+                establishCalls += 1
+                hasSession = true
+                return sessionRecord
+            }
+        } as never,
+        signalStore: {
+            getRemoteIdentity: async () => null,
+            getSessionsBatch: async () => [hasSession ? sessionRecord : null]
+        } as never,
+        signalIdentitySync: {
+            syncIdentityKeys: async () => undefined
+        } as never,
+        signalSessionSync: {
+            fetchKeyBundles: async () => {
+                fetchBatchCalls += 1
+                return [
+                    {
+                        jid,
+                        bundle: buildBundle(8)
+                    }
+                ]
+            },
+            fetchKeyBundle: async () => {
+                fetchCalls += 1
+                await delay(20)
+                return {
+                    jid,
+                    bundle: buildBundle(8)
+                }
+            }
+        } as never,
+        logger: createLogger()
+    })
+
+    const single = resolver.ensureSession(address, jid)
+    await flushMicrotasks(4)
+    const batch = resolver.ensureSessionsBatch([jid])
+
+    t.mock.timers.tick(20)
+    await flushMicrotasks(8)
+    const [, batchResult] = await Promise.all([single, batch])
+
+    assert.equal(fetchCalls, 1)
+    assert.equal(fetchBatchCalls, 1)
+    assert.equal(establishCalls, 1)
+    assert.equal(batchResult.length, 1)
+    assert.equal(batchResult[0].jid, jid)
+})
+
+test('signal session resolver keeps stricter identity checks for concurrent calls', async () => {
+    let syncIdentityCalls = 0
+
+    const resolver = createSignalSessionResolver({
+        signalProtocol: {
+            hasSession: async () => true,
+            establishOutgoingSession: async () => undefined
+        } as never,
+        signalStore: {
+            getRemoteIdentity: async () => new Uint8Array(33).fill(1)
+        } as never,
+        signalIdentitySync: {
+            syncIdentityKeys: async () => {
+                syncIdentityCalls += 1
+            }
+        } as never,
+        signalSessionSync: {
+            fetchKeyBundle: async () => ({
+                jid: '5511999999999:2@s.whatsapp.net',
+                bundle: buildBundle(7)
+            })
+        } as never,
+        logger: createLogger()
+    })
+
+    const address = {
+        user: '5511999999999',
+        device: 2,
+        server: 's.whatsapp.net'
+    } as const
+    const results = await Promise.allSettled([
+        resolver.ensureSession(address, '5511999999999:2@s.whatsapp.net'),
+        resolver.ensureSession(
+            address,
+            '5511999999999:2@s.whatsapp.net',
+            new Uint8Array(32).fill(9),
+            true
+        )
+    ])
+
+    assert.equal(results[0].status, 'fulfilled')
+    assert.equal(results[1].status, 'rejected')
+    if (results[1].status !== 'rejected') {
+        throw new Error('strict ensureSession call should reject on identity mismatch')
+    }
+    assert.match(String(results[1].reason), /identity mismatch/)
+    assert.equal(syncIdentityCalls, 1)
 })

--- a/src/signal/session/__tests__/session.test.ts
+++ b/src/signal/session/__tests__/session.test.ts
@@ -18,7 +18,7 @@ import {
     requirePreKey,
     requireSignedPreKey
 } from '@signal/session/SignalSerializer'
-import type { SignalAddress, SignalRecvChain } from '@signal/types'
+import type { SignalAddress, SignalRecvChain, SignalSessionRecord } from '@signal/types'
 import { WaSignalMemoryStore } from '@store/providers/memory/signal.store'
 import { concatBytes } from '@util/bytes'
 
@@ -46,6 +46,57 @@ function makeAddress(user: string): SignalAddress {
         user,
         server: 's.whatsapp.net',
         device: 0
+    }
+}
+
+class DelayFirstSetSessionStore extends WaSignalMemoryStore {
+    private blockFirstSetSession = true
+    private readonly firstSetSessionStartedPromise: Promise<void>
+    private resolveFirstSetSessionStarted: (() => void) | null = null
+    private readonly firstSetSessionReleasePromise: Promise<void>
+    private resolveFirstSetSessionRelease: (() => void) | null = null
+
+    public constructor() {
+        super()
+        this.firstSetSessionStartedPromise = new Promise<void>((resolve) => {
+            this.resolveFirstSetSessionStarted = resolve
+        })
+        this.firstSetSessionReleasePromise = new Promise<void>((resolve) => {
+            this.resolveFirstSetSessionRelease = resolve
+        })
+    }
+
+    public waitFirstSetSessionStarted(): Promise<void> {
+        return this.firstSetSessionStartedPromise
+    }
+
+    public releaseFirstSetSession(): void {
+        this.resolveFirstSetSessionRelease?.()
+        this.resolveFirstSetSessionRelease = null
+    }
+
+    public override async setSession(
+        address: SignalAddress,
+        session: SignalSessionRecord
+    ): Promise<void> {
+        if (this.blockFirstSetSession) {
+            this.blockFirstSetSession = false
+            this.resolveFirstSetSessionStarted?.()
+            this.resolveFirstSetSessionStarted = null
+            await this.firstSetSessionReleasePromise
+        }
+        await super.setSession(address, session)
+    }
+}
+
+class CountingGetSessionsBatchStore extends WaSignalMemoryStore {
+    public getSessionsBatchCalls = 0
+
+    public override async getSessionsBatch(
+        addresses: readonly SignalAddress[]
+    ): Promise<readonly (SignalSessionRecord | null)[]> {
+        this.getSessionsBatchCalls += 1
+        return super.getSessionsBatch(addresses)
     }
 }
 
@@ -199,4 +250,129 @@ test('signal protocol throws when decrypting msg without an existing session', a
             }),
         /signal session not found/
     )
+})
+
+test('signal protocol serializes decrypt updates for the same address', async () => {
+    const logger = createLogger()
+    const aliceStore = new WaSignalMemoryStore()
+    const bobStore = new DelayFirstSetSessionStore()
+
+    const [aliceRegistration, bobRegistration] = await Promise.all([
+        generateRegistrationInfo(),
+        generateRegistrationInfo()
+    ])
+    await aliceStore.setRegistrationInfo(aliceRegistration)
+    await bobStore.setRegistrationInfo(bobRegistration)
+
+    const bobSignedPreKey = await generateSignedPreKey(1, bobRegistration.identityKeyPair.privKey)
+    const bobOneTimePreKey = await generatePreKeyPair(9)
+    await bobStore.setSignedPreKey(bobSignedPreKey)
+    await bobStore.putPreKey(bobOneTimePreKey)
+
+    const aliceProtocol = new SignalProtocol(aliceStore, logger)
+    const bobProtocol = new SignalProtocol(bobStore, logger)
+    const aliceAddress = makeAddress('5511000000011')
+    const bobAddress = makeAddress('5511000000022')
+
+    await aliceProtocol.establishOutgoingSession(bobAddress, {
+        regId: bobRegistration.registrationId,
+        identity: bobRegistration.identityKeyPair.pubKey,
+        signedKey: {
+            id: bobSignedPreKey.keyId,
+            publicKey: bobSignedPreKey.keyPair.pubKey,
+            signature: bobSignedPreKey.signature
+        },
+        oneTimeKey: {
+            id: bobOneTimePreKey.keyId,
+            publicKey: bobOneTimePreKey.keyPair.pubKey
+        }
+    })
+
+    const firstPlaintext = makeBytes(24, 31)
+    const secondPlaintext = makeBytes(24, 63)
+    const firstEncrypted = await aliceProtocol.encryptMessage(
+        bobAddress,
+        firstPlaintext,
+        bobRegistration.identityKeyPair.pubKey
+    )
+    const secondEncrypted = await aliceProtocol.encryptMessage(
+        bobAddress,
+        secondPlaintext,
+        bobRegistration.identityKeyPair.pubKey
+    )
+    assert.equal(firstEncrypted.type, 'pkmsg')
+
+    const firstDecrypt = bobProtocol.decryptMessage(aliceAddress, {
+        type: firstEncrypted.type,
+        ciphertext: firstEncrypted.ciphertext
+    })
+    await bobStore.waitFirstSetSessionStarted()
+
+    const secondDecrypt = bobProtocol.decryptMessage(aliceAddress, {
+        type: secondEncrypted.type,
+        ciphertext: secondEncrypted.ciphertext
+    })
+
+    bobStore.releaseFirstSetSession()
+    const [decryptedFirst, decryptedSecond] = await Promise.all([firstDecrypt, secondDecrypt])
+    assert.deepEqual(decryptedFirst, firstPlaintext)
+    assert.deepEqual(decryptedSecond, secondPlaintext)
+})
+
+test('signal protocol reloads sessions from store even when prefetched sessions are provided', async () => {
+    const logger = createLogger()
+    const aliceStore = new CountingGetSessionsBatchStore()
+    const bobStore = new WaSignalMemoryStore()
+
+    const [aliceRegistration, bobRegistration] = await Promise.all([
+        generateRegistrationInfo(),
+        generateRegistrationInfo()
+    ])
+    await aliceStore.setRegistrationInfo(aliceRegistration)
+    await bobStore.setRegistrationInfo(bobRegistration)
+
+    const bobSignedPreKey = await generateSignedPreKey(1, bobRegistration.identityKeyPair.privKey)
+    const bobOneTimePreKey = await generatePreKeyPair(9)
+    await bobStore.setSignedPreKey(bobSignedPreKey)
+    await bobStore.putPreKey(bobOneTimePreKey)
+
+    const aliceProtocol = new SignalProtocol(aliceStore, logger)
+    const bobAddress = makeAddress('5511000000055')
+
+    await aliceProtocol.establishOutgoingSession(bobAddress, {
+        regId: bobRegistration.registrationId,
+        identity: bobRegistration.identityKeyPair.pubKey,
+        signedKey: {
+            id: bobSignedPreKey.keyId,
+            publicKey: bobSignedPreKey.keyPair.pubKey,
+            signature: bobSignedPreKey.signature
+        },
+        oneTimeKey: {
+            id: bobOneTimePreKey.keyId,
+            publicKey: bobOneTimePreKey.keyPair.pubKey
+        }
+    })
+
+    const prefetched = await aliceStore.getSession(bobAddress)
+    if (!prefetched) {
+        throw new Error('expected established session for prefetch test')
+    }
+
+    const plaintext = makeBytes(18, 91)
+    await aliceProtocol.encryptMessagesBatch(
+        [
+            {
+                address: bobAddress,
+                plaintext
+            }
+        ],
+        [
+            {
+                address: bobAddress,
+                session: prefetched
+            }
+        ]
+    )
+
+    assert.equal(aliceStore.getSessionsBatchCalls > 0, true)
 })

--- a/src/signal/session/resolver.ts
+++ b/src/signal/session/resolver.ts
@@ -1,12 +1,13 @@
 import { toSerializedPubKey } from '@crypto/core/keys'
 import type { Logger } from '@infra/log/types'
-import { normalizeDeviceJid, parseSignalAddressFromJid } from '@protocol/jid'
+import { PromiseDedup } from '@infra/perf/PromiseDedup'
+import { normalizeDeviceJid, parseSignalAddressFromJid, signalAddressKey } from '@protocol/jid'
 import type { SignalIdentitySyncApi } from '@signal/api/SignalIdentitySyncApi'
 import type { SignalSessionSyncApi } from '@signal/api/SignalSessionSyncApi'
 import type { SignalProtocol } from '@signal/session/SignalProtocol'
-import type { SignalAddress, SignalSessionRecord } from '@signal/types'
+import type { SignalAddress, SignalPreKeyBundle, SignalSessionRecord } from '@signal/types'
 import type { WaSignalStore } from '@store/contracts/signal.store'
-import { uint8Equal } from '@util/bytes'
+import { bytesToHex, uint8Equal } from '@util/bytes'
 import { toError } from '@util/primitives'
 
 export interface SignalResolvedSessionTarget {
@@ -37,12 +38,14 @@ export function createSignalSessionResolver(options: {
     readonly logger: Logger
 }): SignalSessionResolver {
     const { signalProtocol, signalStore, signalIdentitySync, signalSessionSync, logger } = options
+    const dedup = new PromiseDedup()
 
-    const ensureSession = async (
+    const ensureSessionInternal = async (
         address: SignalAddress,
         jid: string,
         expectedIdentity?: Uint8Array,
-        reasonIdentity = false
+        reasonIdentity = false,
+        prefetchedBundle?: SignalPreKeyBundle
     ): Promise<void> => {
         const expectedSerializedIdentity = expectedIdentity
             ? toSerializedPubKey(expectedIdentity)
@@ -59,11 +62,19 @@ export function createSignalSessionResolver(options: {
             }
             return
         }
-        logger.info('signal session missing, fetching remote key bundle', { jid })
-        const fetched = await signalSessionSync.fetchKeyBundle({
-            jid,
-            reasonIdentity
-        })
+        let fetched: { readonly jid: string; readonly bundle: SignalPreKeyBundle }
+        if (prefetchedBundle) {
+            fetched = {
+                jid,
+                bundle: prefetchedBundle
+            }
+        } else {
+            logger.info('signal session missing, fetching remote key bundle', { jid })
+            fetched = await signalSessionSync.fetchKeyBundle({
+                jid,
+                reasonIdentity
+            })
+        }
         const remoteIdentity = toSerializedPubKey(fetched.bundle.identity)
         if (reasonIdentity) {
             const storedIdentity = await signalStore.getRemoteIdentity(address)
@@ -74,13 +85,36 @@ export function createSignalSessionResolver(options: {
         if (expectedSerializedIdentity && !uint8Equal(remoteIdentity, expectedSerializedIdentity)) {
             throw new Error('identity mismatch')
         }
-        await signalProtocol.establishOutgoingSession(address, fetched.bundle)
+        await signalProtocol.establishOutgoingSession(address, fetched.bundle, {
+            reuseExisting: true
+        })
         logger.info('signal session synchronized', {
             jid,
             regId: fetched.bundle.regId,
             hasOneTimeKey: fetched.bundle.oneTimeKey !== undefined
         })
     }
+
+    const ensureSessionWithDedup = (
+        address: SignalAddress,
+        jid: string,
+        expectedIdentity?: Uint8Array,
+        reasonIdentity = false,
+        prefetchedBundle?: SignalPreKeyBundle
+    ): Promise<void> => {
+        const expectedIdentityKey = expectedIdentity ? bytesToHex(expectedIdentity) : 'none'
+        const dedupKey = `signalSession:${signalAddressKey(address)}:${reasonIdentity ? '1' : '0'}:${expectedIdentityKey}`
+        return dedup.run(dedupKey, () =>
+            ensureSessionInternal(address, jid, expectedIdentity, reasonIdentity, prefetchedBundle)
+        )
+    }
+
+    const ensureSession = (
+        address: SignalAddress,
+        jid: string,
+        expectedIdentity?: Uint8Array,
+        reasonIdentity = false
+    ): Promise<void> => ensureSessionWithDedup(address, jid, expectedIdentity, reasonIdentity)
 
     const ensureSessionsBatch = async (
         targetJids: readonly string[],
@@ -113,10 +147,8 @@ export function createSignalSessionResolver(options: {
         if (normalizedExpectedIdentityByJid && expectedIdentityByJid) {
             for (const [jid, identity] of expectedIdentityByJid.entries()) {
                 try {
-                    normalizedExpectedIdentityByJid.set(
-                        normalizeDeviceJid(jid),
-                        toSerializedPubKey(identity)
-                    )
+                    toSerializedPubKey(identity)
+                    normalizedExpectedIdentityByJid.set(normalizeDeviceJid(jid), identity)
                 } catch (error) {
                     logger.trace(
                         'ignoring malformed expected identity jid during batch normalization',
@@ -149,41 +181,15 @@ export function createSignalSessionResolver(options: {
             resolvedTargets.length = resolvedTargetCount
             return resolvedTargets
         }
-        const synchronizeMissingTarget = async (
-            targetIndex: number
-        ): Promise<SignalSessionRecord> => {
-            const targetJid = normalizedTargetJids[targetIndex]
-            const targetAddress = normalizedTargetAddresses[targetIndex]
-            const fetched = await signalSessionSync.fetchKeyBundle({
-                jid: targetJid
-            })
-            const expectedSerializedIdentity = normalizedExpectedIdentityByJid?.get(targetJid)
-            if (
-                expectedSerializedIdentity &&
-                !uint8Equal(toSerializedPubKey(fetched.bundle.identity), expectedSerializedIdentity)
-            ) {
-                throw new Error('identity mismatch')
-            }
-            const session = await signalProtocol.establishOutgoingSession(
-                targetAddress,
-                fetched.bundle
-            )
-            logger.debug('signal session synchronized from single key fetch', {
-                jid: targetJid,
-                regId: fetched.bundle.regId,
-                hasOneTimeKey: fetched.bundle.oneTimeKey !== undefined
-            })
-            return session
-        }
 
         const missingIndices: number[] = []
         for (let index = 0; index < normalizedTargetJids.length; index += 1) {
             const session = resolvedByIndex[index]
-            const expectedSerializedIdentity = normalizedExpectedIdentityByJid?.get(
+            const expectedIdentity = normalizedExpectedIdentityByJid?.get(
                 normalizedTargetJids[index]
             )
-            if (session && expectedSerializedIdentity) {
-                if (!uint8Equal(session.remote.pubKey, expectedSerializedIdentity)) {
+            if (session && expectedIdentity) {
+                if (!uint8Equal(session.remote.pubKey, toSerializedPubKey(expectedIdentity))) {
                     throw new Error('identity mismatch')
                 }
             }
@@ -194,130 +200,84 @@ export function createSignalSessionResolver(options: {
         if (missingIndices.length === 0) {
             return collectResolvedTargets()
         }
+        const batchRequest = new Array<{ readonly jid: string }>(missingIndices.length)
+        for (let index = 0; index < missingIndices.length; index += 1) {
+            batchRequest[index] = { jid: normalizedTargetJids[missingIndices[index]] }
+        }
 
+        let batchResults: readonly unknown[]
         try {
-            const batchRequest = new Array<{ readonly jid: string }>(missingIndices.length)
-            for (let index = 0; index < missingIndices.length; index += 1) {
-                batchRequest[index] = { jid: normalizedTargetJids[missingIndices[index]] }
-            }
-            const batchResults = await signalSessionSync.fetchKeyBundles(batchRequest)
-            const fallbackIndices: number[] = []
-            const establishedIndices = new Array<number>(missingIndices.length)
-            const establishedBundles = new Array<{
-                readonly regId: number
-                readonly hasOneTimeKey: boolean
-            }>(missingIndices.length)
-            const establishPromises = new Array<Promise<SignalSessionRecord>>(missingIndices.length)
-            let establishedCount = 0
-            for (let index = 0; index < missingIndices.length; index += 1) {
-                const targetIndex = missingIndices[index]
-                const result = batchResults[index]
-                if (!result || !('bundle' in result)) {
-                    fallbackIndices.push(targetIndex)
-                    continue
-                }
-                const targetJid = normalizedTargetJids[targetIndex]
-                const expectedSerializedIdentity = normalizedExpectedIdentityByJid?.get(targetJid)
-                if (
-                    expectedSerializedIdentity &&
-                    !uint8Equal(
-                        toSerializedPubKey(result.bundle.identity),
-                        expectedSerializedIdentity
-                    )
-                ) {
-                    throw new Error('identity mismatch')
-                }
-                establishedIndices[establishedCount] = targetIndex
-                establishedBundles[establishedCount] = {
-                    regId: result.bundle.regId,
-                    hasOneTimeKey: result.bundle.oneTimeKey !== undefined
-                }
-                establishPromises[establishedCount] = signalProtocol.establishOutgoingSession(
-                    normalizedTargetAddresses[targetIndex],
-                    result.bundle
-                )
-                establishedCount += 1
-            }
-
-            establishedIndices.length = establishedCount
-            establishedBundles.length = establishedCount
-            establishPromises.length = establishedCount
-            const establishmentResults = await Promise.allSettled(establishPromises)
-            for (let index = 0; index < establishmentResults.length; index += 1) {
-                const result = establishmentResults[index]
-                const targetIndex = establishedIndices[index]
-                if (result.status === 'fulfilled') {
-                    resolvedByIndex[targetIndex] = result.value
-                    logger.debug('signal session synchronized from batch key fetch', {
-                        jid: normalizedTargetJids[targetIndex],
-                        regId: establishedBundles[index].regId,
-                        hasOneTimeKey: establishedBundles[index].hasOneTimeKey
-                    })
-                    continue
-                }
-                const error = toError(result.reason)
-                if (error.message === 'identity mismatch') {
-                    throw error
-                }
-                fallbackIndices.push(targetIndex)
-            }
-
-            if (fallbackIndices.length === 0) {
-                return collectResolvedTargets()
-            }
-
-            logger.warn(
-                'signal batch key fetch returned partial errors, falling back to single requests',
-                {
-                    requested: missingIndices.length,
-                    fallbackTargets: fallbackIndices.length
-                }
-            )
-            for (let index = 0; index < fallbackIndices.length; index += 1) {
-                const targetIndex = fallbackIndices[index]
-                if (resolvedByIndex[targetIndex]) {
-                    continue
-                }
-                try {
-                    resolvedByIndex[targetIndex] = await synchronizeMissingTarget(targetIndex)
-                } catch (error) {
-                    const normalized = toError(error)
-                    if (normalized.message === 'identity mismatch') {
-                        throw normalized
-                    }
-                    logger.warn('signal single key fetch failed after batch fallback', {
-                        jid: normalizedTargetJids[targetIndex],
-                        message: normalized.message
-                    })
-                }
-            }
+            batchResults = await signalSessionSync.fetchKeyBundles(batchRequest)
         } catch (error) {
-            const normalized = toError(error)
-            if (normalized.message === 'identity mismatch') {
-                throw normalized
-            }
-            logger.warn('signal batch key fetch failed, falling back to single requests', {
+            logger.warn('signal batch key fetch failed', {
                 requested: missingIndices.length,
-                message: normalized.message
+                message: toError(error).message
             })
-            for (let index = 0; index < missingIndices.length; index += 1) {
-                const targetIndex = missingIndices[index]
-                if (resolvedByIndex[targetIndex]) {
-                    continue
-                }
-                try {
-                    resolvedByIndex[targetIndex] = await synchronizeMissingTarget(targetIndex)
-                } catch (fallbackError) {
-                    const fallbackNormalized = toError(fallbackError)
-                    if (fallbackNormalized.message === 'identity mismatch') {
-                        throw fallbackNormalized
-                    }
-                    logger.warn('signal single key fetch failed', {
-                        jid: normalizedTargetJids[targetIndex],
-                        message: fallbackNormalized.message
-                    })
-                }
+            return collectResolvedTargets()
+        }
+
+        const ensuredTargetIndices = new Array<number>(missingIndices.length)
+        const ensurePromises = new Array<Promise<void>>(missingIndices.length)
+        let ensureCount = 0
+        for (let index = 0; index < missingIndices.length; index += 1) {
+            const targetIndex = missingIndices[index]
+            const targetJid = normalizedTargetJids[targetIndex]
+            const batchResult = batchResults[index] as
+                | { readonly bundle?: SignalPreKeyBundle; readonly errorText?: string }
+                | undefined
+            if (!batchResult?.bundle) {
+                logger.warn('signal batch key fetch returned target without bundle', {
+                    jid: targetJid,
+                    message: batchResult?.errorText ?? 'missing key bundle user in response'
+                })
+                continue
             }
+            const expectedIdentity = normalizedExpectedIdentityByJid?.get(targetJid)
+            ensuredTargetIndices[ensureCount] = targetIndex
+            ensurePromises[ensureCount] = ensureSessionWithDedup(
+                normalizedTargetAddresses[targetIndex],
+                targetJid,
+                expectedIdentity,
+                false,
+                batchResult.bundle
+            )
+            ensureCount += 1
+        }
+        if (ensureCount === 0) {
+            return collectResolvedTargets()
+        }
+        ensuredTargetIndices.length = ensureCount
+        ensurePromises.length = ensureCount
+        const ensureResults = await Promise.allSettled(ensurePromises)
+
+        const ensuredAddresses = new Array<SignalAddress>(ensuredTargetIndices.length)
+        for (let index = 0; index < ensuredTargetIndices.length; index += 1) {
+            ensuredAddresses[index] = normalizedTargetAddresses[ensuredTargetIndices[index]]
+        }
+        const synchronizedSessions = await signalStore.getSessionsBatch(ensuredAddresses)
+
+        for (let index = 0; index < ensuredTargetIndices.length; index += 1) {
+            const targetIndex = ensuredTargetIndices[index]
+            const ensureResult = ensureResults[index]
+            if (ensureResult.status === 'rejected') {
+                const normalized = toError(ensureResult.reason)
+                if (normalized.message === 'identity mismatch') {
+                    throw normalized
+                }
+                logger.warn('signal session ensure failed during batch resolution', {
+                    jid: normalizedTargetJids[targetIndex],
+                    message: normalized.message
+                })
+                continue
+            }
+            const synchronizedSession = synchronizedSessions[index]
+            if (!synchronizedSession) {
+                logger.warn('signal session ensure completed without persisted session', {
+                    jid: normalizedTargetJids[targetIndex]
+                })
+                continue
+            }
+            resolvedByIndex[targetIndex] = synchronizedSession
         }
 
         return collectResolvedTargets()

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -1,3 +1,13 @@
+import { withAppStateLock } from '@store/locks/appstate.lock'
+import { withAuthLock } from '@store/locks/auth.lock'
+import { withContactLock } from '@store/locks/contact.lock'
+import { withDeviceListLock } from '@store/locks/device-list.lock'
+import { withMessageLock } from '@store/locks/message.lock'
+import { withParticipantsLock } from '@store/locks/participants.lock'
+import { withRetryLock } from '@store/locks/retry.lock'
+import { withSenderKeyLock } from '@store/locks/sender-key.lock'
+import { withSignalLock } from '@store/locks/signal.lock'
+import { withThreadLock } from '@store/locks/thread.lock'
 import {
     NOOP_CONTACT_STORE,
     NOOP_DEVICE_LIST_STORE,
@@ -218,8 +228,8 @@ export function createStore(options: WaCreateStoreOptions): WaStore {
                       } as const)
                     : null
 
-            const authStore = customAuth ?? new WaAuthSqliteStore(sqliteOptions!)
-            const signalStore =
+            const rawAuthStore = customAuth ?? new WaAuthSqliteStore(sqliteOptions!)
+            const rawSignalStore =
                 customSignal ??
                 (providers.signal === 'memory'
                     ? new WaSignalMemoryStore({
@@ -231,7 +241,7 @@ export function createStore(options: WaCreateStoreOptions): WaStore {
                           preKeyBatchSize: sqliteBatchSizes.signalPreKey,
                           hasSessionBatchSize: sqliteBatchSizes.signalHasSession
                       }))
-            const senderKeyStore =
+            const rawSenderKeyStore =
                 customSenderKey ??
                 (providers.senderKey === 'memory'
                     ? new SenderKeyMemoryStore({
@@ -242,7 +252,7 @@ export function createStore(options: WaCreateStoreOptions): WaStore {
                           sqliteOptions!,
                           sqliteBatchSizes.senderKeyDistribution
                       ))
-            const appStateStore =
+            const rawAppStateStore =
                 customAppState ??
                 (providers.appState === 'memory'
                     ? new WaAppStateMemoryStore(undefined, {
@@ -250,12 +260,12 @@ export function createStore(options: WaCreateStoreOptions): WaStore {
                           maxCollectionEntries: memoryLimits.appStateCollectionEntries
                       })
                     : new WaAppStateSqliteStore(sqliteOptions!))
-            const retryStore =
+            const rawRetryStore =
                 customRetry ??
                 (cacheProviders.retry === 'memory'
                     ? new WaRetryMemoryStore(cacheTtlsMs.retry)
                     : new WaRetrySqliteStore(sqliteOptions!, cacheTtlsMs.retry))
-            const participantsStore =
+            const rawParticipantsStore =
                 customParticipants ??
                 (cacheProviders.participants === 'sqlite'
                     ? new WaParticipantsSqliteStore(sqliteOptions!, cacheTtlsMs.participants)
@@ -264,7 +274,7 @@ export function createStore(options: WaCreateStoreOptions): WaStore {
                             maxGroups: memoryLimits.participantsGroups
                         })
                       : NOOP_PARTICIPANTS_STORE)
-            const deviceListStore =
+            const rawDeviceListStore =
                 customDeviceList ??
                 (cacheProviders.deviceList === 'sqlite'
                     ? new WaDeviceListSqliteStore(
@@ -277,7 +287,7 @@ export function createStore(options: WaCreateStoreOptions): WaStore {
                             maxUsers: memoryLimits.deviceListUsers
                         })
                       : NOOP_DEVICE_LIST_STORE)
-            const messageStore =
+            const rawMessageStore =
                 customMessages ??
                 (providers.messages === 'sqlite'
                     ? new WaMessageSqliteStore(sqliteOptions!)
@@ -286,7 +296,7 @@ export function createStore(options: WaCreateStoreOptions): WaStore {
                             maxMessages: memoryLimits.messages
                         })
                       : NOOP_MESSAGE_STORE)
-            const threadStore =
+            const rawThreadStore =
                 customThreads ??
                 (providers.threads === 'sqlite'
                     ? new WaThreadSqliteStore(sqliteOptions!)
@@ -295,7 +305,7 @@ export function createStore(options: WaCreateStoreOptions): WaStore {
                             maxThreads: memoryLimits.threads
                         })
                       : NOOP_THREAD_STORE)
-            const contactStore =
+            const rawContactStore =
                 customContacts ??
                 (providers.contacts === 'sqlite'
                     ? new WaContactSqliteStore(sqliteOptions!)
@@ -304,6 +314,17 @@ export function createStore(options: WaCreateStoreOptions): WaStore {
                             maxContacts: memoryLimits.contacts
                         })
                       : NOOP_CONTACT_STORE)
+
+            const authStore = withAuthLock(rawAuthStore)
+            const signalStore = withSignalLock(rawSignalStore)
+            const senderKeyStore = withSenderKeyLock(rawSenderKeyStore)
+            const appStateStore = withAppStateLock(rawAppStateStore)
+            const retryStore = withRetryLock(rawRetryStore)
+            const participantsStore = withParticipantsLock(rawParticipantsStore)
+            const deviceListStore = withDeviceListLock(rawDeviceListStore)
+            const messageStore = withMessageLock(rawMessageStore)
+            const threadStore = withThreadLock(rawThreadStore)
+            const contactStore = withContactLock(rawContactStore)
 
             let cachesDestroyed = false
             let sessionDestroyed = false

--- a/src/store/locks/__tests__/locks.test.ts
+++ b/src/store/locks/__tests__/locks.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { WaMessageStore, WaStoredMessageRecord } from '@store/contracts/message.store'
+import { withMessageLock } from '@store/locks/message.lock'
+import { delay } from '@util/async'
+
+async function flushMicrotasks(turns = 3): Promise<void> {
+    for (let index = 0; index < turns; index += 1) {
+        await Promise.resolve()
+    }
+}
+
+async function settleWithMockTimers(
+    t: { readonly mock: { readonly timers: { tick: (ms: number) => void } } },
+    target: Promise<unknown>,
+    stepMs = 10,
+    maxSteps = 100
+): Promise<void> {
+    let settled = false
+    let rejected: unknown = null
+    let didReject = false
+    void target.then(
+        () => {
+            settled = true
+        },
+        (error) => {
+            rejected = error
+            didReject = true
+            settled = true
+        }
+    )
+    for (let step = 0; step < maxSteps && !settled; step += 1) {
+        t.mock.timers.tick(stepMs)
+        await flushMicrotasks(8)
+        await new Promise<void>((resolve) => setImmediate(resolve))
+    }
+    if (!settled) {
+        throw new Error('mock timer steps exhausted before promise settled')
+    }
+    if (didReject) {
+        throw rejected
+    }
+}
+
+function createMessageStore(
+    onUpsert: (record: WaStoredMessageRecord) => Promise<void>
+): WaMessageStore {
+    const records = new Map<string, WaStoredMessageRecord>()
+
+    return {
+        upsert: async (record) => {
+            await onUpsert(record)
+            records.set(record.id, record)
+        },
+        upsertBatch: async (batch) => {
+            for (const record of batch) {
+                await onUpsert(record)
+                records.set(record.id, record)
+            }
+        },
+        getById: async (id) => records.get(id) ?? null,
+        listByThread: async (threadJid) =>
+            [...records.values()].filter((record) => record.threadJid === threadJid),
+        deleteById: async (id) => (records.delete(id) ? 1 : 0),
+        clear: async () => {
+            records.clear()
+        }
+    }
+}
+
+test('message lock serializes writes on the same key', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    let inFlight = 0
+    let maxInFlightForSameKey = 0
+
+    const store = withMessageLock(
+        createMessageStore(async (record) => {
+            if (record.id !== 'same') {
+                return
+            }
+            inFlight += 1
+            maxInFlightForSameKey = Math.max(maxInFlightForSameKey, inFlight)
+            await delay(20)
+            inFlight -= 1
+        })
+    )
+
+    const done = Promise.all([
+        store.upsert({ id: 'same', threadJid: 't', fromMe: true }),
+        store.upsert({ id: 'same', threadJid: 't', fromMe: true }),
+        store.upsert({ id: 'same', threadJid: 't', fromMe: true })
+    ])
+    await settleWithMockTimers(t, done, 10, 20)
+    await done
+
+    assert.equal(maxInFlightForSameKey, 1)
+})
+
+test('message lock allows parallel writes for different keys', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    let inFlight = 0
+    let maxInFlight = 0
+
+    const store = withMessageLock(
+        createMessageStore(async () => {
+            inFlight += 1
+            maxInFlight = Math.max(maxInFlight, inFlight)
+            await delay(20)
+            inFlight -= 1
+        })
+    )
+
+    const done = Promise.all([
+        store.upsert({ id: 'a', threadJid: 't', fromMe: true }),
+        store.upsert({ id: 'b', threadJid: 't', fromMe: true })
+    ])
+    await settleWithMockTimers(t, done, 10, 10)
+    await done
+
+    assert.equal(maxInFlight, 2)
+})
+
+test('message lock keeps reads as passthrough', async () => {
+    let reads = 0
+    const store = withMessageLock({
+        ...createMessageStore(async () => undefined),
+        getById: async (_id) => {
+            reads += 1
+            return null
+        }
+    })
+
+    await store.getById('x')
+    assert.equal(reads, 1)
+})

--- a/src/store/locks/appstate.lock.ts
+++ b/src/store/locks/appstate.lock.ts
@@ -1,0 +1,47 @@
+import { SharedExclusiveGate } from '@infra/perf/SharedExclusiveGate'
+import { StoreLock } from '@infra/perf/StoreLock'
+import type { WaAppStateStore } from '@store/contracts/appstate.store'
+import { bytesToHex } from '@util/bytes'
+
+const WA_APPSTATE_CLEAR_KEY = 'appstate:clear'
+
+type WaAppStateStoreWithLockLifecycle = WaAppStateStore & {
+    readonly destroy?: () => Promise<void>
+}
+
+export function withAppStateLock(store: WaAppStateStore): WaAppStateStoreWithLockLifecycle {
+    const lock = new StoreLock()
+    const gate = new SharedExclusiveGate()
+    const destroyStore = store as { destroy?: () => Promise<void> }
+    return {
+        exportData: () => gate.runShared(() => store.exportData()),
+        upsertSyncKeys: (keys) =>
+            gate.runShared(() =>
+                lock.runMany(
+                    keys.map((key) => `appstate:syncKey:${bytesToHex(key.keyId)}`),
+                    () => store.upsertSyncKeys(keys)
+                )
+            ),
+        getSyncKey: (keyId) => gate.runShared(() => store.getSyncKey(keyId)),
+        getSyncKeyData: (keyId) => gate.runShared(() => store.getSyncKeyData(keyId)),
+        getSyncKeyDataBatch: (keyIds) => gate.runShared(() => store.getSyncKeyDataBatch(keyIds)),
+        getActiveSyncKey: () => gate.runShared(() => store.getActiveSyncKey()),
+        getCollectionState: (collection) =>
+            gate.runShared(() => store.getCollectionState(collection)),
+        getCollectionStates: (collections) =>
+            gate.runShared(() => store.getCollectionStates(collections)),
+        setCollectionStates: (updates) =>
+            gate.runShared(() =>
+                lock.runMany(
+                    updates.map((update) => `appstate:collection:${update.collection}`),
+                    () => store.setCollectionStates(updates)
+                )
+            ),
+        clear: () => gate.runExclusive(() => lock.run(WA_APPSTATE_CLEAR_KEY, () => store.clear())),
+        destroy: async () => {
+            await gate.close()
+            await lock.shutdown()
+            await destroyStore.destroy?.()
+        }
+    }
+}

--- a/src/store/locks/auth.lock.ts
+++ b/src/store/locks/auth.lock.ts
@@ -1,0 +1,22 @@
+import { StoreLock } from '@infra/perf/StoreLock'
+import type { WaAuthStore } from '@store/contracts/auth.store'
+
+const WA_AUTH_KEY = 'credentials'
+
+type WaAuthStoreWithLockLifecycle = WaAuthStore & {
+    readonly destroy?: () => Promise<void>
+}
+
+export function withAuthLock(store: WaAuthStore): WaAuthStoreWithLockLifecycle {
+    const lock = new StoreLock()
+    const destroyStore = store as { destroy?: () => Promise<void> }
+    return {
+        load: () => lock.run(WA_AUTH_KEY, () => store.load()),
+        save: (credentials) => lock.run(WA_AUTH_KEY, () => store.save(credentials)),
+        clear: () => lock.run(WA_AUTH_KEY, () => store.clear()),
+        destroy: async () => {
+            await lock.shutdown()
+            await destroyStore.destroy?.()
+        }
+    }
+}

--- a/src/store/locks/contact.lock.ts
+++ b/src/store/locks/contact.lock.ts
@@ -1,0 +1,35 @@
+import { SharedExclusiveGate } from '@infra/perf/SharedExclusiveGate'
+import { StoreLock } from '@infra/perf/StoreLock'
+import type { WaContactStore } from '@store/contracts/contact.store'
+
+const WA_CONTACT_CLEAR_KEY = 'contact:clear'
+
+type WaContactStoreWithLockLifecycle = WaContactStore & {
+    readonly destroy?: () => Promise<void>
+}
+
+export function withContactLock(store: WaContactStore): WaContactStoreWithLockLifecycle {
+    const lock = new StoreLock()
+    const gate = new SharedExclusiveGate()
+    const destroyStore = store as { destroy?: () => Promise<void> }
+    return {
+        upsert: (record) =>
+            gate.runShared(() => lock.run(`contact:${record.jid}`, () => store.upsert(record))),
+        upsertBatch: (records) =>
+            gate.runShared(() =>
+                lock.runMany(
+                    records.map((record) => `contact:${record.jid}`),
+                    () => store.upsertBatch(records)
+                )
+            ),
+        getByJid: (jid) => gate.runShared(() => store.getByJid(jid)),
+        deleteByJid: (jid) =>
+            gate.runShared(() => lock.run(`contact:${jid}`, () => store.deleteByJid(jid))),
+        clear: () => gate.runExclusive(() => lock.run(WA_CONTACT_CLEAR_KEY, () => store.clear())),
+        destroy: async () => {
+            await gate.close()
+            await lock.shutdown()
+            await destroyStore.destroy?.()
+        }
+    }
+}

--- a/src/store/locks/device-list.lock.ts
+++ b/src/store/locks/device-list.lock.ts
@@ -1,0 +1,37 @@
+import { SharedExclusiveGate } from '@infra/perf/SharedExclusiveGate'
+import { StoreLock } from '@infra/perf/StoreLock'
+import type { WaDeviceListStore } from '@store/contracts/device-list.store'
+
+const WA_DEVICE_LIST_CLEAR_KEY = 'deviceList:clear'
+const WA_DEVICE_LIST_CLEANUP_KEY = 'deviceList:cleanup'
+
+export function withDeviceListLock(store: WaDeviceListStore): WaDeviceListStore {
+    const lock = new StoreLock()
+    const gate = new SharedExclusiveGate()
+    return {
+        destroy: async () => {
+            await gate.close()
+            await lock.shutdown()
+            await store.destroy?.()
+        },
+        upsertUserDevicesBatch: (snapshots) =>
+            gate.runShared(() =>
+                lock.runMany(
+                    snapshots.map((snapshot) => `deviceList:user:${snapshot.userJid}`),
+                    () => store.upsertUserDevicesBatch(snapshots)
+                )
+            ),
+        getUserDevicesBatch: (userJids, nowMs) =>
+            gate.runShared(() => store.getUserDevicesBatch(userJids, nowMs)),
+        deleteUserDevices: (userJid) =>
+            gate.runShared(() =>
+                lock.run(`deviceList:user:${userJid}`, () => store.deleteUserDevices(userJid))
+            ),
+        cleanupExpired: (nowMs) =>
+            gate.runExclusive(() =>
+                lock.run(WA_DEVICE_LIST_CLEANUP_KEY, () => store.cleanupExpired(nowMs))
+            ),
+        clear: () =>
+            gate.runExclusive(() => lock.run(WA_DEVICE_LIST_CLEAR_KEY, () => store.clear()))
+    }
+}

--- a/src/store/locks/message.lock.ts
+++ b/src/store/locks/message.lock.ts
@@ -1,0 +1,37 @@
+import { SharedExclusiveGate } from '@infra/perf/SharedExclusiveGate'
+import { StoreLock } from '@infra/perf/StoreLock'
+import type { WaMessageStore } from '@store/contracts/message.store'
+
+const WA_MESSAGE_CLEAR_KEY = 'message:clear'
+
+type WaMessageStoreWithLockLifecycle = WaMessageStore & {
+    readonly destroy?: () => Promise<void>
+}
+
+export function withMessageLock(store: WaMessageStore): WaMessageStoreWithLockLifecycle {
+    const lock = new StoreLock()
+    const gate = new SharedExclusiveGate()
+    const destroyStore = store as { destroy?: () => Promise<void> }
+    return {
+        upsert: (record) =>
+            gate.runShared(() => lock.run(`message:${record.id}`, () => store.upsert(record))),
+        upsertBatch: (records) =>
+            gate.runShared(() =>
+                lock.runMany(
+                    records.map((record) => `message:${record.id}`),
+                    () => store.upsertBatch(records)
+                )
+            ),
+        getById: (id) => gate.runShared(() => store.getById(id)),
+        listByThread: (threadJid, limit, beforeTimestampMs) =>
+            gate.runShared(() => store.listByThread(threadJid, limit, beforeTimestampMs)),
+        deleteById: (id) =>
+            gate.runShared(() => lock.run(`message:${id}`, () => store.deleteById(id))),
+        clear: () => gate.runExclusive(() => lock.run(WA_MESSAGE_CLEAR_KEY, () => store.clear())),
+        destroy: async () => {
+            await gate.close()
+            await lock.shutdown()
+            await destroyStore.destroy?.()
+        }
+    }
+}

--- a/src/store/locks/participants.lock.ts
+++ b/src/store/locks/participants.lock.ts
@@ -1,0 +1,38 @@
+import { SharedExclusiveGate } from '@infra/perf/SharedExclusiveGate'
+import { StoreLock } from '@infra/perf/StoreLock'
+import type { WaParticipantsStore } from '@store/contracts/participants.store'
+
+const WA_PARTICIPANTS_CLEAR_KEY = 'participants:clear'
+const WA_PARTICIPANTS_CLEANUP_KEY = 'participants:cleanup'
+
+export function withParticipantsLock(store: WaParticipantsStore): WaParticipantsStore {
+    const lock = new StoreLock()
+    const gate = new SharedExclusiveGate()
+    return {
+        destroy: async () => {
+            await gate.close()
+            await lock.shutdown()
+            await store.destroy?.()
+        },
+        upsertGroupParticipants: (snapshot) =>
+            gate.runShared(() =>
+                lock.run(`participants:group:${snapshot.groupJid}`, () =>
+                    store.upsertGroupParticipants(snapshot)
+                )
+            ),
+        getGroupParticipants: (groupJid, nowMs) =>
+            gate.runShared(() => store.getGroupParticipants(groupJid, nowMs)),
+        deleteGroupParticipants: (groupJid) =>
+            gate.runShared(() =>
+                lock.run(`participants:group:${groupJid}`, () =>
+                    store.deleteGroupParticipants(groupJid)
+                )
+            ),
+        cleanupExpired: (nowMs) =>
+            gate.runExclusive(() =>
+                lock.run(WA_PARTICIPANTS_CLEANUP_KEY, () => store.cleanupExpired(nowMs))
+            ),
+        clear: () =>
+            gate.runExclusive(() => lock.run(WA_PARTICIPANTS_CLEAR_KEY, () => store.clear()))
+    }
+}

--- a/src/store/locks/retry.lock.ts
+++ b/src/store/locks/retry.lock.ts
@@ -1,0 +1,69 @@
+import { SharedExclusiveGate } from '@infra/perf/SharedExclusiveGate'
+import { StoreLock } from '@infra/perf/StoreLock'
+import type { WaRetryStore } from '@store/contracts/retry.store'
+
+const WA_RETRY_CLEANUP_KEY = 'retry:cleanup'
+const WA_RETRY_CLEAR_KEY = 'retry:clear'
+
+export function withRetryLock(store: WaRetryStore): WaRetryStore {
+    const lock = new StoreLock()
+    const gate = new SharedExclusiveGate()
+    return {
+        getTtlMs: store.getTtlMs?.bind(store),
+        supportsRawReplayPayload: store.supportsRawReplayPayload?.bind(store),
+        destroy: async () => {
+            await gate.close()
+            await lock.shutdown()
+            await store.destroy?.()
+        },
+        getOutboundRequesterStatus: (messageId, requesterDeviceJid) =>
+            gate.runShared(() => store.getOutboundRequesterStatus(messageId, requesterDeviceJid)),
+        upsertOutboundMessage: (record) =>
+            gate.runShared(() =>
+                lock.run(`retry:outbound:${record.messageId}`, () =>
+                    store.upsertOutboundMessage(record)
+                )
+            ),
+        deleteOutboundMessage: (messageId) =>
+            gate.runShared(() =>
+                lock.run(`retry:outbound:${messageId}`, () =>
+                    store.deleteOutboundMessage(messageId)
+                )
+            ),
+        getOutboundMessage: (messageId) =>
+            gate.runShared(() => store.getOutboundMessage(messageId)),
+        updateOutboundMessageState: (messageId, state, updatedAtMs, expiresAtMs) =>
+            gate.runShared(() =>
+                lock.run(`retry:outbound:${messageId}`, () =>
+                    store.updateOutboundMessageState(messageId, state, updatedAtMs, expiresAtMs)
+                )
+            ),
+        markOutboundRequesterDelivered: (messageId, requesterDeviceJid, updatedAtMs, expiresAtMs) =>
+            gate.runShared(() =>
+                lock.runMany(
+                    [
+                        `retry:outbound:${messageId}`,
+                        `retry:outbound:${messageId}:${requesterDeviceJid}`
+                    ],
+                    () =>
+                        store.markOutboundRequesterDelivered(
+                            messageId,
+                            requesterDeviceJid,
+                            updatedAtMs,
+                            expiresAtMs
+                        )
+                )
+            ),
+        incrementInboundCounter: (messageId, requesterJid, updatedAtMs, expiresAtMs) =>
+            gate.runShared(() =>
+                lock.run(`retry:inbound:${messageId}:${requesterJid}`, () =>
+                    store.incrementInboundCounter(messageId, requesterJid, updatedAtMs, expiresAtMs)
+                )
+            ),
+        cleanupExpired: (nowMs) =>
+            gate.runExclusive(() =>
+                lock.run(WA_RETRY_CLEANUP_KEY, () => store.cleanupExpired(nowMs))
+            ),
+        clear: () => gate.runExclusive(() => lock.run(WA_RETRY_CLEAR_KEY, () => store.clear()))
+    }
+}

--- a/src/store/locks/sender-key.lock.ts
+++ b/src/store/locks/sender-key.lock.ts
@@ -1,0 +1,97 @@
+import { SharedExclusiveGate } from '@infra/perf/SharedExclusiveGate'
+import { StoreLock } from '@infra/perf/StoreLock'
+import { signalAddressKey } from '@protocol/jid'
+import type { SignalAddress } from '@signal/types'
+import type { WaSenderKeyStore } from '@store/contracts/sender-key.store'
+
+const WA_SENDER_KEY_CLEAR_KEY = 'senderKey:clear'
+
+function senderKeyLockKey(groupId: string, sender: SignalAddress): string {
+    return `senderKey:${groupId}:${signalAddressKey(sender)}`
+}
+
+function senderDistributionLockKey(groupId: string, sender: SignalAddress): string {
+    return `senderKeyDistribution:${groupId}:${signalAddressKey(sender)}`
+}
+
+function senderAnyLockKey(sender: SignalAddress): string {
+    return `senderKey:any:${signalAddressKey(sender)}`
+}
+
+type WaSenderKeyStoreWithLockLifecycle = WaSenderKeyStore & {
+    readonly destroy?: () => Promise<void>
+}
+
+export function withSenderKeyLock(store: WaSenderKeyStore): WaSenderKeyStoreWithLockLifecycle {
+    const lock = new StoreLock()
+    const gate = new SharedExclusiveGate()
+    const destroyStore = store as { destroy?: () => Promise<void> }
+    return {
+        upsertSenderKey: (record) =>
+            gate.runShared(() =>
+                lock.runMany(
+                    [
+                        senderAnyLockKey(record.sender),
+                        senderKeyLockKey(record.groupId, record.sender)
+                    ],
+                    () => store.upsertSenderKey(record)
+                )
+            ),
+        upsertSenderKeyDistribution: (record) =>
+            gate.runShared(() =>
+                lock.runMany(
+                    [
+                        senderAnyLockKey(record.sender),
+                        senderDistributionLockKey(record.groupId, record.sender)
+                    ],
+                    () => store.upsertSenderKeyDistribution(record)
+                )
+            ),
+        upsertSenderKeyDistributions: (records) =>
+            gate.runShared(() =>
+                lock.runMany(
+                    records.flatMap((record) => [
+                        senderAnyLockKey(record.sender),
+                        senderDistributionLockKey(record.groupId, record.sender)
+                    ]),
+                    () => store.upsertSenderKeyDistributions(records)
+                )
+            ),
+        getGroupSenderKeyList: (groupId) =>
+            gate.runShared(() => store.getGroupSenderKeyList(groupId)),
+        getDeviceSenderKey: (groupId, sender) =>
+            gate.runShared(() => store.getDeviceSenderKey(groupId, sender)),
+        getDeviceSenderKeyDistributions: (groupId, senders) =>
+            gate.runShared(() => store.getDeviceSenderKeyDistributions(groupId, senders)),
+        deleteDeviceSenderKey: (target, groupId) =>
+            gate.runShared(() =>
+                lock.runMany(
+                    groupId
+                        ? [
+                              senderAnyLockKey(target),
+                              senderKeyLockKey(groupId, target),
+                              senderDistributionLockKey(groupId, target)
+                          ]
+                        : [senderAnyLockKey(target)],
+                    () => store.deleteDeviceSenderKey(target, groupId)
+                )
+            ),
+        markForgetSenderKey: (groupId, participants) =>
+            gate.runShared(() =>
+                lock.runMany(
+                    participants.flatMap((participant) => [
+                        senderAnyLockKey(participant),
+                        senderKeyLockKey(groupId, participant)
+                    ]),
+                    () => store.markForgetSenderKey(groupId, participants)
+                )
+            ),
+        clear: () =>
+            gate.runExclusive(() => lock.run(WA_SENDER_KEY_CLEAR_KEY, () => store.clear())),
+        destroy: async () => {
+            await gate.close()
+            await lock.shutdown()
+            await destroyStore.destroy?.()
+        }
+    }
+}

--- a/src/store/locks/signal.lock.ts
+++ b/src/store/locks/signal.lock.ts
@@ -1,0 +1,83 @@
+import { SharedExclusiveGate } from '@infra/perf/SharedExclusiveGate'
+import { StoreLock } from '@infra/perf/StoreLock'
+import type { WaSignalStore } from '@store/contracts/signal.store'
+
+const WA_SIGNAL_REGISTRATION_KEY = 'signal:registration'
+const WA_SIGNAL_SIGNED_PREKEY_KEY = 'signal:signedPreKey'
+const WA_SIGNAL_PREKEYS_KEY = 'signal:prekeys'
+const WA_SIGNAL_SERVER_HAS_PREKEYS_KEY = 'signal:serverHasPreKeys'
+const WA_SIGNAL_CLEAR_KEY = 'signal:clear'
+
+type WaSignalStoreWithLockLifecycle = WaSignalStore & {
+    readonly destroy?: () => Promise<void>
+}
+
+export function withSignalLock(store: WaSignalStore): WaSignalStoreWithLockLifecycle {
+    const lock = new StoreLock()
+    const gate = new SharedExclusiveGate()
+    const destroyStore = store as { destroy?: () => Promise<void> }
+    return {
+        getRegistrationInfo: () => gate.runShared(() => store.getRegistrationInfo()),
+        setRegistrationInfo: (info) =>
+            gate.runShared(() =>
+                lock.run(WA_SIGNAL_REGISTRATION_KEY, () => store.setRegistrationInfo(info))
+            ),
+        getSignedPreKey: () => gate.runShared(() => store.getSignedPreKey()),
+        setSignedPreKey: (record) =>
+            gate.runShared(() =>
+                lock.run(WA_SIGNAL_SIGNED_PREKEY_KEY, () => store.setSignedPreKey(record))
+            ),
+        getSignedPreKeyById: (keyId) => gate.runShared(() => store.getSignedPreKeyById(keyId)),
+        setSignedPreKeyRotationTs: (value) =>
+            gate.runShared(() =>
+                lock.run(WA_SIGNAL_SIGNED_PREKEY_KEY, () => store.setSignedPreKeyRotationTs(value))
+            ),
+        getSignedPreKeyRotationTs: () => gate.runShared(() => store.getSignedPreKeyRotationTs()),
+        putPreKey: (record) =>
+            gate.runShared(() => lock.run(WA_SIGNAL_PREKEYS_KEY, () => store.putPreKey(record))),
+        getOrGenPreKeys: (count, generator) =>
+            gate.runShared(() =>
+                lock.run(WA_SIGNAL_PREKEYS_KEY, () => store.getOrGenPreKeys(count, generator))
+            ),
+        getPreKeyById: (keyId) => gate.runShared(() => store.getPreKeyById(keyId)),
+        getPreKeysById: (keyIds) => gate.runShared(() => store.getPreKeysById(keyIds)),
+        consumePreKeyById: (keyId) =>
+            gate.runShared(() =>
+                lock.run(WA_SIGNAL_PREKEYS_KEY, () => store.consumePreKeyById(keyId))
+            ),
+        getOrGenSinglePreKey: (generator) =>
+            gate.runShared(() =>
+                lock.run(WA_SIGNAL_PREKEYS_KEY, () => store.getOrGenSinglePreKey(generator))
+            ),
+        markKeyAsUploaded: (keyId) =>
+            gate.runShared(() =>
+                lock.run(WA_SIGNAL_PREKEYS_KEY, () => store.markKeyAsUploaded(keyId))
+            ),
+        setServerHasPreKeys: (value) =>
+            gate.runShared(() =>
+                lock.run(WA_SIGNAL_SERVER_HAS_PREKEYS_KEY, () => store.setServerHasPreKeys(value))
+            ),
+        getServerHasPreKeys: () => gate.runShared(() => store.getServerHasPreKeys()),
+        getSignalMeta: () => gate.runShared(() => store.getSignalMeta()),
+        hasSession: (address) => gate.runShared(() => store.hasSession(address)),
+        hasSessions: (addresses) => gate.runShared(() => store.hasSessions(addresses)),
+        getSession: (address) => gate.runShared(() => store.getSession(address)),
+        getSessionsBatch: (addresses) => gate.runShared(() => store.getSessionsBatch(addresses)),
+        // Session and identity read-modify-write semantics are serialized in SignalProtocol per address.
+        setSession: (address, session) => gate.runShared(() => store.setSession(address, session)),
+        setSessionsBatch: (entries) => gate.runShared(() => store.setSessionsBatch(entries)),
+        deleteSession: (address) => gate.runShared(() => store.deleteSession(address)),
+        getRemoteIdentity: (address) => gate.runShared(() => store.getRemoteIdentity(address)),
+        getRemoteIdentities: (addresses) =>
+            gate.runShared(() => store.getRemoteIdentities(addresses)),
+        setRemoteIdentity: (address, identityKey) =>
+            gate.runShared(() => store.setRemoteIdentity(address, identityKey)),
+        setRemoteIdentities: (entries) => gate.runShared(() => store.setRemoteIdentities(entries)),
+        clear: () => gate.runExclusive(() => lock.run(WA_SIGNAL_CLEAR_KEY, () => store.clear())),
+        destroy: async () => {
+            await gate.close()
+            await lock.shutdown()
+            await destroyStore.destroy?.()
+        }
+    }
+}

--- a/src/store/locks/thread.lock.ts
+++ b/src/store/locks/thread.lock.ts
@@ -1,0 +1,36 @@
+import { SharedExclusiveGate } from '@infra/perf/SharedExclusiveGate'
+import { StoreLock } from '@infra/perf/StoreLock'
+import type { WaThreadStore } from '@store/contracts/thread.store'
+
+const WA_THREAD_CLEAR_KEY = 'thread:clear'
+
+type WaThreadStoreWithLockLifecycle = WaThreadStore & {
+    readonly destroy?: () => Promise<void>
+}
+
+export function withThreadLock(store: WaThreadStore): WaThreadStoreWithLockLifecycle {
+    const lock = new StoreLock()
+    const gate = new SharedExclusiveGate()
+    const destroyStore = store as { destroy?: () => Promise<void> }
+    return {
+        upsert: (record) =>
+            gate.runShared(() => lock.run(`thread:${record.jid}`, () => store.upsert(record))),
+        upsertBatch: (records) =>
+            gate.runShared(() =>
+                lock.runMany(
+                    records.map((record) => `thread:${record.jid}`),
+                    () => store.upsertBatch(records)
+                )
+            ),
+        getByJid: (jid) => gate.runShared(() => store.getByJid(jid)),
+        list: (limit) => gate.runShared(() => store.list(limit)),
+        deleteByJid: (jid) =>
+            gate.runShared(() => lock.run(`thread:${jid}`, () => store.deleteByJid(jid))),
+        clear: () => gate.runExclusive(() => lock.run(WA_THREAD_CLEAR_KEY, () => store.clear())),
+        destroy: async () => {
+            await gate.close()
+            await lock.shutdown()
+            await destroyStore.destroy?.()
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable write-behind persistence with tunable queue settings and a manual flush/destroy API.
  * Incoming-event gating that pauses new inbound handling and waits for in-flight handlers during shutdown.

* **Refactor**
  * Switched to per-record write‑behind queuing with periodic flushing and aggregated drain reporting.
  * Added store-level concurrency wrappers and per-key serialization to reduce races across many store types.

* **Tests**
  * Added extensive tests for persistence, background queues, concurrency primitives, locks, coordinators, and session flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->