### PR TITLE
feat: add privacy settings queries with typed coordinator API

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -146,7 +146,6 @@ async function startSession(client: WaClient): Promise<void> {
                 text: `pong ${deltaSeconds.toFixed(3)}`
             }
         })
-        //await client.setChatArchive(to, true)
         console.log(`[incoming_message] pong enviado para ${to}`)
     })
     client.on('group_event', (event) => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    WA_PRIVACY_CATEGORIES,
+    WA_PRIVACY_CATEGORY_TO_SETTING,
+    WA_PRIVACY_DISALLOWED_LIST_CATEGORIES,
+    WA_PRIVACY_SETTING_TO_CATEGORY,
+    WA_PRIVACY_TAGS,
+    WA_PRIVACY_VALUES
+} from '../index'
+import type { WaPrivacyCategory, WaPrivacySettingName, WaPrivacyValue } from '../index'
+
+test('root index exports privacy constants and type surfaces', () => {
+    const category: WaPrivacyCategory = WA_PRIVACY_CATEGORIES.ABOUT
+    const setting: WaPrivacySettingName = WA_PRIVACY_CATEGORY_TO_SETTING[category]
+    const value: WaPrivacyValue = WA_PRIVACY_VALUES.CONTACTS
+
+    assert.equal(setting, 'about')
+    assert.equal(value, 'contacts')
+    assert.equal(WA_PRIVACY_SETTING_TO_CATEGORY.groupAdd, WA_PRIVACY_CATEGORIES.GROUP_ADD)
+    assert.equal(WA_PRIVACY_DISALLOWED_LIST_CATEGORIES.ABOUT, WA_PRIVACY_CATEGORIES.ABOUT)
+    assert.equal(WA_PRIVACY_TAGS.USER, 'user')
+})

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -13,6 +13,7 @@ import type { WaGroupCoordinator } from '@client/coordinators/WaGroupCoordinator
 import type { WaIncomingNodeCoordinator } from '@client/coordinators/WaIncomingNodeCoordinator'
 import type { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
 import type { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTasksCoordinator'
+import type { WaPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordinator'
 import type { WaTrustedContactTokenCoordinator } from '@client/coordinators/WaTrustedContactTokenCoordinator'
 import { parseChatEventFromAppStateMutation } from '@client/events/chat'
 import { processHistorySyncNotification } from '@client/history-sync'
@@ -20,11 +21,7 @@ import { persistIncomingMailboxEntities } from '@client/mailbox'
 import type { WriteBehindDrainResult } from '@client/persistence/WriteBehindPersistence'
 import { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
 import type {
-    WaAppStateMessageKey,
-    WaClearChatOptions,
     WaClientOptions,
-    WaDeleteChatOptions,
-    WaDeleteMessageForMeOptions,
     WaSendMessageOptions,
     WaClientEventMap,
     WaIncomingProtocolMessageEvent,
@@ -92,12 +89,13 @@ export class WaClient extends EventEmitter {
     private readonly nodeTransport!: WaNodeTransport
     private readonly signalDeviceSync!: SignalDeviceSyncApi
     public readonly appStateSync!: WaAppStateSyncClient
-    private readonly appStateMutations!: WaAppStateMutationCoordinator
+    public readonly chatCoordinator!: WaAppStateMutationCoordinator
     private readonly incomingNode!: WaIncomingNodeCoordinator
     public readonly mediaTransfer!: WaMediaTransferClient
     public readonly messageDispatch!: WaMessageDispatchCoordinator
     public readonly messageClient!: WaMessageClient
     public readonly groupCoordinator!: WaGroupCoordinator
+    public readonly privacyCoordinator!: WaPrivacyCoordinator
     private readonly passiveTasks!: WaPassiveTasksCoordinator
     private readonly keepAlive!: WaKeepAlive
     private readonly receiptQueue!: WaReceiptQueue
@@ -647,55 +645,22 @@ export class WaClient extends EventEmitter {
         }
     }
 
+    public get chat(): WaAppStateMutationCoordinator {
+        return this.chatCoordinator
+    }
+    public get group(): WaGroupCoordinator {
+        return this.groupCoordinator
+    }
+    public get privacy(): WaPrivacyCoordinator {
+        return this.privacyCoordinator
+    }
+
     public sendReceipt(input: WaSendReceiptInput): Promise<void> {
         return this.messageDispatch.sendReceipt(input)
     }
 
-    public setChatMute(
-        chatJid: string,
-        muted: boolean,
-        muteEndTimestampMs?: number
-    ): Promise<void> {
-        return this.appStateMutations.setChatMute(chatJid, muted, muteEndTimestampMs)
-    }
-
-    public setChatRead(chatJid: string, read: boolean): Promise<void> {
-        return this.appStateMutations.setChatRead(chatJid, read)
-    }
-
-    public setChatPin(chatJid: string, pinned: boolean): Promise<void> {
-        return this.appStateMutations.setChatPin(chatJid, pinned)
-    }
-
-    public setChatArchive(chatJid: string, archived: boolean): Promise<void> {
-        return this.appStateMutations.setChatArchive(chatJid, archived)
-    }
-
-    public clearChat(chatJid: string, options: WaClearChatOptions = {}): Promise<void> {
-        return this.appStateMutations.clearChat(chatJid, options)
-    }
-
-    public deleteChat(chatJid: string, options: WaDeleteChatOptions = {}): Promise<void> {
-        return this.appStateMutations.deleteChat(chatJid, options)
-    }
-
-    public setChatLock(chatJid: string, locked: boolean): Promise<void> {
-        return this.appStateMutations.setChatLock(chatJid, locked)
-    }
-
-    public setMessageStar(message: WaAppStateMessageKey, starred: boolean): Promise<void> {
-        return this.appStateMutations.setMessageStar(message, starred)
-    }
-
-    public deleteMessageForMe(
-        message: WaAppStateMessageKey,
-        options: WaDeleteMessageForMeOptions = {}
-    ): Promise<void> {
-        return this.appStateMutations.deleteMessageForMe(message, options)
-    }
-
     public flushAppStateMutations(): Promise<void> {
-        return this.appStateMutations.flushMutations()
+        return this.chatCoordinator.flushMutations()
     }
 
     public flushWriteBehind(timeoutMs?: number): Promise<WriteBehindDrainResult> {

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -12,6 +12,10 @@ import {
 import { WaIncomingNodeCoordinator } from '@client/coordinators/WaIncomingNodeCoordinator'
 import { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
 import { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTasksCoordinator'
+import {
+    createPrivacyCoordinator,
+    type WaPrivacyCoordinator
+} from '@client/coordinators/WaPrivacyCoordinator'
 import { WaRetryCoordinator } from '@client/coordinators/WaRetryCoordinator'
 import {
     createStreamControlHandler,
@@ -122,11 +126,12 @@ interface WaClientDependencies {
     readonly messageDispatch: WaMessageDispatchCoordinator
     readonly retryCoordinator: WaRetryCoordinator
     readonly appStateSync: WaAppStateSyncClient
-    readonly appStateMutations: WaAppStateMutationCoordinator
+    readonly chatCoordinator: WaAppStateMutationCoordinator
     readonly streamControl: WaStreamControlHandler
     readonly incomingNode: WaIncomingNodeCoordinator
     readonly passiveTasks: WaPassiveTasksCoordinator
     readonly groupCoordinator: WaGroupCoordinator
+    readonly privacyCoordinator: WaPrivacyCoordinator
     readonly receiptQueue: WaReceiptQueue
     readonly keyShareCoordinator: WaKeyShareCoordinator
     readonly connectionManager: WaConnectionManager
@@ -465,6 +470,10 @@ export function buildWaClientDependencies(input: {
     const getCurrentSignedIdentity = () => getCurrentCredentials()?.signedIdentity
 
     const groupCoordinator = createGroupCoordinator({
+        queryWithContext: runtime.queryWithContext
+    })
+
+    const privacyCoordinator = createPrivacyCoordinator({
         queryWithContext: runtime.queryWithContext
     })
 
@@ -960,11 +969,12 @@ export function buildWaClientDependencies(input: {
         messageDispatch,
         retryCoordinator,
         appStateSync,
-        appStateMutations,
+        chatCoordinator: appStateMutations,
         streamControl,
         incomingNode,
         passiveTasks,
         groupCoordinator,
+        privacyCoordinator,
         receiptQueue,
         keyShareCoordinator,
         connectionManager,

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -6,9 +6,10 @@ import { parseDirtyBits } from '@client/dirty'
 import { processHistorySyncNotification } from '@client/history-sync'
 import type { WaClientOptions } from '@client/types'
 import { WaClient } from '@client/WaClient'
-import { resolveWaClientBase } from '@client/WaClientFactory'
+import { buildWaClientDependencies, resolveWaClientBase } from '@client/WaClientFactory'
 import type { Logger } from '@infra/log/types'
 import { proto } from '@proto'
+import type { BinaryNode } from '@transport/types'
 
 function createLogger(): Logger {
     return {
@@ -318,12 +319,62 @@ test('resolveWaClientBase accepts proxy agent shapes', () => {
     assert.doesNotThrow(() => resolveWaClientBase(options, createLogger()))
 })
 
+test('buildWaClientDependencies wires privacy coordinator', () => {
+    const sessionStore = {
+        auth: {} as never,
+        signal: {} as never,
+        senderKey: {} as never,
+        appState: {} as never,
+        messages: {} as never,
+        threads: {} as never,
+        contacts: {} as never,
+        retry: {} as never,
+        participants: {} as never,
+        deviceList: {} as never,
+        privacyToken: {} as never
+    }
+    const options = {
+        store: {
+            session: () => sessionStore
+        },
+        sessionId: 'session'
+    } as unknown as WaClientOptions
+
+    const base = resolveWaClientBase(options, createLogger())
+    const runtime = {
+        sendNode: async (_node: BinaryNode) => undefined,
+        query: async (_node: BinaryNode) =>
+            ({ tag: 'iq', attrs: { type: 'result' } }) as BinaryNode,
+        queryWithContext: async (_context: string, _node: BinaryNode) =>
+            ({ tag: 'iq', attrs: { type: 'result' } }) as BinaryNode,
+        syncAppState: async () => undefined,
+        syncAppStateWithOptions: async () => ({ collections: [] }) as never,
+        emitEvent: (() => undefined) as never,
+        handleIncomingMessageEvent: async () => undefined,
+        handleError: (_error: Error) => undefined,
+        handleIncomingFrame: async (_frame: Uint8Array) => undefined,
+        clearStoredState: async () => undefined,
+        resumeIncomingEvents: () => undefined
+    }
+
+    const dependencies = buildWaClientDependencies({ base, runtime })
+    assert.equal(typeof dependencies.privacyCoordinator.getPrivacySettings, 'function')
+})
+
 function getClearStoredStateMethod() {
     return (
         WaClient.prototype as unknown as {
             readonly clearStoredState: (this: unknown) => Promise<void>
         }
     ).clearStoredState
+}
+
+function getCoordinatorGetterMethod(name: 'chat' | 'group' | 'privacy') {
+    const descriptor = Object.getOwnPropertyDescriptor(WaClient.prototype, name)
+    if (!descriptor?.get) {
+        throw new Error(`expected WaClient.${name} getter`)
+    }
+    return descriptor.get as (this: unknown) => unknown
 }
 
 function createClearStoredStateHarness(logoutStoreClear?: {
@@ -428,6 +479,21 @@ test('clearStoredState clears every store domain by default', async () => {
         'threads',
         'privacyToken'
     ])
+})
+
+test('WaClient exposes chat/group/privacy coordinator getters', () => {
+    const chatCoordinator = { flushMutations: async () => undefined }
+    const groupCoordinator = { queryGroupMetadata: async () => ({}) }
+    const privacyCoordinator = { getPrivacySettings: async () => ({}) }
+    const fakeClient = {
+        chatCoordinator,
+        groupCoordinator,
+        privacyCoordinator
+    }
+
+    assert.equal(getCoordinatorGetterMethod('chat').call(fakeClient), chatCoordinator)
+    assert.equal(getCoordinatorGetterMethod('group').call(fakeClient), groupCoordinator)
+    assert.equal(getCoordinatorGetterMethod('privacy').call(fakeClient), privacyCoordinator)
 })
 
 test('clearStoredState respects logoutStoreClear domain toggles', async () => {

--- a/src/client/coordinators/WaPrivacyCoordinator.ts
+++ b/src/client/coordinators/WaPrivacyCoordinator.ts
@@ -1,0 +1,217 @@
+import type {
+    WaPrivacyCategory,
+    WaPrivacyDisallowedListSettingName,
+    WaPrivacySettingName,
+    WaPrivacySettingValueMap,
+    WaPrivacyValue
+} from '@protocol/privacy'
+import {
+    WA_PRIVACY_CATEGORY_TO_SETTING,
+    WA_PRIVACY_SETTING_TO_CATEGORY,
+    WA_PRIVACY_TAGS,
+    WA_PRIVACY_VALUES
+} from '@protocol/privacy'
+import {
+    buildBlocklistChangeIq,
+    buildGetBlocklistIq,
+    buildGetPrivacyDisallowedListIq,
+    buildGetPrivacySettingsIq,
+    buildSetPrivacyCategoryIq
+} from '@transport/node/builders/privacy'
+import { findNodeChild, getNodeChildren, getNodeChildrenByTag } from '@transport/node/helpers'
+import { assertIqResult } from '@transport/node/query'
+import type { BinaryNode } from '@transport/types'
+
+export type WaPrivacySettings = {
+    readonly [K in WaPrivacySettingName]?: WaPrivacySettingValueMap[K]
+}
+
+export interface WaPrivacyDisallowedListResult {
+    readonly jids: readonly string[]
+    readonly dhash?: string
+}
+
+export interface WaBlocklistResult {
+    readonly jids: readonly string[]
+    readonly dhash?: string
+}
+
+export interface WaPrivacyCoordinator {
+    readonly getPrivacySettings: () => Promise<WaPrivacySettings>
+    readonly setPrivacySetting: <S extends WaPrivacySettingName>(
+        setting: S,
+        value: WaPrivacySettingValueMap[S]
+    ) => Promise<void>
+    readonly getDisallowedList: (
+        category: WaPrivacyDisallowedListSettingName
+    ) => Promise<WaPrivacyDisallowedListResult>
+    readonly getBlocklist: () => Promise<WaBlocklistResult>
+    readonly blockUser: (jid: string) => Promise<void>
+    readonly unblockUser: (jid: string) => Promise<void>
+}
+
+interface WaPrivacyCoordinatorOptions {
+    readonly queryWithContext: (
+        context: string,
+        node: BinaryNode,
+        timeoutMs?: number,
+        contextData?: Readonly<Record<string, unknown>>
+    ) => Promise<BinaryNode>
+}
+
+const IGNORED_SERVER_CATEGORIES = new Set([
+    'pix',
+    'linked_profiles',
+    'stickers',
+    'dependentaccountmessages',
+    'cover_photo',
+    'dependent_account_calling',
+    'groupcreation'
+])
+
+function isValidPrivacyValue(value: string): value is WaPrivacyValue {
+    return (
+        value !== WA_PRIVACY_VALUES.ERROR &&
+        Object.values(WA_PRIVACY_VALUES).includes(value as WaPrivacyValue)
+    )
+}
+
+function parsePrivacySettings(result: BinaryNode): WaPrivacySettings {
+    const privacyNode = findNodeChild(result, 'privacy')
+    if (!privacyNode) {
+        return {}
+    }
+
+    const settings: Record<string, WaPrivacyValue> = {}
+    const categories = getNodeChildrenByTag(privacyNode, WA_PRIVACY_TAGS.CATEGORY)
+
+    for (let i = 0; i < categories.length; i += 1) {
+        const node = categories[i]
+        const name = node.attrs.name as string | undefined
+        const value = node.attrs.value as string | undefined
+
+        if (!name || !value) {
+            continue
+        }
+        if (IGNORED_SERVER_CATEGORIES.has(name)) {
+            continue
+        }
+        if (!isValidPrivacyValue(value)) {
+            continue
+        }
+
+        const settingName = (WA_PRIVACY_CATEGORY_TO_SETTING as Record<string, string | undefined>)[
+            name
+        ]
+        if (settingName) {
+            settings[settingName] = value
+        }
+    }
+
+    return settings as WaPrivacySettings
+}
+
+function parseDisallowedList(result: BinaryNode): WaPrivacyDisallowedListResult {
+    const privacyNode = findNodeChild(result, 'privacy')
+    if (!privacyNode) {
+        return { jids: [] }
+    }
+
+    const listNode = findNodeChild(privacyNode, WA_PRIVACY_TAGS.LIST)
+    if (!listNode) {
+        return { jids: [] }
+    }
+
+    const dhash = listNode.attrs.dhash as string | undefined
+    const userNodes = getNodeChildrenByTag(listNode, WA_PRIVACY_TAGS.USER)
+    const jids = new Array<string>(userNodes.length)
+    let jidsCount = 0
+
+    for (let i = 0; i < userNodes.length; i += 1) {
+        const jid = userNodes[i].attrs.jid as string | undefined
+        if (jid) {
+            jids[jidsCount] = jid
+            jidsCount += 1
+        }
+    }
+    jids.length = jidsCount
+
+    return { jids, dhash }
+}
+
+function parseBlocklist(result: BinaryNode): WaBlocklistResult {
+    const listNode = findNodeChild(result, 'list')
+    if (!listNode) {
+        return { jids: [] }
+    }
+
+    const dhash = listNode.attrs.dhash as string | undefined
+    const itemNodes = getNodeChildren(listNode)
+    const jids = new Array<string>(itemNodes.length)
+    let jidsCount = 0
+
+    for (let i = 0; i < itemNodes.length; i += 1) {
+        const jid = itemNodes[i].attrs.jid as string | undefined
+        if (jid) {
+            jids[jidsCount] = jid
+            jidsCount += 1
+        }
+    }
+    jids.length = jidsCount
+
+    return { jids, dhash }
+}
+
+export function createPrivacyCoordinator(
+    options: WaPrivacyCoordinatorOptions
+): WaPrivacyCoordinator {
+    const { queryWithContext } = options
+
+    return {
+        getPrivacySettings: async () => {
+            const node = buildGetPrivacySettingsIq()
+            const result = await queryWithContext('privacy.getSettings', node)
+            assertIqResult(result, 'privacy.getSettings')
+            return parsePrivacySettings(result)
+        },
+
+        setPrivacySetting: async (setting, value) => {
+            const category: WaPrivacyCategory = WA_PRIVACY_SETTING_TO_CATEGORY[setting]
+            const node = buildSetPrivacyCategoryIq(category, value)
+            const result = await queryWithContext('privacy.setSetting', node, undefined, {
+                category,
+                value
+            })
+            assertIqResult(result, 'privacy.setSetting')
+        },
+
+        getDisallowedList: async (setting) => {
+            const category: WaPrivacyCategory = WA_PRIVACY_SETTING_TO_CATEGORY[setting]
+            const node = buildGetPrivacyDisallowedListIq(category)
+            const result = await queryWithContext('privacy.getDisallowedList', node, undefined, {
+                category
+            })
+            assertIqResult(result, 'privacy.getDisallowedList')
+            return parseDisallowedList(result)
+        },
+
+        getBlocklist: async () => {
+            const node = buildGetBlocklistIq()
+            const result = await queryWithContext('privacy.getBlocklist', node)
+            assertIqResult(result, 'privacy.getBlocklist')
+            return parseBlocklist(result)
+        },
+
+        blockUser: async (jid) => {
+            const node = buildBlocklistChangeIq(jid, 'block')
+            const result = await queryWithContext('privacy.blockUser', node, undefined, { jid })
+            assertIqResult(result, 'privacy.blockUser')
+        },
+
+        unblockUser: async (jid) => {
+            const node = buildBlocklistChangeIq(jid, 'unblock')
+            const result = await queryWithContext('privacy.unblockUser', node, undefined, { jid })
+            assertIqResult(result, 'privacy.unblockUser')
+        }
+    }
+}

--- a/src/client/coordinators/__tests__/privacy-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/privacy-coordinator.test.ts
@@ -1,0 +1,212 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordinator'
+import { WA_PRIVACY_CATEGORIES, WA_PRIVACY_TAGS } from '@protocol/constants'
+import type { BinaryNode } from '@transport/types'
+
+function createIqResult(content?: readonly BinaryNode[]): BinaryNode {
+    return {
+        tag: 'iq',
+        attrs: { type: 'result' },
+        content
+    }
+}
+
+test('privacy coordinator parses settings and ignores error/ignored categories', async () => {
+    const calls: Array<{
+        readonly context: string
+        readonly node: BinaryNode
+        readonly contextData?: Readonly<Record<string, unknown>>
+    }> = []
+
+    const coordinator = createPrivacyCoordinator({
+        queryWithContext: async (context, node, _timeoutMs, contextData) => {
+            calls.push({ context, node, contextData })
+            return createIqResult([
+                {
+                    tag: 'privacy',
+                    attrs: {},
+                    content: [
+                        {
+                            tag: WA_PRIVACY_TAGS.CATEGORY,
+                            attrs: { name: WA_PRIVACY_CATEGORIES.READ_RECEIPTS, value: 'all' }
+                        },
+                        {
+                            tag: WA_PRIVACY_TAGS.CATEGORY,
+                            attrs: { name: WA_PRIVACY_CATEGORIES.LAST_SEEN, value: 'contacts' }
+                        },
+                        {
+                            tag: WA_PRIVACY_TAGS.CATEGORY,
+                            attrs: { name: WA_PRIVACY_CATEGORIES.CALL_ADD, value: 'known' }
+                        },
+                        {
+                            tag: WA_PRIVACY_TAGS.CATEGORY,
+                            attrs: {
+                                name: WA_PRIVACY_CATEGORIES.DEFENSE_MODE,
+                                value: 'on_standard'
+                            }
+                        },
+                        {
+                            tag: WA_PRIVACY_TAGS.CATEGORY,
+                            attrs: { name: WA_PRIVACY_CATEGORIES.GROUP_ADD, value: 'error' }
+                        },
+                        {
+                            tag: WA_PRIVACY_TAGS.CATEGORY,
+                            attrs: { name: 'pix', value: 'all' }
+                        }
+                    ]
+                }
+            ])
+        }
+    })
+
+    const settings = await coordinator.getPrivacySettings()
+
+    assert.deepEqual(settings, {
+        readReceipts: 'all',
+        lastSeen: 'contacts',
+        callAdd: 'known',
+        defenseMode: 'on_standard'
+    })
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].context, 'privacy.getSettings')
+    assert.equal(calls[0].node.attrs.type, 'get')
+    assert.equal(calls[0].node.attrs.xmlns, 'privacy')
+})
+
+test('privacy coordinator maps setting/category for set and disallowed list queries', async () => {
+    const calls: Array<{
+        readonly context: string
+        readonly node: BinaryNode
+        readonly contextData?: Readonly<Record<string, unknown>>
+    }> = []
+
+    const coordinator = createPrivacyCoordinator({
+        queryWithContext: async (context, node, _timeoutMs, contextData) => {
+            calls.push({ context, node, contextData })
+            if (context === 'privacy.getDisallowedList') {
+                return createIqResult([
+                    {
+                        tag: 'privacy',
+                        attrs: {},
+                        content: [
+                            {
+                                tag: WA_PRIVACY_TAGS.LIST,
+                                attrs: { dhash: 'dhash-1' },
+                                content: [
+                                    {
+                                        tag: WA_PRIVACY_TAGS.USER,
+                                        attrs: { jid: 'a@s.whatsapp.net' }
+                                    },
+                                    {
+                                        tag: WA_PRIVACY_TAGS.USER,
+                                        attrs: { jid: 'b@s.whatsapp.net' }
+                                    },
+                                    { tag: WA_PRIVACY_TAGS.USER, attrs: {} }
+                                ]
+                            }
+                        ]
+                    }
+                ])
+            }
+            return createIqResult()
+        }
+    })
+
+    await coordinator.setPrivacySetting('readReceipts', 'none')
+    const disallowed = await coordinator.getDisallowedList('about')
+
+    assert.deepEqual(disallowed, {
+        jids: ['a@s.whatsapp.net', 'b@s.whatsapp.net'],
+        dhash: 'dhash-1'
+    })
+
+    assert.equal(calls.length, 2)
+    assert.equal(calls[0].context, 'privacy.setSetting')
+    assert.deepEqual(calls[0].contextData, {
+        category: WA_PRIVACY_CATEGORIES.READ_RECEIPTS,
+        value: 'none'
+    })
+    assert.ok(Array.isArray(calls[0].node.content))
+    if (!Array.isArray(calls[0].node.content)) {
+        throw new Error('expected set privacy node content array')
+    }
+    assert.equal(calls[0].node.content[0].tag, 'privacy')
+    assert.ok(Array.isArray(calls[0].node.content[0].content))
+    if (!Array.isArray(calls[0].node.content[0].content)) {
+        throw new Error('expected set privacy category content array')
+    }
+    assert.equal(
+        calls[0].node.content[0].content[0].attrs.name,
+        WA_PRIVACY_CATEGORIES.READ_RECEIPTS
+    )
+    assert.equal(calls[0].node.content[0].content[0].attrs.value, 'none')
+
+    assert.equal(calls[1].context, 'privacy.getDisallowedList')
+    assert.deepEqual(calls[1].contextData, {
+        category: WA_PRIVACY_CATEGORIES.ABOUT
+    })
+    assert.ok(Array.isArray(calls[1].node.content))
+    if (!Array.isArray(calls[1].node.content)) {
+        throw new Error('expected disallowed list query content array')
+    }
+    assert.ok(Array.isArray(calls[1].node.content[0].content))
+    if (!Array.isArray(calls[1].node.content[0].content)) {
+        throw new Error('expected disallowed list payload content array')
+    }
+    assert.equal(calls[1].node.content[0].content[0].attrs.name, WA_PRIVACY_CATEGORIES.ABOUT)
+    assert.equal(calls[1].node.content[0].content[0].attrs.value, 'contact_blacklist')
+})
+
+test('privacy coordinator parses blocklist and sends block/unblock actions', async () => {
+    const calls: Array<{
+        readonly context: string
+        readonly node: BinaryNode
+        readonly contextData?: Readonly<Record<string, unknown>>
+    }> = []
+
+    const coordinator = createPrivacyCoordinator({
+        queryWithContext: async (context, node, _timeoutMs, contextData) => {
+            calls.push({ context, node, contextData })
+            if (context === 'privacy.getBlocklist') {
+                return createIqResult([
+                    {
+                        tag: 'list',
+                        attrs: { dhash: 'block-hash' },
+                        content: [
+                            { tag: 'item', attrs: { jid: 'x@s.whatsapp.net' } },
+                            { tag: 'item', attrs: { jid: 'y@s.whatsapp.net' } },
+                            { tag: 'item', attrs: {} }
+                        ]
+                    }
+                ])
+            }
+            return createIqResult()
+        }
+    })
+
+    const blocklist = await coordinator.getBlocklist()
+    await coordinator.blockUser('123@s.whatsapp.net')
+    await coordinator.unblockUser('123@s.whatsapp.net')
+
+    assert.deepEqual(blocklist, {
+        jids: ['x@s.whatsapp.net', 'y@s.whatsapp.net'],
+        dhash: 'block-hash'
+    })
+    assert.equal(calls.length, 3)
+    assert.equal(calls[0].context, 'privacy.getBlocklist')
+    assert.equal(calls[1].context, 'privacy.blockUser')
+    assert.deepEqual(calls[1].contextData, { jid: '123@s.whatsapp.net' })
+    assert.ok(Array.isArray(calls[1].node.content))
+    if (!Array.isArray(calls[1].node.content)) {
+        throw new Error('expected blocklist change content array')
+    }
+    assert.equal(calls[1].node.content[0].attrs.action, 'block')
+    assert.equal(calls[2].context, 'privacy.unblockUser')
+    assert.ok(Array.isArray(calls[2].node.content))
+    if (!Array.isArray(calls[2].node.content)) {
+        throw new Error('expected unblock content array')
+    }
+    assert.equal(calls[2].node.content[0].attrs.action, 'unblock')
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,12 @@ export type {
     WaHistorySyncOptions,
     WaWriteBehindOptions
 } from '@client'
+export type {
+    WaBlocklistResult,
+    WaPrivacyCoordinator,
+    WaPrivacyDisallowedListResult,
+    WaPrivacySettings
+} from '@client/coordinators/WaPrivacyCoordinator'
 export { ConsoleLogger } from '@infra/log/ConsoleLogger'
 export { PinoLogger, createPinoLogger } from '@infra/log/PinoLogger'
 export type { PinoLoggerOptions } from '@infra/log/PinoLogger'
@@ -78,6 +84,13 @@ export {
     WA_SIGNALING,
     WA_STREAM_SIGNALING,
     WA_SUPPORTED_DIRTY_TYPES,
+    WA_PRIVACY_CATEGORIES,
+    WA_PRIVACY_CATEGORY_TO_SETTING,
+    WA_PRIVACY_DISALLOWED_LIST_CATEGORIES,
+    WA_PRIVACY_SETTING_TO_CATEGORY,
+    WA_PRIVACY_TAGS,
+    WA_PRIVACY_VALUES,
     WA_XMLNS
 } from '@protocol'
+export type { WaPrivacyCategory, WaPrivacySettingName, WaPrivacyValue } from '@protocol'
 export { proto } from '@proto'

--- a/src/protocol/__tests__/protocol.test.ts
+++ b/src/protocol/__tests__/protocol.test.ts
@@ -6,6 +6,11 @@ import {
     getWaCompanionPlatformId,
     WA_COMPANION_PLATFORM_IDS,
     WA_DEFAULTS,
+    WA_PRIVACY_CATEGORIES,
+    WA_PRIVACY_CATEGORY_TO_SETTING,
+    WA_PRIVACY_DISALLOWED_LIST_CATEGORIES,
+    WA_PRIVACY_SETTING_TO_CATEGORY,
+    WA_PRIVACY_VALUES,
     WA_MEDIA_HKDF_INFO,
     getWaMediaHkdfInfo
 } from '@protocol/constants'
@@ -27,6 +32,10 @@ import {
     splitJid,
     toUserJid
 } from '@protocol/jid'
+import type {
+    WaPrivacyDisallowedListSettingName,
+    WaPrivacySettingValueMap
+} from '@protocol/privacy'
 
 test('jid split and normalization helpers', () => {
     assert.deepEqual(splitJid('123@s.whatsapp.net'), {
@@ -119,4 +128,25 @@ test('login identity parsing and protocol constants', () => {
     assert.equal(WA_APP_STATE_CHAT_MUTATION_SPECS.MUTE.action, 'mute')
     assert.equal(WA_APP_STATE_CHAT_MUTATION_SPECS.DELETE_MESSAGE_FOR_ME.version, 3)
     assert.equal(WA_APP_STATE_CHAT_MUTATION_SPECS.LOCK_CHAT.version, 7)
+})
+
+test('privacy protocol constants keep mapping invariants', () => {
+    const disallowedSettingsTypeCheck: Record<WaPrivacyDisallowedListSettingName, true> = {
+        about: true,
+        groupAdd: true,
+        lastSeen: true,
+        profilePicture: true
+    }
+    const validGroupAddValue: WaPrivacySettingValueMap['groupAdd'] = 'contact_blacklist'
+    void disallowedSettingsTypeCheck
+    void validGroupAddValue
+
+    assert.equal(WA_PRIVACY_VALUES.ERROR, 'error')
+    assert.equal(WA_PRIVACY_SETTING_TO_CATEGORY.groupAdd, WA_PRIVACY_CATEGORIES.GROUP_ADD)
+    assert.equal(WA_PRIVACY_CATEGORY_TO_SETTING[WA_PRIVACY_CATEGORIES.GROUP_ADD], 'groupAdd')
+
+    const disallowedSettings = Object.values(WA_PRIVACY_DISALLOWED_LIST_CATEGORIES).map(
+        (category) => WA_PRIVACY_CATEGORY_TO_SETTING[category]
+    )
+    assert.deepEqual(disallowedSettings.sort(), ['about', 'groupAdd', 'lastSeen', 'profilePicture'])
 })

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -40,6 +40,15 @@ export {
     WA_PRIVACY_TOKEN_TYPES,
     WA_TC_TOKEN_DEFAULTS
 } from '@protocol/privacy-token'
+export {
+    WA_PRIVACY_CATEGORIES,
+    WA_PRIVACY_CATEGORY_TO_SETTING,
+    WA_PRIVACY_DISALLOWED_LIST_CATEGORIES,
+    WA_PRIVACY_SETTING_TO_CATEGORY,
+    WA_PRIVACY_TAGS,
+    WA_PRIVACY_VALUES
+} from '@protocol/privacy'
+export type { WaPrivacyCategory, WaPrivacySettingName, WaPrivacyValue } from '@protocol/privacy'
 export { WA_DEFAULTS } from '@protocol/defaults'
 export { WA_GROUP_PARTICIPANT_TYPES, type WaGroupSetting } from '@protocol/group'
 export { WA_USYNC_CONTEXTS, WA_USYNC_DEFAULTS, WA_USYNC_MODES } from '@protocol/usync'

--- a/src/protocol/privacy.ts
+++ b/src/protocol/privacy.ts
@@ -1,0 +1,87 @@
+export const WA_PRIVACY_CATEGORIES = Object.freeze({
+    READ_RECEIPTS: 'readreceipts',
+    LAST_SEEN: 'last',
+    ONLINE: 'online',
+    PROFILE_PICTURE: 'profile',
+    ABOUT: 'status',
+    GROUP_ADD: 'groupadd',
+    CALL_ADD: 'calladd',
+    MESSAGES: 'messages',
+    DEFENSE_MODE: 'defense'
+} as const)
+
+export type WaPrivacyCategory = (typeof WA_PRIVACY_CATEGORIES)[keyof typeof WA_PRIVACY_CATEGORIES]
+
+export const WA_PRIVACY_VALUES = Object.freeze({
+    ALL: 'all',
+    CONTACTS: 'contacts',
+    CONTACT_BLACKLIST: 'contact_blacklist',
+    NONE: 'none',
+    MATCH_LAST_SEEN: 'match_last_seen',
+    KNOWN: 'known',
+    OFF: 'off',
+    ON_STANDARD: 'on_standard',
+    ERROR: 'error'
+} as const)
+
+export type WaPrivacyValue = (typeof WA_PRIVACY_VALUES)[keyof typeof WA_PRIVACY_VALUES]
+
+export const WA_PRIVACY_CATEGORY_TO_SETTING = Object.freeze({
+    [WA_PRIVACY_CATEGORIES.READ_RECEIPTS]: 'readReceipts',
+    [WA_PRIVACY_CATEGORIES.LAST_SEEN]: 'lastSeen',
+    [WA_PRIVACY_CATEGORIES.ONLINE]: 'online',
+    [WA_PRIVACY_CATEGORIES.PROFILE_PICTURE]: 'profilePicture',
+    [WA_PRIVACY_CATEGORIES.ABOUT]: 'about',
+    [WA_PRIVACY_CATEGORIES.GROUP_ADD]: 'groupAdd',
+    [WA_PRIVACY_CATEGORIES.CALL_ADD]: 'callAdd',
+    [WA_PRIVACY_CATEGORIES.MESSAGES]: 'messages',
+    [WA_PRIVACY_CATEGORIES.DEFENSE_MODE]: 'defenseMode'
+} as const)
+
+export const WA_PRIVACY_SETTING_TO_CATEGORY = Object.freeze({
+    readReceipts: WA_PRIVACY_CATEGORIES.READ_RECEIPTS,
+    lastSeen: WA_PRIVACY_CATEGORIES.LAST_SEEN,
+    online: WA_PRIVACY_CATEGORIES.ONLINE,
+    profilePicture: WA_PRIVACY_CATEGORIES.PROFILE_PICTURE,
+    about: WA_PRIVACY_CATEGORIES.ABOUT,
+    groupAdd: WA_PRIVACY_CATEGORIES.GROUP_ADD,
+    callAdd: WA_PRIVACY_CATEGORIES.CALL_ADD,
+    messages: WA_PRIVACY_CATEGORIES.MESSAGES,
+    defenseMode: WA_PRIVACY_CATEGORIES.DEFENSE_MODE
+} as const)
+
+export type WaPrivacySettingName = keyof typeof WA_PRIVACY_SETTING_TO_CATEGORY
+
+export type WaPrivacyVisibility = 'all' | 'contacts' | 'contact_blacklist' | 'none'
+
+export interface WaPrivacySettingValueMap {
+    readonly readReceipts: 'all' | 'none'
+    readonly lastSeen: WaPrivacyVisibility
+    readonly online: 'all' | 'none' | 'match_last_seen'
+    readonly profilePicture: WaPrivacyVisibility
+    readonly about: WaPrivacyVisibility
+    readonly groupAdd: 'all' | 'contacts' | 'contact_blacklist'
+    readonly callAdd: 'all' | 'known' | 'contacts'
+    readonly messages: 'all' | 'contacts'
+    readonly defenseMode: 'off' | 'on_standard'
+}
+
+export const WA_PRIVACY_DISALLOWED_LIST_CATEGORIES = Object.freeze({
+    ABOUT: WA_PRIVACY_CATEGORIES.ABOUT,
+    GROUP_ADD: WA_PRIVACY_CATEGORIES.GROUP_ADD,
+    LAST_SEEN: WA_PRIVACY_CATEGORIES.LAST_SEEN,
+    PROFILE_PICTURE: WA_PRIVACY_CATEGORIES.PROFILE_PICTURE
+} as const)
+
+type DisallowedCategoryToSetting = {
+    readonly [K in keyof typeof WA_PRIVACY_DISALLOWED_LIST_CATEGORIES]: (typeof WA_PRIVACY_CATEGORY_TO_SETTING)[(typeof WA_PRIVACY_DISALLOWED_LIST_CATEGORIES)[K]]
+}
+
+export type WaPrivacyDisallowedListSettingName =
+    DisallowedCategoryToSetting[keyof DisallowedCategoryToSetting]
+
+export const WA_PRIVACY_TAGS = Object.freeze({
+    CATEGORY: 'category',
+    LIST: 'list',
+    USER: 'user'
+} as const)

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -4,8 +4,11 @@ import test from 'node:test'
 import {
     WA_DEFAULTS,
     WA_NODE_TAGS,
+    WA_PRIVACY_CATEGORIES,
+    WA_PRIVACY_TAGS,
     WA_PRIVACY_TOKEN_TAGS,
     WA_PRIVACY_TOKEN_TYPES,
+    WA_XMLNS,
     WA_USYNC_CONTEXTS,
     WA_USYNC_MODES
 } from '@protocol/constants'
@@ -36,6 +39,13 @@ import {
     buildGroupRetryMessageNode
 } from '@transport/node/builders/message'
 import { buildMissingPreKeysFetchIq, buildPreKeyUploadIq } from '@transport/node/builders/prekeys'
+import {
+    buildBlocklistChangeIq,
+    buildGetBlocklistIq,
+    buildGetPrivacyDisallowedListIq,
+    buildGetPrivacySettingsIq,
+    buildSetPrivacyCategoryIq
+} from '@transport/node/builders/privacy'
 import {
     buildCsTokenMessageNode,
     buildPrivacyTokenIqNode,
@@ -360,6 +370,65 @@ test('privacy token builders create iq and message token nodes', () => {
     const csNode = buildCsTokenMessageNode(new Uint8Array([8]))
     assert.equal(csNode.tag, WA_PRIVACY_TOKEN_TAGS.CS_TOKEN)
     assert.ok(csNode.content instanceof Uint8Array)
+})
+
+test('privacy builders generate expected iq payloads', () => {
+    const getSettings = buildGetPrivacySettingsIq()
+    assert.equal(getSettings.attrs.type, 'get')
+    assert.equal(getSettings.attrs.xmlns, WA_XMLNS.PRIVACY)
+    assert.ok(Array.isArray(getSettings.content))
+    if (!Array.isArray(getSettings.content)) {
+        throw new Error('expected get privacy settings content array')
+    }
+    assert.equal(getSettings.content[0].tag, WA_NODE_TAGS.PRIVACY)
+
+    const setCategory = buildSetPrivacyCategoryIq(WA_PRIVACY_CATEGORIES.ONLINE, 'match_last_seen')
+    assert.equal(setCategory.attrs.type, 'set')
+    assert.equal(setCategory.attrs.xmlns, WA_XMLNS.PRIVACY)
+    assert.ok(Array.isArray(setCategory.content))
+    if (!Array.isArray(setCategory.content)) {
+        throw new Error('expected set privacy category content array')
+    }
+    assert.equal(setCategory.content[0].tag, WA_NODE_TAGS.PRIVACY)
+    assert.ok(Array.isArray(setCategory.content[0].content))
+    if (!Array.isArray(setCategory.content[0].content)) {
+        throw new Error('expected set privacy category payload array')
+    }
+    assert.equal(setCategory.content[0].content[0].tag, WA_PRIVACY_TAGS.CATEGORY)
+    assert.equal(setCategory.content[0].content[0].attrs.name, WA_PRIVACY_CATEGORIES.ONLINE)
+    assert.equal(setCategory.content[0].content[0].attrs.value, 'match_last_seen')
+
+    const disallowed = buildGetPrivacyDisallowedListIq(WA_PRIVACY_CATEGORIES.ABOUT)
+    assert.equal(disallowed.attrs.type, 'get')
+    assert.equal(disallowed.attrs.xmlns, WA_XMLNS.PRIVACY)
+    assert.ok(Array.isArray(disallowed.content))
+    if (!Array.isArray(disallowed.content)) {
+        throw new Error('expected get disallowed list content array')
+    }
+    assert.equal(disallowed.content[0].tag, WA_NODE_TAGS.PRIVACY)
+    assert.ok(Array.isArray(disallowed.content[0].content))
+    if (!Array.isArray(disallowed.content[0].content)) {
+        throw new Error('expected get disallowed list payload array')
+    }
+    assert.equal(disallowed.content[0].content[0].tag, WA_PRIVACY_TAGS.LIST)
+    assert.equal(disallowed.content[0].content[0].attrs.name, WA_PRIVACY_CATEGORIES.ABOUT)
+    assert.equal(disallowed.content[0].content[0].attrs.value, 'contact_blacklist')
+
+    const blocklist = buildGetBlocklistIq()
+    assert.equal(blocklist.attrs.type, 'get')
+    assert.equal(blocklist.attrs.xmlns, WA_XMLNS.BLOCKLIST)
+    assert.equal(blocklist.content, undefined)
+
+    const block = buildBlocklistChangeIq('5511999999999@s.whatsapp.net', 'block')
+    assert.equal(block.attrs.type, 'set')
+    assert.equal(block.attrs.xmlns, WA_XMLNS.BLOCKLIST)
+    assert.ok(Array.isArray(block.content))
+    if (!Array.isArray(block.content)) {
+        throw new Error('expected blocklist change content array')
+    }
+    assert.equal(block.content[0].tag, 'item')
+    assert.equal(block.content[0].attrs.jid, '5511999999999@s.whatsapp.net')
+    assert.equal(block.content[0].attrs.action, 'block')
 })
 
 test('message builders cover group and inbound receipt branches', () => {

--- a/src/transport/node/builders/privacy.ts
+++ b/src/transport/node/builders/privacy.ts
@@ -1,0 +1,57 @@
+import { WA_DEFAULTS } from '@protocol/defaults'
+import { WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
+import { WA_PRIVACY_TAGS, type WaPrivacyCategory, type WaPrivacyValue } from '@protocol/privacy'
+import { buildIqNode } from '@transport/node/query'
+import type { BinaryNode } from '@transport/types'
+
+export function buildGetPrivacySettingsIq(): BinaryNode {
+    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PRIVACY, [
+        { tag: WA_NODE_TAGS.PRIVACY, attrs: {} }
+    ])
+}
+
+export function buildSetPrivacyCategoryIq(
+    category: WaPrivacyCategory,
+    value: WaPrivacyValue
+): BinaryNode {
+    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PRIVACY, [
+        {
+            tag: WA_NODE_TAGS.PRIVACY,
+            attrs: {},
+            content: [
+                {
+                    tag: WA_PRIVACY_TAGS.CATEGORY,
+                    attrs: { name: category, value }
+                }
+            ]
+        }
+    ])
+}
+
+export function buildGetPrivacyDisallowedListIq(category: WaPrivacyCategory): BinaryNode {
+    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PRIVACY, [
+        {
+            tag: WA_NODE_TAGS.PRIVACY,
+            attrs: {},
+            content: [
+                {
+                    tag: WA_PRIVACY_TAGS.LIST,
+                    attrs: { name: category, value: 'contact_blacklist' }
+                }
+            ]
+        }
+    ])
+}
+
+export function buildGetBlocklistIq(): BinaryNode {
+    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BLOCKLIST)
+}
+
+export function buildBlocklistChangeIq(jid: string, action: 'block' | 'unblock'): BinaryNode {
+    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BLOCKLIST, [
+        {
+            tag: 'item',
+            attrs: { jid, action }
+        }
+    ])
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-facing privacy management: view/update privacy settings, fetch disallowed lists, view/manage blocklist, and block/unblock contacts.

* **Refactor**
  * Reorganized client surface to expose coordinator-based privacy and chat/group accessors for cleaner modularity.

* **Chores**
  * Removed several legacy chat mutation APIs; use the new coordinator accessors instead.

* **Tests**
  * Added comprehensive tests for privacy constants, builders, coordinator behavior, and client exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->