### PR TITLE
feat: add monorepo structure with Turborepo and @zapo-js/store-mysql package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 dist
+packages/*/dist
+.turbo
 node_modules
 .auth
 example.js

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ module.exports = [
     {
         ignores: [
             'dist/**',
+            'packages/*/dist/**',
             'deobfuscated/**',
             'coverage/**',
             'proto/index.js',
@@ -28,6 +29,15 @@ module.exports = [
             parserOptions: {
                 tsconfigRootDir: __dirname,
                 project: ['./tsconfig.json', './bench/tsconfig.json', './examples/tsconfig.json']
+            }
+        }
+    },
+    {
+        files: ['packages/*/src/**/*.ts'],
+        languageOptions: {
+            parserOptions: {
+                tsconfigRootDir: __dirname,
+                project: ['./packages/store-mysql/tsconfig.json']
             }
         }
     }

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -2,7 +2,37 @@
     "extends": "../tsconfig.json",
     "compilerOptions": {
         "noEmit": true,
-        "rootDir": ".."
+        "rootDir": "..",
+        "paths": {
+            "@appstate": ["src/appstate/index.ts"],
+            "@appstate/*": ["src/appstate/*"],
+            "@auth": ["src/auth/index.ts"],
+            "@auth/*": ["src/auth/*"],
+            "@client": ["src/client/index.ts"],
+            "@client/*": ["src/client/*"],
+            "@crypto": ["src/crypto/index.ts"],
+            "@crypto/*": ["src/crypto/*"],
+            "@infra/*": ["src/infra/*"],
+            "@media": ["src/media/index.ts"],
+            "@media/*": ["src/media/*"],
+            "@message": ["src/message/index.ts"],
+            "@message/*": ["src/message/*"],
+            "@protocol": ["src/protocol/index.ts"],
+            "@protocol/*": ["src/protocol/*"],
+            "@proto": ["src/proto.ts"],
+            "@retry": ["src/retry/index.ts"],
+            "@retry/*": ["src/retry/*"],
+            "@signal": ["src/signal/index.ts"],
+            "@signal/*": ["src/signal/*"],
+            "@store": ["src/store/index.ts"],
+            "@store/*": ["src/store/*"],
+            "@transport": ["src/transport/index.ts"],
+            "@transport/*": ["src/transport/*"],
+            "@util/*": ["src/util/*"],
+            "zapo-js": ["src/index.ts"],
+            "zapo-js/*": ["src/*/index.ts"],
+            "@zapo-js/*": ["packages/*/src"]
+        }
     },
-    "include": ["./**/*", "../src/**/*"]
+    "include": ["./**/*", "../src/**/*", "../packages/*/src/**/*"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,18 @@
 {
     "name": "zapo-js",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "lockfileVersion": 3,
     "requires": true,
+    "dev": true,
     "packages": {
         "": {
             "name": "zapo-js",
-            "version": "0.1.1",
+            "version": "0.1.2",
+            "dev": true,
             "hasInstallScript": true,
+            "workspaces": [
+                "packages/*"
+            ],
             "devDependencies": {
                 "@changesets/cli": "^2.30.0",
                 "@types/node": "^22.13.14",
@@ -24,12 +29,17 @@
                 "prettier": "^3.8.1",
                 "tsc-alias": "^1.8.16",
                 "tsx": "^4.20.6",
+                "turbo": "^2.8.20",
                 "typescript": "^5.7.3",
                 "typescript-eslint": "^8.56.1",
                 "ws": "^8.18.3"
             },
             "engines": {
                 "node": ">=20.9.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/vinikjkkj"
             },
             "peerDependencies": {
                 "better-sqlite3": "^11.9.1",
@@ -1337,6 +1347,90 @@
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
             }
         },
+        "node_modules/@turbo/darwin-64": {
+            "version": "2.8.20",
+            "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.8.20.tgz",
+            "integrity": "sha512-FQ9EX1xMU5nbwjxXxM3yU88AQQ6Sqc6S44exPRroMcx9XZHqqppl5ymJF0Ig/z3nvQNwDmz1Gsnvxubo+nXWjQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@turbo/darwin-arm64": {
+            "version": "2.8.20",
+            "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.8.20.tgz",
+            "integrity": "sha512-Gpyh9ATFGThD6/s9L95YWY54cizg/VRWl2B67h0yofG8BpHf67DFAh9nuJVKG7bY0+SBJDAo5cMur+wOl9YOYw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@turbo/linux-64": {
+            "version": "2.8.20",
+            "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.8.20.tgz",
+            "integrity": "sha512-p2QxWUYyYUgUFG0b0kR+pPi8t7c9uaVlRtjTTI1AbCvVqkpjUfCcReBn6DgG/Hu8xrWdKLuyQFaLYFzQskZbcA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@turbo/linux-arm64": {
+            "version": "2.8.20",
+            "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.8.20.tgz",
+            "integrity": "sha512-Gn5yjlZGLRZWarLWqdQzv0wMqyBNIdq1QLi48F1oY5Lo9kiohuf7BPQWtWxeNVS2NgJ1+nb/DzK1JduYC4AWOA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@turbo/windows-64": {
+            "version": "2.8.20",
+            "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.8.20.tgz",
+            "integrity": "sha512-vyaDpYk/8T6Qz5V/X+ihKvKFEZFUoC0oxYpC1sZanK6gaESJlmV3cMRT3Qhcg4D2VxvtC2Jjs9IRkrZGL+exLw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@turbo/windows-arm64": {
+            "version": "2.8.20",
+            "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.8.20.tgz",
+            "integrity": "sha512-voicVULvUV5yaGXo0Iue13BcHGYW3u0VgqSbfQwBaHbpj1zLjYV4KIe+7fYIo6DO8FVUJzxFps3ODCQG/Wy2Qw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1637,6 +1731,10 @@
                 "typescript-eslint": "^8.12.2"
             }
         },
+        "node_modules/@zapo-js/store-mysql": {
+            "resolved": "packages/store-mysql",
+            "link": true
+        },
         "node_modules/acorn": {
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1914,6 +2012,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/aws-ssl-profiles": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+            "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6.0.0"
             }
         },
         "node_modules/balanced-match": {
@@ -2519,6 +2627,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/denque": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+            "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.10"
             }
         },
         "node_modules/detect-indent": {
@@ -3491,6 +3609,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/generate-function": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+            "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-property": "^1.0.2"
+            }
+        },
         "node_modules/generator-function": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -4286,6 +4414,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-property": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/is-regex": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4641,6 +4776,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/long": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/lowercase-keys": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
@@ -4662,6 +4804,22 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
+            }
+        },
+        "node_modules/lru.min": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+            "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "bun": ">=1.0.0",
+                "deno": ">=1.30.0",
+                "node": ">=8.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wellwelwel"
             }
         },
         "node_modules/make-dir": {
@@ -4812,6 +4970,42 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/raouldeheer"
+            }
+        },
+        "node_modules/mysql2": {
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.20.0.tgz",
+            "integrity": "sha512-eCLUs7BNbgA6nf/MZXsaBO1SfGs0LtLVrJD3WeWq+jPLDWkSufTD+aGMwykfUVPdZnblaUK1a8G/P63cl9FkKg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "aws-ssl-profiles": "^1.1.2",
+                "denque": "^2.1.0",
+                "generate-function": "^2.3.1",
+                "iconv-lite": "^0.7.2",
+                "long": "^5.3.2",
+                "lru.min": "^1.1.4",
+                "named-placeholders": "^1.1.6",
+                "sql-escaper": "^1.3.3"
+            },
+            "engines": {
+                "node": ">= 8.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">= 8"
+            }
+        },
+        "node_modules/named-placeholders": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+            "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lru.min": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/napi-build-utils": {
@@ -6117,6 +6311,22 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
+        "node_modules/sql-escaper": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
+            "integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "bun": ">=1.0.0",
+                "deno": ">=2.0.0",
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+            }
+        },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -6457,6 +6667,24 @@
             },
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/turbo": {
+            "version": "2.8.20",
+            "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.8.20.tgz",
+            "integrity": "sha512-Rb4qk5YT8RUwwdXtkLpkVhNEe/lor6+WV7S5tTlLpxSz6MjV5Qi8jGNn4gS6NAvrYGA/rNrE6YUQM85sCZUDbQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "turbo": "bin/turbo"
+            },
+            "optionalDependencies": {
+                "@turbo/darwin-64": "2.8.20",
+                "@turbo/darwin-arm64": "2.8.20",
+                "@turbo/linux-64": "2.8.20",
+                "@turbo/linux-arm64": "2.8.20",
+                "@turbo/windows-64": "2.8.20",
+                "@turbo/windows-arm64": "2.8.20"
             }
         },
         "node_modules/type-check": {
@@ -6883,6 +7111,30 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zapo-js": {
+            "resolved": "",
+            "link": true
+        },
+        "packages/store-mysql": {
+            "name": "@zapo-js/store-mysql",
+            "version": "0.1.0",
+            "devDependencies": {
+                "mysql2": "^3.14.0",
+                "zapo-js": "file:../.."
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "peerDependencies": {
+                "mysql2": ">=3.0.0",
+                "zapo-js": ">=0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "zapo-js": {
+                    "optional": true
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "type": "github",
         "url": "https://github.com/sponsors/vinikjkkj"
     },
+    "packageManager": "npm@10.0.0",
     "main": "dist/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/types/index.d.ts",
@@ -70,6 +71,24 @@
             "import": "./dist/esm/transport/index.js",
             "default": "./dist/transport/index.js"
         },
+        "./protocol": {
+            "types": "./dist/types/protocol/index.d.ts",
+            "require": "./dist/protocol/index.js",
+            "import": "./dist/esm/protocol/index.js",
+            "default": "./dist/protocol/index.js"
+        },
+        "./retry": {
+            "types": "./dist/types/retry/index.d.ts",
+            "require": "./dist/retry/index.js",
+            "import": "./dist/esm/retry/index.js",
+            "default": "./dist/retry/index.js"
+        },
+        "./util": {
+            "types": "./dist/types/util/index.d.ts",
+            "require": "./dist/util/index.js",
+            "import": "./dist/esm/util/index.js",
+            "default": "./dist/util/index.js"
+        },
         "./proto": {
             "types": "./dist/types/proto.d.ts",
             "require": "./dist/proto.js",
@@ -84,6 +103,9 @@
         "proto/index.d.ts",
         "scripts/check-node-version.cjs"
     ],
+    "workspaces": [
+        "packages/*"
+    ],
     "engines": {
         "node": ">=20.9.0"
     },
@@ -92,13 +114,14 @@
         "changeset": "changeset",
         "changeset:status": "changeset status --verbose",
         "version:packages": "changeset version",
-        "release:publish": "npm run build && changeset publish",
+        "release:publish": "npm run build && npm run build:packages && changeset publish",
         "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
         "build:cjs": "tsc -p tsconfig.build.cjs.json && tsc-alias -p tsconfig.build.cjs.json",
         "build:esm": "tsc -p tsconfig.build.esm.json && tsc-alias -p tsconfig.build.esm.json",
         "build:types": "tsc -p tsconfig.build.types.json && tsc-alias -p tsconfig.build.types.json",
         "build:esm:finalize": "node ./scripts/finalize-esm-build.cjs",
         "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:types && npm run build:esm:finalize",
+        "build:packages": "turbo run build",
         "proto:generate": "node ./scripts/generate-proto.cjs",
         "example": "tsx examples/example.ts",
         "bench:media": "node --expose-gc --import tsx bench/media-streaming.bench.ts",
@@ -120,7 +143,6 @@
         "format": "prettier . --write",
         "format:check": "prettier . --check"
     },
-    "dependencies": {},
     "peerDependencies": {
         "better-sqlite3": "^11.9.1",
         "got": "14.6.4",
@@ -161,6 +183,7 @@
         "prettier": "^3.8.1",
         "tsc-alias": "^1.8.16",
         "tsx": "^4.20.6",
+        "turbo": "^2.8.20",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.56.1",
         "ws": "^8.18.3"

--- a/packages/store-mysql/package.json
+++ b/packages/store-mysql/package.json
@@ -1,0 +1,40 @@
+{
+    "name": "@zapo-js/store-mysql",
+    "version": "0.1.0",
+    "description": "MySQL store provider for zapo-js",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "require": "./dist/index.js",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": [
+        "dist"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsc -p tsconfig.build.cjs.json",
+        "typecheck": "tsc --noEmit"
+    },
+    "peerDependencies": {
+        "zapo-js": ">=0.1.0",
+        "mysql2": ">=3.0.0"
+    },
+    "peerDependenciesMeta": {
+        "zapo-js": {
+            "optional": true
+        }
+    },
+    "devDependencies": {
+        "mysql2": "^3.14.0",
+        "zapo-js": "file:../.."
+    },
+    "engines": {
+        "node": ">=20.9.0"
+    }
+}

--- a/packages/store-mysql/src/BaseMysqlStore.ts
+++ b/packages/store-mysql/src/BaseMysqlStore.ts
@@ -1,0 +1,63 @@
+import type { Pool, PoolConnection } from 'mysql2/promise'
+
+import { ensureMysqlMigrations } from './connection'
+import { assertSafeTablePrefix } from './helpers'
+import type { WaMysqlMigrationDomain, WaMysqlStorageOptions } from './types'
+
+export abstract class BaseMysqlStore {
+    protected readonly pool: Pool
+    protected readonly sessionId: string
+    protected readonly tablePrefix: string
+    private readonly migrationDomains: readonly WaMysqlMigrationDomain[]
+    private migrationPromise: Promise<void> | null
+
+    protected constructor(
+        options: WaMysqlStorageOptions,
+        migrationDomains: readonly WaMysqlMigrationDomain[]
+    ) {
+        this.pool = options.pool
+        this.sessionId = options.sessionId
+        this.tablePrefix = options.tablePrefix ?? ''
+        assertSafeTablePrefix(this.tablePrefix)
+        this.migrationDomains = migrationDomains
+        this.migrationPromise = null
+    }
+
+    protected t(name: string): string {
+        return `\`${this.tablePrefix}${name}\``
+    }
+
+    protected async ensureReady(): Promise<void> {
+        if (!this.migrationPromise) {
+            this.migrationPromise = ensureMysqlMigrations(
+                this.pool,
+                this.migrationDomains,
+                this.tablePrefix
+            ).catch((err) => {
+                this.migrationPromise = null
+                throw err
+            })
+        }
+        return this.migrationPromise
+    }
+
+    protected async withTransaction<T>(run: (conn: PoolConnection) => Promise<T>): Promise<T> {
+        await this.ensureReady()
+        const conn = await this.pool.getConnection()
+        try {
+            await conn.beginTransaction()
+            const result = await run(conn)
+            await conn.commit()
+            return result
+        } catch (err) {
+            await conn.rollback()
+            throw err
+        } finally {
+            conn.release()
+        }
+    }
+
+    public async destroy(): Promise<void> {
+        this.migrationPromise = null
+    }
+}

