### PR TITLE
feat: add message stanza attributes, ICDC device-list metadata, stream media uploads, and PTV support

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -565,6 +565,7 @@ export function buildWaClientDependencies(input: {
         senderKeyManager,
         signalProtocol,
         signalStore: sessionStore.signal,
+        deviceListStore: sessionStore.deviceList,
         getCurrentMeJid,
         getCurrentMeLid,
         getCurrentSignedIdentity,

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -6,8 +6,15 @@ import type { WaGroupEvent, WaSignalMessagePublishInput, WaSendMessageOptions } 
 import { randomBytesAsync, sha256 } from '@crypto'
 import type { Logger } from '@infra/log/types'
 import { ensureMessageSecret } from '@message'
-import { resolveMessageTypeAttr } from '@message/content'
+import {
+    resolveEditAttr,
+    resolveEncMediaType,
+    resolveMessageTypeAttr,
+    resolveMetaAttrs
+} from '@message/content'
 import { wrapDeviceSentMessage } from '@message/device-sent'
+import { injectDeviceListMetadata, resolveIcdcMeta } from '@message/icdc'
+import type { IcdcMeta } from '@message/icdc'
 import { writeRandomPadMax16 } from '@message/padding'
 import { computePhashV2 } from '@message/phash'
 import {
@@ -40,11 +47,13 @@ import type { SenderKeyManager } from '@signal/group/SenderKeyManager'
 import type { SignalResolvedSessionTarget, SignalSessionResolver } from '@signal/session/resolver'
 import type { SignalProtocol } from '@signal/session/SignalProtocol'
 import type { SignalAddress } from '@signal/types'
+import type { WaDeviceListStore } from '@store/contracts/device-list.store'
 import type { WaSignalStore } from '@store/contracts/signal.store'
 import { encodeBinaryNode } from '@transport/binary'
 import {
     buildDirectMessageFanoutNode,
-    buildGroupSenderKeyMessageNode
+    buildGroupSenderKeyMessageNode,
+    buildMetaNode
 } from '@transport/node/builders/message'
 import type { BinaryNode } from '@transport/types'
 import { bytesToHex, concatBytes, TEXT_ENCODER } from '@util/bytes'
@@ -62,6 +71,7 @@ interface WaMessageDispatchCoordinatorOptions {
     readonly senderKeyManager: SenderKeyManager
     readonly signalProtocol: SignalProtocol
     readonly signalStore: WaSignalStore
+    readonly deviceListStore: WaDeviceListStore
     readonly getCurrentMeJid: () => string | null | undefined
     readonly getCurrentMeLid: () => string | null | undefined
     readonly getCurrentSignedIdentity: () => Proto.IADVSignedDeviceIdentity | null | undefined
@@ -89,6 +99,7 @@ export class WaMessageDispatchCoordinator {
     private readonly senderKeyManager: SenderKeyManager
     private readonly signalProtocol: SignalProtocol
     private readonly signalStore: WaSignalStore
+    private readonly deviceListStore: WaDeviceListStore
     private readonly getCurrentMeJid: () => string | null | undefined
     private readonly getCurrentMeLid: () => string | null | undefined
     private readonly getCurrentSignedIdentity: () =>
@@ -110,6 +121,7 @@ export class WaMessageDispatchCoordinator {
         this.senderKeyManager = options.senderKeyManager
         this.signalProtocol = options.signalProtocol
         this.signalStore = options.signalStore
+        this.deviceListStore = options.deviceListStore
         this.getCurrentMeJid = options.getCurrentMeJid
         this.getCurrentMeLid = options.getCurrentMeLid
         this.getCurrentSignedIdentity = options.getCurrentSignedIdentity
@@ -243,37 +255,71 @@ export class WaMessageDispatchCoordinator {
             this.withResolvedMessageId(options)
         ])
         const messageWithSecret = await ensureMessageSecret(message)
-        const plaintext = await writeRandomPadMax16(
-            proto.Message.encode(messageWithSecret).finish()
-        )
-        const type = resolveMessageTypeAttr(messageWithSecret)
 
-        if (isGroupJid(recipientJid)) {
-            if (this.shouldUseGroupDirectPath(messageWithSecret)) {
+        const meJid = this.getCurrentMeJid()
+        const regInfo = meJid ? await this.signalStore.getRegistrationInfo() : null
+        const localPubKey = regInfo?.identityKeyPair.pubKey
+        const meUserJid = meJid ? toUserJid(meJid) : undefined
+        const localIdentity =
+            meJid && localPubKey
+                ? { address: parseSignalAddressFromJid(meJid), pubKey: localPubKey }
+                : undefined
+        const isGroup = isGroupJid(recipientJid)
+
+        const [senderIcdc, recipientIcdc] = await Promise.all([
+            meUserJid ? this.resolveUserIcdc(meUserJid, localIdentity) : null,
+            !isGroup ? this.resolveUserIcdc(toUserJid(recipientJid)) : null
+        ])
+        const messageWithIcdc = injectDeviceListMetadata(
+            messageWithSecret,
+            senderIcdc,
+            recipientIcdc
+        )
+
+        const plaintext = await writeRandomPadMax16(proto.Message.encode(messageWithIcdc).finish())
+        const type = resolveMessageTypeAttr(messageWithIcdc)
+        const edit = resolveEditAttr(messageWithIcdc, sendOptions.subtype) ?? undefined
+        const mediatype = resolveEncMediaType(messageWithIcdc) ?? undefined
+        const metaAttrs = resolveMetaAttrs(messageWithIcdc)
+        const metaNode = metaAttrs ? buildMetaNode(metaAttrs as Record<string, string>) : undefined
+
+        if (isGroup) {
+            if (this.shouldUseGroupDirectPath(messageWithIcdc)) {
                 return this.publishGroupDirectMessage(
                     recipientJid,
-                    messageWithSecret,
+                    messageWithIcdc,
                     plaintext,
                     type,
-                    sendOptions
+                    sendOptions,
+                    {},
+                    edit,
+                    mediatype,
+                    metaNode
                 )
             }
             return this.publishGroupSenderKeyMessage(
                 recipientJid,
-                messageWithSecret,
+                messageWithIcdc,
                 plaintext,
                 type,
-                sendOptions
+                sendOptions,
+                {},
+                edit,
+                mediatype,
+                metaNode
             )
         }
 
         const directRecipientJid = toUserJid(recipientJid)
         return this.publishDirectSignalMessageWithFanout(
             directRecipientJid,
-            messageWithSecret,
+            messageWithIcdc,
             plaintext,
             type,
-            sendOptions
+            sendOptions,
+            edit,
+            mediatype,
+            metaNode
         )
     }
 
@@ -324,7 +370,10 @@ export class WaMessageDispatchCoordinator {
         plaintext: Uint8Array,
         type: string,
         options: WaSendMessageOptions,
-        retryContext: GroupSendRetryContext = {}
+        retryContext: GroupSendRetryContext = {},
+        edit?: string,
+        mediatype?: string,
+        metaNode?: BinaryNode
     ): Promise<WaMessagePublishResult> {
         const sendOptions = await this.withResolvedMessageId(options)
         const meJid = this.requireCurrentMeJid('sendMessage')
@@ -403,13 +452,16 @@ export class WaMessageDispatchCoordinator {
             to: groupJid,
             type,
             id: sendOptions.id,
+            edit,
             phash: localPhash,
             addressingMode,
             participants,
             deviceIdentity: shouldAttachDeviceIdentity
                 ? this.getEncodedSignedDeviceIdentity()
                 : undefined,
-            reportingNode: reportingArtifacts?.node ?? undefined
+            reportingNode: reportingArtifacts?.node ?? undefined,
+            metaNode,
+            mediatype
         })
         const replayPayload: WaRetryReplayPayload = {
             mode: 'plaintext',
@@ -460,7 +512,10 @@ export class WaMessageDispatchCoordinator {
                     retried: true,
                     forceRefreshParticipants: true,
                     forceAddressingMode: serverAddressingMode
-                }
+                },
+                edit,
+                mediatype,
+                metaNode
             )
         }
         return result
@@ -472,7 +527,10 @@ export class WaMessageDispatchCoordinator {
         plaintext: Uint8Array,
         type: string,
         options: WaSendMessageOptions,
-        retryContext: GroupSendRetryContext = {}
+        retryContext: GroupSendRetryContext = {},
+        edit?: string,
+        mediatype?: string,
+        metaNode?: BinaryNode
     ): Promise<WaMessagePublishResult> {
         const sendOptions = await this.withResolvedMessageId(options)
         const meJid = this.requireCurrentMeJid('sendMessage')
@@ -522,6 +580,7 @@ export class WaMessageDispatchCoordinator {
             to: groupJid,
             type,
             id: sendOptions.id,
+            edit,
             phash: localPhash,
             addressingMode,
             groupCiphertext: groupCiphertext.ciphertext,
@@ -529,7 +588,9 @@ export class WaMessageDispatchCoordinator {
             deviceIdentity: shouldAttachDeviceIdentity
                 ? this.getEncodedSignedDeviceIdentity()
                 : undefined,
-            reportingNode: reportingArtifacts?.node ?? undefined
+            reportingNode: reportingArtifacts?.node ?? undefined,
+            metaNode,
+            mediatype
         })
 
         const replayPayload: WaRetryReplayPayload = {
@@ -598,7 +659,10 @@ export class WaMessageDispatchCoordinator {
                     retried: true,
                     forceRefreshParticipants: true,
                     forceAddressingMode: serverAddressingMode
-                }
+                },
+                edit,
+                mediatype,
+                metaNode
             )
         }
         return result
@@ -814,7 +878,10 @@ export class WaMessageDispatchCoordinator {
         message: Proto.IMessage,
         plaintext: Uint8Array,
         type: string,
-        options: WaSendMessageOptions
+        options: WaSendMessageOptions,
+        edit?: string,
+        mediatype?: string,
+        metaNode?: BinaryNode
     ): Promise<WaMessagePublishResult> {
         const sendOptions = await this.withResolvedMessageId(options)
         const meJid = this.requireCurrentMeJid('sendMessage')
@@ -980,10 +1047,13 @@ export class WaMessageDispatchCoordinator {
             to: recipientJid,
             type,
             id: sendOptions.id,
+            edit,
             participants,
             deviceIdentity,
             reportingNode: reportingArtifacts?.node ?? undefined,
-            privacyTokenNode
+            privacyTokenNode,
+            metaNode,
+            mediatype
         })
 
         const replayPayload: WaRetryReplayPayload = {
@@ -1087,6 +1157,31 @@ export class WaMessageDispatchCoordinator {
             throw new Error('missing signed identity for pkmsg fanout')
         }
         return proto.ADVSignedDeviceIdentity.encode(signedIdentity).finish()
+    }
+
+    private async resolveUserIcdc(
+        userJid: string,
+        localIdentity?: { readonly address: SignalAddress; readonly pubKey: Uint8Array }
+    ): Promise<IcdcMeta | null> {
+        try {
+            const snapshots = await this.deviceListStore.getUserDevicesBatch([userJid])
+            const snapshot = snapshots[0]
+            if (!snapshot || snapshot.deviceJids.length === 0) {
+                return null
+            }
+            return resolveIcdcMeta(
+                snapshot.deviceJids,
+                this.signalStore,
+                snapshot.updatedAtMs,
+                localIdentity
+            )
+        } catch (error) {
+            this.logger.trace('icdc resolution failed', {
+                userJid,
+                message: toError(error).message
+            })
+            return null
+        }
     }
 
     private requireCurrentMeJid(context: string): string {

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -118,6 +118,7 @@ function createMessageDispatchCoordinator(
         senderKeyManager: {} as never,
         signalProtocol: {} as never,
         signalStore: {} as never,
+        deviceListStore: {} as never,
         getCurrentMeJid: () => null,
         getCurrentMeLid: () => null,
         getCurrentSignedIdentity: () => null,

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -1,7 +1,10 @@
+import { createReadStream } from 'node:fs'
+import type { Readable } from 'node:stream'
+
 import type { Logger } from '@infra/log/types'
 import { parseMediaConnResponse } from '@media/conn'
 import { MEDIA_CONN_CACHE_GRACE_MS, MEDIA_UPLOAD_PATHS } from '@media/constants'
-import type { WaMediaConn } from '@media/types'
+import type { MediaCryptoType, WaMediaConn } from '@media/types'
 import { WaMediaCrypto } from '@media/WaMediaCrypto'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
 import { isSendMediaMessage } from '@message/content'
@@ -10,8 +13,7 @@ import type { Proto } from '@proto'
 import { WA_DEFAULTS } from '@protocol/constants'
 import { buildMediaConnIq } from '@transport/node/builders/media'
 import type { BinaryNode } from '@transport/types'
-import { bytesToBase64UrlSafe } from '@util/bytes'
-import { TEXT_DECODER, toBytesView } from '@util/bytes'
+import { bytesToBase64UrlSafe, TEXT_DECODER, toBytesView } from '@util/bytes'
 import { toError } from '@util/primitives'
 
 export interface WaMediaMessageOptions {
@@ -65,18 +67,34 @@ export async function getMediaConn(
     return mediaConn
 }
 
+function resolveUploadType(content: WaSendMediaMessage): MediaCryptoType {
+    if (content.type === 'video' && content.gifPlayback) return 'gif'
+    if (content.type === 'audio' && content.ptt) return 'ptt'
+    return content.type as MediaCryptoType
+}
+
+function isReadableStream(value: unknown): value is Readable {
+    return (
+        !!value &&
+        typeof value === 'object' &&
+        'pipe' in value &&
+        typeof (value as Readable).pipe === 'function'
+    )
+}
+
 async function buildMediaMessage(
     options: WaMediaMessageOptions,
     content: WaSendMediaMessage
 ): Promise<Proto.IMessage> {
-    const mediaBytes = toBytesView(content.media)
-    const uploaded = await uploadMedia(options, content, mediaBytes)
+    const uploaded = isReadableStream(content.media)
+        ? await uploadMediaStream(options, content, content.media)
+        : await uploadMediaBytes(options, content, toBytesView(content.media))
     const mediaKeyTimestamp = Math.floor(Date.now() / 1000)
     const common = {
         url: uploaded.url,
         mimetype: content.mimetype,
         fileSha256: uploaded.fileSha256,
-        fileLength: mediaBytes.byteLength,
+        fileLength: uploaded.fileLength,
         mediaKey: uploaded.mediaKey,
         fileEncSha256: uploaded.fileEncSha256,
         directPath: uploaded.directPath,
@@ -105,6 +123,15 @@ async function buildMediaMessage(
                     metadataUrl: uploaded.metadataUrl
                 }
             }
+        case 'ptv':
+            return {
+                ptvMessage: {
+                    ...common,
+                    seconds: content.seconds,
+                    width: content.width,
+                    height: content.height
+                }
+            }
         case 'audio':
             return {
                 audioMessage: {
@@ -131,38 +158,86 @@ async function buildMediaMessage(
                 }
             }
         default:
-            throw new Error(`unsupported media type: ${(content as { type: string }).type}`)
+            throw new Error(
+                `unsupported media message type: ${String((content as Record<string, unknown>).type)}`
+            )
     }
 }
 
-async function uploadMedia(
-    options: WaMediaMessageOptions,
-    content: WaSendMediaMessage,
-    mediaBytes: Uint8Array
-): Promise<{
+interface UploadResult {
     readonly url: string
     readonly directPath: string
     readonly mediaKey: Uint8Array
     readonly fileSha256: Uint8Array
     readonly fileEncSha256: Uint8Array
+    readonly fileLength: number
     readonly metadataUrl?: string
-}> {
+}
+
+function buildUploadUrl(
+    host: string,
+    uploadType: MediaCryptoType,
+    auth: string,
+    fileEncSha256: Uint8Array
+): string {
+    const hashToken = bytesToBase64UrlSafe(fileEncSha256)
+    const uploadPath = MEDIA_UPLOAD_PATHS[uploadType as keyof typeof MEDIA_UPLOAD_PATHS]
+    if (!uploadPath) {
+        throw new Error(`unknown media upload type: ${String(uploadType)}`)
+    }
+    return `https://${host}${uploadPath}/${hashToken}?auth=${encodeURIComponent(auth)}&token=${encodeURIComponent(hashToken)}`
+}
+
+function parseUploadResponse(
+    body: Uint8Array,
+    status: number
+): {
+    readonly url: string
+    readonly directPath: string
+    readonly metadataUrl?: string
+} {
+    if (status < 200 || status >= 300) {
+        throw new Error(`media upload failed with status ${status}`)
+    }
+    let parsed: {
+        readonly url?: string
+        readonly direct_path?: string
+        readonly metadata_url?: string
+    }
+    try {
+        parsed = JSON.parse(TEXT_DECODER.decode(body)) as typeof parsed
+    } catch (error) {
+        throw new Error(`media upload returned invalid json: ${toError(error).message}`)
+    }
+    if (!parsed.url || !parsed.direct_path) {
+        throw new Error('media upload response missing url/direct_path')
+    }
+    return {
+        url: parsed.url,
+        directPath: parsed.direct_path,
+        ...(parsed.metadata_url ? { metadataUrl: parsed.metadata_url } : {})
+    }
+}
+
+async function uploadMediaBytes(
+    options: WaMediaMessageOptions,
+    content: WaSendMediaMessage,
+    mediaBytes: Uint8Array
+): Promise<UploadResult> {
+    const uploadType = resolveUploadType(content)
     const mediaKey = await WaMediaCrypto.generateMediaKey()
-    const uploadType =
-        content.type === 'video' && content.gifPlayback
-            ? 'gif'
-            : content.type === 'audio' && content.ptt
-              ? 'ptt'
-              : content.type
     const [encrypted, mediaConn] = await Promise.all([
         WaMediaCrypto.encryptBytes(uploadType, mediaKey, mediaBytes),
         getMediaConn(options)
     ])
     const selectedHost =
         mediaConn.hosts.find((host) => !host.isFallback)?.hostname ?? mediaConn.hosts[0].hostname
-    const uploadPath = MEDIA_UPLOAD_PATHS[uploadType]
-    const hashToken = bytesToBase64UrlSafe(encrypted.fileEncSha256)
-    const uploadUrl = `https://${selectedHost}${uploadPath}/${hashToken}?auth=${encodeURIComponent(mediaConn.auth)}&token=${encodeURIComponent(hashToken)}`
+    const uploadUrl = buildUploadUrl(
+        selectedHost,
+        uploadType,
+        mediaConn.auth,
+        encrypted.fileEncSha256
+    )
 
     options.logger.debug('sending media upload request', {
         mediaType: content.type,
@@ -176,36 +251,68 @@ async function uploadMedia(
         contentLength: encrypted.ciphertextHmac.byteLength,
         contentType: content.mimetype
     })
-    const uploadBody = await options.mediaTransfer.readResponseBytes(uploadResponse)
-    if (!uploadResponse.ok) {
-        throw new Error(`media upload failed with status ${uploadResponse.status}`)
-    }
-
-    let parsedBody: {
-        readonly url?: string
-        readonly direct_path?: string
-        readonly metadata_url?: string
-    }
-    try {
-        parsedBody = JSON.parse(TEXT_DECODER.decode(uploadBody)) as {
-            readonly url?: string
-            readonly direct_path?: string
-            readonly metadata_url?: string
-        }
-    } catch (error) {
-        throw new Error(`media upload returned invalid json: ${toError(error).message}`)
-    }
-
-    if (!parsedBody.url || !parsedBody.direct_path) {
-        throw new Error('media upload response missing url/direct_path')
-    }
-
+    const responseBody = await options.mediaTransfer.readResponseBytes(uploadResponse)
+    const parsed = parseUploadResponse(responseBody, uploadResponse.status)
     return {
-        url: parsedBody.url,
-        directPath: parsedBody.direct_path,
+        ...parsed,
         mediaKey,
         fileSha256: encrypted.fileSha256,
         fileEncSha256: encrypted.fileEncSha256,
-        ...(parsedBody.metadata_url ? { metadataUrl: parsedBody.metadata_url } : {})
+        fileLength: mediaBytes.byteLength
+    }
+}
+
+async function uploadMediaStream(
+    options: WaMediaMessageOptions,
+    content: WaSendMediaMessage,
+    stream: Readable
+): Promise<UploadResult> {
+    const uploadType = resolveUploadType(content)
+    const mediaKey = await WaMediaCrypto.generateMediaKey()
+    const encResult = await WaMediaCrypto.encryptToFile(uploadType, mediaKey, stream)
+    let readStream: ReturnType<typeof createReadStream> | undefined
+    try {
+        const mediaConn = await getMediaConn(options)
+        const selectedHost =
+            mediaConn.hosts.find((host) => !host.isFallback)?.hostname ??
+            mediaConn.hosts[0].hostname
+        const uploadUrl = buildUploadUrl(
+            selectedHost,
+            uploadType,
+            mediaConn.auth,
+            encResult.fileEncSha256
+        )
+
+        options.logger.debug('sending media stream upload request', {
+            mediaType: content.type,
+            uploadType,
+            host: selectedHost,
+            encryptedSize: encResult.fileSize
+        })
+        readStream = createReadStream(encResult.filePath)
+        const uploadResponse = await options.mediaTransfer.uploadStream({
+            url: uploadUrl,
+            method: 'POST',
+            body: readStream,
+            contentLength: encResult.fileSize,
+            contentType: content.mimetype
+        })
+        const responseBody = await options.mediaTransfer.readResponseBytes(uploadResponse)
+        const parsed = parseUploadResponse(responseBody, uploadResponse.status)
+        return {
+            ...parsed,
+            mediaKey,
+            fileSha256: encResult.fileSha256,
+            fileEncSha256: encResult.fileEncSha256,
+            fileLength: encResult.plaintextLength
+        }
+    } finally {
+        if (readStream && !readStream.closed) {
+            await new Promise<void>((resolve) => {
+                readStream!.once('close', resolve)
+                readStream!.destroy()
+            })
+        }
+        await WaMediaCrypto.cleanupEncryptedFile(encResult.filePath)
     }
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -84,6 +84,7 @@ export interface WaSignalMessagePublishInput {
 export interface WaSendMessageOptions extends WaMessagePublishOptions {
     readonly id?: string
     readonly expectedIdentity?: Uint8Array
+    readonly subtype?: string
 }
 
 export interface WaClearChatOptions {

--- a/src/media/WaMediaCrypto.ts
+++ b/src/media/WaMediaCrypto.ts
@@ -1,7 +1,11 @@
 import { createCipheriv, createDecipheriv, createHash, createHmac } from 'node:crypto'
 import { once } from 'node:events'
+import { createWriteStream } from 'node:fs'
+import { stat, unlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
-import type { Readable } from 'node:stream'
+import type { Readable, Writable } from 'node:stream'
 
 import { hkdf } from '@crypto/core/hkdf'
 import {
@@ -28,6 +32,7 @@ import type {
     WaMediaDecryptionResult,
     WaMediaDerivedKeys,
     WaMediaEncryptionResult,
+    WaMediaFileEncryptionResult,
     WaMediaReadableDecryptionResult,
     WaMediaReadableEncryptionResult
 } from '@media/types'
@@ -148,6 +153,31 @@ export class WaMediaCrypto {
         return { encrypted, metadata }
     }
 
+    static async encryptToFile(
+        mediaType: MediaCryptoType,
+        mediaKey: Uint8Array,
+        plaintext: Readable
+    ): Promise<WaMediaFileEncryptionResult> {
+        const keys = await WaMediaCrypto.deriveKeys(mediaType, mediaKey)
+        const filePath = join(
+            tmpdir(),
+            `zapo-enc-${Date.now()}-${Math.random().toString(36).slice(2)}`
+        )
+        const output = createWriteStream(filePath)
+        try {
+            const metadata = await pumpEncryptionToWritable(plaintext, output, keys)
+            const fileSize = (await stat(filePath)).size
+            return { filePath, fileSize, ...metadata }
+        } catch (error) {
+            await unlink(filePath).catch(() => undefined)
+            throw error
+        }
+    }
+
+    static async cleanupEncryptedFile(filePath: string): Promise<void> {
+        await unlink(filePath).catch(() => undefined)
+    }
+
     static async decryptReadable(
         encrypted: Readable,
         options: WaMediaDecryptReadableOptions
@@ -171,11 +201,16 @@ async function pumpEncryption(
     plaintext: Readable,
     encrypted: PassThrough,
     keys: WaMediaDerivedKeys
-): Promise<{ readonly fileSha256: Uint8Array; readonly fileEncSha256: Uint8Array }> {
+): Promise<{
+    readonly fileSha256: Uint8Array
+    readonly fileEncSha256: Uint8Array
+    readonly plaintextLength: number
+}> {
     const plainHash = createHash('sha256')
     const encHash = createHash('sha256')
     const hmac = createHmac('sha256', keys.macKey)
     const cipher = createCipheriv('aes-256-cbc', keys.encKey, keys.iv)
+    let plaintextLength = 0
 
     hmac.update(keys.iv)
     try {
@@ -184,6 +219,7 @@ async function pumpEncryption(
             if (plainChunk.byteLength === 0) {
                 continue
             }
+            plaintextLength += plainChunk.byteLength
             plainHash.update(plainChunk)
             const encryptedChunk = cipher.update(plainChunk)
             if (encryptedChunk.byteLength > 0) {
@@ -207,11 +243,96 @@ async function pumpEncryption(
 
         return {
             fileSha256: toBytesView(plainHash.digest()),
-            fileEncSha256: toBytesView(encHash.digest())
+            fileEncSha256: toBytesView(encHash.digest()),
+            plaintextLength
         }
     } catch (error) {
         const normalized = toError(error)
         encrypted.destroy(normalized)
+        throw normalized
+    }
+}
+
+async function writeChunkToWritable(stream: Writable, chunk: Uint8Array): Promise<void> {
+    if (chunk.byteLength === 0) {
+        return
+    }
+    if (stream.write(chunk)) {
+        return
+    }
+    await new Promise<void>((resolve, reject) => {
+        const onDrain = (): void => {
+            stream.off('error', onError)
+            resolve()
+        }
+        const onError = (err: Error): void => {
+            stream.off('drain', onDrain)
+            reject(err)
+        }
+        stream.once('drain', onDrain)
+        stream.once('error', onError)
+    })
+}
+
+async function endWritable(stream: Writable): Promise<void> {
+    return new Promise((resolve, reject) => {
+        stream.on('error', reject)
+        stream.end(() => resolve())
+    })
+}
+
+async function pumpEncryptionToWritable(
+    plaintext: Readable,
+    output: Writable,
+    keys: WaMediaDerivedKeys
+): Promise<{
+    readonly fileSha256: Uint8Array
+    readonly fileEncSha256: Uint8Array
+    readonly plaintextLength: number
+}> {
+    const plainHash = createHash('sha256')
+    const encHash = createHash('sha256')
+    const hmac = createHmac('sha256', keys.macKey)
+    const cipher = createCipheriv('aes-256-cbc', keys.encKey, keys.iv)
+    let plaintextLength = 0
+
+    hmac.update(keys.iv)
+    try {
+        for await (const chunk of plaintext) {
+            const plainChunk = toChunkBytes(chunk)
+            if (plainChunk.byteLength === 0) {
+                continue
+            }
+            plaintextLength += plainChunk.byteLength
+            plainHash.update(plainChunk)
+            const encryptedChunk = cipher.update(plainChunk)
+            if (encryptedChunk.byteLength > 0) {
+                hmac.update(encryptedChunk)
+                encHash.update(encryptedChunk)
+                await writeChunkToWritable(output, encryptedChunk)
+            }
+        }
+
+        const encryptedFinal = cipher.final()
+        if (encryptedFinal.byteLength > 0) {
+            hmac.update(encryptedFinal)
+            encHash.update(encryptedFinal)
+            await writeChunkToWritable(output, encryptedFinal)
+        }
+
+        const signature = hmac.digest().subarray(0, HMAC_TRUNCATED_SIZE)
+        encHash.update(signature)
+        await writeChunkToWritable(output, signature)
+        await endWritable(output)
+
+        return {
+            fileSha256: toBytesView(plainHash.digest()),
+            fileEncSha256: toBytesView(encHash.digest()),
+            plaintextLength
+        }
+    } catch (error) {
+        const normalized = toError(error)
+        output.destroy(normalized)
         throw normalized
     }
 }

--- a/src/media/WaMediaTransferClient.ts
+++ b/src/media/WaMediaTransferClient.ts
@@ -64,6 +64,7 @@ interface EncryptedUploadResult {
     readonly mediaKey: Uint8Array
     readonly fileSha256: Uint8Array
     readonly fileEncSha256: Uint8Array
+    readonly plaintextLength: number
 }
 
 interface EncryptedDownloadRequest extends StreamDownloadRequest {
@@ -311,7 +312,8 @@ export class WaMediaTransferClient {
             transfer,
             mediaKey,
             fileSha256: metadata.fileSha256,
-            fileEncSha256: metadata.fileEncSha256
+            fileEncSha256: metadata.fileEncSha256,
+            plaintextLength: metadata.plaintextLength
         }
     }
 
@@ -548,6 +550,7 @@ export class WaMediaTransferClient {
         readonly metadata: Promise<{
             readonly fileSha256: Uint8Array
             readonly fileEncSha256: Uint8Array
+            readonly plaintextLength: number
         }>
         cleanup(error: Error): Promise<void>
     }> {
@@ -562,7 +565,8 @@ export class WaMediaTransferClient {
                 contentLength: encrypted.ciphertextHmac.byteLength,
                 metadata: Promise.resolve({
                     fileSha256: encrypted.fileSha256,
-                    fileEncSha256: encrypted.fileEncSha256
+                    fileEncSha256: encrypted.fileEncSha256,
+                    plaintextLength: request.plaintext.byteLength
                 }),
                 cleanup: async () => undefined
             }

--- a/src/media/__tests__/media.test.ts
+++ b/src/media/__tests__/media.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { stat } from 'node:fs/promises'
 import http from 'node:http'
 import { Readable } from 'node:stream'
 import test from 'node:test'
@@ -18,6 +19,20 @@ function createLogger(): Logger {
         info: () => undefined,
         warn: () => undefined,
         error: () => undefined
+    }
+}
+
+function buildMediaConnNode(auth = 'token', ttl = '120'): BinaryNode {
+    return {
+        tag: 'iq',
+        attrs: { type: 'result' },
+        content: [
+            {
+                tag: 'media_conn',
+                attrs: { auth, ttl },
+                content: [{ tag: 'host', attrs: { hostname: 'mmg.whatsapp.net' } }]
+            }
+        ]
     }
 }
 
@@ -151,6 +166,171 @@ test('media message builder supports text passthrough and conn caching', async (
 
     assert.equal(cached.auth, 'token')
     assert.equal(queryCount, 1)
+})
+
+test('media message builder uploads ptv bytes and maps upload response fields', async () => {
+    const logger = createLogger()
+    const encoder = new TextEncoder()
+    const uploadedRequests: {
+        readonly url: string
+        readonly contentLength?: number
+    }[] = []
+
+    const message = await buildMediaMessageContent(
+        {
+            logger,
+            mediaTransfer: {
+                uploadStream: async (request: {
+                    readonly url: string
+                    readonly contentLength?: number
+                }) => {
+                    uploadedRequests.push({
+                        url: request.url,
+                        contentLength: request.contentLength
+                    })
+                    return { status: 200 } as Response
+                },
+                readResponseBytes: async () =>
+                    encoder.encode(
+                        JSON.stringify({
+                            url: 'https://mmg.whatsapp.net/mms/video/ok',
+                            direct_path: '/mms/video/ok'
+                        })
+                    )
+            } as never,
+            queryWithContext: async () => buildMediaConnNode('auth-token', '120'),
+            getMediaConnCache: () => null,
+            setMediaConnCache: () => undefined
+        },
+        {
+            type: 'ptv',
+            media: new Uint8Array([1, 2, 3, 4]),
+            mimetype: 'video/mp4',
+            seconds: 7
+        }
+    )
+
+    assert.ok(message.ptvMessage)
+    assert.equal(message.ptvMessage?.fileLength, 4)
+    assert.equal(message.ptvMessage?.seconds, 7)
+    assert.equal(uploadedRequests.length, 1)
+    assert.match(uploadedRequests[0].url, /\/mms\/video\//)
+    assert.match(uploadedRequests[0].url, /auth=auth-token/)
+    assert.match(uploadedRequests[0].url, /token=/)
+    assert.ok((uploadedRequests[0].contentLength ?? 0) > 0)
+})
+
+test('media message builder propagates upload response errors for byte uploads', async () => {
+    const logger = createLogger()
+    const content = {
+        type: 'image' as const,
+        media: new Uint8Array([1, 2, 3]),
+        mimetype: 'image/jpeg'
+    }
+
+    await assert.rejects(
+        () =>
+            buildMediaMessageContent(
+                {
+                    logger,
+                    mediaTransfer: {
+                        uploadStream: async () => ({ status: 500 }) as Response,
+                        readResponseBytes: async () => new TextEncoder().encode('{}')
+                    } as never,
+                    queryWithContext: async () => buildMediaConnNode(),
+                    getMediaConnCache: () => null,
+                    setMediaConnCache: () => undefined
+                },
+                content
+            ),
+        /media upload failed with status 500/
+    )
+
+    await assert.rejects(
+        () =>
+            buildMediaMessageContent(
+                {
+                    logger,
+                    mediaTransfer: {
+                        uploadStream: async () => ({ status: 200 }) as Response,
+                        readResponseBytes: async () => new TextEncoder().encode('not-json')
+                    } as never,
+                    queryWithContext: async () => buildMediaConnNode(),
+                    getMediaConnCache: () => null,
+                    setMediaConnCache: () => undefined
+                },
+                content
+            ),
+        /media upload returned invalid json/
+    )
+
+    await assert.rejects(
+        () =>
+            buildMediaMessageContent(
+                {
+                    logger,
+                    mediaTransfer: {
+                        uploadStream: async () => ({ status: 200 }) as Response,
+                        readResponseBytes: async () =>
+                            new TextEncoder().encode(JSON.stringify({ url: 'https://mmg/a' }))
+                    } as never,
+                    queryWithContext: async () => buildMediaConnNode(),
+                    getMediaConnCache: () => null,
+                    setMediaConnCache: () => undefined
+                },
+                content
+            ),
+        /media upload response missing url\/direct_path/
+    )
+})
+
+test('media message builder cleans encrypted temp file when stream upload fails', async () => {
+    const logger = createLogger()
+    const originalCleanup = WaMediaCrypto.cleanupEncryptedFile
+    const cleanupPaths: string[] = []
+    ;(
+        WaMediaCrypto as unknown as {
+            cleanupEncryptedFile: (filePath: string) => Promise<void>
+        }
+    ).cleanupEncryptedFile = async (filePath: string) => {
+        cleanupPaths.push(filePath)
+        await originalCleanup(filePath)
+    }
+
+    try {
+        await assert.rejects(
+            () =>
+                buildMediaMessageContent(
+                    {
+                        logger,
+                        mediaTransfer: {
+                            uploadStream: async (request: { readonly body?: Readable }) => {
+                                request.body?.on('error', () => undefined)
+                                throw new Error('forced stream upload failure')
+                            },
+                            readResponseBytes: async () => new Uint8Array([])
+                        } as never,
+                        queryWithContext: async () => buildMediaConnNode(),
+                        getMediaConnCache: () => null,
+                        setMediaConnCache: () => undefined
+                    },
+                    {
+                        type: 'audio',
+                        media: Readable.from([new Uint8Array([1, 2, 3, 4])]),
+                        mimetype: 'audio/ogg'
+                    }
+                ),
+            /forced stream upload failure/
+        )
+        assert.equal(cleanupPaths.length, 1)
+        await assert.rejects(() => stat(cleanupPaths[0]), /ENOENT|no such file/i)
+    } finally {
+        ;(
+            WaMediaCrypto as unknown as {
+                cleanupEncryptedFile: (filePath: string) => Promise<void>
+            }
+        ).cleanupEncryptedFile = originalCleanup
+    }
 })
 
 test('media transfer client applies separate upload/download dispatchers', async () => {

--- a/src/media/constants.ts
+++ b/src/media/constants.ts
@@ -13,7 +13,7 @@ export const MAC_KEY_END = 80
 export const HMAC_TRUNCATED_SIZE = 10
 
 export const MEDIA_UPLOAD_PATHS: Readonly<
-    Record<'image' | 'video' | 'audio' | 'document' | 'sticker' | 'gif' | 'ptt', string>
+    Record<'image' | 'video' | 'audio' | 'document' | 'sticker' | 'gif' | 'ptt' | 'ptv', string>
 > = Object.freeze({
     image: '/mms/image',
     video: '/mms/video',
@@ -21,5 +21,6 @@ export const MEDIA_UPLOAD_PATHS: Readonly<
     document: '/mms/document',
     sticker: '/mms/sticker',
     gif: '/mms/gif',
-    ptt: '/mms/ptt'
+    ptt: '/mms/ptt',
+    ptv: '/mms/video'
 })

--- a/src/media/types.ts
+++ b/src/media/types.ts
@@ -3,8 +3,8 @@ import type { Readable } from 'node:stream'
 import type { Logger } from '@infra/log/types'
 import type { WaProxyAgent, WaProxyDispatcher } from '@transport/types'
 
-export type MediaKind = 'image' | 'video' | 'audio' | 'document' | 'sticker'
-export type MediaCryptoType = MediaKind | 'ptt' | 'gif' | 'ptv' | 'history' | 'md-app-state'
+export type MediaKind = 'image' | 'video' | 'audio' | 'document' | 'sticker' | 'ptv'
+export type MediaCryptoType = MediaKind | 'ptt' | 'gif' | 'history' | 'md-app-state'
 
 export interface WaMediaConnHost {
     readonly hostname: string
@@ -53,6 +53,7 @@ export interface WaMediaReadableEncryptionResult {
     readonly metadata: Promise<{
         readonly fileSha256: Uint8Array
         readonly fileEncSha256: Uint8Array
+        readonly plaintextLength: number
     }>
 }
 
@@ -62,6 +63,14 @@ export interface WaMediaReadableDecryptionResult {
         readonly fileSha256: Uint8Array
         readonly fileEncSha256: Uint8Array
     }>
+}
+
+export interface WaMediaFileEncryptionResult {
+    readonly filePath: string
+    readonly fileSize: number
+    readonly fileSha256: Uint8Array
+    readonly fileEncSha256: Uint8Array
+    readonly plaintextLength: number
 }
 
 export interface WaMediaDecryptReadableOptions {

--- a/src/message/WaMessageClient.ts
+++ b/src/message/WaMessageClient.ts
@@ -166,6 +166,9 @@ export class WaMessageClient {
         if (input.id) {
             attrs.id = input.id
         }
+        if (input.edit) {
+            attrs.edit = input.edit
+        }
         if (input.category) {
             attrs.category = input.category
         }
@@ -185,6 +188,9 @@ export class WaMessageClient {
             v: WA_MESSAGE_TYPES.ENC_VERSION,
             type: input.encType
         }
+        if (input.mediatype) {
+            encAttrs.mediatype = input.mediatype
+        }
         if (input.encCount !== undefined && input.encCount > 0) {
             encAttrs.count = String(Math.trunc(input.encCount))
         }
@@ -201,6 +207,9 @@ export class WaMessageClient {
                 attrs: {},
                 content: input.deviceIdentity
             })
+        }
+        if (input.metaNode) {
+            content.push(input.metaNode)
         }
         const node: BinaryNode = {
             tag: WA_MESSAGE_TAGS.MESSAGE,

--- a/src/message/__tests__/message.test.ts
+++ b/src/message/__tests__/message.test.ts
@@ -8,8 +8,15 @@ import {
     isRetryableNegativeAck
 } from '@message/ack'
 import { decryptAddonPayload, encryptAddonPayload } from '@message/addon-crypto'
-import { isSendMediaMessage, resolveMessageTypeAttr } from '@message/content'
+import {
+    isSendMediaMessage,
+    resolveEditAttr,
+    resolveEncMediaType,
+    resolveMessageTypeAttr,
+    resolveMetaAttrs
+} from '@message/content'
 import { unwrapDeviceSentMessage, wrapDeviceSentMessage } from '@message/device-sent'
+import { computeDeviceKeyHash, injectDeviceListMetadata } from '@message/icdc'
 import { unpadPkcs7, writeRandomPadMax16 } from '@message/padding'
 import { computePhashV2 } from '@message/phash'
 import { buildReportingTokenArtifacts } from '@message/reporting-token'
@@ -39,8 +46,135 @@ test('content helpers detect media payload and resolve message type', () => {
     assert.equal(isSendMediaMessage({}), false)
 
     assert.equal(resolveMessageTypeAttr({ reactionMessage: {} }), 'reaction')
+    assert.equal(resolveMessageTypeAttr({ encReactionMessage: {} }), 'reaction')
     assert.equal(resolveMessageTypeAttr({ imageMessage: {} }), 'media')
+    assert.equal(resolveMessageTypeAttr({ videoMessage: {} }), 'media')
+    assert.equal(resolveMessageTypeAttr({ audioMessage: {} }), 'media')
+    assert.equal(resolveMessageTypeAttr({ documentMessage: {} }), 'media')
+    assert.equal(resolveMessageTypeAttr({ stickerMessage: {} }), 'media')
     assert.equal(resolveMessageTypeAttr({ conversation: 'text' }), 'text')
+    assert.equal(resolveMessageTypeAttr({ protocolMessage: {} }), 'text')
+    assert.equal(resolveMessageTypeAttr({ keepInChatMessage: {} }), 'text')
+    assert.equal(resolveMessageTypeAttr({ pinInChatMessage: {} }), 'text')
+    assert.equal(resolveMessageTypeAttr({ pollCreationMessage: {} }), 'poll')
+    assert.equal(resolveMessageTypeAttr({ pollCreationMessageV2: {} }), 'poll')
+    assert.equal(resolveMessageTypeAttr({ pollUpdateMessage: {} }), 'poll')
+    assert.equal(resolveMessageTypeAttr({ eventMessage: {} }), 'event')
+    assert.equal(resolveMessageTypeAttr({ encEventResponseMessage: {} }), 'event')
+    assert.equal(
+        resolveMessageTypeAttr({ extendedTextMessage: { matchedText: 'https://example.com' } }),
+        'media'
+    )
+    assert.equal(resolveMessageTypeAttr({ extendedTextMessage: { text: 'hello' } }), 'text')
+    assert.equal(
+        resolveMessageTypeAttr({ ephemeralMessage: { message: { imageMessage: {} } } }),
+        'media'
+    )
+    assert.equal(
+        resolveMessageTypeAttr({ deviceSentMessage: { message: { reactionMessage: {} } } }),
+        'reaction'
+    )
+    assert.equal(resolveMessageTypeAttr({ contactMessage: {} }), 'media')
+    assert.equal(resolveMessageTypeAttr({ locationMessage: {} }), 'media')
+    assert.equal(resolveMessageTypeAttr({ messageHistoryBundle: {} }), 'media')
+    assert.equal(resolveMessageTypeAttr({ messageHistoryNotice: {} }), 'text')
+    assert.equal(resolveMessageTypeAttr({ pollResultSnapshotMessage: {} }), 'text')
+    assert.equal(resolveMessageTypeAttr({ pollResultSnapshotMessageV3: {} }), 'text')
+    assert.equal(
+        resolveMessageTypeAttr({
+            ephemeralMessage: { message: { viewOnceMessage: { message: { imageMessage: {} } } } }
+        }),
+        'media'
+    )
+})
+
+test('content helpers unwrap deeply nested wrappers for edit and media attrs', () => {
+    assert.equal(
+        resolveEditAttr({
+            ephemeralMessage: {
+                message: {
+                    viewOnceMessage: {
+                        message: {
+                            protocolMessage: { type: 14 }
+                        }
+                    }
+                }
+            }
+        }),
+        '1'
+    )
+    assert.equal(
+        resolveEncMediaType({
+            deviceSentMessage: {
+                message: {
+                    ephemeralMessage: {
+                        message: {
+                            videoMessage: { gifPlayback: true }
+                        }
+                    }
+                }
+            }
+        }),
+        'gif'
+    )
+})
+
+test('resolveEditAttr maps protobuf to correct edit attribute values', () => {
+    assert.equal(resolveEditAttr({ conversation: 'hello' }), null)
+    assert.equal(resolveEditAttr({ protocolMessage: { type: 0 } }), '7')
+    assert.equal(resolveEditAttr({ protocolMessage: { type: 0 } }, 'admin_revoke'), '8')
+    assert.equal(resolveEditAttr({ protocolMessage: { type: 14 } }), '1')
+    assert.equal(resolveEditAttr({ reactionMessage: { text: '' } }), '7')
+    assert.equal(resolveEditAttr({ reactionMessage: { text: '\u{1F44D}' } }), null)
+    assert.equal(resolveEditAttr({ pinInChatMessage: {} }), '2')
+    assert.equal(
+        resolveEditAttr({
+            keepInChatMessage: { key: { fromMe: true }, keepType: 2 }
+        }),
+        '7'
+    )
+    assert.equal(
+        resolveEditAttr({ keepInChatMessage: { key: { fromMe: true }, keepType: 1 } }),
+        null
+    )
+})
+
+test('resolveEncMediaType maps protobuf to correct media type string', () => {
+    assert.equal(resolveEncMediaType({ conversation: 'hello' }), null)
+    assert.equal(resolveEncMediaType({ imageMessage: {} }), 'image')
+    assert.equal(resolveEncMediaType({ videoMessage: {} }), 'video')
+    assert.equal(resolveEncMediaType({ videoMessage: { gifPlayback: true } }), 'gif')
+    assert.equal(resolveEncMediaType({ audioMessage: {} }), 'audio')
+    assert.equal(resolveEncMediaType({ audioMessage: { ptt: true } }), 'ptt')
+    assert.equal(resolveEncMediaType({ documentMessage: {} }), 'document')
+    assert.equal(resolveEncMediaType({ stickerMessage: {} }), 'sticker')
+    assert.equal(resolveEncMediaType({ contactMessage: {} }), 'vcard')
+    assert.equal(resolveEncMediaType({ contactsArrayMessage: {} }), 'contact_array')
+    assert.equal(resolveEncMediaType({ locationMessage: {} }), 'location')
+    assert.equal(resolveEncMediaType({ locationMessage: { isLive: true } }), 'livelocation')
+    assert.equal(resolveEncMediaType({ groupInviteMessage: {} }), 'url')
+    assert.equal(
+        resolveEncMediaType({ extendedTextMessage: { matchedText: 'https://example.com' } }),
+        'url'
+    )
+    assert.equal(
+        resolveEncMediaType({ ephemeralMessage: { message: { imageMessage: {} } } }),
+        'image'
+    )
+})
+
+test('resolveMetaAttrs returns attrs for polls events and view-once', () => {
+    assert.equal(resolveMetaAttrs({ conversation: 'hello' }), null)
+    assert.deepEqual(resolveMetaAttrs({ pollCreationMessage: {} }), { polltype: 'creation' })
+    assert.deepEqual(resolveMetaAttrs({ pollUpdateMessage: {} }), { polltype: 'vote' })
+    assert.equal(resolveMetaAttrs({ pollResultSnapshotMessage: {} }), null)
+    assert.equal(resolveMetaAttrs({ pollResultSnapshotMessageV3: {} }), null)
+    assert.deepEqual(resolveMetaAttrs({ eventMessage: {} }), { event_type: 'creation' })
+    assert.deepEqual(resolveMetaAttrs({ encEventResponseMessage: {} }), { event_type: 'response' })
+    assert.deepEqual(resolveMetaAttrs({ viewOnceMessage: { message: {} } }), { view_once: 'true' })
+    assert.deepEqual(resolveMetaAttrs({ viewOnceMessageV2: { message: {} } }), {
+        view_once: 'true'
+    })
 })
 
 test('device-sent wrapping preserves context and unwrap restores nested payload', () => {
@@ -209,4 +343,47 @@ test('addon crypto helpers encrypt/decrypt payloads and validate aad', async () 
             }),
         /addon iv must be 12 bytes/
     )
+})
+
+test('computeDeviceKeyHash produces deterministic 8-byte hash from identity keys', async () => {
+    const key1 = new Uint8Array(33).fill(1)
+    key1[0] = 5
+    const key2 = new Uint8Array(33).fill(2)
+    key2[0] = 5
+
+    const hash1 = await computeDeviceKeyHash([key1, key2])
+    const hash2 = await computeDeviceKeyHash([key1, key2])
+    assert.equal(hash1.byteLength, 8)
+    assert.deepEqual(hash1, hash2)
+
+    const hashDiff = await computeDeviceKeyHash([key2, key1])
+    assert.notDeepEqual(hash1, hashDiff)
+
+    const emptyHash = await computeDeviceKeyHash([])
+    assert.equal(emptyHash.byteLength, 8)
+    assert.deepEqual(emptyHash, new Uint8Array(8))
+})
+
+test('injectDeviceListMetadata sets sender and recipient fields', () => {
+    const msg = { conversation: 'hi', messageContextInfo: { messageSecret: new Uint8Array(32) } }
+    const sender = { keyHash: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]), timestamp: 1000 }
+    const recipient = {
+        keyHash: new Uint8Array([9, 10, 11, 12, 13, 14, 15, 16]),
+        timestamp: undefined
+    }
+
+    const result = injectDeviceListMetadata(msg, sender, recipient)
+    assert.ok(result.messageContextInfo?.deviceListMetadata)
+    assert.deepEqual(result.messageContextInfo?.deviceListMetadata?.senderKeyHash, sender.keyHash)
+    assert.equal(result.messageContextInfo?.deviceListMetadata?.senderTimestamp, 1000)
+    assert.deepEqual(
+        result.messageContextInfo?.deviceListMetadata?.recipientKeyHash,
+        recipient.keyHash
+    )
+    assert.equal(result.messageContextInfo?.deviceListMetadata?.recipientTimestamp, undefined)
+    assert.equal(result.messageContextInfo?.deviceListMetadataVersion, 2)
+    assert.deepEqual(result.messageContextInfo?.messageSecret, new Uint8Array(32))
+
+    const unchanged = injectDeviceListMetadata(msg, null, null)
+    assert.equal(unchanged, msg)
 })

--- a/src/message/content.ts
+++ b/src/message/content.ts
@@ -1,5 +1,13 @@
 import type { WaSendMediaMessage } from '@message/types'
+import { proto } from '@proto'
 import type { Proto } from '@proto'
+import {
+    WA_EDIT_ATTRS,
+    WA_ENC_MEDIA_TYPES,
+    WA_EVENT_META_TYPES,
+    WA_POLL_META_TYPES,
+    WA_STANZA_MSG_TYPES
+} from '@protocol/constants'
 
 export function isSendMediaMessage(content: unknown): content is WaSendMediaMessage {
     return (
@@ -11,18 +19,223 @@ export function isSendMediaMessage(content: unknown): content is WaSendMediaMess
     )
 }
 
+function unwrapMessage(message: Proto.IMessage): Proto.IMessage {
+    let msg = message
+    for (;;) {
+        const inner =
+            msg.ephemeralMessage?.message ??
+            msg.groupMentionedMessage?.message ??
+            msg.botInvokeMessage?.message ??
+            msg.deviceSentMessage?.message ??
+            msg.viewOnceMessage?.message ??
+            msg.viewOnceMessageV2?.message ??
+            msg.documentWithCaptionMessage?.message
+        if (!inner) return msg
+        msg = inner
+    }
+}
+
 export function resolveMessageTypeAttr(message: Proto.IMessage): string {
-    if (message.reactionMessage) {
-        return 'reaction'
+    const msg = unwrapMessage(message)
+
+    if (msg.reactionMessage || msg.encReactionMessage) {
+        return WA_STANZA_MSG_TYPES.REACTION
     }
+
     if (
-        message.imageMessage ||
-        message.videoMessage ||
-        message.audioMessage ||
-        message.documentMessage ||
-        message.stickerMessage
+        msg.eventMessage ||
+        msg.encEventResponseMessage ||
+        msg.secretEncryptedMessage?.secretEncType ===
+            proto.Message.SecretEncryptedMessage.SecretEncType.EVENT_EDIT
     ) {
-        return 'media'
+        return WA_STANZA_MSG_TYPES.EVENT
     }
-    return 'text'
+
+    if (
+        msg.pollCreationMessage ||
+        msg.pollCreationMessageV2 ||
+        msg.pollCreationMessageV3 ||
+        msg.pollCreationMessageV5 ||
+        msg.pollUpdateMessage ||
+        msg.secretEncryptedMessage?.secretEncType ===
+            proto.Message.SecretEncryptedMessage.SecretEncType.POLL_EDIT ||
+        msg.secretEncryptedMessage?.secretEncType ===
+            proto.Message.SecretEncryptedMessage.SecretEncType.POLL_ADD_OPTION
+    ) {
+        return WA_STANZA_MSG_TYPES.POLL
+    }
+
+    if (msg.extendedTextMessage?.matchedText && msg.extendedTextMessage.matchedText.trim() !== '') {
+        return WA_STANZA_MSG_TYPES.MEDIA
+    }
+
+    if (
+        (msg.conversation !== undefined && msg.conversation !== null) ||
+        (msg.extendedTextMessage && !msg.extendedTextMessage.matchedText) ||
+        msg.protocolMessage ||
+        msg.interactiveMessage ||
+        msg.keepInChatMessage ||
+        msg.requestPhoneNumberMessage ||
+        msg.editedMessage ||
+        msg.pinInChatMessage ||
+        msg.encCommentMessage ||
+        msg.newsletterAdminInviteMessage ||
+        msg.pollResultSnapshotMessage ||
+        msg.pollResultSnapshotMessageV3 ||
+        msg.templateButtonReplyMessage ||
+        msg.messageHistoryNotice ||
+        msg.secretEncryptedMessage?.secretEncType ===
+            proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT ||
+        msg.secretEncryptedMessage?.secretEncType ===
+            proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_SCHEDULE
+    ) {
+        return WA_STANZA_MSG_TYPES.TEXT
+    }
+
+    return WA_STANZA_MSG_TYPES.MEDIA
+}
+
+const REVOKED_REACTION_TEXT = ''
+
+export function resolveEditAttr(message: Proto.IMessage, subtype?: string): string | null {
+    const msg = unwrapMessage(message)
+
+    if (msg.protocolMessage) {
+        const protocolType = msg.protocolMessage.type
+        if (protocolType === proto.Message.ProtocolMessage.Type.REVOKE) {
+            return subtype === 'admin_revoke'
+                ? WA_EDIT_ATTRS.ADMIN_REVOKE
+                : WA_EDIT_ATTRS.SENDER_REVOKE
+        }
+        if (protocolType === proto.Message.ProtocolMessage.Type.MESSAGE_EDIT) {
+            return WA_EDIT_ATTRS.MESSAGE_EDIT
+        }
+        return null
+    }
+
+    if (msg.secretEncryptedMessage) {
+        const encType = msg.secretEncryptedMessage.secretEncType
+        if (
+            encType === proto.Message.SecretEncryptedMessage.SecretEncType.EVENT_EDIT ||
+            encType === proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT
+        ) {
+            return WA_EDIT_ATTRS.MESSAGE_EDIT
+        }
+    }
+
+    if (msg.editedMessage) {
+        return WA_EDIT_ATTRS.MESSAGE_EDIT
+    }
+
+    if (msg.reactionMessage) {
+        if (msg.reactionMessage.text === REVOKED_REACTION_TEXT) {
+            return WA_EDIT_ATTRS.SENDER_REVOKE
+        }
+        return null
+    }
+
+    if (msg.keepInChatMessage) {
+        if (
+            msg.keepInChatMessage.key?.fromMe === true &&
+            msg.keepInChatMessage.keepType === proto.KeepType.UNDO_KEEP_FOR_ALL
+        ) {
+            return WA_EDIT_ATTRS.SENDER_REVOKE
+        }
+        return null
+    }
+
+    if (msg.pinInChatMessage) {
+        return WA_EDIT_ATTRS.PIN_IN_CHAT
+    }
+
+    return null
+}
+
+export function resolveEncMediaType(message: Proto.IMessage): string | null {
+    const msg = unwrapMessage(message)
+
+    if (msg.imageMessage) return WA_ENC_MEDIA_TYPES.IMAGE
+    if (msg.stickerMessage) return WA_ENC_MEDIA_TYPES.STICKER
+    if (msg.locationMessage) {
+        return msg.locationMessage.isLive
+            ? WA_ENC_MEDIA_TYPES.LIVE_LOCATION
+            : WA_ENC_MEDIA_TYPES.LOCATION
+    }
+    if (msg.contactMessage) return WA_ENC_MEDIA_TYPES.VCARD
+    if (msg.contactsArrayMessage) return WA_ENC_MEDIA_TYPES.CONTACT_ARRAY
+    if (msg.documentMessage) return WA_ENC_MEDIA_TYPES.DOCUMENT
+    if (msg.audioMessage) {
+        return msg.audioMessage.ptt ? WA_ENC_MEDIA_TYPES.PTT : WA_ENC_MEDIA_TYPES.AUDIO
+    }
+    if (msg.videoMessage) {
+        return msg.videoMessage.gifPlayback ? WA_ENC_MEDIA_TYPES.GIF : WA_ENC_MEDIA_TYPES.VIDEO
+    }
+    if (msg.ptvMessage) return WA_ENC_MEDIA_TYPES.PTV
+    if (msg.buttonsMessage) return WA_ENC_MEDIA_TYPES.BUTTON
+    if (msg.buttonsResponseMessage) return WA_ENC_MEDIA_TYPES.BUTTON_RESPONSE
+    if (msg.listMessage) return WA_ENC_MEDIA_TYPES.LIST
+    if (msg.listResponseMessage) return WA_ENC_MEDIA_TYPES.LIST_RESPONSE
+    if (msg.orderMessage) return WA_ENC_MEDIA_TYPES.ORDER
+    if (msg.productMessage) return WA_ENC_MEDIA_TYPES.PRODUCT
+    if (msg.groupInviteMessage) return WA_ENC_MEDIA_TYPES.URL
+    if (msg.interactiveResponseMessage) return WA_ENC_MEDIA_TYPES.NATIVE_FLOW_RESPONSE
+    if (msg.messageHistoryBundle) return WA_ENC_MEDIA_TYPES.GROUP_HISTORY
+    if (msg.extendedTextMessage?.matchedText && msg.extendedTextMessage.matchedText.trim() !== '') {
+        return WA_ENC_MEDIA_TYPES.URL
+    }
+    return null
+}
+
+export interface MessageMetaAttrs {
+    readonly polltype?: string
+    readonly event_type?: string
+    readonly view_once?: string
+}
+
+export function resolveMetaAttrs(message: Proto.IMessage): MessageMetaAttrs | null {
+    const msg = unwrapMessage(message)
+    let polltype: string | undefined
+    let eventType: string | undefined
+    let viewOnce: string | undefined
+
+    if (msg.pollCreationMessage || msg.pollCreationMessageV2 || msg.pollCreationMessageV3) {
+        polltype = WA_POLL_META_TYPES.CREATION
+    } else if (msg.pollUpdateMessage) {
+        polltype = WA_POLL_META_TYPES.VOTE
+    } else if (
+        msg.secretEncryptedMessage?.secretEncType ===
+        proto.Message.SecretEncryptedMessage.SecretEncType.POLL_EDIT
+    ) {
+        polltype = WA_POLL_META_TYPES.EDIT
+    } else if (
+        msg.secretEncryptedMessage?.secretEncType ===
+        proto.Message.SecretEncryptedMessage.SecretEncType.POLL_ADD_OPTION
+    ) {
+        polltype = WA_POLL_META_TYPES.EDIT
+    }
+
+    if (msg.eventMessage) {
+        eventType = WA_EVENT_META_TYPES.CREATION
+    } else if (msg.encEventResponseMessage) {
+        eventType = WA_EVENT_META_TYPES.RESPONSE
+    } else if (
+        msg.secretEncryptedMessage?.secretEncType ===
+        proto.Message.SecretEncryptedMessage.SecretEncType.EVENT_EDIT
+    ) {
+        eventType = WA_EVENT_META_TYPES.EDIT
+    }
+
+    if (message.viewOnceMessage || message.viewOnceMessageV2) {
+        viewOnce = 'true'
+    }
+
+    if (!polltype && !eventType && !viewOnce) {
+        return null
+    }
+
+    const attrs: Record<string, string> = {}
+    if (polltype) attrs.polltype = polltype
+    if (eventType) attrs.event_type = eventType
+    if (viewOnce) attrs.view_once = viewOnce
+    return attrs as MessageMetaAttrs
 }

--- a/src/message/icdc.ts
+++ b/src/message/icdc.ts
@@ -1,0 +1,100 @@
+import { sha256, toRawPubKey } from '@crypto'
+import type { Proto } from '@proto'
+import { parseSignalAddressFromJid } from '@protocol/jid'
+import type { SignalAddress } from '@signal/types'
+import type { WaSignalStore } from '@store/contracts/signal.store'
+import { concatBytes } from '@util/bytes'
+
+const ICDC_HASH_LENGTH = 8
+const ICDC_FRESHNESS_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1_000
+const DEVICE_LIST_METADATA_VERSION = 2
+
+export interface IcdcMeta {
+    readonly keyHash: Uint8Array
+    readonly timestamp: number | undefined
+}
+
+export async function computeDeviceKeyHash(
+    identityKeys: readonly Uint8Array[]
+): Promise<Uint8Array> {
+    if (identityKeys.length === 0) {
+        return new Uint8Array(ICDC_HASH_LENGTH)
+    }
+    const rawKeys: Uint8Array[] = new Array(identityKeys.length)
+    for (let i = 0; i < identityKeys.length; i += 1) {
+        rawKeys[i] =
+            identityKeys[i].byteLength === 33 ? toRawPubKey(identityKeys[i]) : identityKeys[i]
+    }
+    const combined = concatBytes(rawKeys)
+    const hash = await sha256(combined)
+    return hash.subarray(0, ICDC_HASH_LENGTH)
+}
+
+export async function resolveIcdcMeta(
+    deviceJids: readonly string[],
+    signalStore: WaSignalStore,
+    updatedAtMs: number | undefined,
+    localIdentity?: { readonly address: SignalAddress; readonly pubKey: Uint8Array }
+): Promise<IcdcMeta | null> {
+    if (deviceJids.length === 0) {
+        return null
+    }
+    const addresses: SignalAddress[] = new Array(deviceJids.length)
+    for (let i = 0; i < deviceJids.length; i += 1) {
+        addresses[i] = parseSignalAddressFromJid(deviceJids[i])
+    }
+    const remoteKeys = await signalStore.getRemoteIdentities(addresses)
+    const keys: Uint8Array[] = []
+    for (let i = 0; i < addresses.length; i += 1) {
+        const key = remoteKeys[i]
+        if (key) {
+            keys.push(key)
+        } else if (
+            localIdentity &&
+            addresses[i].user === localIdentity.address.user &&
+            addresses[i].device === localIdentity.address.device
+        ) {
+            keys.push(localIdentity.pubKey)
+        }
+    }
+    if (keys.length === 0) {
+        return null
+    }
+    const keyHash = await computeDeviceKeyHash(keys)
+    const timestamp =
+        updatedAtMs !== undefined && Date.now() - updatedAtMs < ICDC_FRESHNESS_THRESHOLD_MS
+            ? Math.floor(updatedAtMs / 1_000)
+            : undefined
+    return { keyHash, timestamp }
+}
+
+export function injectDeviceListMetadata(
+    message: Proto.IMessage,
+    senderIcdc: IcdcMeta | null,
+    recipientIcdc: IcdcMeta | null
+): Proto.IMessage {
+    if (!senderIcdc && !recipientIcdc) {
+        return message
+    }
+    const deviceListMetadata: Proto.IDeviceListMetadata = {}
+    if (senderIcdc) {
+        deviceListMetadata.senderKeyHash = senderIcdc.keyHash
+        if (senderIcdc.timestamp !== undefined) {
+            deviceListMetadata.senderTimestamp = senderIcdc.timestamp
+        }
+    }
+    if (recipientIcdc) {
+        deviceListMetadata.recipientKeyHash = recipientIcdc.keyHash
+        if (recipientIcdc.timestamp !== undefined) {
+            deviceListMetadata.recipientTimestamp = recipientIcdc.timestamp
+        }
+    }
+    return {
+        ...message,
+        messageContextInfo: {
+            ...message.messageContextInfo,
+            deviceListMetadata,
+            deviceListMetadataVersion: DEVICE_LIST_METADATA_VERSION
+        }
+    }
+}

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -1,4 +1,5 @@
-import type { MediaKind } from '@media/types'
+import type { Readable } from 'node:stream'
+
 import type { Proto } from '@proto'
 import type { BinaryNode } from '@transport/types'
 
@@ -25,18 +26,62 @@ export interface WaMessagePublishResult {
     readonly ack: WaMessageAckMetadata
 }
 
-export interface WaSendMediaMessage {
-    readonly type: MediaKind
-    readonly media: Uint8Array | ArrayBuffer
+type MediaInput = Uint8Array | ArrayBuffer | Readable
+
+interface WaSendMediaBase {
+    readonly media: MediaInput
     readonly mimetype: string
+    readonly fileLength?: number
+}
+
+interface WaSendImageMessage extends WaSendMediaBase {
+    readonly type: 'image'
     readonly caption?: string
-    readonly fileName?: string
-    readonly ptt?: boolean
+    readonly width?: number
+    readonly height?: number
+}
+
+interface WaSendVideoMessage extends WaSendMediaBase {
+    readonly type: 'video'
+    readonly caption?: string
     readonly gifPlayback?: boolean
     readonly seconds?: number
     readonly width?: number
     readonly height?: number
 }
+
+interface WaSendPtvMessage extends WaSendMediaBase {
+    readonly type: 'ptv'
+    readonly seconds?: number
+    readonly width?: number
+    readonly height?: number
+}
+
+interface WaSendAudioMessage extends WaSendMediaBase {
+    readonly type: 'audio'
+    readonly ptt?: boolean
+    readonly seconds?: number
+}
+
+interface WaSendDocumentMessage extends WaSendMediaBase {
+    readonly type: 'document'
+    readonly caption?: string
+    readonly fileName?: string
+}
+
+interface WaSendStickerMessage extends WaSendMediaBase {
+    readonly type: 'sticker'
+    readonly width?: number
+    readonly height?: number
+}
+
+export type WaSendMediaMessage =
+    | WaSendImageMessage
+    | WaSendVideoMessage
+    | WaSendPtvMessage
+    | WaSendAudioMessage
+    | WaSendDocumentMessage
+    | WaSendStickerMessage
 
 export type WaSendMessageContent = string | Proto.IMessage | WaSendMediaMessage
 
@@ -49,10 +94,13 @@ export interface WaEncryptedMessageInput {
     readonly encCount?: number
     readonly id?: string
     readonly type?: string
+    readonly edit?: string
+    readonly mediatype?: string
     readonly category?: string
     readonly pushPriority?: string
     readonly participant?: string
     readonly deviceFanout?: string
+    readonly metaNode?: BinaryNode
 }
 
 export interface WaSendReceiptInput {

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -16,7 +16,16 @@ export type {
     WaStreamErrorCode
 } from '@protocol/stream'
 export { WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
-export { WA_MESSAGE_TAGS, WA_MESSAGE_TYPES, WA_RETRYABLE_ACK_CODES } from '@protocol/message'
+export {
+    WA_EDIT_ATTRS,
+    WA_ENC_MEDIA_TYPES,
+    WA_EVENT_META_TYPES,
+    WA_MESSAGE_TAGS,
+    WA_MESSAGE_TYPES,
+    WA_POLL_META_TYPES,
+    WA_RETRYABLE_ACK_CODES,
+    WA_STANZA_MSG_TYPES
+} from '@protocol/message'
 export {
     WA_APP_STATE_COLLECTIONS,
     WA_APP_STATE_COLLECTION_STATES,

--- a/src/protocol/message.ts
+++ b/src/protocol/message.ts
@@ -26,3 +26,58 @@ export const WA_MESSAGE_TYPES = Object.freeze({
 } as const)
 
 export const WA_RETRYABLE_ACK_CODES = Object.freeze(['408', '429', '500', '503'] as const)
+
+export const WA_STANZA_MSG_TYPES = Object.freeze({
+    TEXT: 'text',
+    MEDIA: 'media',
+    MEDIA_NOTIFY: 'medianotify',
+    PAY: 'pay',
+    POLL: 'poll',
+    REACTION: 'reaction',
+    EVENT: 'event'
+} as const)
+
+export const WA_EDIT_ATTRS = Object.freeze({
+    MESSAGE_EDIT: '1',
+    PIN_IN_CHAT: '2',
+    SENDER_REVOKE: '7',
+    ADMIN_REVOKE: '8'
+} as const)
+
+export const WA_POLL_META_TYPES = Object.freeze({
+    CREATION: 'creation',
+    VOTE: 'vote',
+    RESULT_SNAPSHOT: 'result_snapshot',
+    EDIT: 'edit'
+} as const)
+
+export const WA_EVENT_META_TYPES = Object.freeze({
+    CREATION: 'creation',
+    RESPONSE: 'response',
+    EDIT: 'edit'
+} as const)
+
+export const WA_ENC_MEDIA_TYPES = Object.freeze({
+    IMAGE: 'image',
+    VIDEO: 'video',
+    PTV: 'ptv',
+    AUDIO: 'audio',
+    PTT: 'ptt',
+    LOCATION: 'location',
+    LIVE_LOCATION: 'livelocation',
+    VCARD: 'vcard',
+    CONTACT_ARRAY: 'contact_array',
+    DOCUMENT: 'document',
+    URL: 'url',
+    GIF: 'gif',
+    STICKER: 'sticker',
+    STICKER_PACK: 'sticker_pack',
+    LIST: 'list',
+    LIST_RESPONSE: 'list_response',
+    BUTTON: 'button',
+    BUTTON_RESPONSE: 'buttons_response',
+    ORDER: 'order',
+    PRODUCT: 'product',
+    NATIVE_FLOW_RESPONSE: 'native_flow_response',
+    GROUP_HISTORY: 'group_history'
+} as const)

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -36,7 +36,8 @@ import {
 } from '@transport/node/builders'
 import {
     buildDirectMessageFanoutNode,
-    buildGroupRetryMessageNode
+    buildGroupRetryMessageNode,
+    buildMetaNode
 } from '@transport/node/builders/message'
 import { buildMissingPreKeysFetchIq, buildPreKeyUploadIq } from '@transport/node/builders/prekeys'
 import {
@@ -932,4 +933,66 @@ test('prekeys builders include expected key material and targets', () => {
     assert.equal(rotate.attrs.type, 'set')
     assert.ok(Array.isArray(rotate.content))
     assert.equal(rotate.content[0].tag, WA_NODE_TAGS.ROTATE)
+})
+
+test('message builders include edit mediatype and meta node when provided', () => {
+    const participant = {
+        jid: '5511:0@s.whatsapp.net',
+        encType: 'msg' as const,
+        ciphertext: new Uint8Array([1])
+    }
+    const meta = buildMetaNode({ polltype: 'creation' })
+    assert.equal(meta.tag, 'meta')
+    assert.equal(meta.attrs.polltype, 'creation')
+
+    const direct = buildDirectMessageFanoutNode({
+        to: '5511@s.whatsapp.net',
+        type: 'poll',
+        id: 'p1',
+        edit: '7',
+        participants: [participant],
+        metaNode: meta,
+        mediatype: 'image'
+    })
+    assert.equal(direct.attrs.edit, '7')
+    assert.ok(Array.isArray(direct.content))
+    const metaChild = direct.content.find((c) => c.tag === 'meta')
+    assert.ok(metaChild)
+    assert.equal(metaChild?.attrs.polltype, 'creation')
+    const encChild = Array.isArray(direct.content[0].content)
+        ? direct.content[0].content[0].content?.[0]
+        : null
+    assert.equal(encChild?.attrs.mediatype, 'image')
+
+    const group = buildGroupSenderKeyMessageNode({
+        to: '123@g.us',
+        type: 'media',
+        id: 'g1',
+        edit: '1',
+        groupCiphertext: new Uint8Array([2]),
+        participants: [participant],
+        metaNode: buildMetaNode({ event_type: 'creation' }),
+        mediatype: 'video'
+    })
+    assert.equal(group.attrs.edit, '1')
+    assert.ok(Array.isArray(group.content))
+    const groupMeta = group.content.find((c) => c.tag === 'meta')
+    assert.ok(groupMeta)
+    assert.equal(groupMeta?.attrs.event_type, 'creation')
+    const skmsgEnc = group.content.find((c) => c.tag === 'enc' && c.attrs.type === 'skmsg')
+    assert.equal(skmsgEnc?.attrs.mediatype, 'video')
+
+    const retry = buildGroupRetryMessageNode({
+        to: '123@g.us',
+        type: 'media',
+        id: 'r1',
+        requesterJid: '5511:0@s.whatsapp.net',
+        addressingMode: 'pn',
+        encType: 'msg',
+        ciphertext: new Uint8Array([3]),
+        retryCount: 1,
+        mediatype: 'document'
+    })
+    assert.ok(Array.isArray(retry.content))
+    assert.equal(retry.content[0].attrs.mediatype, 'document')
 })

--- a/src/transport/node/builders/index.ts
+++ b/src/transport/node/builders/index.ts
@@ -17,7 +17,8 @@ export { buildMediaConnIq } from '@transport/node/builders/media'
 export {
     buildDirectMessageFanoutNode,
     buildGroupRetryMessageNode,
-    buildGroupSenderKeyMessageNode
+    buildGroupSenderKeyMessageNode,
+    buildMetaNode
 } from '@transport/node/builders/message'
 export { buildRetryReceiptNode } from '@transport/node/builders/retry'
 export {

--- a/src/transport/node/builders/message.ts
+++ b/src/transport/node/builders/message.ts
@@ -11,10 +11,13 @@ type DirectMessageFanoutInput = {
     readonly to: string
     readonly type: string
     readonly id?: string
+    readonly edit?: string
     readonly participants: readonly EncryptedParticipant[]
     readonly deviceIdentity?: Uint8Array
     readonly reportingNode?: BinaryNode
     readonly privacyTokenNode?: BinaryNode
+    readonly metaNode?: BinaryNode
+    readonly mediatype?: string
 }
 
 type GroupMessageFanoutInput = DirectMessageFanoutInput & {
@@ -36,13 +39,35 @@ type GroupRetryMessageInput = {
     readonly ciphertext: Uint8Array
     readonly retryCount: number
     readonly deviceIdentity?: Uint8Array
+    readonly mediatype?: string
 }
 
-export function buildDirectMessageFanoutNode(input: GroupMessageFanoutInput): BinaryNode {
-    if (input.participants.length === 0) {
-        throw new Error('direct message fanout requires at least one participant')
+function buildEncAttrs(
+    encType: string,
+    mediatype?: string,
+    retryCount?: number
+): Record<string, string> {
+    const attrs: Record<string, string> = {
+        v: WA_MESSAGE_TYPES.ENC_VERSION,
+        type: encType
     }
+    if (mediatype) {
+        attrs.mediatype = mediatype
+    }
+    if (retryCount !== undefined && retryCount > 0) {
+        attrs.count = String(Math.trunc(retryCount))
+    }
+    return attrs
+}
 
+function buildMessageAttrs(input: {
+    readonly to: string
+    readonly type: string
+    readonly id?: string
+    readonly edit?: string
+    readonly phash?: string
+    readonly addressingMode?: string
+}): Record<string, string> {
     const attrs: Record<string, string> = {
         to: input.to,
         type: input.type
@@ -50,13 +75,51 @@ export function buildDirectMessageFanoutNode(input: GroupMessageFanoutInput): Bi
     if (input.id) {
         attrs.id = input.id
     }
+    if (input.edit) {
+        attrs.edit = input.edit
+    }
     if (input.phash) {
         attrs.phash = input.phash
     }
     if (input.addressingMode) {
         attrs.addressing_mode = input.addressingMode
     }
+    return attrs
+}
 
+function pushOptionalNodes(
+    content: BinaryNode[],
+    input: {
+        readonly deviceIdentity?: Uint8Array
+        readonly reportingNode?: BinaryNode
+        readonly privacyTokenNode?: BinaryNode
+        readonly metaNode?: BinaryNode
+    }
+): void {
+    if (input.deviceIdentity) {
+        content.push({
+            tag: WA_NODE_TAGS.DEVICE_IDENTITY,
+            attrs: {},
+            content: input.deviceIdentity
+        })
+    }
+    if (input.metaNode) {
+        content.push(input.metaNode)
+    }
+    if (input.reportingNode) {
+        content.push(input.reportingNode)
+    }
+    if (input.privacyTokenNode) {
+        content.push(input.privacyTokenNode)
+    }
+}
+
+export function buildDirectMessageFanoutNode(input: GroupMessageFanoutInput): BinaryNode {
+    if (input.participants.length === 0) {
+        throw new Error('direct message fanout requires at least one participant')
+    }
+
+    const attrs = buildMessageAttrs(input)
     const content: BinaryNode[] = [
         {
             tag: WA_NODE_TAGS.PARTICIPANTS,
@@ -69,29 +132,14 @@ export function buildDirectMessageFanoutNode(input: GroupMessageFanoutInput): Bi
                 content: [
                     {
                         tag: WA_MESSAGE_TAGS.ENC,
-                        attrs: {
-                            v: WA_MESSAGE_TYPES.ENC_VERSION,
-                            type: participant.encType
-                        },
+                        attrs: buildEncAttrs(participant.encType, input.mediatype),
                         content: participant.ciphertext
                     }
                 ]
             }))
         }
     ]
-    if (input.deviceIdentity) {
-        content.push({
-            tag: WA_NODE_TAGS.DEVICE_IDENTITY,
-            attrs: {},
-            content: input.deviceIdentity
-        })
-    }
-    if (input.reportingNode) {
-        content.push(input.reportingNode)
-    }
-    if (input.privacyTokenNode) {
-        content.push(input.privacyTokenNode)
-    }
+    pushOptionalNodes(content, input)
 
     return {
         tag: WA_MESSAGE_TAGS.MESSAGE,
@@ -101,21 +149,9 @@ export function buildDirectMessageFanoutNode(input: GroupMessageFanoutInput): Bi
 }
 
 export function buildGroupSenderKeyMessageNode(input: GroupSenderKeyMessageInput): BinaryNode {
-    const attrs: Record<string, string> = {
-        to: input.to,
-        type: input.type
-    }
-    if (input.id) {
-        attrs.id = input.id
-    }
-    if (input.phash) {
-        attrs.phash = input.phash
-    }
-    if (input.addressingMode) {
-        attrs.addressing_mode = input.addressingMode
-    }
-
+    const attrs = buildMessageAttrs(input)
     const content: BinaryNode[] = []
+
     if (input.participants.length > 0) {
         content.push({
             tag: WA_NODE_TAGS.PARTICIPANTS,
@@ -128,10 +164,7 @@ export function buildGroupSenderKeyMessageNode(input: GroupSenderKeyMessageInput
                 content: [
                     {
                         tag: WA_MESSAGE_TAGS.ENC,
-                        attrs: {
-                            v: WA_MESSAGE_TYPES.ENC_VERSION,
-                            type: participant.encType
-                        },
+                        attrs: buildEncAttrs(participant.encType, input.mediatype),
                         content: participant.ciphertext
                     }
                 ]
@@ -140,22 +173,10 @@ export function buildGroupSenderKeyMessageNode(input: GroupSenderKeyMessageInput
     }
     content.push({
         tag: WA_MESSAGE_TAGS.ENC,
-        attrs: {
-            v: WA_MESSAGE_TYPES.ENC_VERSION,
-            type: 'skmsg'
-        },
+        attrs: buildEncAttrs('skmsg', input.mediatype),
         content: input.groupCiphertext
     })
-    if (input.deviceIdentity) {
-        content.push({
-            tag: WA_NODE_TAGS.DEVICE_IDENTITY,
-            attrs: {},
-            content: input.deviceIdentity
-        })
-    }
-    if (input.reportingNode) {
-        content.push(input.reportingNode)
-    }
+    pushOptionalNodes(content, input)
 
     return {
         tag: WA_MESSAGE_TAGS.MESSAGE,
@@ -165,17 +186,10 @@ export function buildGroupSenderKeyMessageNode(input: GroupSenderKeyMessageInput
 }
 
 export function buildGroupRetryMessageNode(input: GroupRetryMessageInput): BinaryNode {
-    const encAttrs: Record<string, string> = {
-        v: WA_MESSAGE_TYPES.ENC_VERSION,
-        type: input.encType
-    }
-    if (input.retryCount > 0) {
-        encAttrs.count = String(Math.trunc(input.retryCount))
-    }
     const content: BinaryNode[] = [
         {
             tag: WA_MESSAGE_TAGS.ENC,
-            attrs: encAttrs,
+            attrs: buildEncAttrs(input.encType, input.mediatype, input.retryCount),
             content: input.ciphertext
         }
     ]
@@ -197,5 +211,13 @@ export function buildGroupRetryMessageNode(input: GroupRetryMessageInput): Binar
             addressing_mode: input.addressingMode
         },
         content
+    }
+}
+
+export function buildMetaNode(attrs: Record<string, string>): BinaryNode {
+    return {
+        tag: 'meta',
+        attrs,
+        content: undefined
     }
 }


### PR DESCRIPTION
- Implement edit, mediatype, and meta node attributes on outgoing message stanzas
- Add ICDC (device list metadata) resolution and injection into outgoing messages
- Support streaming media uploads via encryptToFile for large files
- Add PTV (video note) message type with upload path and typed media unions
- Expand resolveMessageTypeAttr to cover polls, events, reactions, and protocol messages
- Add resolveEditAttr, resolveEncMediaType, and resolveMetaAttrs content helpers
- Define WA_STANZA_MSG_TYPES, WA_EDIT_ATTRS, WA_ENC_MEDIA_TYPES, WA_POLL_META_TYPES, WA_EVENT_META_TYPES constants
- Refactor node builders to share buildEncAttrs, buildMessageAttrs, and pushOptionalNodes helpers
- Add comprehensive test coverage for all new functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PTV (photo‑video) messages with duration and dimensions
  * Streaming uploads for large media

* **Improvements**
  * File‑based media encryption with safer temp‑file cleanup and more robust upload/error handling
  * Media messages report actual uploaded file length
  * Message metadata enhanced with device‑list metadata and richer edit/mediatype/meta propagation (including retries)
  * Broader message‑type detection for edits, polls, events, and encrypted media
<!-- end of auto-generated comment: release notes by coderabbit.ai -->