--- a/packages/store-mysql/src/appstate.store.ts
+++ b/packages/store-mysql/src/appstate.store.ts
@@ -1,0 +1,404 @@
+import type { PoolConnection } from 'mysql2/promise'
+import type {
+    AppStateCollectionName,
+    WaAppStateSyncKey,
+    WaAppStateStoreData
+} from 'zapo-js/appstate'
+import {
+    APP_STATE_EMPTY_LT_HASH,
+    encodeAppStateFingerprint,
+    decodeAppStateFingerprint,
+    keyEpoch
+} from 'zapo-js/appstate'
+import type {
+    WaAppStateStore,
+    WaAppStateCollectionStoreState,
+    WaAppStateCollectionStateUpdate
+} from 'zapo-js/store'
+
+import { BaseMysqlStore } from './BaseMysqlStore'
+import { queryFirst, queryRows, toBytes, toBytesOrNull, bytesToHex, uint8Equal } from './helpers'
+import type { MysqlParam, WaMysqlStorageOptions } from './types'
+
+const BATCH_SIZE = 500
+
+export class WaAppStateMysqlStore extends BaseMysqlStore implements WaAppStateStore {
+    public constructor(options: WaMysqlStorageOptions) {
+        super(options, ['appState'])
+    }
+
+    public async exportData(): Promise<WaAppStateStoreData> {
+        return this.withTransaction(async (conn) => {
+            const keyRows = queryRows(
+                await conn.execute(
+                    `SELECT key_id, key_data, timestamp, fingerprint
+                     FROM ${this.t('appstate_sync_keys')}
+                     WHERE session_id = ?`,
+                    [this.sessionId]
+                )
+            )
+            const versionRows = queryRows(
+                await conn.execute(
+                    `SELECT collection, version, hash
+                     FROM ${this.t('appstate_collection_versions')}
+                     WHERE session_id = ?`,
+                    [this.sessionId]
+                )
+            )
+            const valueRows = queryRows(
+                await conn.execute(
+                    `SELECT collection, index_mac_hex, value_mac
+                     FROM ${this.t('appstate_collection_index_values')}
+                     WHERE session_id = ?`,
+                    [this.sessionId]
+                )
+            )
+
+            const keys: WaAppStateSyncKey[] = keyRows.map((row) => ({
+                keyId: toBytes(row.key_id),
+                keyData: toBytes(row.key_data),
+                timestamp: Number(row.timestamp),
+                fingerprint: decodeAppStateFingerprint(toBytesOrNull(row.fingerprint))
+            }))
+
+            const collections: WaAppStateStoreData['collections'] = {}
+            for (const row of versionRows) {
+                const name = String(row.collection) as AppStateCollectionName
+                collections[name] = {
+                    version: Number(row.version),
+                    hash: toBytes(row.hash),
+                    indexValueMap: {}
+                }
+            }
+            for (const row of valueRows) {
+                const name = String(row.collection) as AppStateCollectionName
+                const entry = collections[name]
+                if (entry) {
+                    ;(entry.indexValueMap as Record<string, Uint8Array>)[
+                        String(row.index_mac_hex)
+                    ] = toBytes(row.value_mac)
+                }
+            }
+
+            return { keys, collections }
+        })
+    }
+
+    public async upsertSyncKeys(keys: readonly WaAppStateSyncKey[]): Promise<number> {
+        if (keys.length === 0) return 0
+        let inserted = 0
+        await this.withTransaction(async (conn) => {
+            const keyIds = keys.map((k) => k.keyId)
+            const existingByHex = await this.selectSyncKeyDataByIds(conn, keyIds)
+
+            for (const key of keys) {
+                const existing = existingByHex.get(bytesToHex(key.keyId))
+                if (existing && uint8Equal(existing, key.keyData)) {
+                    continue
+                }
+                await conn.execute(
+                    `INSERT INTO ${this.t('appstate_sync_keys')} (
+                        session_id, key_id, key_data, timestamp, fingerprint, key_epoch
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    ON DUPLICATE KEY UPDATE
+                        key_data = VALUES(key_data),
+                        timestamp = VALUES(timestamp),
+                        fingerprint = VALUES(fingerprint),
+                        key_epoch = VALUES(key_epoch)`,
+                    [
+                        this.sessionId,
+                        key.keyId,
+                        key.keyData,
+                        key.timestamp,
+                        encodeAppStateFingerprint(key.fingerprint),
+                        keyEpoch(key.keyId)
+                    ]
+                )
+                inserted += 1
+            }
+        })
+        return inserted
+    }
+
+    public async getSyncKeysBatch(
+        keyIds: readonly Uint8Array[]
+    ): Promise<readonly (WaAppStateSyncKey | null)[]> {
+        if (keyIds.length === 0) return []
+        await this.ensureReady()
+        const byHex = await this.selectSyncKeysByIds(keyIds)
+        return keyIds.map((id) => byHex.get(bytesToHex(id)) ?? null)
+    }
+
+    public async getSyncKeyData(keyId: Uint8Array): Promise<Uint8Array | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT key_data
+             FROM ${this.t('appstate_sync_keys')}
+             WHERE session_id = ? AND key_id = ?`,
+                [this.sessionId, keyId]
+            )
+        )
+        if (!row) return null
+        return toBytes(row.key_data)
+    }
+
+    public async getSyncKeyDataBatch(
+        keyIds: readonly Uint8Array[]
+    ): Promise<readonly (Uint8Array | null)[]> {
+        if (keyIds.length === 0) return []
+        await this.ensureReady()
+        const byHex = await this.selectSyncKeyDataByIds(this.pool, keyIds)
+        return keyIds.map((id) => byHex.get(bytesToHex(id)) ?? null)
+    }
+
+    public async getActiveSyncKey(): Promise<WaAppStateSyncKey | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT key_id, key_data, timestamp, fingerprint
+             FROM ${this.t('appstate_sync_keys')}
+             WHERE session_id = ?
+             ORDER BY key_epoch DESC, key_id ASC
+             LIMIT 1`,
+                [this.sessionId]
+            )
+        )
+        if (!row) return null
+        return {
+            keyId: toBytes(row.key_id),
+            keyData: toBytes(row.key_data),
+            timestamp: Number(row.timestamp),
+            fingerprint: decodeAppStateFingerprint(toBytesOrNull(row.fingerprint))
+        }
+    }
+
+    public async getCollectionState(
+        collection: AppStateCollectionName
+    ): Promise<WaAppStateCollectionStoreState> {
+        return this.withTransaction(async (conn) => {
+            const versionRow = queryFirst(
+                await conn.execute(
+                    `SELECT version, hash
+                     FROM ${this.t('appstate_collection_versions')}
+                     WHERE session_id = ? AND collection = ?`,
+                    [this.sessionId, collection]
+                )
+            )
+            if (!versionRow) {
+                return {
+                    initialized: false,
+                    version: 0,
+                    hash: APP_STATE_EMPTY_LT_HASH,
+                    indexValueMap: new Map()
+                }
+            }
+
+            const valueRows = queryRows(
+                await conn.execute(
+                    `SELECT index_mac_hex, value_mac
+                     FROM ${this.t('appstate_collection_index_values')}
+                     WHERE session_id = ? AND collection = ?`,
+                    [this.sessionId, collection]
+                )
+            )
+            const indexValueMap = new Map<string, Uint8Array>()
+            for (const row of valueRows) {
+                indexValueMap.set(String(row.index_mac_hex), toBytes(row.value_mac))
+            }
+
+            return {
+                initialized: true,
+                version: Number(versionRow.version),
+                hash: toBytes(versionRow.hash),
+                indexValueMap
+            }
+        })
+    }
+
+    public async getCollectionStates(
+        collections: readonly AppStateCollectionName[]
+    ): Promise<readonly WaAppStateCollectionStoreState[]> {
+        if (collections.length === 0) return []
+        return this.withTransaction(async (conn) => {
+            const uniqueCollections = [...new Set(collections)]
+            const placeholders = uniqueCollections.map(() => '?').join(', ')
+            const params: MysqlParam[] = [this.sessionId, ...uniqueCollections]
+
+            const versionRows = queryRows(
+                await conn.execute(
+                    `SELECT collection, version, hash
+                     FROM ${this.t('appstate_collection_versions')}
+                     WHERE session_id = ? AND collection IN (${placeholders})`,
+                    params
+                )
+            )
+            const valueRows = queryRows(
+                await conn.execute(
+                    `SELECT collection, index_mac_hex, value_mac
+                     FROM ${this.t('appstate_collection_index_values')}
+                     WHERE session_id = ? AND collection IN (${placeholders})`,
+                    params
+                )
+            )
+
+            const versionsByCollection = new Map<
+                AppStateCollectionName,
+                { version: number; hash: Uint8Array }
+            >()
+            for (const row of versionRows) {
+                const name = String(row.collection) as AppStateCollectionName
+                versionsByCollection.set(name, {
+                    version: Number(row.version),
+                    hash: toBytes(row.hash)
+                })
+            }
+
+            const indexValueMaps = new Map<AppStateCollectionName, Map<string, Uint8Array>>()
+            for (const row of valueRows) {
+                const name = String(row.collection) as AppStateCollectionName
+                let map = indexValueMaps.get(name)
+                if (!map) {
+                    map = new Map<string, Uint8Array>()
+                    indexValueMaps.set(name, map)
+                }
+                map.set(String(row.index_mac_hex), toBytes(row.value_mac))
+            }
+
+            return collections.map((collection) => {
+                const version = versionsByCollection.get(collection)
+                if (!version) {
+                    return {
+                        initialized: false,
+                        version: 0,
+                        hash: APP_STATE_EMPTY_LT_HASH,
+                        indexValueMap: new Map()
+                    }
+                }
+                return {
+                    initialized: true,
+                    version: version.version,
+                    hash: version.hash,
+                    indexValueMap: indexValueMaps.get(collection) ?? new Map()
+                }
+            })
+        })
+    }
+
+    public async setCollectionStates(
+        updates: readonly WaAppStateCollectionStateUpdate[]
+    ): Promise<void> {
+        if (updates.length === 0) return
+        await this.withTransaction(async (conn) => {
+            for (const update of updates) {
+                await conn.execute(
+                    `INSERT INTO ${this.t('appstate_collection_versions')} (
+                        session_id, collection, version, hash
+                    ) VALUES (?, ?, ?, ?)
+                    ON DUPLICATE KEY UPDATE
+                        version = VALUES(version),
+                        hash = VALUES(hash)`,
+                    [this.sessionId, update.collection, update.version, update.hash]
+                )
+
+                await conn.execute(
+                    `DELETE FROM ${this.t('appstate_collection_index_values')}
+                     WHERE session_id = ? AND collection = ?`,
+                    [this.sessionId, update.collection]
+                )
+
+                for (const [indexMacHex, valueMac] of update.indexValueMap.entries()) {
+                    await conn.execute(
+                        `INSERT INTO ${this.t('appstate_collection_index_values')} (
+                            session_id, collection, index_mac_hex, value_mac
+                        ) VALUES (?, ?, ?, ?)`,
+                        [this.sessionId, update.collection, indexMacHex, valueMac]
+                    )
+                }
+            }
+        })
+    }
+
+    public async clear(): Promise<void> {
+        await this.withTransaction(async (conn) => {
+            await conn.execute(`DELETE FROM ${this.t('appstate_sync_keys')} WHERE session_id = ?`, [
+                this.sessionId
+            ])
+            await conn.execute(
+                `DELETE FROM ${this.t('appstate_collection_versions')} WHERE session_id = ?`,
+                [this.sessionId]
+            )
+            await conn.execute(
+                `DELETE FROM ${this.t('appstate_collection_index_values')} WHERE session_id = ?`,
+                [this.sessionId]
+            )
+        })
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────
+
+    private async selectSyncKeyDataByIds(
+        executor: { execute: PoolConnection['execute'] },
+        keyIds: readonly Uint8Array[]
+    ): Promise<Map<string, Uint8Array>> {
+        const uniqueByHex = new Map<string, Uint8Array>()
+        for (const keyId of keyIds) {
+            uniqueByHex.set(bytesToHex(keyId), keyId)
+        }
+        const uniqueKeyIds = Array.from(uniqueByHex.values())
+        if (uniqueKeyIds.length === 0) return new Map()
+        const byHex = new Map<string, Uint8Array>()
+        for (let start = 0; start < uniqueKeyIds.length; start += BATCH_SIZE) {
+            const batch = uniqueKeyIds.slice(start, start + BATCH_SIZE)
+            const placeholders = batch.map(() => '?').join(', ')
+            const params: MysqlParam[] = [this.sessionId, ...batch]
+            const rows = queryRows(
+                await executor.execute(
+                    `SELECT key_id, key_data
+                 FROM ${this.t('appstate_sync_keys')}
+                 WHERE session_id = ? AND key_id IN (${placeholders})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                byHex.set(bytesToHex(toBytes(row.key_id)), toBytes(row.key_data))
+            }
+        }
+        return byHex
+    }
+
+    private async selectSyncKeysByIds(
+        keyIds: readonly Uint8Array[]
+    ): Promise<Map<string, WaAppStateSyncKey>> {
+        const uniqueByHex = new Map<string, Uint8Array>()
+        for (const keyId of keyIds) {
+            uniqueByHex.set(bytesToHex(keyId), keyId)
+        }
+        const uniqueKeyIds = Array.from(uniqueByHex.values())
+        if (uniqueKeyIds.length === 0) return new Map()
+        const byHex = new Map<string, WaAppStateSyncKey>()
+        for (let start = 0; start < uniqueKeyIds.length; start += BATCH_SIZE) {
+            const batch = uniqueKeyIds.slice(start, start + BATCH_SIZE)
+            const placeholders = batch.map(() => '?').join(', ')
+            const params: MysqlParam[] = [this.sessionId, ...batch]
+            const rows = queryRows(
+                await this.pool.execute(
+                    `SELECT key_id, key_data, timestamp, fingerprint
+                 FROM ${this.t('appstate_sync_keys')}
+                 WHERE session_id = ? AND key_id IN (${placeholders})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                const keyId = toBytes(row.key_id)
+                byHex.set(bytesToHex(keyId), {
+                    keyId,
+                    keyData: toBytes(row.key_data),
+                    timestamp: Number(row.timestamp),
+                    fingerprint: decodeAppStateFingerprint(toBytesOrNull(row.fingerprint))
+                })
+            }
+        }
+        return byHex
+    }
+}

--- a/packages/store-mysql/src/auth.store.ts
+++ b/packages/store-mysql/src/auth.store.ts
@@ -1,0 +1,159 @@
+import type { WaAuthCredentials } from 'zapo-js/auth'
+import { proto } from 'zapo-js/proto'
+import type { WaAuthStore } from 'zapo-js/store'
+
+import { BaseMysqlStore } from './BaseMysqlStore'
+import { queryFirst, toBytes, toBytesOrNull } from './helpers'
+import type { WaMysqlStorageOptions } from './types'
+
+export class WaAuthMysqlStore extends BaseMysqlStore implements WaAuthStore {
+    public constructor(options: WaMysqlStorageOptions) {
+        super(options, ['auth'])
+    }
+
+    public async load(): Promise<WaAuthCredentials | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT noise_pub_key, noise_priv_key, registration_id,
+                    identity_pub_key, identity_priv_key,
+                    signed_prekey_id, signed_prekey_pub_key, signed_prekey_priv_key, signed_prekey_signature,
+                    adv_secret_key, signed_identity,
+                    me_jid, me_lid, me_display_name, companion_enc_static,
+                    platform, server_static_key, server_has_prekeys, routing_info,
+                    last_success_ts, props_version, ab_props_version,
+                    connection_location, account_creation_ts
+             FROM ${this.t('auth_credentials')}
+             WHERE session_id = ?`,
+                [this.sessionId]
+            )
+        )
+        if (!row) return null
+
+        const signedIdentityBytes = toBytesOrNull(row.signed_identity)
+
+        return {
+            noiseKeyPair: {
+                pubKey: toBytes(row.noise_pub_key),
+                privKey: toBytes(row.noise_priv_key)
+            },
+            registrationInfo: {
+                registrationId: Number(row.registration_id),
+                identityKeyPair: {
+                    pubKey: toBytes(row.identity_pub_key),
+                    privKey: toBytes(row.identity_priv_key)
+                }
+            },
+            signedPreKey: {
+                keyId: Number(row.signed_prekey_id),
+                keyPair: {
+                    pubKey: toBytes(row.signed_prekey_pub_key),
+                    privKey: toBytes(row.signed_prekey_priv_key)
+                },
+                signature: toBytes(row.signed_prekey_signature),
+                uploaded: false
+            },
+            advSecretKey: toBytes(row.adv_secret_key),
+            signedIdentity: signedIdentityBytes
+                ? proto.ADVSignedDeviceIdentity.decode(signedIdentityBytes)
+                : undefined,
+            meJid: (row.me_jid as string | null) ?? undefined,
+            meLid: (row.me_lid as string | null) ?? undefined,
+            meDisplayName: (row.me_display_name as string | null) ?? undefined,
+            companionEncStatic: toBytesOrNull(row.companion_enc_static) ?? undefined,
+            platform: (row.platform as string | null) ?? undefined,
+            serverStaticKey: toBytesOrNull(row.server_static_key) ?? undefined,
+            serverHasPreKeys:
+                row.server_has_prekeys === null ? undefined : Number(row.server_has_prekeys) === 1,
+            routingInfo: toBytesOrNull(row.routing_info) ?? undefined,
+            lastSuccessTs: row.last_success_ts !== null ? Number(row.last_success_ts) : undefined,
+            propsVersion: row.props_version !== null ? Number(row.props_version) : undefined,
+            abPropsVersion:
+                row.ab_props_version !== null ? Number(row.ab_props_version) : undefined,
+            connectionLocation: (row.connection_location as string | null) ?? undefined,
+            accountCreationTs:
+                row.account_creation_ts !== null ? Number(row.account_creation_ts) : undefined
+        }
+    }
+
+    public async save(credentials: WaAuthCredentials): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(
+            `INSERT INTO ${this.t('auth_credentials')} (
+                session_id, noise_pub_key, noise_priv_key,
+                registration_id, identity_pub_key, identity_priv_key,
+                signed_prekey_id, signed_prekey_pub_key, signed_prekey_priv_key, signed_prekey_signature,
+                adv_secret_key, signed_identity,
+                me_jid, me_lid, me_display_name, companion_enc_static,
+                platform, server_static_key, server_has_prekeys, routing_info,
+                last_success_ts, props_version, ab_props_version,
+                connection_location, account_creation_ts
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                noise_pub_key = VALUES(noise_pub_key),
+                noise_priv_key = VALUES(noise_priv_key),
+                registration_id = VALUES(registration_id),
+                identity_pub_key = VALUES(identity_pub_key),
+                identity_priv_key = VALUES(identity_priv_key),
+                signed_prekey_id = VALUES(signed_prekey_id),
+                signed_prekey_pub_key = VALUES(signed_prekey_pub_key),
+                signed_prekey_priv_key = VALUES(signed_prekey_priv_key),
+                signed_prekey_signature = VALUES(signed_prekey_signature),
+                adv_secret_key = VALUES(adv_secret_key),
+                signed_identity = VALUES(signed_identity),
+                me_jid = VALUES(me_jid),
+                me_lid = VALUES(me_lid),
+                me_display_name = VALUES(me_display_name),
+                companion_enc_static = VALUES(companion_enc_static),
+                platform = VALUES(platform),
+                server_static_key = VALUES(server_static_key),
+                server_has_prekeys = VALUES(server_has_prekeys),
+                routing_info = VALUES(routing_info),
+                last_success_ts = VALUES(last_success_ts),
+                props_version = VALUES(props_version),
+                ab_props_version = VALUES(ab_props_version),
+                connection_location = VALUES(connection_location),
+                account_creation_ts = VALUES(account_creation_ts)`,
+            [
+                this.sessionId,
+                credentials.noiseKeyPair.pubKey,
+                credentials.noiseKeyPair.privKey,
+                credentials.registrationInfo.registrationId,
+                credentials.registrationInfo.identityKeyPair.pubKey,
+                credentials.registrationInfo.identityKeyPair.privKey,
+                credentials.signedPreKey.keyId,
+                credentials.signedPreKey.keyPair.pubKey,
+                credentials.signedPreKey.keyPair.privKey,
+                credentials.signedPreKey.signature,
+                credentials.advSecretKey,
+                credentials.signedIdentity
+                    ? proto.ADVSignedDeviceIdentity.encode(credentials.signedIdentity).finish()
+                    : null,
+                credentials.meJid ?? null,
+                credentials.meLid ?? null,
+                credentials.meDisplayName ?? null,
+                credentials.companionEncStatic ?? null,
+                credentials.platform ?? null,
+                credentials.serverStaticKey ?? null,
+                credentials.serverHasPreKeys === undefined
+                    ? null
+                    : credentials.serverHasPreKeys
+                      ? 1
+                      : 0,
+                credentials.routingInfo ?? null,
+                credentials.lastSuccessTs ?? null,
+                credentials.propsVersion ?? null,
+                credentials.abPropsVersion ?? null,
+                credentials.connectionLocation ?? null,
+                credentials.accountCreationTs ?? null
+            ]
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(`DELETE FROM ${this.t('auth_credentials')} WHERE session_id = ?`, [
+            this.sessionId
+        ])
+    }
+}

--- a/packages/store-mysql/src/cleanup.ts
+++ b/packages/store-mysql/src/cleanup.ts
@@ -1,0 +1,93 @@
+import type { WaDeviceListStore, WaParticipantsStore, WaRetryStore } from 'zapo-js/store'
+
+export interface MysqlCleanupPollerOptions {
+    readonly intervalMs?: number
+    readonly retry?: WaRetryStore
+    readonly participants?: WaParticipantsStore
+    readonly deviceList?: WaDeviceListStore
+    readonly onError?: (error: Error) => void
+}
+
+const DEFAULT_INTERVAL_MS = 60_000
+
+export class MysqlCleanupPoller {
+    private readonly intervalMs: number
+    private readonly retry: WaRetryStore | undefined
+    private readonly participants: WaParticipantsStore | undefined
+    private readonly deviceList: WaDeviceListStore | undefined
+    private readonly onError: ((error: Error) => void) | undefined
+    private timer: ReturnType<typeof setInterval> | null
+    private inFlight: boolean
+
+    public constructor(options: MysqlCleanupPollerOptions) {
+        const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS
+        if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+            throw new Error('cleanup intervalMs must be a positive finite number')
+        }
+        this.intervalMs = intervalMs
+        this.retry = options.retry
+        this.participants = options.participants
+        this.deviceList = options.deviceList
+        this.onError = options.onError
+        this.timer = null
+        this.inFlight = false
+    }
+
+    public start(): void {
+        if (this.timer) return
+        this.timer = setInterval(() => {
+            if (this.inFlight) return
+            this.inFlight = true
+            this.cleanup()
+                .catch((error: unknown) => {
+                    if (this.onError) {
+                        this.onError(error instanceof Error ? error : new Error(String(error)))
+                    }
+                })
+                .finally(() => {
+                    this.inFlight = false
+                })
+        }, this.intervalMs)
+        if (typeof this.timer === 'object' && 'unref' in this.timer) {
+            this.timer.unref()
+        }
+    }
+
+    public stop(): void {
+        if (!this.timer) return
+        clearInterval(this.timer)
+        this.timer = null
+    }
+
+    public async cleanup(): Promise<number> {
+        const nowMs = Date.now()
+        const tasks: Promise<number>[] = []
+        if (this.retry) tasks.push(this.retry.cleanupExpired(nowMs))
+        if (this.participants) tasks.push(this.participants.cleanupExpired(nowMs))
+        if (this.deviceList) tasks.push(this.deviceList.cleanupExpired(nowMs))
+
+        const results = await Promise.allSettled(tasks)
+        let total = 0
+        const errors: Error[] = []
+        for (const result of results) {
+            if (result.status === 'fulfilled') {
+                total += result.value
+            } else {
+                errors.push(
+                    result.reason instanceof Error
+                        ? result.reason
+                        : new Error(String(result.reason))
+                )
+            }
+        }
+        if (errors.length === 1) {
+            throw errors[0]
+        }
+        if (errors.length > 1) {
+            throw new Error(
+                `${errors.length} cleanup tasks failed: ${errors.map((e) => e.message).join('; ')}`
+            )
+        }
+        return total
+    }
+}

--- a/packages/store-mysql/src/connection.ts
+++ b/packages/store-mysql/src/connection.ts
@@ -1,0 +1,361 @@
+import mysql from 'mysql2/promise'
+import type { Pool, PoolOptions } from 'mysql2/promise'
+
+import { queryRows } from './helpers'
+import type { WaMysqlMigrationDomain } from './types'
+
+interface Migration {
+    readonly name: string
+    readonly domain: WaMysqlMigrationDomain
+    readonly sql: string
+}
+
+const MIGRATIONS: readonly Migration[] = [
+    {
+        name: '0001_auth_credentials',
+        domain: 'auth',
+        sql: `
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__auth_credentials\` (
+                session_id VARCHAR(255) NOT NULL,
+                noise_pub_key LONGBLOB NOT NULL,
+                noise_priv_key LONGBLOB NOT NULL,
+                registration_id BIGINT NOT NULL,
+                identity_pub_key LONGBLOB NOT NULL,
+                identity_priv_key LONGBLOB NOT NULL,
+                signed_prekey_id BIGINT NOT NULL,
+                signed_prekey_pub_key LONGBLOB NOT NULL,
+                signed_prekey_priv_key LONGBLOB NOT NULL,
+                signed_prekey_signature LONGBLOB NOT NULL,
+                adv_secret_key LONGBLOB NOT NULL,
+                signed_identity LONGBLOB,
+                me_jid VARCHAR(255),
+                me_lid VARCHAR(255),
+                me_display_name VARCHAR(255),
+                companion_enc_static LONGBLOB,
+                platform VARCHAR(100),
+                server_static_key LONGBLOB,
+                server_has_prekeys TINYINT(1),
+                routing_info LONGBLOB,
+                last_success_ts BIGINT,
+                props_version BIGINT,
+                ab_props_version BIGINT,
+                connection_location VARCHAR(255),
+                account_creation_ts BIGINT,
+                PRIMARY KEY (session_id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+        `
+    },
+    {
+        name: '0002_signal_schema',
+        domain: 'signal',
+        sql: `
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__signal_meta\` (
+                session_id VARCHAR(255) NOT NULL,
+                server_has_prekeys TINYINT(1) NOT NULL DEFAULT 0,
+                next_prekey_id BIGINT NOT NULL DEFAULT 1,
+                signed_prekey_rotation_ts BIGINT,
+                PRIMARY KEY (session_id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__signal_registration\` (
+                session_id VARCHAR(255) NOT NULL,
+                registration_id BIGINT NOT NULL,
+                identity_pub_key LONGBLOB NOT NULL,
+                identity_priv_key LONGBLOB NOT NULL,
+                PRIMARY KEY (session_id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__signal_signed_prekey\` (
+                session_id VARCHAR(255) NOT NULL,
+                key_id BIGINT NOT NULL,
+                pub_key LONGBLOB NOT NULL,
+                priv_key LONGBLOB NOT NULL,
+                signature LONGBLOB NOT NULL,
+                uploaded TINYINT(1) NOT NULL DEFAULT 0,
+                PRIMARY KEY (session_id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__signal_prekey\` (
+                session_id VARCHAR(255) NOT NULL,
+                key_id BIGINT NOT NULL,
+                pub_key LONGBLOB NOT NULL,
+                priv_key LONGBLOB NOT NULL,
+                uploaded TINYINT(1) NOT NULL DEFAULT 0,
+                PRIMARY KEY (session_id, key_id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__signal_session\` (
+                session_id VARCHAR(128) NOT NULL,
+                user VARCHAR(128) NOT NULL,
+                server VARCHAR(128) NOT NULL,
+                device INT NOT NULL,
+                record LONGBLOB NOT NULL,
+                PRIMARY KEY (session_id, user, server, device)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__signal_identity\` (
+                session_id VARCHAR(128) NOT NULL,
+                user VARCHAR(128) NOT NULL,
+                server VARCHAR(128) NOT NULL,
+                device INT NOT NULL,
+                identity_key LONGBLOB NOT NULL,
+                PRIMARY KEY (session_id, user, server, device)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+        `
+    },
+    {
+        name: '0003_sender_key_schema',
+        domain: 'senderKey',
+        sql: `
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__sender_keys\` (
+                session_id VARCHAR(128) NOT NULL,
+                group_id VARCHAR(128) NOT NULL,
+                sender_user VARCHAR(128) NOT NULL,
+                sender_server VARCHAR(128) NOT NULL,
+                sender_device INT NOT NULL,
+                record LONGBLOB NOT NULL,
+                PRIMARY KEY (session_id, group_id, sender_user, sender_server, sender_device)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__sender_key_distribution\` (
+                session_id VARCHAR(128) NOT NULL,
+                group_id VARCHAR(128) NOT NULL,
+                sender_user VARCHAR(128) NOT NULL,
+                sender_server VARCHAR(128) NOT NULL,
+                sender_device INT NOT NULL,
+                key_id BIGINT NOT NULL,
+                timestamp_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, group_id, sender_user, sender_server, sender_device)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+        `
+    },
+    {
+        name: '0004_appstate_schema',
+        domain: 'appState',
+        sql: `
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__appstate_sync_keys\` (
+                session_id VARCHAR(255) NOT NULL,
+                key_id VARBINARY(255) NOT NULL,
+                key_data LONGBLOB NOT NULL,
+                timestamp BIGINT NOT NULL,
+                fingerprint LONGBLOB,
+                key_epoch INT NOT NULL DEFAULT 0,
+                PRIMARY KEY (session_id, key_id(64))
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__appstate_collection_versions\` (
+                session_id VARCHAR(255) NOT NULL,
+                collection VARCHAR(100) NOT NULL,
+                version BIGINT NOT NULL,
+                hash LONGBLOB NOT NULL,
+                PRIMARY KEY (session_id, collection)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__appstate_collection_index_values\` (
+                session_id VARCHAR(255) NOT NULL,
+                collection VARCHAR(100) NOT NULL,
+                index_mac_hex VARCHAR(255) NOT NULL,
+                value_mac LONGBLOB NOT NULL,
+                PRIMARY KEY (session_id, collection, index_mac_hex)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+        `
+    },
+    {
+        name: '0005_retry_schema',
+        domain: 'retry',
+        sql: `
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__retry_outbound_messages\` (
+                session_id VARCHAR(255) NOT NULL,
+                message_id VARCHAR(255) NOT NULL,
+                to_jid VARCHAR(255) NOT NULL,
+                participant_jid VARCHAR(255),
+                recipient_jid VARCHAR(255),
+                message_type VARCHAR(100) NOT NULL,
+                replay_mode VARCHAR(100) NOT NULL,
+                replay_payload LONGBLOB NOT NULL,
+                requesters_json TEXT,
+                state VARCHAR(50) NOT NULL,
+                created_at_ms BIGINT NOT NULL,
+                updated_at_ms BIGINT NOT NULL,
+                expires_at_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, message_id),
+                INDEX idx_retry_outbound_expires (session_id, expires_at_ms),
+                INDEX idx_retry_outbound_state (session_id, state)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__retry_inbound_counters\` (
+                session_id VARCHAR(255) NOT NULL,
+                message_id VARCHAR(255) NOT NULL,
+                requester_jid VARCHAR(255) NOT NULL,
+                retry_count INT NOT NULL DEFAULT 0,
+                updated_at_ms BIGINT NOT NULL,
+                expires_at_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, message_id, requester_jid),
+                INDEX idx_retry_inbound_expires (session_id, expires_at_ms)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+        `
+    },
+    {
+        name: '0006_mailbox_schema',
+        domain: 'mailbox',
+        sql: `
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__mailbox_messages\` (
+                session_id VARCHAR(255) NOT NULL,
+                message_id VARCHAR(255) NOT NULL,
+                thread_jid VARCHAR(255) NOT NULL,
+                sender_jid VARCHAR(255),
+                participant_jid VARCHAR(255),
+                from_me TINYINT(1) NOT NULL DEFAULT 0,
+                timestamp_ms BIGINT,
+                enc_type VARCHAR(50),
+                plaintext LONGBLOB,
+                message_bytes LONGBLOB,
+                PRIMARY KEY (session_id, message_id),
+                INDEX idx_messages_thread_ts (session_id, thread_jid, timestamp_ms DESC, message_id DESC)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__mailbox_threads\` (
+                session_id VARCHAR(255) NOT NULL,
+                jid VARCHAR(255) NOT NULL,
+                name VARCHAR(255),
+                unread_count INT,
+                archived TINYINT(1),
+                pinned INT,
+                mute_end_ms BIGINT,
+                marked_as_unread TINYINT(1),
+                ephemeral_expiration INT,
+                PRIMARY KEY (session_id, jid)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__mailbox_contacts\` (
+                session_id VARCHAR(255) NOT NULL,
+                jid VARCHAR(255) NOT NULL,
+                display_name VARCHAR(255),
+                push_name VARCHAR(255),
+                lid VARCHAR(255),
+                phone_number VARCHAR(50),
+                last_updated_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, jid)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+        `
+    },
+    {
+        name: '0007_participants_cache_schema',
+        domain: 'participants',
+        sql: `
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__group_participants_cache\` (
+                session_id VARCHAR(255) NOT NULL,
+                group_jid VARCHAR(255) NOT NULL,
+                participants_json TEXT NOT NULL,
+                updated_at_ms BIGINT NOT NULL,
+                expires_at_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, group_jid),
+                INDEX idx_participants_expires (session_id, expires_at_ms)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+        `
+    },
+    {
+        name: '0008_device_list_cache_schema',
+        domain: 'deviceList',
+        sql: `
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__device_list_cache\` (
+                session_id VARCHAR(255) NOT NULL,
+                user_jid VARCHAR(255) NOT NULL,
+                device_jids_json TEXT NOT NULL,
+                updated_at_ms BIGINT NOT NULL,
+                expires_at_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, user_jid),
+                INDEX idx_device_list_expires (session_id, expires_at_ms)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+        `
+    },
+    {
+        name: '0009_privacy_token_schema',
+        domain: 'privacyToken',
+        sql: `
+            CREATE TABLE IF NOT EXISTS \`__PREFIX__privacy_tokens\` (
+                session_id VARCHAR(255) NOT NULL,
+                jid VARCHAR(255) NOT NULL,
+                tc_token LONGBLOB,
+                tc_token_timestamp BIGINT,
+                tc_token_sender_timestamp BIGINT,
+                nct_salt LONGBLOB,
+                updated_at_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, jid)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+        `
+    }
+]
+
+export function createMysqlPool(options: PoolOptions): Pool {
+    const userTypeCast = options.typeCast
+    return mysql.createPool({
+        ...options,
+        typeCast: function (field, next) {
+            if (
+                field.type === 'BLOB' ||
+                field.type === 'LONG_BLOB' ||
+                field.type === 'MEDIUM_BLOB' ||
+                field.type === 'TINY_BLOB'
+            ) {
+                const buf = field.buffer()
+                return buf ? new Uint8Array(buf) : null
+            }
+            if (typeof userTypeCast === 'function') {
+                return userTypeCast(field, next)
+            }
+            return next()
+        }
+    })
+}
+
+export async function ensureMysqlMigrations(
+    pool: Pool,
+    domains: readonly WaMysqlMigrationDomain[],
+    tablePrefix = ''
+): Promise<void> {
+    const t = (name: string) => `${tablePrefix}${name}`
+    const domainSet = new Set(domains)
+    const pending = MIGRATIONS.filter((m) => domainSet.has(m.domain))
+    if (pending.length === 0) return
+
+    await pool.execute(`
+        CREATE TABLE IF NOT EXISTS \`${t('_migrations')}\` (
+            name VARCHAR(255) PRIMARY KEY,
+            applied_at BIGINT NOT NULL
+        )
+    `)
+
+    const applied = new Set(
+        queryRows(await pool.execute(`SELECT name FROM \`${t('_migrations')}\``)).map(
+            (r) => r.name as string
+        )
+    )
+
+    for (const migration of pending) {
+        if (applied.has(migration.name)) continue
+
+        const conn = await pool.getConnection()
+        try {
+            await conn.beginTransaction()
+            const sql = migration.sql.replace(/__PREFIX__/g, tablePrefix)
+            const statements = sql
+                .split(';')
+                .map((s) => s.trim())
+                .filter(Boolean)
+            for (const stmt of statements) {
+                await conn.execute(stmt)
+            }
+            await conn.execute(
+                `INSERT IGNORE INTO \`${t('_migrations')}\` (name, applied_at) VALUES (?, ?)`,
+                [migration.name, Date.now()]
+            )
+            await conn.commit()
+        } catch (err) {
+            await conn.rollback()
+            throw err
+        } finally {
+            conn.release()
+        }
+    }
+}

--- a/packages/store-mysql/src/contact.store.ts
+++ b/packages/store-mysql/src/contact.store.ts
@@ -1,0 +1,106 @@
+import type { WaContactStore, WaStoredContactRecord } from 'zapo-js/store'
+
+import { BaseMysqlStore } from './BaseMysqlStore'
+import { affectedRows, queryFirst } from './helpers'
+import type { WaMysqlStorageOptions } from './types'
+
+export class WaContactMysqlStore extends BaseMysqlStore implements WaContactStore {
+    public constructor(options: WaMysqlStorageOptions) {
+        super(options, ['mailbox'])
+    }
+
+    public async upsert(record: WaStoredContactRecord): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(
+            `INSERT INTO ${this.t('mailbox_contacts')} (
+                session_id, jid, display_name, push_name, lid,
+                phone_number, last_updated_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                display_name = COALESCE(VALUES(display_name), display_name),
+                push_name = COALESCE(VALUES(push_name), push_name),
+                lid = COALESCE(VALUES(lid), lid),
+                phone_number = COALESCE(VALUES(phone_number), phone_number),
+                last_updated_ms = VALUES(last_updated_ms)`,
+            [
+                this.sessionId,
+                record.jid,
+                record.displayName ?? null,
+                record.pushName ?? null,
+                record.lid ?? null,
+                record.phoneNumber ?? null,
+                record.lastUpdatedMs
+            ]
+        )
+    }
+
+    public async upsertBatch(records: readonly WaStoredContactRecord[]): Promise<void> {
+        if (records.length === 0) return
+
+        await this.withTransaction(async (conn) => {
+            for (const record of records) {
+                await conn.execute(
+                    `INSERT INTO ${this.t('mailbox_contacts')} (
+                        session_id, jid, display_name, push_name, lid,
+                        phone_number, last_updated_ms
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON DUPLICATE KEY UPDATE
+                        display_name = COALESCE(VALUES(display_name), display_name),
+                        push_name = COALESCE(VALUES(push_name), push_name),
+                        lid = COALESCE(VALUES(lid), lid),
+                        phone_number = COALESCE(VALUES(phone_number), phone_number),
+                        last_updated_ms = VALUES(last_updated_ms)`,
+                    [
+                        this.sessionId,
+                        record.jid,
+                        record.displayName ?? null,
+                        record.pushName ?? null,
+                        record.lid ?? null,
+                        record.phoneNumber ?? null,
+                        record.lastUpdatedMs
+                    ]
+                )
+            }
+        })
+    }
+
+    public async getByJid(jid: string): Promise<WaStoredContactRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT jid, display_name, push_name, lid,
+                    phone_number, last_updated_ms
+             FROM ${this.t('mailbox_contacts')}
+             WHERE session_id = ? AND jid = ?`,
+                [this.sessionId, jid]
+            )
+        )
+        if (!row) return null
+        return {
+            jid: row.jid as string,
+            displayName: (row.display_name as string | null) ?? undefined,
+            pushName: (row.push_name as string | null) ?? undefined,
+            lid: (row.lid as string | null) ?? undefined,
+            phoneNumber: (row.phone_number as string | null) ?? undefined,
+            lastUpdatedMs: Number(row.last_updated_ms)
+        }
+    }
+
+    public async deleteByJid(jid: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.execute(
+                `DELETE FROM ${this.t('mailbox_contacts')}
+             WHERE session_id = ? AND jid = ?`,
+                [this.sessionId, jid]
+            )
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(`DELETE FROM ${this.t('mailbox_contacts')} WHERE session_id = ?`, [
+            this.sessionId
+        ])
+    }
+}

--- a/packages/store-mysql/src/createMysqlStore.ts
+++ b/packages/store-mysql/src/createMysqlStore.ts
@@ -1,0 +1,115 @@
+import type { Pool, PoolOptions } from 'mysql2/promise'
+
+import { WaAppStateMysqlStore } from './appstate.store'
+import { WaAuthMysqlStore } from './auth.store'
+import { MysqlCleanupPoller } from './cleanup'
+import { createMysqlPool } from './connection'
+import { WaContactMysqlStore } from './contact.store'
+import { WaDeviceListMysqlStore } from './device-list.store'
+import { WaMessageMysqlStore } from './message.store'
+import { WaParticipantsMysqlStore } from './participants.store'
+import { WaPrivacyTokenMysqlStore } from './privacy-token.store'
+import { WaRetryMysqlStore } from './retry.store'
+import { WaSenderKeyMysqlStore } from './sender-key.store'
+import { WaSignalMysqlStore } from './signal.store'
+import { WaThreadMysqlStore } from './thread.store'
+import type { WaMysqlStorageOptions } from './types'
+
+export interface WaMysqlStoreConfig {
+    readonly pool: Pool | PoolOptions
+    readonly tablePrefix?: string
+    readonly cacheTtlMs?: {
+        readonly retryMs?: number
+        readonly participantsMs?: number
+        readonly deviceListMs?: number
+    }
+    readonly cleanup?: {
+        readonly enabled?: boolean
+        readonly intervalMs?: number
+        readonly onError?: (error: Error) => void
+    }
+}
+
+export interface WaMysqlStoreResult {
+    readonly pool: Pool
+    readonly stores: {
+        readonly auth: (sessionId: string) => WaAuthMysqlStore
+        readonly signal: (sessionId: string) => WaSignalMysqlStore
+        readonly senderKey: (sessionId: string) => WaSenderKeyMysqlStore
+        readonly appState: (sessionId: string) => WaAppStateMysqlStore
+        readonly messages: (sessionId: string) => WaMessageMysqlStore
+        readonly threads: (sessionId: string) => WaThreadMysqlStore
+        readonly contacts: (sessionId: string) => WaContactMysqlStore
+        readonly privacyToken: (sessionId: string) => WaPrivacyTokenMysqlStore
+    }
+    readonly caches: {
+        readonly retry: (sessionId: string) => WaRetryMysqlStore
+        readonly participants: (sessionId: string) => WaParticipantsMysqlStore
+        readonly deviceList: (sessionId: string) => WaDeviceListMysqlStore
+    }
+    startCleanup(sessionId: string): MysqlCleanupPoller
+    destroy(): Promise<void>
+}
+
+function isPool(value: Pool | PoolOptions): value is Pool {
+    return typeof (value as Pool).execute === 'function'
+}
+
+export function createMysqlStore(config: WaMysqlStoreConfig): WaMysqlStoreResult {
+    const pool = isPool(config.pool) ? config.pool : createMysqlPool(config.pool)
+    const tablePrefix = config.tablePrefix ?? ''
+    const retryTtlMs = config.cacheTtlMs?.retryMs
+    const participantsTtlMs = config.cacheTtlMs?.participantsMs
+    const deviceListTtlMs = config.cacheTtlMs?.deviceListMs
+    const ownsPool = !isPool(config.pool)
+
+    const opts = (sessionId: string): WaMysqlStorageOptions => ({
+        pool,
+        sessionId,
+        tablePrefix
+    })
+
+    const cleanupPollers = new Set<MysqlCleanupPoller>()
+
+    return {
+        pool,
+        stores: {
+            auth: (sessionId) => new WaAuthMysqlStore(opts(sessionId)),
+            signal: (sessionId) => new WaSignalMysqlStore(opts(sessionId)),
+            senderKey: (sessionId) => new WaSenderKeyMysqlStore(opts(sessionId)),
+            appState: (sessionId) => new WaAppStateMysqlStore(opts(sessionId)),
+            messages: (sessionId) => new WaMessageMysqlStore(opts(sessionId)),
+            threads: (sessionId) => new WaThreadMysqlStore(opts(sessionId)),
+            contacts: (sessionId) => new WaContactMysqlStore(opts(sessionId)),
+            privacyToken: (sessionId) => new WaPrivacyTokenMysqlStore(opts(sessionId))
+        },
+        caches: {
+            retry: (sessionId) => new WaRetryMysqlStore(opts(sessionId), retryTtlMs),
+            participants: (sessionId) =>
+                new WaParticipantsMysqlStore(opts(sessionId), participantsTtlMs),
+            deviceList: (sessionId) => new WaDeviceListMysqlStore(opts(sessionId), deviceListTtlMs)
+        },
+        startCleanup(sessionId: string): MysqlCleanupPoller {
+            const o = opts(sessionId)
+            const poller = new MysqlCleanupPoller({
+                intervalMs: config.cleanup?.intervalMs,
+                retry: new WaRetryMysqlStore(o, retryTtlMs),
+                participants: new WaParticipantsMysqlStore(o, participantsTtlMs),
+                deviceList: new WaDeviceListMysqlStore(o, deviceListTtlMs),
+                onError: config.cleanup?.onError
+            })
+            poller.start()
+            cleanupPollers.add(poller)
+            return poller
+        },
+        async destroy(): Promise<void> {
+            for (const poller of cleanupPollers) {
+                poller.stop()
+            }
+            cleanupPollers.clear()
+            if (ownsPool) {
+                await pool.end()
+            }
+        }
+    }
+}

--- a/packages/store-mysql/src/device-list.store.ts
+++ b/packages/store-mysql/src/device-list.store.ts
@@ -1,0 +1,129 @@
+import type { WaDeviceListSnapshot, WaDeviceListStore } from 'zapo-js/store'
+
+import { BaseMysqlStore } from './BaseMysqlStore'
+import { affectedRows, queryRows } from './helpers'
+import type { WaMysqlStorageOptions } from './types'
+
+const DEFAULT_DEVICE_LIST_TTL_MS = 5 * 60 * 1000
+const BATCH_SIZE = 500
+
+export class WaDeviceListMysqlStore extends BaseMysqlStore implements WaDeviceListStore {
+    private readonly ttlMs: number
+
+    public constructor(options: WaMysqlStorageOptions, ttlMs = DEFAULT_DEVICE_LIST_TTL_MS) {
+        super(options, ['deviceList'])
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('device-list ttlMs must be a non-negative finite number')
+        }
+        this.ttlMs = ttlMs
+    }
+
+    public async upsertUserDevicesBatch(snapshots: readonly WaDeviceListSnapshot[]): Promise<void> {
+        if (snapshots.length === 0) return
+        await this.withTransaction(async (conn) => {
+            for (const snapshot of snapshots) {
+                await conn.execute(
+                    `INSERT INTO ${this.t('device_list_cache')} (
+                        session_id, user_jid, device_jids_json, updated_at_ms, expires_at_ms
+                    ) VALUES (?, ?, ?, ?, ?)
+                    ON DUPLICATE KEY UPDATE
+                        device_jids_json = VALUES(device_jids_json),
+                        updated_at_ms = VALUES(updated_at_ms),
+                        expires_at_ms = VALUES(expires_at_ms)`,
+                    [
+                        this.sessionId,
+                        snapshot.userJid,
+                        JSON.stringify(snapshot.deviceJids),
+                        snapshot.updatedAtMs,
+                        snapshot.updatedAtMs + this.ttlMs
+                    ]
+                )
+            }
+        })
+    }
+
+    public async getUserDevicesBatch(
+        userJids: readonly string[],
+        nowMs = Date.now()
+    ): Promise<readonly (WaDeviceListSnapshot | null)[]> {
+        if (userJids.length === 0) return []
+        await this.ensureReady()
+
+        const uniqueUserJids = [...new Set(userJids)]
+        const activeByUserJid = new Map<string, WaDeviceListSnapshot>()
+        const expiredUserJids: string[] = []
+
+        for (let start = 0; start < uniqueUserJids.length; start += BATCH_SIZE) {
+            const batch = uniqueUserJids.slice(start, start + BATCH_SIZE)
+            const placeholders = batch.map(() => '?').join(', ')
+            const rows = queryRows(
+                await this.pool.execute(
+                    `SELECT user_jid, device_jids_json, updated_at_ms, expires_at_ms
+                     FROM ${this.t('device_list_cache')}
+                     WHERE session_id = ? AND user_jid IN (${placeholders})`,
+                    [this.sessionId, ...batch]
+                )
+            )
+            for (const row of rows) {
+                const userJid = String(row.user_jid)
+                const expiresAtMs = Number(row.expires_at_ms)
+                if (expiresAtMs <= nowMs) {
+                    expiredUserJids.push(userJid)
+                    continue
+                }
+                const parsed: unknown = JSON.parse(row.device_jids_json as string)
+                if (!Array.isArray(parsed)) {
+                    throw new Error('device_list_cache.device_jids_json must be an array')
+                }
+                activeByUserJid.set(userJid, {
+                    userJid,
+                    deviceJids: parsed.map((entry: unknown) => String(entry)),
+                    updatedAtMs: Number(row.updated_at_ms)
+                })
+            }
+        }
+
+        if (expiredUserJids.length > 0) {
+            for (let start = 0; start < expiredUserJids.length; start += BATCH_SIZE) {
+                const batch = expiredUserJids.slice(start, start + BATCH_SIZE)
+                const placeholders = batch.map(() => '?').join(', ')
+                await this.pool.execute(
+                    `DELETE FROM ${this.t('device_list_cache')}
+                     WHERE session_id = ? AND expires_at_ms <= ? AND user_jid IN (${placeholders})`,
+                    [this.sessionId, nowMs, ...batch]
+                )
+            }
+        }
+
+        return userJids.map((jid) => activeByUserJid.get(jid) ?? null)
+    }
+
+    public async deleteUserDevices(userJid: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.execute(
+                `DELETE FROM ${this.t('device_list_cache')}
+             WHERE session_id = ? AND user_jid = ?`,
+                [this.sessionId, userJid]
+            )
+        )
+    }
+
+    public async cleanupExpired(nowMs: number): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.execute(
+                `DELETE FROM ${this.t('device_list_cache')}
+             WHERE session_id = ? AND expires_at_ms <= ?`,
+                [this.sessionId, nowMs]
+            )
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(`DELETE FROM ${this.t('device_list_cache')} WHERE session_id = ?`, [
+            this.sessionId
+        ])
+    }
+}

--- a/packages/store-mysql/src/helpers.ts
+++ b/packages/store-mysql/src/helpers.ts
@@ -1,0 +1,39 @@
+import type { FieldPacket, ResultSetHeader } from 'mysql2/promise'
+import { bytesToHex, normalizeQueryLimit, toBytesView, uint8Equal } from 'zapo-js/util'
+
+export type MysqlRow = Record<string, unknown>
+type QueryOutput = [unknown, FieldPacket[]]
+
+export function queryRows(output: QueryOutput): MysqlRow[] {
+    return output[0] as MysqlRow[]
+}
+
+export function queryFirst(output: QueryOutput): MysqlRow | undefined {
+    return (output[0] as MysqlRow[])[0]
+}
+
+export function affectedRows(output: QueryOutput): number {
+    return (output[0] as ResultSetHeader).affectedRows
+}
+
+export function toBytes(value: unknown): Uint8Array {
+    if (value instanceof Uint8Array) return value
+    if (value instanceof ArrayBuffer) return new Uint8Array(value)
+    if (ArrayBuffer.isView(value)) return toBytesView(value)
+    throw new Error('expected binary data')
+}
+
+export function toBytesOrNull(value: unknown): Uint8Array | null {
+    if (value === null || value === undefined) return null
+    return toBytes(value)
+}
+
+const SAFE_PREFIX_RE = /^[A-Za-z0-9_]*$/
+
+export function assertSafeTablePrefix(prefix: string): void {
+    if (!SAFE_PREFIX_RE.test(prefix)) {
+        throw new Error('tablePrefix must contain only letters, numbers, and underscores')
+    }
+}
+
+export { bytesToHex, normalizeQueryLimit as safeLimit, uint8Equal }

--- a/packages/store-mysql/src/index.ts
+++ b/packages/store-mysql/src/index.ts
@@ -1,0 +1,24 @@
+export type {
+    WaMysqlStorageOptions,
+    WaMysqlCreateStoreOptions,
+    WaMysqlMigrationDomain
+} from './types'
+export { createMysqlPool, ensureMysqlMigrations } from './connection'
+export { BaseMysqlStore } from './BaseMysqlStore'
+export { WaAuthMysqlStore } from './auth.store'
+export { WaSignalMysqlStore } from './signal.store'
+export { WaSenderKeyMysqlStore } from './sender-key.store'
+export { WaAppStateMysqlStore } from './appstate.store'
+export { WaRetryMysqlStore } from './retry.store'
+export { WaParticipantsMysqlStore } from './participants.store'
+export { WaDeviceListMysqlStore } from './device-list.store'
+export { WaMessageMysqlStore } from './message.store'
+export { WaThreadMysqlStore } from './thread.store'
+export { WaContactMysqlStore } from './contact.store'
+export { WaPrivacyTokenMysqlStore } from './privacy-token.store'
+export { MysqlCleanupPoller, type MysqlCleanupPollerOptions } from './cleanup'
+export {
+    createMysqlStore,
+    type WaMysqlStoreConfig,
+    type WaMysqlStoreResult
+} from './createMysqlStore'

--- a/packages/store-mysql/src/message.store.ts
+++ b/packages/store-mysql/src/message.store.ts
@@ -1,0 +1,167 @@
+import type { WaMessageStore, WaStoredMessageRecord } from 'zapo-js/store'
+
+import { BaseMysqlStore } from './BaseMysqlStore'
+import {
+    affectedRows,
+    queryFirst,
+    queryRows,
+    safeLimit,
+    toBytesOrNull,
+    type MysqlRow
+} from './helpers'
+import type { WaMysqlStorageOptions } from './types'
+
+function rowToRecord(row: MysqlRow): WaStoredMessageRecord {
+    return {
+        id: row.message_id as string,
+        threadJid: row.thread_jid as string,
+        senderJid: (row.sender_jid as string | null) ?? undefined,
+        participantJid: (row.participant_jid as string | null) ?? undefined,
+        fromMe: Number(row.from_me) === 1,
+        timestampMs: row.timestamp_ms !== null ? Number(row.timestamp_ms) : undefined,
+        encType: (row.enc_type as string | null) ?? undefined,
+        plaintext: toBytesOrNull(row.plaintext) ?? undefined,
+        messageBytes: toBytesOrNull(row.message_bytes) ?? undefined
+    }
+}
+
+export class WaMessageMysqlStore extends BaseMysqlStore implements WaMessageStore {
+    public constructor(options: WaMysqlStorageOptions) {
+        super(options, ['mailbox'])
+    }
+
+    public async upsert(record: WaStoredMessageRecord): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(
+            `INSERT INTO ${this.t('mailbox_messages')} (
+                session_id, message_id, thread_jid, sender_jid, participant_jid,
+                from_me, timestamp_ms, enc_type, plaintext, message_bytes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                thread_jid = VALUES(thread_jid),
+                sender_jid = VALUES(sender_jid),
+                participant_jid = VALUES(participant_jid),
+                from_me = VALUES(from_me),
+                timestamp_ms = VALUES(timestamp_ms),
+                enc_type = VALUES(enc_type),
+                plaintext = VALUES(plaintext),
+                message_bytes = VALUES(message_bytes)`,
+            [
+                this.sessionId,
+                record.id,
+                record.threadJid,
+                record.senderJid ?? null,
+                record.participantJid ?? null,
+                record.fromMe ? 1 : 0,
+                record.timestampMs ?? null,
+                record.encType ?? null,
+                record.plaintext ?? null,
+                record.messageBytes ?? null
+            ]
+        )
+    }
+
+    public async upsertBatch(records: readonly WaStoredMessageRecord[]): Promise<void> {
+        if (records.length === 0) return
+
+        await this.withTransaction(async (conn) => {
+            for (const record of records) {
+                await conn.execute(
+                    `INSERT INTO ${this.t('mailbox_messages')} (
+                        session_id, message_id, thread_jid, sender_jid, participant_jid,
+                        from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON DUPLICATE KEY UPDATE
+                        thread_jid = VALUES(thread_jid),
+                        sender_jid = VALUES(sender_jid),
+                        participant_jid = VALUES(participant_jid),
+                        from_me = VALUES(from_me),
+                        timestamp_ms = VALUES(timestamp_ms),
+                        enc_type = VALUES(enc_type),
+                        plaintext = VALUES(plaintext),
+                        message_bytes = VALUES(message_bytes)`,
+                    [
+                        this.sessionId,
+                        record.id,
+                        record.threadJid,
+                        record.senderJid ?? null,
+                        record.participantJid ?? null,
+                        record.fromMe ? 1 : 0,
+                        record.timestampMs ?? null,
+                        record.encType ?? null,
+                        record.plaintext ?? null,
+                        record.messageBytes ?? null
+                    ]
+                )
+            }
+        })
+    }
+
+    public async getById(id: string): Promise<WaStoredMessageRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT message_id, thread_jid, sender_jid, participant_jid,
+                    from_me, timestamp_ms, enc_type, plaintext, message_bytes
+             FROM ${this.t('mailbox_messages')}
+             WHERE session_id = ? AND message_id = ?`,
+                [this.sessionId, id]
+            )
+        )
+        if (!row) return null
+        return rowToRecord(row)
+    }
+
+    public async listByThread(
+        threadJid: string,
+        limit?: number,
+        beforeTimestampMs?: number
+    ): Promise<readonly WaStoredMessageRecord[]> {
+        await this.ensureReady()
+        const resolved = safeLimit(limit, 50)
+
+        if (beforeTimestampMs !== undefined) {
+            return queryRows(
+                await this.pool.execute(
+                    `SELECT message_id, thread_jid, sender_jid, participant_jid,
+                        from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                 FROM ${this.t('mailbox_messages')}
+                 WHERE session_id = ? AND thread_jid = ? AND timestamp_ms < ?
+                 ORDER BY timestamp_ms DESC, message_id DESC
+                 LIMIT ${resolved}`,
+                    [this.sessionId, threadJid, beforeTimestampMs]
+                )
+            ).map(rowToRecord)
+        }
+
+        return queryRows(
+            await this.pool.execute(
+                `SELECT message_id, thread_jid, sender_jid, participant_jid,
+                    from_me, timestamp_ms, enc_type, plaintext, message_bytes
+             FROM ${this.t('mailbox_messages')}
+             WHERE session_id = ? AND thread_jid = ?
+             ORDER BY timestamp_ms DESC, message_id DESC
+             LIMIT ${resolved}`,
+                [this.sessionId, threadJid]
+            )
+        ).map(rowToRecord)
+    }
+
+    public async deleteById(id: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.execute(
+                `DELETE FROM ${this.t('mailbox_messages')}
+             WHERE session_id = ? AND message_id = ?`,
+                [this.sessionId, id]
+            )
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(`DELETE FROM ${this.t('mailbox_messages')} WHERE session_id = ?`, [
+            this.sessionId
+        ])
+    }
+}

--- a/packages/store-mysql/src/participants.store.ts
+++ b/packages/store-mysql/src/participants.store.ts
@@ -1,0 +1,105 @@
+import type { WaParticipantsSnapshot, WaParticipantsStore } from 'zapo-js/store'
+
+import { BaseMysqlStore } from './BaseMysqlStore'
+import { affectedRows, queryFirst } from './helpers'
+import type { WaMysqlStorageOptions } from './types'
+
+const DEFAULT_PARTICIPANTS_TTL_MS = 5 * 60 * 1000
+
+export class WaParticipantsMysqlStore extends BaseMysqlStore implements WaParticipantsStore {
+    private readonly ttlMs: number
+
+    public constructor(options: WaMysqlStorageOptions, ttlMs = DEFAULT_PARTICIPANTS_TTL_MS) {
+        super(options, ['participants'])
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('participants ttlMs must be a non-negative finite number')
+        }
+        this.ttlMs = ttlMs
+    }
+
+    public async upsertGroupParticipants(snapshot: WaParticipantsSnapshot): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(
+            `INSERT INTO ${this.t('group_participants_cache')} (
+                session_id, group_jid, participants_json, updated_at_ms, expires_at_ms
+            ) VALUES (?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                participants_json = VALUES(participants_json),
+                updated_at_ms = VALUES(updated_at_ms),
+                expires_at_ms = VALUES(expires_at_ms)`,
+            [
+                this.sessionId,
+                snapshot.groupJid,
+                JSON.stringify(snapshot.participants),
+                snapshot.updatedAtMs,
+                snapshot.updatedAtMs + this.ttlMs
+            ]
+        )
+    }
+
+    public async getGroupParticipants(
+        groupJid: string,
+        nowMs = Date.now()
+    ): Promise<WaParticipantsSnapshot | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT group_jid, participants_json, updated_at_ms, expires_at_ms
+             FROM ${this.t('group_participants_cache')}
+             WHERE session_id = ? AND group_jid = ?`,
+                [this.sessionId, groupJid]
+            )
+        )
+        if (!row) return null
+
+        if (Number(row.expires_at_ms) <= nowMs) {
+            await this.pool.execute(
+                `DELETE FROM ${this.t('group_participants_cache')}
+                 WHERE session_id = ? AND group_jid = ? AND expires_at_ms <= ?`,
+                [this.sessionId, groupJid, nowMs]
+            )
+            return null
+        }
+
+        const parsed: unknown = JSON.parse(row.participants_json as string)
+        if (!Array.isArray(parsed)) {
+            throw new Error('group_participants_cache.participants_json must be an array')
+        }
+
+        return {
+            groupJid: String(row.group_jid),
+            participants: parsed.map((entry: unknown) => String(entry)),
+            updatedAtMs: Number(row.updated_at_ms)
+        }
+    }
+
+    public async deleteGroupParticipants(groupJid: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.execute(
+                `DELETE FROM ${this.t('group_participants_cache')}
+             WHERE session_id = ? AND group_jid = ?`,
+                [this.sessionId, groupJid]
+            )
+        )
+    }
+
+    public async cleanupExpired(nowMs: number): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.execute(
+                `DELETE FROM ${this.t('group_participants_cache')}
+             WHERE session_id = ? AND expires_at_ms <= ?`,
+                [this.sessionId, nowMs]
+            )
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(
+            `DELETE FROM ${this.t('group_participants_cache')} WHERE session_id = ?`,
+            [this.sessionId]
+        )
+    }
+}

--- a/packages/store-mysql/src/privacy-token.store.ts
+++ b/packages/store-mysql/src/privacy-token.store.ts
@@ -1,0 +1,114 @@
+import type { WaPrivacyTokenStore, WaStoredPrivacyTokenRecord } from 'zapo-js/store'
+
+import { BaseMysqlStore } from './BaseMysqlStore'
+import { affectedRows, queryFirst, toBytesOrNull } from './helpers'
+import type { WaMysqlStorageOptions } from './types'
+
+export class WaPrivacyTokenMysqlStore extends BaseMysqlStore implements WaPrivacyTokenStore {
+    public constructor(options: WaMysqlStorageOptions) {
+        super(options, ['privacyToken'])
+    }
+
+    public async upsert(record: WaStoredPrivacyTokenRecord): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(
+            `INSERT INTO ${this.t('privacy_tokens')} (
+                session_id, jid, tc_token, tc_token_timestamp,
+                tc_token_sender_timestamp, nct_salt, updated_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                tc_token = COALESCE(VALUES(tc_token), tc_token),
+                tc_token_timestamp = COALESCE(VALUES(tc_token_timestamp), tc_token_timestamp),
+                tc_token_sender_timestamp = COALESCE(VALUES(tc_token_sender_timestamp), tc_token_sender_timestamp),
+                nct_salt = COALESCE(VALUES(nct_salt), nct_salt),
+                updated_at_ms = VALUES(updated_at_ms)`,
+            [
+                this.sessionId,
+                record.jid,
+                record.tcToken ?? null,
+                record.tcTokenTimestamp ?? null,
+                record.tcTokenSenderTimestamp ?? null,
+                record.nctSalt ?? null,
+                record.updatedAtMs
+            ]
+        )
+    }
+
+    public async upsertBatch(records: readonly WaStoredPrivacyTokenRecord[]): Promise<void> {
+        if (records.length === 0) return
+
+        await this.withTransaction(async (conn) => {
+            for (const record of records) {
+                await conn.execute(
+                    `INSERT INTO ${this.t('privacy_tokens')} (
+                        session_id, jid, tc_token, tc_token_timestamp,
+                        tc_token_sender_timestamp, nct_salt, updated_at_ms
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON DUPLICATE KEY UPDATE
+                        tc_token = COALESCE(VALUES(tc_token), tc_token),
+                        tc_token_timestamp = COALESCE(VALUES(tc_token_timestamp), tc_token_timestamp),
+                        tc_token_sender_timestamp = COALESCE(VALUES(tc_token_sender_timestamp), tc_token_sender_timestamp),
+                        nct_salt = COALESCE(VALUES(nct_salt), nct_salt),
+                        updated_at_ms = VALUES(updated_at_ms)`,
+                    [
+                        this.sessionId,
+                        record.jid,
+                        record.tcToken ?? null,
+                        record.tcTokenTimestamp ?? null,
+                        record.tcTokenSenderTimestamp ?? null,
+                        record.nctSalt ?? null,
+                        record.updatedAtMs
+                    ]
+                )
+            }
+        })
+    }
+
+    public async getByJid(jid: string): Promise<WaStoredPrivacyTokenRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT jid, tc_token, tc_token_timestamp,
+                    tc_token_sender_timestamp, nct_salt, updated_at_ms
+             FROM ${this.t('privacy_tokens')}
+             WHERE session_id = ? AND jid = ?`,
+                [this.sessionId, jid]
+            )
+        )
+        if (!row) return null
+        return {
+            jid: row.jid as string,
+            tcToken: toBytesOrNull(row.tc_token) ?? undefined,
+            tcTokenTimestamp:
+                row.tc_token_timestamp !== null ? Number(row.tc_token_timestamp) : undefined,
+            tcTokenSenderTimestamp:
+                row.tc_token_sender_timestamp !== null
+                    ? Number(row.tc_token_sender_timestamp)
+                    : undefined,
+            nctSalt: toBytesOrNull(row.nct_salt) ?? undefined,
+            updatedAtMs: Number(row.updated_at_ms)
+        }
+    }
+
+    public async deleteByJid(jid: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.execute(
+                `DELETE FROM ${this.t('privacy_tokens')}
+             WHERE session_id = ? AND jid = ?`,
+                [this.sessionId, jid]
+            )
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(`DELETE FROM ${this.t('privacy_tokens')} WHERE session_id = ?`, [
+            this.sessionId
+        ])
+    }
+
+    public async destroy(): Promise<void> {
+        // no-op
+    }
+}

--- a/packages/store-mysql/src/retry.store.ts
+++ b/packages/store-mysql/src/retry.store.ts
@@ -1,0 +1,401 @@
+import type { WaRetryOutboundMessageRecord, WaRetryOutboundState } from 'zapo-js/retry'
+import type { WaRetryStore } from 'zapo-js/store'
+
+import { BaseMysqlStore } from './BaseMysqlStore'
+import { affectedRows, queryFirst, toBytes } from './helpers'
+import type { WaMysqlStorageOptions } from './types'
+
+interface RetryRequesterStatusPayload {
+    readonly eligible: readonly string[]
+    readonly delivered: readonly string[]
+}
+
+const DEFAULT_RETRY_TTL_MS = 60 * 1000
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+export class WaRetryMysqlStore extends BaseMysqlStore implements WaRetryStore {
+    private readonly ttlMs: number
+
+    public constructor(options: WaMysqlStorageOptions, ttlMs = DEFAULT_RETRY_TTL_MS) {
+        super(options, ['retry'])
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('retry ttlMs must be a non-negative finite number')
+        }
+        this.ttlMs = ttlMs
+    }
+
+    public getTtlMs(): number {
+        return this.ttlMs
+    }
+
+    public supportsRawReplayPayload(): boolean {
+        return false
+    }
+
+    public async getOutboundRequesterStatus(
+        messageId: string,
+        requesterDeviceJid: string
+    ): Promise<{
+        readonly eligible: boolean
+        readonly delivered: boolean
+    } | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT requesters_json
+             FROM ${this.t('retry_outbound_messages')}
+             WHERE session_id = ? AND message_id = ?
+             LIMIT 1`,
+                [this.sessionId, messageId]
+            )
+        )
+        if (!row) {
+            return null
+        }
+        const requestersJson = row.requesters_json !== null ? String(row.requesters_json) : null
+        if (!requestersJson) {
+            return null
+        }
+        const requesters = this.parseRequesterStatusPayload(requestersJson)
+        if (requesters.eligible.length === 0) {
+            return null
+        }
+        let isEligible = false
+        for (let index = 0; index < requesters.eligible.length; index += 1) {
+            if (requesters.eligible[index] === requesterDeviceJid) {
+                isEligible = true
+                break
+            }
+        }
+        if (!isEligible) {
+            return {
+                eligible: false,
+                delivered: false
+            }
+        }
+        for (let index = 0; index < requesters.delivered.length; index += 1) {
+            if (requesters.delivered[index] === requesterDeviceJid) {
+                return {
+                    eligible: true,
+                    delivered: true
+                }
+            }
+        }
+        return {
+            eligible: true,
+            delivered: false
+        }
+    }
+
+    public async upsertOutboundMessage(record: WaRetryOutboundMessageRecord): Promise<void> {
+        await this.ensureReady()
+        const requestersJson = this.serializeRequesterStatusPayload(
+            record.eligibleRequesterDeviceJids,
+            record.deliveredRequesterDeviceJids
+        )
+        if (!(record.replayPayload instanceof Uint8Array)) {
+            throw new Error('retry_outbound_messages.replay_payload must be Uint8Array')
+        }
+        const replayPayload = record.replayPayload
+        await this.pool.execute(
+            `INSERT INTO ${this.t('retry_outbound_messages')} (
+                session_id,
+                message_id,
+                to_jid,
+                participant_jid,
+                recipient_jid,
+                message_type,
+                replay_mode,
+                replay_payload,
+                requesters_json,
+                state,
+                created_at_ms,
+                updated_at_ms,
+                expires_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                to_jid = VALUES(to_jid),
+                participant_jid = VALUES(participant_jid),
+                recipient_jid = VALUES(recipient_jid),
+                message_type = VALUES(message_type),
+                replay_mode = VALUES(replay_mode),
+                replay_payload = VALUES(replay_payload),
+                requesters_json = VALUES(requesters_json),
+                state = VALUES(state),
+                created_at_ms = VALUES(created_at_ms),
+                updated_at_ms = VALUES(updated_at_ms),
+                expires_at_ms = VALUES(expires_at_ms)`,
+            [
+                this.sessionId,
+                record.messageId,
+                record.toJid,
+                record.participantJid ?? null,
+                record.recipientJid ?? null,
+                record.messageType,
+                record.replayMode,
+                replayPayload,
+                requestersJson,
+                record.state,
+                record.createdAtMs,
+                record.updatedAtMs,
+                record.expiresAtMs
+            ]
+        )
+    }
+
+    public async deleteOutboundMessage(messageId: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.execute(
+                `DELETE FROM ${this.t('retry_outbound_messages')}
+             WHERE session_id = ? AND message_id = ?`,
+                [this.sessionId, messageId]
+            )
+        )
+    }
+
+    public async getOutboundMessage(
+        messageId: string
+    ): Promise<WaRetryOutboundMessageRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT
+                message_id,
+                to_jid,
+                participant_jid,
+                recipient_jid,
+                message_type,
+                replay_mode,
+                replay_payload,
+                requesters_json,
+                state,
+                created_at_ms,
+                updated_at_ms,
+                expires_at_ms
+            FROM ${this.t('retry_outbound_messages')}
+            WHERE session_id = ? AND message_id = ?`,
+                [this.sessionId, messageId]
+            )
+        )
+        if (!row) {
+            return null
+        }
+        const requestersJson = row.requesters_json !== null ? String(row.requesters_json) : null
+        const requesters = requestersJson
+            ? this.parseRequesterStatusPayload(requestersJson)
+            : {
+                  eligible: [] as readonly string[],
+                  delivered: [] as readonly string[]
+              }
+        return {
+            messageId: String(row.message_id),
+            toJid: String(row.to_jid),
+            participantJid: row.participant_jid !== null ? String(row.participant_jid) : undefined,
+            recipientJid: row.recipient_jid !== null ? String(row.recipient_jid) : undefined,
+            eligibleRequesterDeviceJids:
+                requesters.eligible.length > 0 ? requesters.eligible : undefined,
+            deliveredRequesterDeviceJids:
+                requesters.delivered.length > 0 ? requesters.delivered : undefined,
+            messageType: String(row.message_type),
+            replayMode: String(row.replay_mode) as WaRetryOutboundMessageRecord['replayMode'],
+            replayPayload: toBytes(row.replay_payload),
+            state: String(row.state) as WaRetryOutboundState,
+            createdAtMs: Number(row.created_at_ms),
+            updatedAtMs: Number(row.updated_at_ms),
+            expiresAtMs: Number(row.expires_at_ms)
+        }
+    }
+
+    public async updateOutboundMessageState(
+        messageId: string,
+        state: WaRetryOutboundState,
+        updatedAtMs: number,
+        expiresAtMs: number
+    ): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(
+            `UPDATE ${this.t('retry_outbound_messages')}
+             SET state = ?, updated_at_ms = ?, expires_at_ms = ?
+             WHERE session_id = ? AND message_id = ?`,
+            [state, updatedAtMs, expiresAtMs, this.sessionId, messageId]
+        )
+    }
+
+    public async markOutboundRequesterDelivered(
+        messageId: string,
+        requesterDeviceJid: string,
+        updatedAtMs: number,
+        expiresAtMs: number
+    ): Promise<void> {
+        await this.withTransaction(async (conn) => {
+            const row = queryFirst(
+                await conn.execute(
+                    `SELECT requesters_json
+                 FROM ${this.t('retry_outbound_messages')}
+                 WHERE session_id = ? AND message_id = ?
+                 FOR UPDATE`,
+                    [this.sessionId, messageId]
+                )
+            )
+            if (!row) {
+                return
+            }
+            const requestersJson = row.requesters_json !== null ? String(row.requesters_json) : null
+            if (!requestersJson) {
+                return
+            }
+            const requesters = this.parseRequesterStatusPayload(requestersJson)
+            let isEligible = false
+            for (let index = 0; index < requesters.eligible.length; index += 1) {
+                if (requesters.eligible[index] === requesterDeviceJid) {
+                    isEligible = true
+                    break
+                }
+            }
+            if (!isEligible) {
+                return
+            }
+            for (let index = 0; index < requesters.delivered.length; index += 1) {
+                if (requesters.delivered[index] === requesterDeviceJid) {
+                    return
+                }
+            }
+            const nextRequestersJson = this.serializeRequesterStatusPayload(requesters.eligible, [
+                ...requesters.delivered,
+                requesterDeviceJid
+            ])
+            await conn.execute(
+                `UPDATE ${this.t('retry_outbound_messages')}
+                 SET requesters_json = ?, updated_at_ms = ?, expires_at_ms = ?
+                 WHERE session_id = ? AND message_id = ?`,
+                [nextRequestersJson, updatedAtMs, expiresAtMs, this.sessionId, messageId]
+            )
+        })
+    }
+
+    public async incrementInboundCounter(
+        messageId: string,
+        requesterJid: string,
+        updatedAtMs: number,
+        expiresAtMs: number
+    ): Promise<number> {
+        return this.withTransaction(async (conn) => {
+            await conn.execute(
+                `INSERT INTO ${this.t('retry_inbound_counters')} (
+                    session_id, message_id, requester_jid, retry_count, updated_at_ms, expires_at_ms
+                ) VALUES (?, ?, ?, LAST_INSERT_ID(1), ?, ?)
+                ON DUPLICATE KEY UPDATE
+                    retry_count = LAST_INSERT_ID(retry_count + 1),
+                    updated_at_ms = VALUES(updated_at_ms),
+                    expires_at_ms = VALUES(expires_at_ms)`,
+                [this.sessionId, messageId, requesterJid, updatedAtMs, expiresAtMs]
+            )
+            const row = queryFirst(await conn.execute('SELECT LAST_INSERT_ID() AS retry_count', []))
+            return row ? Number(row.retry_count) : 1
+        })
+    }
+
+    public async cleanupExpired(nowMs: number): Promise<number> {
+        await this.ensureReady()
+        const outboundCount = affectedRows(
+            await this.pool.execute(
+                `DELETE FROM ${this.t('retry_outbound_messages')}
+             WHERE session_id = ? AND expires_at_ms <= ?`,
+                [this.sessionId, nowMs]
+            )
+        )
+        const inboundCount = affectedRows(
+            await this.pool.execute(
+                `DELETE FROM ${this.t('retry_inbound_counters')}
+             WHERE session_id = ? AND expires_at_ms <= ?`,
+                [this.sessionId, nowMs]
+            )
+        )
+        return outboundCount + inboundCount
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(
+            `DELETE FROM ${this.t('retry_outbound_messages')} WHERE session_id = ?`,
+            [this.sessionId]
+        )
+        await this.pool.execute(
+            `DELETE FROM ${this.t('retry_inbound_counters')} WHERE session_id = ?`,
+            [this.sessionId]
+        )
+    }
+
+    private serializeRequesterStatusPayload(
+        eligibleRequesterDeviceJids: readonly string[] | undefined,
+        deliveredRequesterDeviceJids: readonly string[] | undefined
+    ): string | null {
+        const eligible = this.toUniqueStrings(
+            eligibleRequesterDeviceJids ?? [],
+            'requesters_json.eligible'
+        )
+        if (eligible.length === 0) {
+            return null
+        }
+        const eligibleSet = new Set(eligible)
+        const delivered = this.toUniqueStrings(
+            deliveredRequesterDeviceJids ?? [],
+            'requesters_json.delivered'
+        ).filter((jid) => eligibleSet.has(jid))
+        const payload =
+            delivered.length > 0
+                ? {
+                      eligible,
+                      delivered
+                  }
+                : {
+                      eligible
+                  }
+        return JSON.stringify(payload)
+    }
+
+    private parseRequesterStatusPayload(raw: string): RetryRequesterStatusPayload {
+        const parsed = JSON.parse(raw)
+        if (!isObjectRecord(parsed)) {
+            throw new Error('retry_outbound_messages.requesters_json must be an object')
+        }
+        const eligibleRaw = parsed.eligible
+        if (!Array.isArray(eligibleRaw)) {
+            throw new Error('retry_outbound_messages.requesters_json.eligible must be an array')
+        }
+        const eligible = this.toUniqueStrings(eligibleRaw, 'requesters_json.eligible')
+        const deliveredRaw = parsed.delivered
+        if (deliveredRaw !== undefined && !Array.isArray(deliveredRaw)) {
+            throw new Error('retry_outbound_messages.requesters_json.delivered must be an array')
+        }
+        const eligibleSet = new Set(eligible)
+        const delivered = this.toUniqueStrings(
+            Array.isArray(deliveredRaw) ? deliveredRaw : [],
+            'requesters_json.delivered'
+        ).filter((jid) => eligibleSet.has(jid))
+        return {
+            eligible,
+            delivered
+        }
+    }
+
+    private toUniqueStrings(values: readonly unknown[], field: string): readonly string[] {
+        const deduped = new Set<string>()
+        for (let index = 0; index < values.length; index += 1) {
+            const rawValue = values[index]
+            if (typeof rawValue !== 'string') {
+                throw new Error(`${field} must contain only strings`)
+            }
+            const normalized = rawValue.trim()
+            if (!normalized) {
+                continue
+            }
+            deduped.add(normalized)
+        }
+        return Array.from(deduped)
+    }
+}

--- a/packages/store-mysql/src/sender-key.store.ts
+++ b/packages/store-mysql/src/sender-key.store.ts
@@ -1,0 +1,289 @@
+import type { PoolConnection } from 'mysql2/promise'
+import type { SenderKeyDistributionRecord, SenderKeyRecord, SignalAddress } from 'zapo-js/signal'
+import {
+    encodeSenderKeyRecord,
+    decodeSenderKeyRecord,
+    toSignalAddressParts,
+    type SignalAddressParts
+} from 'zapo-js/signal'
+import type { WaSenderKeyStore } from 'zapo-js/store'
+
+import { BaseMysqlStore } from './BaseMysqlStore'
+import { affectedRows, queryFirst, queryRows, toBytes } from './helpers'
+import type { MysqlParam } from './types'
+import type { WaMysqlStorageOptions } from './types'
+
+const BATCH_SIZE = 250
+
+export class WaSenderKeyMysqlStore extends BaseMysqlStore implements WaSenderKeyStore {
+    public constructor(options: WaMysqlStorageOptions) {
+        super(options, ['senderKey'])
+    }
+
+    public async upsertSenderKey(record: SenderKeyRecord): Promise<void> {
+        await this.ensureReady()
+        const sender = toSignalAddressParts(record.sender)
+        await this.pool.execute(
+            `INSERT INTO ${this.t('sender_keys')} (
+                session_id, group_id, sender_user, sender_server, sender_device, record
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                record = VALUES(record)`,
+            [
+                this.sessionId,
+                record.groupId,
+                sender.user,
+                sender.server,
+                sender.device,
+                encodeSenderKeyRecord(record)
+            ]
+        )
+    }
+
+    public async upsertSenderKeyDistribution(record: SenderKeyDistributionRecord): Promise<void> {
+        await this.ensureReady()
+        const sender = toSignalAddressParts(record.sender)
+        await this.upsertSenderKeyDistributionRow(this.pool, record, sender)
+    }
+
+    public async upsertSenderKeyDistributions(
+        records: readonly SenderKeyDistributionRecord[]
+    ): Promise<void> {
+        if (records.length === 0) return
+        await this.withTransaction(async (conn) => {
+            for (const record of records) {
+                const sender = toSignalAddressParts(record.sender)
+                await this.upsertSenderKeyDistributionRow(conn, record, sender)
+            }
+        })
+    }
+
+    public async getGroupSenderKeyList(groupId: string): Promise<{
+        readonly skList: readonly SenderKeyRecord[]
+        readonly skDistribList: readonly SenderKeyDistributionRecord[]
+    }> {
+        await this.ensureReady()
+        const senderRows = queryRows(
+            await this.pool.execute(
+                `SELECT group_id, sender_user, sender_server, sender_device, record
+             FROM ${this.t('sender_keys')}
+             WHERE session_id = ? AND group_id = ?`,
+                [this.sessionId, groupId]
+            )
+        )
+        const distributionRows = queryRows(
+            await this.pool.execute(
+                `SELECT group_id, sender_user, sender_server, sender_device, key_id, timestamp_ms
+             FROM ${this.t('sender_key_distribution')}
+             WHERE session_id = ? AND group_id = ?`,
+                [this.sessionId, groupId]
+            )
+        )
+
+        const skList: SenderKeyRecord[] = senderRows.map((row) =>
+            decodeSenderKeyRecord(toBytes(row.record), String(row.group_id), {
+                user: String(row.sender_user),
+                server: String(row.sender_server),
+                device: Number(row.sender_device)
+            })
+        )
+
+        const skDistribList: SenderKeyDistributionRecord[] = distributionRows.map((row) => ({
+            groupId: String(row.group_id),
+            sender: {
+                user: String(row.sender_user),
+                server: String(row.sender_server),
+                device: Number(row.sender_device)
+            },
+            keyId: Number(row.key_id),
+            timestampMs: Number(row.timestamp_ms)
+        }))
+
+        return { skList, skDistribList }
+    }
+
+    public async getDeviceSenderKey(
+        groupId: string,
+        sender: SignalAddress
+    ): Promise<SenderKeyRecord | null> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(sender)
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT group_id, sender_user, sender_server, sender_device, record
+             FROM ${this.t('sender_keys')}
+             WHERE session_id = ?
+               AND group_id = ?
+               AND sender_user = ?
+               AND sender_server = ?
+               AND sender_device = ?`,
+                [this.sessionId, groupId, target.user, target.server, target.device]
+            )
+        )
+        if (!row) return null
+        return decodeSenderKeyRecord(toBytes(row.record), String(row.group_id), {
+            user: String(row.sender_user),
+            server: String(row.sender_server),
+            device: Number(row.sender_device)
+        })
+    }
+
+    public async getDeviceSenderKeyDistributions(
+        groupId: string,
+        senders: readonly SignalAddress[]
+    ): Promise<readonly (SenderKeyDistributionRecord | null)[]> {
+        if (senders.length === 0) return []
+        await this.ensureReady()
+        const targets = senders.map((s) => toSignalAddressParts(s))
+        const byKey = new Map<string, SenderKeyDistributionRecord>()
+        for (let start = 0; start < targets.length; start += BATCH_SIZE) {
+            const batch = targets.slice(start, start + BATCH_SIZE)
+            const placeholders = batch
+                .map(() => '(sender_user = ? AND sender_server = ? AND sender_device = ?)')
+                .join(' OR ')
+            const params: MysqlParam[] = [
+                this.sessionId,
+                groupId,
+                ...batch.flatMap((t) => [t.user, t.server, t.device])
+            ]
+            const rows = queryRows(
+                await this.pool.execute(
+                    `SELECT group_id, sender_user, sender_server, sender_device, key_id, timestamp_ms
+                     FROM ${this.t('sender_key_distribution')}
+                     WHERE session_id = ? AND group_id = ? AND (${placeholders})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                const key = this.distributionTargetKey(
+                    String(row.sender_user),
+                    String(row.sender_server),
+                    Number(row.sender_device)
+                )
+                byKey.set(key, {
+                    groupId: String(row.group_id),
+                    sender: {
+                        user: String(row.sender_user),
+                        server: String(row.sender_server),
+                        device: Number(row.sender_device)
+                    },
+                    keyId: Number(row.key_id),
+                    timestampMs: Number(row.timestamp_ms)
+                })
+            }
+        }
+        return targets.map(
+            (t) => byKey.get(this.distributionTargetKey(t.user, t.server, t.device)) ?? null
+        )
+    }
+
+    public async deleteDeviceSenderKey(target: SignalAddress, groupId?: string): Promise<number> {
+        const sender = toSignalAddressParts(target)
+        return this.withTransaction(async (conn) => {
+            const senderCount = await this.countDelete(conn, 'sender_keys', sender, groupId)
+            const distributionCount = await this.countDelete(
+                conn,
+                'sender_key_distribution',
+                sender,
+                groupId
+            )
+            return senderCount + distributionCount
+        })
+    }
+
+    public async markForgetSenderKey(
+        groupId: string,
+        participants: readonly SignalAddress[]
+    ): Promise<number> {
+        if (participants.length === 0) return 0
+        return this.withTransaction(async (conn) => {
+            let total = 0
+            for (let start = 0; start < participants.length; start += BATCH_SIZE) {
+                const batch = participants.slice(start, start + BATCH_SIZE)
+                const filters: string[] = []
+                const senderParams: MysqlParam[] = []
+                for (const participant of batch) {
+                    const sender = toSignalAddressParts(participant)
+                    filters.push('(sender_user = ? AND sender_server = ? AND sender_device = ?)')
+                    senderParams.push(sender.user, sender.server, sender.device)
+                }
+                const where = `session_id = ? AND group_id = ? AND (${filters.join(' OR ')})`
+                const params: MysqlParam[] = [this.sessionId, groupId, ...senderParams]
+                total += affectedRows(
+                    await conn.execute(
+                        `DELETE FROM ${this.t('sender_keys')} WHERE ${where}`,
+                        params
+                    )
+                )
+                total += affectedRows(
+                    await conn.execute(
+                        `DELETE FROM ${this.t('sender_key_distribution')} WHERE ${where}`,
+                        params
+                    )
+                )
+            }
+            return total
+        })
+    }
+
+    public async clear(): Promise<void> {
+        await this.withTransaction(async (conn) => {
+            await conn.execute(`DELETE FROM ${this.t('sender_keys')} WHERE session_id = ?`, [
+                this.sessionId
+            ])
+            await conn.execute(
+                `DELETE FROM ${this.t('sender_key_distribution')} WHERE session_id = ?`,
+                [this.sessionId]
+            )
+        })
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────
+
+    private async upsertSenderKeyDistributionRow(
+        executor: { execute: PoolConnection['execute'] },
+        record: SenderKeyDistributionRecord,
+        sender: SignalAddressParts
+    ): Promise<void> {
+        await executor.execute(
+            `INSERT INTO ${this.t('sender_key_distribution')} (
+                session_id, group_id, sender_user, sender_server, sender_device,
+                key_id, timestamp_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                key_id = VALUES(key_id),
+                timestamp_ms = VALUES(timestamp_ms)`,
+            [
+                this.sessionId,
+                record.groupId,
+                sender.user,
+                sender.server,
+                sender.device,
+                record.keyId,
+                record.timestampMs
+            ]
+        )
+    }
+
+    private async countDelete(
+        conn: PoolConnection,
+        table: 'sender_keys' | 'sender_key_distribution',
+        target: SignalAddressParts,
+        groupId?: string
+    ): Promise<number> {
+        const whereBase =
+            'session_id = ? AND sender_user = ? AND sender_server = ? AND sender_device = ?'
+        const where = groupId ? `${whereBase} AND group_id = ?` : whereBase
+        const params: MysqlParam[] = groupId
+            ? [this.sessionId, target.user, target.server, target.device, groupId]
+            : [this.sessionId, target.user, target.server, target.device]
+
+        return affectedRows(
+            await conn.execute(`DELETE FROM ${this.t(table)} WHERE ${where}`, params)
+        )
+    }
+
+    private distributionTargetKey(user: string, server: string, device: number): string {
+        return `${user}|${server}|${device}`
+    }
+}

--- a/packages/store-mysql/src/signal.store.ts
+++ b/packages/store-mysql/src/signal.store.ts
@@ -1,0 +1,779 @@
+import type { PoolConnection } from 'mysql2/promise'
+import { signalAddressKey } from 'zapo-js/protocol'
+import type {
+    PreKeyRecord,
+    RegistrationInfo,
+    SignalAddress,
+    SignalSessionRecord,
+    SignedPreKeyRecord
+} from 'zapo-js/signal'
+import {
+    encodeSignalSessionRecord,
+    decodeSignalSessionRecord,
+    toSignalAddressParts,
+    type SignalAddressParts
+} from 'zapo-js/signal'
+import type { WaSignalStore, WaSignalMetaSnapshot } from 'zapo-js/store'
+
+import { BaseMysqlStore } from './BaseMysqlStore'
+import { queryFirst, queryRows, safeLimit, toBytes, toBytesOrNull, type MysqlRow } from './helpers'
+import type { MysqlParam, WaMysqlStorageOptions } from './types'
+
+const BATCH_SIZE = 250
+
+export class WaSignalMysqlStore extends BaseMysqlStore implements WaSignalStore {
+    public constructor(options: WaMysqlStorageOptions) {
+        super(options, ['signal'])
+    }
+
+    // ── Registration ──────────────────────────────────────────────────
+
+    public async getRegistrationInfo(): Promise<RegistrationInfo | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT registration_id, identity_pub_key, identity_priv_key
+             FROM ${this.t('signal_registration')}
+             WHERE session_id = ?`,
+                [this.sessionId]
+            )
+        )
+        if (!row) return null
+        return {
+            registrationId: Number(row.registration_id),
+            identityKeyPair: {
+                pubKey: toBytes(row.identity_pub_key),
+                privKey: toBytes(row.identity_priv_key)
+            }
+        }
+    }
+
+    public async setRegistrationInfo(info: RegistrationInfo): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(
+            `INSERT INTO ${this.t('signal_registration')} (
+                session_id, registration_id, identity_pub_key, identity_priv_key
+            ) VALUES (?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                registration_id = VALUES(registration_id),
+                identity_pub_key = VALUES(identity_pub_key),
+                identity_priv_key = VALUES(identity_priv_key)`,
+            [
+                this.sessionId,
+                info.registrationId,
+                info.identityKeyPair.pubKey,
+                info.identityKeyPair.privKey
+            ]
+        )
+    }
+
+    // ── Signed PreKey ─────────────────────────────────────────────────
+
+    public async getSignedPreKey(): Promise<SignedPreKeyRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT key_id, pub_key, priv_key, signature, uploaded
+             FROM ${this.t('signal_signed_prekey')}
+             WHERE session_id = ?`,
+                [this.sessionId]
+            )
+        )
+        if (!row) return null
+        return this.decodeSignedPreKeyRow(row)
+    }
+
+    public async setSignedPreKey(record: SignedPreKeyRecord): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(
+            `INSERT INTO ${this.t('signal_signed_prekey')} (
+                session_id, key_id, pub_key, priv_key, signature, uploaded
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                key_id = VALUES(key_id),
+                pub_key = VALUES(pub_key),
+                priv_key = VALUES(priv_key),
+                signature = VALUES(signature),
+                uploaded = VALUES(uploaded)`,
+            [
+                this.sessionId,
+                record.keyId,
+                record.keyPair.pubKey,
+                record.keyPair.privKey,
+                record.signature,
+                record.uploaded === true ? 1 : 0
+            ]
+        )
+    }
+
+    public async getSignedPreKeyById(keyId: number): Promise<SignedPreKeyRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT key_id, pub_key, priv_key, signature, uploaded
+             FROM ${this.t('signal_signed_prekey')}
+             WHERE session_id = ? AND key_id = ?`,
+                [this.sessionId, keyId]
+            )
+        )
+        if (!row) return null
+        return this.decodeSignedPreKeyRow(row)
+    }
+
+    public async setSignedPreKeyRotationTs(value: number | null): Promise<void> {
+        await this.withTransaction(async (conn) => {
+            await this.ensureMetaRow(conn)
+            await conn.execute(
+                `UPDATE ${this.t('signal_meta')}
+                 SET signed_prekey_rotation_ts = ?
+                 WHERE session_id = ?`,
+                [value, this.sessionId]
+            )
+        })
+    }
+
+    public async getSignedPreKeyRotationTs(): Promise<number | null> {
+        const meta = await this.withTransaction(async (conn) => this.getMeta(conn))
+        return meta.signedPreKeyRotationTs
+    }
+
+    // ── PreKeys ───────────────────────────────────────────────────────
+
+    public async putPreKey(record: PreKeyRecord): Promise<void> {
+        await this.withTransaction(async (conn) => {
+            await this.ensureMetaRow(conn)
+            await this.upsertPreKey(conn, record)
+            await conn.execute(
+                `UPDATE ${this.t('signal_meta')}
+                 SET next_prekey_id = GREATEST(next_prekey_id, ?)
+                 WHERE session_id = ?`,
+                [record.keyId + 1, this.sessionId]
+            )
+        })
+    }
+
+    public async getOrGenPreKeys(
+        count: number,
+        generator: (keyId: number) => PreKeyRecord | Promise<PreKeyRecord>
+    ): Promise<readonly PreKeyRecord[]> {
+        if (!Number.isSafeInteger(count) || count <= 0) {
+            throw new Error(`invalid prekey count: ${count}`)
+        }
+
+        while (true) {
+            const reservation = await this.withTransaction(async (conn) => {
+                await this.ensureMetaRow(conn)
+                const available = await this.selectAvailablePreKeys(conn, count)
+                const missing = count - available.length
+                if (missing <= 0) {
+                    return { available, reservedKeyIds: [] as number[] }
+                }
+                const meta = await this.getMeta(conn)
+                const reservedKeyIds = Array.from(
+                    { length: missing },
+                    (_, i) => meta.nextPreKeyId + i
+                )
+                await conn.execute(
+                    `UPDATE ${this.t('signal_meta')}
+                     SET next_prekey_id = GREATEST(next_prekey_id, ?)
+                     WHERE session_id = ?`,
+                    [meta.nextPreKeyId + missing, this.sessionId]
+                )
+                return { available, reservedKeyIds }
+            })
+
+            if (reservation.reservedKeyIds.length === 0) {
+                return reservation.available
+            }
+
+            const generated: PreKeyRecord[] = []
+            let maxId = reservation.reservedKeyIds[reservation.reservedKeyIds.length - 1]
+            for (const keyId of reservation.reservedKeyIds) {
+                const record = await generator(keyId)
+                generated.push(record)
+                if (record.keyId > maxId) {
+                    maxId = record.keyId
+                }
+            }
+
+            await this.withTransaction(async (conn) => {
+                await this.ensureMetaRow(conn)
+                for (const record of generated) {
+                    await conn.execute(
+                        `INSERT IGNORE INTO ${this.t('signal_prekey')} (
+                            session_id, key_id, pub_key, priv_key, uploaded
+                        ) VALUES (?, ?, ?, ?, ?)`,
+                        [
+                            this.sessionId,
+                            record.keyId,
+                            record.keyPair.pubKey,
+                            record.keyPair.privKey,
+                            record.uploaded === true ? 1 : 0
+                        ]
+                    )
+                }
+                await conn.execute(
+                    `UPDATE ${this.t('signal_meta')}
+                     SET next_prekey_id = GREATEST(next_prekey_id, ?)
+                     WHERE session_id = ?`,
+                    [maxId + 1, this.sessionId]
+                )
+            })
+
+            const available = await this.withTransaction(async (conn) =>
+                this.selectAvailablePreKeys(conn, count)
+            )
+            if (available.length >= count) {
+                return available
+            }
+        }
+    }
+
+    public async getPreKeyById(keyId: number): Promise<PreKeyRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT key_id, pub_key, priv_key, uploaded
+             FROM ${this.t('signal_prekey')}
+             WHERE session_id = ? AND key_id = ?`,
+                [this.sessionId, keyId]
+            )
+        )
+        if (!row) return null
+        return this.decodePreKeyRow(row)
+    }
+
+    public async getPreKeysById(
+        keyIds: readonly number[]
+    ): Promise<readonly (PreKeyRecord | null)[]> {
+        if (keyIds.length === 0) return []
+        await this.ensureReady()
+        const uniqueKeyIds = [...new Set(keyIds)]
+        const byId = new Map<number, PreKeyRecord>()
+        for (let start = 0; start < uniqueKeyIds.length; start += BATCH_SIZE) {
+            const batch = uniqueKeyIds.slice(start, start + BATCH_SIZE)
+            const placeholders = batch.map(() => '?').join(', ')
+            const params: MysqlParam[] = [this.sessionId, ...batch]
+            const rows = queryRows(
+                await this.pool.execute(
+                    `SELECT key_id, pub_key, priv_key, uploaded
+                 FROM ${this.t('signal_prekey')}
+                 WHERE session_id = ? AND key_id IN (${placeholders})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                const record = this.decodePreKeyRow(row)
+                byId.set(record.keyId, record)
+            }
+        }
+        return keyIds.map((id) => byId.get(id) ?? null)
+    }
+
+    public async consumePreKeyById(keyId: number): Promise<PreKeyRecord | null> {
+        return this.withTransaction(async (conn) => {
+            const row = queryFirst(
+                await conn.execute(
+                    `SELECT key_id, pub_key, priv_key, uploaded
+                 FROM ${this.t('signal_prekey')}
+                 WHERE session_id = ? AND key_id = ?
+                 FOR UPDATE`,
+                    [this.sessionId, keyId]
+                )
+            )
+            if (!row) return null
+            await conn.execute(
+                `DELETE FROM ${this.t('signal_prekey')}
+                 WHERE session_id = ? AND key_id = ?`,
+                [this.sessionId, keyId]
+            )
+            return this.decodePreKeyRow(row)
+        })
+    }
+
+    public async getOrGenSinglePreKey(
+        generator: (keyId: number) => PreKeyRecord | Promise<PreKeyRecord>
+    ): Promise<PreKeyRecord> {
+        const records = await this.getOrGenPreKeys(1, generator)
+        return records[0]
+    }
+
+    public async markKeyAsUploaded(keyId: number): Promise<void> {
+        await this.ensureReady()
+        const meta = await this.withTransaction(async (conn) => this.getMeta(conn))
+        if (keyId < 0 || keyId >= meta.nextPreKeyId) {
+            throw new Error(`prekey ${keyId} is out of boundary`)
+        }
+        await this.pool.execute(
+            `UPDATE ${this.t('signal_prekey')}
+             SET uploaded = 1
+             WHERE session_id = ? AND key_id <= ?`,
+            [this.sessionId, keyId]
+        )
+    }
+
+    // ── Server State ──────────────────────────────────────────────────
+
+    public async setServerHasPreKeys(value: boolean): Promise<void> {
+        await this.withTransaction(async (conn) => {
+            await this.ensureMetaRow(conn)
+            await conn.execute(
+                `UPDATE ${this.t('signal_meta')}
+                 SET server_has_prekeys = ?
+                 WHERE session_id = ?`,
+                [value ? 1 : 0, this.sessionId]
+            )
+        })
+    }
+
+    public async getServerHasPreKeys(): Promise<boolean> {
+        const meta = await this.withTransaction(async (conn) => this.getMeta(conn))
+        return meta.serverHasPreKeys
+    }
+
+    // ── Meta ──────────────────────────────────────────────────────────
+
+    public async getSignalMeta(): Promise<WaSignalMetaSnapshot> {
+        return this.withTransaction(async (conn) => {
+            await this.ensureMetaRow(conn)
+            const row = queryFirst(
+                await conn.execute(
+                    `SELECT
+                    m.server_has_prekeys AS server_has_prekeys,
+                    m.signed_prekey_rotation_ts AS signed_prekey_rotation_ts,
+                    r.registration_id AS registration_id,
+                    r.identity_pub_key AS identity_pub_key,
+                    r.identity_priv_key AS identity_priv_key,
+                    s.key_id AS signed_key_id,
+                    s.pub_key AS signed_pub_key,
+                    s.priv_key AS signed_priv_key,
+                    s.signature AS signed_signature,
+                    s.uploaded AS signed_uploaded
+                 FROM ${this.t('signal_meta')} AS m
+                 LEFT JOIN ${this.t('signal_registration')} AS r
+                    ON r.session_id = m.session_id
+                 LEFT JOIN ${this.t('signal_signed_prekey')} AS s
+                    ON s.session_id = m.session_id
+                 WHERE m.session_id = ?`,
+                    [this.sessionId]
+                )
+            )
+            if (!row) {
+                throw new Error('signal meta row not found')
+            }
+
+            const registrationId =
+                row.registration_id !== null ? Number(row.registration_id) : undefined
+            const registrationPubKey = toBytesOrNull(row.identity_pub_key)
+            const registrationPrivKey = toBytesOrNull(row.identity_priv_key)
+            const registrationInfo: RegistrationInfo | null =
+                registrationId !== undefined && registrationPubKey && registrationPrivKey
+                    ? {
+                          registrationId,
+                          identityKeyPair: {
+                              pubKey: registrationPubKey,
+                              privKey: registrationPrivKey
+                          }
+                      }
+                    : null
+
+            const signedKeyId = row.signed_key_id !== null ? Number(row.signed_key_id) : undefined
+            const signedPubKey = toBytesOrNull(row.signed_pub_key)
+            const signedPrivKey = toBytesOrNull(row.signed_priv_key)
+            const signedSignature = toBytesOrNull(row.signed_signature)
+            const signedPreKey: SignedPreKeyRecord | null =
+                signedKeyId !== undefined && signedPubKey && signedPrivKey && signedSignature
+                    ? {
+                          keyId: signedKeyId,
+                          keyPair: { pubKey: signedPubKey, privKey: signedPrivKey },
+                          signature: signedSignature,
+                          uploaded:
+                              row.signed_uploaded !== null
+                                  ? Number(row.signed_uploaded) === 1
+                                  : undefined
+                      }
+                    : null
+
+            return {
+                serverHasPreKeys: Number(row.server_has_prekeys) === 1,
+                signedPreKeyRotationTs:
+                    row.signed_prekey_rotation_ts !== null
+                        ? Number(row.signed_prekey_rotation_ts)
+                        : null,
+                registrationInfo,
+                signedPreKey
+            }
+        })
+    }
+
+    // ── Sessions ──────────────────────────────────────────────────────
+
+    public async hasSession(address: SignalAddress): Promise<boolean> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(address)
+        return (
+            queryRows(
+                await this.pool.execute(
+                    `SELECT 1 AS has_session
+             FROM ${this.t('signal_session')}
+             WHERE session_id = ? AND user = ? AND server = ? AND device = ?
+             LIMIT 1`,
+                    [this.sessionId, target.user, target.server, target.device]
+                )
+            ).length > 0
+        )
+    }
+
+    public async hasSessions(addresses: readonly SignalAddress[]): Promise<readonly boolean[]> {
+        if (addresses.length === 0) return []
+        await this.ensureReady()
+        const targets = addresses.map((a) => toSignalAddressParts(a))
+        const existingKeys = new Set<string>()
+        for (let start = 0; start < targets.length; start += BATCH_SIZE) {
+            const batch = targets.slice(start, start + BATCH_SIZE)
+            const placeholders = batch
+                .map(() => '(user = ? AND server = ? AND device = ?)')
+                .join(' OR ')
+            const params: MysqlParam[] = [
+                this.sessionId,
+                ...batch.flatMap((t) => [t.user, t.server, t.device])
+            ]
+            const rows = queryRows(
+                await this.pool.execute(
+                    `SELECT user, server, device
+                 FROM ${this.t('signal_session')}
+                 WHERE session_id = ? AND (${placeholders})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                existingKeys.add(
+                    signalAddressKey({
+                        user: String(row.user),
+                        server: String(row.server),
+                        device: Number(row.device)
+                    })
+                )
+            }
+        }
+        return targets.map((t) => existingKeys.has(signalAddressKey(t)))
+    }
+
+    public async getSession(address: SignalAddress): Promise<SignalSessionRecord | null> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(address)
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT record
+             FROM ${this.t('signal_session')}
+             WHERE session_id = ? AND user = ? AND server = ? AND device = ?`,
+                [this.sessionId, target.user, target.server, target.device]
+            )
+        )
+        if (!row) return null
+        return decodeSignalSessionRecord(toBytes(row.record))
+    }
+
+    public async getSessionsBatch(
+        addresses: readonly SignalAddress[]
+    ): Promise<readonly (SignalSessionRecord | null)[]> {
+        if (addresses.length === 0) return []
+        await this.ensureReady()
+        const targets = addresses.map((a) => toSignalAddressParts(a))
+        const byKey = new Map<string, SignalSessionRecord>()
+        for (let start = 0; start < targets.length; start += BATCH_SIZE) {
+            const batch = targets.slice(start, start + BATCH_SIZE)
+            const placeholders = batch
+                .map(() => '(user = ? AND server = ? AND device = ?)')
+                .join(' OR ')
+            const params: MysqlParam[] = [
+                this.sessionId,
+                ...batch.flatMap((t) => [t.user, t.server, t.device])
+            ]
+            const rows = queryRows(
+                await this.pool.execute(
+                    `SELECT user, server, device, record
+                 FROM ${this.t('signal_session')}
+                 WHERE session_id = ? AND (${placeholders})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                byKey.set(
+                    signalAddressKey({
+                        user: String(row.user),
+                        server: String(row.server),
+                        device: Number(row.device)
+                    }),
+                    decodeSignalSessionRecord(toBytes(row.record))
+                )
+            }
+        }
+        return targets.map((t) => byKey.get(signalAddressKey(t)) ?? null)
+    }
+
+    public async setSession(address: SignalAddress, session: SignalSessionRecord): Promise<void> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(address)
+        await this.upsertSession(this.pool, target, session)
+    }
+
+    public async setSessionsBatch(
+        entries: readonly {
+            readonly address: SignalAddress
+            readonly session: SignalSessionRecord
+        }[]
+    ): Promise<void> {
+        if (entries.length === 0) return
+        await this.withTransaction(async (conn) => {
+            for (const entry of entries) {
+                const target = toSignalAddressParts(entry.address)
+                await this.upsertSession(conn, target, entry.session)
+            }
+        })
+    }
+
+    public async deleteSession(address: SignalAddress): Promise<void> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(address)
+        await this.pool.execute(
+            `DELETE FROM ${this.t('signal_session')}
+             WHERE session_id = ? AND user = ? AND server = ? AND device = ?`,
+            [this.sessionId, target.user, target.server, target.device]
+        )
+    }
+
+    // ── Identities ────────────────────────────────────────────────────
+
+    public async getRemoteIdentity(address: SignalAddress): Promise<Uint8Array | null> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(address)
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT identity_key
+             FROM ${this.t('signal_identity')}
+             WHERE session_id = ? AND user = ? AND server = ? AND device = ?`,
+                [this.sessionId, target.user, target.server, target.device]
+            )
+        )
+        if (!row) return null
+        return toBytes(row.identity_key)
+    }
+
+    public async getRemoteIdentities(
+        addresses: readonly SignalAddress[]
+    ): Promise<readonly (Uint8Array | null)[]> {
+        if (addresses.length === 0) return []
+        await this.ensureReady()
+        const targets = addresses.map((a) => toSignalAddressParts(a))
+        const byKey = new Map<string, Uint8Array>()
+        for (let start = 0; start < targets.length; start += BATCH_SIZE) {
+            const batch = targets.slice(start, start + BATCH_SIZE)
+            const placeholders = batch
+                .map(() => '(user = ? AND server = ? AND device = ?)')
+                .join(' OR ')
+            const params: MysqlParam[] = [
+                this.sessionId,
+                ...batch.flatMap((t) => [t.user, t.server, t.device])
+            ]
+            const rows = queryRows(
+                await this.pool.execute(
+                    `SELECT user, server, device, identity_key
+                 FROM ${this.t('signal_identity')}
+                 WHERE session_id = ? AND (${placeholders})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                byKey.set(
+                    signalAddressKey({
+                        user: String(row.user),
+                        server: String(row.server),
+                        device: Number(row.device)
+                    }),
+                    toBytes(row.identity_key)
+                )
+            }
+        }
+        return targets.map((t) => byKey.get(signalAddressKey(t)) ?? null)
+    }
+
+    public async setRemoteIdentity(address: SignalAddress, identityKey: Uint8Array): Promise<void> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(address)
+        await this.upsertRemoteIdentity(this.pool, target, identityKey)
+    }
+
+    public async setRemoteIdentities(
+        entries: readonly {
+            readonly address: SignalAddress
+            readonly identityKey: Uint8Array
+        }[]
+    ): Promise<void> {
+        if (entries.length === 0) return
+        await this.withTransaction(async (conn) => {
+            for (const entry of entries) {
+                const target = toSignalAddressParts(entry.address)
+                await this.upsertRemoteIdentity(conn, target, entry.identityKey)
+            }
+        })
+    }
+
+    // ── Clear ─────────────────────────────────────────────────────────
+
+    public async clear(): Promise<void> {
+        await this.withTransaction(async (conn) => {
+            await conn.execute(
+                `DELETE FROM ${this.t('signal_registration')} WHERE session_id = ?`,
+                [this.sessionId]
+            )
+            await conn.execute(
+                `DELETE FROM ${this.t('signal_signed_prekey')} WHERE session_id = ?`,
+                [this.sessionId]
+            )
+            await conn.execute(`DELETE FROM ${this.t('signal_prekey')} WHERE session_id = ?`, [
+                this.sessionId
+            ])
+            await conn.execute(`DELETE FROM ${this.t('signal_session')} WHERE session_id = ?`, [
+                this.sessionId
+            ])
+            await conn.execute(`DELETE FROM ${this.t('signal_identity')} WHERE session_id = ?`, [
+                this.sessionId
+            ])
+            await conn.execute(`DELETE FROM ${this.t('signal_meta')} WHERE session_id = ?`, [
+                this.sessionId
+            ])
+        })
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────
+
+    private async ensureMetaRow(conn: PoolConnection): Promise<void> {
+        await conn.execute(
+            `INSERT IGNORE INTO ${this.t('signal_meta')} (
+                session_id, server_has_prekeys, next_prekey_id
+            ) VALUES (?, 0, 1)`,
+            [this.sessionId]
+        )
+    }
+
+    private async getMeta(conn: PoolConnection): Promise<{
+        serverHasPreKeys: boolean
+        nextPreKeyId: number
+        signedPreKeyRotationTs: number | null
+    }> {
+        await this.ensureMetaRow(conn)
+        const row = queryFirst(
+            await conn.execute(
+                `SELECT server_has_prekeys, next_prekey_id, signed_prekey_rotation_ts
+             FROM ${this.t('signal_meta')}
+             WHERE session_id = ?`,
+                [this.sessionId]
+            )
+        )
+        if (!row) throw new Error('signal meta row not found')
+        return {
+            serverHasPreKeys: Number(row.server_has_prekeys) === 1,
+            nextPreKeyId: Number(row.next_prekey_id),
+            signedPreKeyRotationTs:
+                row.signed_prekey_rotation_ts !== null
+                    ? Number(row.signed_prekey_rotation_ts)
+                    : null
+        }
+    }
+
+    private async selectAvailablePreKeys(
+        conn: PoolConnection,
+        limit: number
+    ): Promise<PreKeyRecord[]> {
+        const resolved = safeLimit(limit, 100)
+        return queryRows(
+            await conn.execute(
+                `SELECT key_id, pub_key, priv_key, uploaded
+             FROM ${this.t('signal_prekey')}
+             WHERE session_id = ? AND uploaded = 0
+             ORDER BY key_id ASC
+             LIMIT ${resolved}`,
+                [this.sessionId]
+            )
+        ).map((row) => this.decodePreKeyRow(row))
+    }
+
+    private async upsertPreKey(conn: PoolConnection, record: PreKeyRecord): Promise<void> {
+        await conn.execute(
+            `INSERT INTO ${this.t('signal_prekey')} (
+                session_id, key_id, pub_key, priv_key, uploaded
+            ) VALUES (?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                pub_key = VALUES(pub_key),
+                priv_key = VALUES(priv_key),
+                uploaded = VALUES(uploaded)`,
+            [
+                this.sessionId,
+                record.keyId,
+                record.keyPair.pubKey,
+                record.keyPair.privKey,
+                record.uploaded === true ? 1 : 0
+            ]
+        )
+    }
+
+    private async upsertSession(
+        executor: { execute: PoolConnection['execute'] },
+        target: SignalAddressParts,
+        session: SignalSessionRecord
+    ): Promise<void> {
+        await executor.execute(
+            `INSERT INTO ${this.t('signal_session')} (
+                session_id, user, server, device, record
+            ) VALUES (?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                record = VALUES(record)`,
+            [
+                this.sessionId,
+                target.user,
+                target.server,
+                target.device,
+                encodeSignalSessionRecord(session)
+            ]
+        )
+    }
+
+    private async upsertRemoteIdentity(
+        executor: { execute: PoolConnection['execute'] },
+        target: SignalAddressParts,
+        identityKey: Uint8Array
+    ): Promise<void> {
+        await executor.execute(
+            `INSERT INTO ${this.t('signal_identity')} (
+                session_id, user, server, device, identity_key
+            ) VALUES (?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                identity_key = VALUES(identity_key)`,
+            [this.sessionId, target.user, target.server, target.device, identityKey]
+        )
+    }
+
+    private decodePreKeyRow(row: MysqlRow): PreKeyRecord {
+        return {
+            keyId: Number(row.key_id),
+            keyPair: {
+                pubKey: toBytes(row.pub_key),
+                privKey: toBytes(row.priv_key)
+            },
+            uploaded: row.uploaded !== null ? Number(row.uploaded) === 1 : undefined
+        }
+    }
+
+    private decodeSignedPreKeyRow(row: MysqlRow): SignedPreKeyRecord {
+        return {
+            keyId: Number(row.key_id),
+            keyPair: {
+                pubKey: toBytes(row.pub_key),
+                privKey: toBytes(row.priv_key)
+            },
+            signature: toBytes(row.signature),
+            uploaded: row.uploaded !== null ? Number(row.uploaded) === 1 : undefined
+        }
+    }
+}

--- a/packages/store-mysql/src/thread.store.ts
+++ b/packages/store-mysql/src/thread.store.ts
@@ -1,0 +1,137 @@
+import type { WaThreadStore, WaStoredThreadRecord } from 'zapo-js/store'
+
+import { BaseMysqlStore } from './BaseMysqlStore'
+import { affectedRows, queryFirst, queryRows, safeLimit, type MysqlRow } from './helpers'
+import type { WaMysqlStorageOptions } from './types'
+
+export class WaThreadMysqlStore extends BaseMysqlStore implements WaThreadStore {
+    public constructor(options: WaMysqlStorageOptions) {
+        super(options, ['mailbox'])
+    }
+
+    public async upsert(record: WaStoredThreadRecord): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(
+            `INSERT INTO ${this.t('mailbox_threads')} (
+                session_id, jid, name, unread_count, archived, pinned,
+                mute_end_ms, marked_as_unread, ephemeral_expiration
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+                name = COALESCE(VALUES(name), name),
+                unread_count = COALESCE(VALUES(unread_count), unread_count),
+                archived = COALESCE(VALUES(archived), archived),
+                pinned = COALESCE(VALUES(pinned), pinned),
+                mute_end_ms = COALESCE(VALUES(mute_end_ms), mute_end_ms),
+                marked_as_unread = COALESCE(VALUES(marked_as_unread), marked_as_unread),
+                ephemeral_expiration = COALESCE(VALUES(ephemeral_expiration), ephemeral_expiration)`,
+            [
+                this.sessionId,
+                record.jid,
+                record.name ?? null,
+                record.unreadCount ?? null,
+                record.archived === undefined ? null : record.archived ? 1 : 0,
+                record.pinned ?? null,
+                record.muteEndMs ?? null,
+                record.markedAsUnread === undefined ? null : record.markedAsUnread ? 1 : 0,
+                record.ephemeralExpiration ?? null
+            ]
+        )
+    }
+
+    public async upsertBatch(records: readonly WaStoredThreadRecord[]): Promise<void> {
+        if (records.length === 0) return
+
+        await this.withTransaction(async (conn) => {
+            for (const record of records) {
+                await conn.execute(
+                    `INSERT INTO ${this.t('mailbox_threads')} (
+                        session_id, jid, name, unread_count, archived, pinned,
+                        mute_end_ms, marked_as_unread, ephemeral_expiration
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON DUPLICATE KEY UPDATE
+                        name = COALESCE(VALUES(name), name),
+                        unread_count = COALESCE(VALUES(unread_count), unread_count),
+                        archived = COALESCE(VALUES(archived), archived),
+                        pinned = COALESCE(VALUES(pinned), pinned),
+                        mute_end_ms = COALESCE(VALUES(mute_end_ms), mute_end_ms),
+                        marked_as_unread = COALESCE(VALUES(marked_as_unread), marked_as_unread),
+                        ephemeral_expiration = COALESCE(VALUES(ephemeral_expiration), ephemeral_expiration)`,
+                    [
+                        this.sessionId,
+                        record.jid,
+                        record.name ?? null,
+                        record.unreadCount ?? null,
+                        record.archived === undefined ? null : record.archived ? 1 : 0,
+                        record.pinned ?? null,
+                        record.muteEndMs ?? null,
+                        record.markedAsUnread === undefined ? null : record.markedAsUnread ? 1 : 0,
+                        record.ephemeralExpiration ?? null
+                    ]
+                )
+            }
+        })
+    }
+
+    public async getByJid(jid: string): Promise<WaStoredThreadRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT jid, name, unread_count, archived, pinned,
+                    mute_end_ms, marked_as_unread, ephemeral_expiration
+             FROM ${this.t('mailbox_threads')}
+             WHERE session_id = ? AND jid = ?`,
+                [this.sessionId, jid]
+            )
+        )
+        if (!row) return null
+        return rowToRecord(row)
+    }
+
+    public async list(limit?: number): Promise<readonly WaStoredThreadRecord[]> {
+        await this.ensureReady()
+        const resolved = safeLimit(limit, 100)
+        return queryRows(
+            await this.pool.execute(
+                `SELECT jid, name, unread_count, archived, pinned,
+                    mute_end_ms, marked_as_unread, ephemeral_expiration
+             FROM ${this.t('mailbox_threads')}
+             WHERE session_id = ?
+             LIMIT ${resolved}`,
+                [this.sessionId]
+            )
+        ).map(rowToRecord)
+    }
+
+    public async deleteByJid(jid: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.execute(
+                `DELETE FROM ${this.t('mailbox_threads')}
+             WHERE session_id = ? AND jid = ?`,
+                [this.sessionId, jid]
+            )
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.execute(`DELETE FROM ${this.t('mailbox_threads')} WHERE session_id = ?`, [
+            this.sessionId
+        ])
+    }
+}
+
+function rowToRecord(row: MysqlRow): WaStoredThreadRecord {
+    return {
+        jid: row.jid as string,
+        name: (row.name as string | null) ?? undefined,
+        unreadCount: row.unread_count !== null ? Number(row.unread_count) : undefined,
+        archived: row.archived === null ? undefined : Number(row.archived) === 1,
+        pinned: row.pinned !== null ? Number(row.pinned) : undefined,
+        muteEndMs: row.mute_end_ms !== null ? Number(row.mute_end_ms) : undefined,
+        markedAsUnread:
+            row.marked_as_unread === null ? undefined : Number(row.marked_as_unread) === 1,
+        ephemeralExpiration:
+            row.ephemeral_expiration !== null ? Number(row.ephemeral_expiration) : undefined
+    }
+}

--- a/packages/store-mysql/src/types.ts
+++ b/packages/store-mysql/src/types.ts
@@ -1,0 +1,25 @@
+import type { Pool, PoolOptions } from 'mysql2/promise'
+
+export type MysqlParam = string | number | bigint | Uint8Array | boolean | null
+
+export type WaMysqlMigrationDomain =
+    | 'auth'
+    | 'signal'
+    | 'senderKey'
+    | 'appState'
+    | 'retry'
+    | 'mailbox'
+    | 'participants'
+    | 'deviceList'
+    | 'privacyToken'
+
+export interface WaMysqlStorageOptions {
+    readonly pool: Pool
+    readonly sessionId: string
+    readonly tablePrefix?: string
+}
+
+export interface WaMysqlCreateStoreOptions {
+    readonly pool: Pool | PoolOptions
+    readonly tablePrefix?: string
+}

--- a/packages/store-mysql/tsconfig.build.cjs.json
+++ b/packages/store-mysql/tsconfig.build.cjs.json
@@ -1,0 +1,26 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "baseUrl": "../..",
+        "paths": {
+            "zapo-js": ["dist/types/index.d.ts"],
+            "zapo-js/store": ["dist/types/store/index.d.ts"],
+            "zapo-js/signal": ["dist/types/signal/index.d.ts"],
+            "zapo-js/auth": ["dist/types/auth/index.d.ts"],
+            "zapo-js/appstate": ["dist/types/appstate/index.d.ts"],
+            "zapo-js/retry": ["dist/types/retry/index.d.ts"],
+            "zapo-js/proto": ["dist/types/proto.d.ts"],
+            "zapo-js/protocol": ["dist/types/protocol/index.d.ts"],
+            "zapo-js/util": ["dist/types/util/index.d.ts"]
+        }
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/store-mysql/tsconfig.json
+++ b/packages/store-mysql/tsconfig.json
@@ -1,0 +1,36 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "types": ["node"],
+        "rootDir": "../..",
+        "baseUrl": "../..",
+        "paths": {
+            "zapo-js": ["src/index.ts"],
+            "zapo-js/store": ["src/store/index.ts"],
+            "zapo-js/signal": ["src/signal/index.ts"],
+            "zapo-js/auth": ["src/auth/index.ts"],
+            "zapo-js/appstate": ["src/appstate/index.ts"],
+            "zapo-js/retry": ["src/retry/index.ts"],
+            "zapo-js/proto": ["src/proto.ts"],
+            "zapo-js/protocol": ["src/protocol/index.ts"],
+            "zapo-js/util": ["src/util/index.ts"],
+            "@appstate/*": ["src/appstate/*"],
+            "@auth/*": ["src/auth/*"],
+            "@client/*": ["src/client/*"],
+            "@crypto/*": ["src/crypto/*"],
+            "@infra/*": ["src/infra/*"],
+            "@media/*": ["src/media/*"],
+            "@message/*": ["src/message/*"],
+            "@protocol/*": ["src/protocol/*"],
+            "@proto": ["src/proto.ts"],
+            "@retry/*": ["src/retry/*"],
+            "@signal/*": ["src/signal/*"],
+            "@store/*": ["src/store/*"],
+            "@transport/*": ["src/transport/*"],
+            "@util/*": ["src/util/*"]
+        },
+        "noEmit": true
+    },
+    "include": ["src"],
+    "exclude": ["dist", "node_modules"]
+}

--- a/src/appstate/__tests__/encoding.test.ts
+++ b/src/appstate/__tests__/encoding.test.ts
@@ -6,7 +6,7 @@ import {
     decodeAppStateFingerprint,
     decodeAppStateSyncKeys,
     encodeAppStateFingerprint
-} from '@appstate/store/sqlite'
+} from '@appstate/encoding'
 
 test('appstate sqlite helper encodes/decodes sync key fingerprints', () => {
     const fingerprint = {

--- a/src/appstate/encoding.ts
+++ b/src/appstate/encoding.ts
@@ -6,7 +6,7 @@ import type {
 import { proto } from '@proto'
 import { asBytes, asNumber, asOptionalBytes, asString } from '@util/coercion'
 
-type SqliteRow = Readonly<Record<string, unknown>>
+type StoreRow = Readonly<Record<string, unknown>>
 
 export function encodeAppStateFingerprint(
     fingerprint: WaAppStateSyncKey['fingerprint']
@@ -32,7 +32,7 @@ export function decodeAppStateFingerprint(
     }
 }
 
-export function decodeAppStateSyncKeys(rows: readonly SqliteRow[]): readonly WaAppStateSyncKey[] {
+export function decodeAppStateSyncKeys(rows: readonly StoreRow[]): readonly WaAppStateSyncKey[] {
     const decoded = new Array<WaAppStateSyncKey>(rows.length)
     for (let i = 0; i < rows.length; i += 1) {
         const row = rows[i]
@@ -47,8 +47,8 @@ export function decodeAppStateSyncKeys(rows: readonly SqliteRow[]): readonly WaA
 }
 
 export function decodeAppStateCollections(
-    versionRows: readonly SqliteRow[],
-    valueRows: readonly SqliteRow[]
+    versionRows: readonly StoreRow[],
+    valueRows: readonly StoreRow[]
 ): WaAppStateStoreData['collections'] {
     const valueMapByCollection = new Map<string, Record<string, Uint8Array>>()
     for (const row of valueRows) {

--- a/src/appstate/index.ts
+++ b/src/appstate/index.ts
@@ -1,5 +1,11 @@
 export * from '@appstate/constants'
-export type { WaAppStateSyncOptions } from '@appstate/types'
+export type {
+    AppStateCollectionName,
+    WaAppStateStoreData,
+    WaAppStateSyncKey,
+    WaAppStateSyncOptions
+} from '@appstate/types'
+export { encodeAppStateFingerprint, decodeAppStateFingerprint } from '@appstate/encoding'
 export * from '@appstate/utils'
 export { WaAppStateCrypto } from '@appstate/WaAppStateCrypto'
 export { parseSyncResponse } from '@appstate/WaAppStateSyncResponseParser'

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -13,5 +13,6 @@ export {
     parsePhoneJid,
     parseSignalAddressFromJid,
     splitJid,
+    signalAddressKey,
     toUserJid
 } from '@protocol/jid'

--- a/src/signal/__tests__/encoding.test.ts
+++ b/src/signal/__tests__/encoding.test.ts
@@ -12,11 +12,11 @@ import {
     decodeSignalRegistrationRow,
     decodeSignalSessionRecord,
     decodeSignalSignedPreKeyRow,
-    decodeSqliteCount,
+    decodeStoreCount,
     encodeSenderKeyRecord,
     encodeSignalSessionRecord,
     toSignalAddressParts
-} from '@signal/store/sqlite'
+} from '@signal/encoding'
 import type { SignalAddress, SignalSessionRecord } from '@signal/types'
 import { toBytesView } from '@util/bytes'
 
@@ -217,6 +217,6 @@ test('sqlite signal helpers encode/decode sender key records and distribution ro
 })
 
 test('sqlite signal helpers decode count rows safely', () => {
-    assert.equal(decodeSqliteCount(null, 'count.field'), 0)
-    assert.equal(decodeSqliteCount({ count: 12 }, 'count.field'), 12)
+    assert.equal(decodeStoreCount(null, 'count.field'), 0)
+    assert.equal(decodeStoreCount({ count: 12 }, 'count.field'), 12)
 })

--- a/src/signal/encoding.ts
+++ b/src/signal/encoding.ts
@@ -85,7 +85,7 @@ export interface SenderKeyDistributionRow extends Record<string, unknown> {
     readonly timestamp_ms: unknown
 }
 
-export interface SqliteCountRow extends Record<string, unknown> {
+export interface StoreCountRow extends Record<string, unknown> {
     readonly count: unknown
 }
 
@@ -536,7 +536,7 @@ export function decodeSenderKeyDistributionRow(
     }
 }
 
-export function decodeSqliteCount(row: SqliteCountRow | null, field: string): number {
+export function decodeStoreCount(row: StoreCountRow | null, field: string): number {
     return row ? asNumber(row.count, field) : 0
 }
 

--- a/src/signal/index.ts
+++ b/src/signal/index.ts
@@ -7,6 +7,16 @@ export {
     SignalPreKeyBundle,
     SignedPreKeyRecord
 } from '@signal/types'
+export type { SignalSessionRecord } from '@signal/types'
+export {
+    encodeSignalSessionRecord,
+    decodeSignalSessionRecord,
+    encodeSenderKeyRecord,
+    decodeSenderKeyRecord,
+    decodeSenderKeyDistributionRow,
+    toSignalAddressParts,
+    type SignalAddressParts
+} from '@signal/encoding'
 export {
     generatePreKeyPair,
     generateRegistrationId,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -27,13 +27,18 @@ export type {
     WaParticipantsStore
 } from '@store/contracts/participants.store'
 export type {
+    WaAppStateCollectionStateUpdate,
     WaAppStateCollectionStoreState,
     WaAppStateStore
 } from '@store/contracts/appstate.store'
 export type { WaSenderKeyStore } from '@store/contracts/sender-key.store'
-export type { WaSignalStore } from '@store/contracts/signal.store'
+export type { WaSignalMetaSnapshot, WaSignalStore } from '@store/contracts/signal.store'
 export type { WaRetryStore } from '@store/contracts/retry.store'
 export type { WaStoredThreadRecord, WaThreadStore } from '@store/contracts/thread.store'
+export type {
+    WaPrivacyTokenStore,
+    WaStoredPrivacyTokenRecord
+} from '@store/contracts/privacy-token.store'
 export { WaSignalSqliteStore } from '@store/providers/sqlite/signal.store'
 export { SenderKeySqliteStore } from '@store/providers/sqlite/sender-key.store'
 export { WaRetrySqliteStore } from '@store/providers/sqlite/retry.store'

--- a/src/store/providers/sqlite/appstate.store.ts
+++ b/src/store/providers/sqlite/appstate.store.ts
@@ -4,7 +4,7 @@ import {
     decodeAppStateFingerprint,
     decodeAppStateSyncKeys,
     encodeAppStateFingerprint
-} from '@appstate/store/sqlite'
+} from '@appstate/encoding'
 import type {
     AppStateCollectionName,
     WaAppStateSyncKey,

--- a/src/store/providers/sqlite/sender-key.store.ts
+++ b/src/store/providers/sqlite/sender-key.store.ts
@@ -6,7 +6,7 @@ import {
     type SenderKeyDistributionRow,
     type SenderKeyRow,
     type SignalAddressParts
-} from '@signal/store/sqlite'
+} from '@signal/encoding'
 import type { SenderKeyDistributionRecord, SenderKeyRecord, SignalAddress } from '@signal/types'
 import type { WaSenderKeyStore as WaSenderKeyStoreContract } from '@store/contracts/sender-key.store'
 import { BaseSqliteStore } from '@store/providers/sqlite/BaseSqliteStore'

--- a/src/store/providers/sqlite/signal.store.ts
+++ b/src/store/providers/sqlite/signal.store.ts
@@ -13,7 +13,7 @@ import {
     type SignalRegistrationRow,
     type SignalSessionRow,
     type SignalSignedPreKeyRow
-} from '@signal/store/sqlite'
+} from '@signal/encoding'
 import type {
     PreKeyRecord,
     RegistrationInfo,

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,2 @@
+export { bytesToHex, toBytesView, uint8Equal } from '@util/bytes'
+export { normalizeQueryLimit } from '@util/collections'

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "lib": ["ES2020"],
+        "module": "CommonJS",
+        "moduleResolution": "Node",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "noEmit": true
+    }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://turbo.build/schema.json",
+    "tasks": {
+        "build": {
+            "dependsOn": ["^build"],
+            "outputs": ["dist/**"]
+        },
+        "test": {
+            "dependsOn": ["build"]
+        },
+        "lint": {},
+        "typecheck": {
+            "dependsOn": ["^build"]
+        }
+    }
+}


### PR DESCRIPTION
- set up npm workspaces + Turborepo for optional packages alongside the core library
- add @zapo-js/store-mysql with all 11 store contracts backed by mysql2
- implement lazy per-domain migrations that only run for stores actually used
- add batch-chunked queries to avoid MySQL parameter limits on large IN/OR clauses
- add MysqlCleanupPoller for periodic TTL expiration with error callback
- add createMysqlStore() helper for plug-and-play integration with createStore()
- support user-provided Pool or PoolOptions with configurable table prefix
- make migrations concurrency-safe with INSERT IGNORE on tracking table
- add protocol and retry sub-path exports to core package.json
- export signal/appstate encoding helpers and additional store contract types
- rename signal/appstate store/sqlite.ts to encoding.ts and move to parent dir
- move encoding tests out of store/ subdirectories into __tests__/
- add tsconfig.base.json for shared TypeScript config across packages
- extend eslint config to lint packages/ directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MySQL-backed storage option with full set of session-scoped stores (auth, signal, sender keys, app state, retry, mailbox, participants, device list, messages, threads, contacts, privacy tokens), migrations, pool factory, and automated cleanup poller.
  * Expanded public exports and encoding/decoding utilities for protocol, signal, and app-state consumers.

* **Chores**
  * Converted to monorepo workspace, added root build scripts and Turbo pipeline.
  * Updated package metadata, ESLint and TypeScript configs, and ignore rules to exclude build outputs and cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->