### PR TITLE
fix: pad dynamic batch queries to fixed size to prevent prepared statement leak

### DIFF
--- a/packages/store-mysql/src/appstate.store.ts
+++ b/packages/store-mysql/src/appstate.store.ts
@@ -21,6 +21,10 @@ import { queryFirst, queryRows, toBytes, toBytesOrNull, bytesToHex, uint8Equal }
 import type { MysqlParam, WaMysqlStorageOptions } from './types'
 
 const BATCH_SIZE = 500
+const FIXED_IN_PLACEHOLDERS = Array.from({ length: BATCH_SIZE }, () => '?').join(', ')
+const COLLECTION_BATCH = 8
+const FIXED_COLLECTION_PLACEHOLDERS = Array.from({ length: COLLECTION_BATCH }, () => '?').join(', ')
+const EMPTY_KEY_PAD = new Uint8Array(0)
 
 export class WaAppStateMysqlStore extends BaseMysqlStore implements WaAppStateStore {
     public constructor(options: WaMysqlStorageOptions) {
@@ -221,15 +225,15 @@ export class WaAppStateMysqlStore extends BaseMysqlStore implements WaAppStateSt
     ): Promise<readonly WaAppStateCollectionStoreState[]> {
         if (collections.length === 0) return []
         return this.withTransaction(async (conn) => {
-            const uniqueCollections = [...new Set(collections)]
-            const placeholders = uniqueCollections.map(() => '?').join(', ')
+            const uniqueCollections: string[] = [...new Set(collections)]
+            while (uniqueCollections.length < COLLECTION_BATCH) uniqueCollections.push('')
             const params: MysqlParam[] = [this.sessionId, ...uniqueCollections]
 
             const versionRows = queryRows(
                 await conn.execute(
                     `SELECT collection, version, hash
                      FROM ${this.t('appstate_collection_versions')}
-                     WHERE session_id = ? AND collection IN (${placeholders})`,
+                     WHERE session_id = ? AND collection IN (${FIXED_COLLECTION_PLACEHOLDERS})`,
                     params
                 )
             )
@@ -237,7 +241,7 @@ export class WaAppStateMysqlStore extends BaseMysqlStore implements WaAppStateSt
                 await conn.execute(
                     `SELECT collection, index_mac_hex, value_mac
                      FROM ${this.t('appstate_collection_index_values')}
-                     WHERE session_id = ? AND collection IN (${placeholders})`,
+                     WHERE session_id = ? AND collection IN (${FIXED_COLLECTION_PLACEHOLDERS})`,
                     params
                 )
             )
@@ -350,13 +354,13 @@ export class WaAppStateMysqlStore extends BaseMysqlStore implements WaAppStateSt
         const byHex = new Map<string, Uint8Array>()
         for (let start = 0; start < uniqueKeyIds.length; start += BATCH_SIZE) {
             const batch = uniqueKeyIds.slice(start, start + BATCH_SIZE)
-            const placeholders = batch.map(() => '?').join(', ')
+            while (batch.length < BATCH_SIZE) batch.push(EMPTY_KEY_PAD)
             const params: MysqlParam[] = [this.sessionId, ...batch]
             const rows = queryRows(
                 await executor.execute(
                     `SELECT key_id, key_data
                  FROM ${this.t('appstate_sync_keys')}
-                 WHERE session_id = ? AND key_id IN (${placeholders})`,
+                 WHERE session_id = ? AND key_id IN (${FIXED_IN_PLACEHOLDERS})`,
                     params
                 )
             )
@@ -379,13 +383,13 @@ export class WaAppStateMysqlStore extends BaseMysqlStore implements WaAppStateSt
         const byHex = new Map<string, WaAppStateSyncKey>()
         for (let start = 0; start < uniqueKeyIds.length; start += BATCH_SIZE) {
             const batch = uniqueKeyIds.slice(start, start + BATCH_SIZE)
-            const placeholders = batch.map(() => '?').join(', ')
+            while (batch.length < BATCH_SIZE) batch.push(EMPTY_KEY_PAD)
             const params: MysqlParam[] = [this.sessionId, ...batch]
             const rows = queryRows(
                 await this.pool.execute(
                     `SELECT key_id, key_data, timestamp, fingerprint
                  FROM ${this.t('appstate_sync_keys')}
-                 WHERE session_id = ? AND key_id IN (${placeholders})`,
+                 WHERE session_id = ? AND key_id IN (${FIXED_IN_PLACEHOLDERS})`,
                     params
                 )
             )

--- a/packages/store-mysql/src/device-list.store.ts
+++ b/packages/store-mysql/src/device-list.store.ts
@@ -6,6 +6,7 @@ import type { WaMysqlStorageOptions } from './types'
 
 const DEFAULT_DEVICE_LIST_TTL_MS = 5 * 60 * 1000
 const BATCH_SIZE = 500
+const FIXED_IN_PLACEHOLDERS = Array.from({ length: BATCH_SIZE }, () => '?').join(', ')
 
 export class WaDeviceListMysqlStore extends BaseMysqlStore implements WaDeviceListStore {
     private readonly ttlMs: number
@@ -55,12 +56,12 @@ export class WaDeviceListMysqlStore extends BaseMysqlStore implements WaDeviceLi
 
         for (let start = 0; start < uniqueUserJids.length; start += BATCH_SIZE) {
             const batch = uniqueUserJids.slice(start, start + BATCH_SIZE)
-            const placeholders = batch.map(() => '?').join(', ')
+            while (batch.length < BATCH_SIZE) batch.push('')
             const rows = queryRows(
                 await this.pool.execute(
                     `SELECT user_jid, device_jids_json, updated_at_ms, expires_at_ms
                      FROM ${this.t('device_list_cache')}
-                     WHERE session_id = ? AND user_jid IN (${placeholders})`,
+                     WHERE session_id = ? AND user_jid IN (${FIXED_IN_PLACEHOLDERS})`,
                     [this.sessionId, ...batch]
                 )
             )
@@ -86,10 +87,10 @@ export class WaDeviceListMysqlStore extends BaseMysqlStore implements WaDeviceLi
         if (expiredUserJids.length > 0) {
             for (let start = 0; start < expiredUserJids.length; start += BATCH_SIZE) {
                 const batch = expiredUserJids.slice(start, start + BATCH_SIZE)
-                const placeholders = batch.map(() => '?').join(', ')
+                while (batch.length < BATCH_SIZE) batch.push('')
                 await this.pool.execute(
                     `DELETE FROM ${this.t('device_list_cache')}
-                     WHERE session_id = ? AND expires_at_ms <= ? AND user_jid IN (${placeholders})`,
+                     WHERE session_id = ? AND expires_at_ms <= ? AND user_jid IN (${FIXED_IN_PLACEHOLDERS})`,
                     [this.sessionId, nowMs, ...batch]
                 )
             }

--- a/packages/store-mysql/src/sender-key.store.ts
+++ b/packages/store-mysql/src/sender-key.store.ts
@@ -14,6 +14,11 @@ import type { MysqlParam } from './types'
 import type { WaMysqlStorageOptions } from './types'
 
 const BATCH_SIZE = 250
+const FIXED_SENDER_PLACEHOLDERS = Array.from(
+    { length: BATCH_SIZE },
+    () => '(sender_user = ? AND sender_server = ? AND sender_device = ?)'
+).join(' OR ')
+const NO_MATCH_SENDER: SignalAddressParts = { user: '', server: '', device: -1 }
 
 export class WaSenderKeyMysqlStore extends BaseMysqlStore implements WaSenderKeyStore {
     public constructor(options: WaMysqlStorageOptions) {
@@ -138,9 +143,7 @@ export class WaSenderKeyMysqlStore extends BaseMysqlStore implements WaSenderKey
         const byKey = new Map<string, SenderKeyDistributionRecord>()
         for (let start = 0; start < targets.length; start += BATCH_SIZE) {
             const batch = targets.slice(start, start + BATCH_SIZE)
-            const placeholders = batch
-                .map(() => '(sender_user = ? AND sender_server = ? AND sender_device = ?)')
-                .join(' OR ')
+            while (batch.length < BATCH_SIZE) batch.push(NO_MATCH_SENDER)
             const params: MysqlParam[] = [
                 this.sessionId,
                 groupId,
@@ -150,7 +153,7 @@ export class WaSenderKeyMysqlStore extends BaseMysqlStore implements WaSenderKey
                 await this.pool.execute(
                     `SELECT group_id, sender_user, sender_server, sender_device, key_id, timestamp_ms
                      FROM ${this.t('sender_key_distribution')}
-                     WHERE session_id = ? AND group_id = ? AND (${placeholders})`,
+                     WHERE session_id = ? AND group_id = ? AND (${FIXED_SENDER_PLACEHOLDERS})`,
                     params
                 )
             )
@@ -200,14 +203,20 @@ export class WaSenderKeyMysqlStore extends BaseMysqlStore implements WaSenderKey
             let total = 0
             for (let start = 0; start < participants.length; start += BATCH_SIZE) {
                 const batch = participants.slice(start, start + BATCH_SIZE)
-                const filters: string[] = []
                 const senderParams: MysqlParam[] = []
                 for (const participant of batch) {
                     const sender = toSignalAddressParts(participant)
-                    filters.push('(sender_user = ? AND sender_server = ? AND sender_device = ?)')
                     senderParams.push(sender.user, sender.server, sender.device)
                 }
-                const where = `session_id = ? AND group_id = ? AND (${filters.join(' OR ')})`
+                const remaining = BATCH_SIZE - batch.length
+                for (let i = 0; i < remaining; i++) {
+                    senderParams.push(
+                        NO_MATCH_SENDER.user,
+                        NO_MATCH_SENDER.server,
+                        NO_MATCH_SENDER.device
+                    )
+                }
+                const where = `session_id = ? AND group_id = ? AND (${FIXED_SENDER_PLACEHOLDERS})`
                 const params: MysqlParam[] = [this.sessionId, groupId, ...senderParams]
                 total += affectedRows(
                     await conn.execute(

--- a/packages/store-mysql/src/signal.store.ts
+++ b/packages/store-mysql/src/signal.store.ts
@@ -20,6 +20,12 @@ import { queryFirst, queryRows, safeLimit, toBytes, toBytesOrNull, type MysqlRow
 import type { MysqlParam, WaMysqlStorageOptions } from './types'
 
 const BATCH_SIZE = 250
+const FIXED_IN_PLACEHOLDERS = Array.from({ length: BATCH_SIZE }, () => '?').join(', ')
+const FIXED_ADDR_PLACEHOLDERS = Array.from(
+    { length: BATCH_SIZE },
+    () => '(user = ? AND server = ? AND device = ?)'
+).join(' OR ')
+const NO_MATCH_ADDRESS: SignalAddressParts = { user: '', server: '', device: -1 }
 
 export class WaSignalMysqlStore extends BaseMysqlStore implements WaSignalStore {
     public constructor(options: WaMysqlStorageOptions) {
@@ -252,13 +258,13 @@ export class WaSignalMysqlStore extends BaseMysqlStore implements WaSignalStore 
         const byId = new Map<number, PreKeyRecord>()
         for (let start = 0; start < uniqueKeyIds.length; start += BATCH_SIZE) {
             const batch = uniqueKeyIds.slice(start, start + BATCH_SIZE)
-            const placeholders = batch.map(() => '?').join(', ')
+            while (batch.length < BATCH_SIZE) batch.push(-1)
             const params: MysqlParam[] = [this.sessionId, ...batch]
             const rows = queryRows(
                 await this.pool.execute(
                     `SELECT key_id, pub_key, priv_key, uploaded
                  FROM ${this.t('signal_prekey')}
-                 WHERE session_id = ? AND key_id IN (${placeholders})`,
+                 WHERE session_id = ? AND key_id IN (${FIXED_IN_PLACEHOLDERS})`,
                     params
                 )
             )
@@ -431,9 +437,7 @@ export class WaSignalMysqlStore extends BaseMysqlStore implements WaSignalStore 
         const existingKeys = new Set<string>()
         for (let start = 0; start < targets.length; start += BATCH_SIZE) {
             const batch = targets.slice(start, start + BATCH_SIZE)
-            const placeholders = batch
-                .map(() => '(user = ? AND server = ? AND device = ?)')
-                .join(' OR ')
+            while (batch.length < BATCH_SIZE) batch.push(NO_MATCH_ADDRESS)
             const params: MysqlParam[] = [
                 this.sessionId,
                 ...batch.flatMap((t) => [t.user, t.server, t.device])
@@ -442,7 +446,7 @@ export class WaSignalMysqlStore extends BaseMysqlStore implements WaSignalStore 
                 await this.pool.execute(
                     `SELECT user, server, device
                  FROM ${this.t('signal_session')}
-                 WHERE session_id = ? AND (${placeholders})`,
+                 WHERE session_id = ? AND (${FIXED_ADDR_PLACEHOLDERS})`,
                     params
                 )
             )
@@ -483,9 +487,7 @@ export class WaSignalMysqlStore extends BaseMysqlStore implements WaSignalStore 
         const byKey = new Map<string, SignalSessionRecord>()
         for (let start = 0; start < targets.length; start += BATCH_SIZE) {
             const batch = targets.slice(start, start + BATCH_SIZE)
-            const placeholders = batch
-                .map(() => '(user = ? AND server = ? AND device = ?)')
-                .join(' OR ')
+            while (batch.length < BATCH_SIZE) batch.push(NO_MATCH_ADDRESS)
             const params: MysqlParam[] = [
                 this.sessionId,
                 ...batch.flatMap((t) => [t.user, t.server, t.device])
@@ -494,7 +496,7 @@ export class WaSignalMysqlStore extends BaseMysqlStore implements WaSignalStore 
                 await this.pool.execute(
                     `SELECT user, server, device, record
                  FROM ${this.t('signal_session')}
-                 WHERE session_id = ? AND (${placeholders})`,
+                 WHERE session_id = ? AND (${FIXED_ADDR_PLACEHOLDERS})`,
                     params
                 )
             )
@@ -569,9 +571,7 @@ export class WaSignalMysqlStore extends BaseMysqlStore implements WaSignalStore 
         const byKey = new Map<string, Uint8Array>()
         for (let start = 0; start < targets.length; start += BATCH_SIZE) {
             const batch = targets.slice(start, start + BATCH_SIZE)
-            const placeholders = batch
-                .map(() => '(user = ? AND server = ? AND device = ?)')
-                .join(' OR ')
+            while (batch.length < BATCH_SIZE) batch.push(NO_MATCH_ADDRESS)
             const params: MysqlParam[] = [
                 this.sessionId,
                 ...batch.flatMap((t) => [t.user, t.server, t.device])
@@ -580,7 +580,7 @@ export class WaSignalMysqlStore extends BaseMysqlStore implements WaSignalStore 
                 await this.pool.execute(
                     `SELECT user, server, device, identity_key
                  FROM ${this.t('signal_identity')}
-                 WHERE session_id = ? AND (${placeholders})`,
+                 WHERE session_id = ? AND (${FIXED_ADDR_PLACEHOLDERS})`,
                     params
                 )
             )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal database query handling in the MySQL storage layer by implementing fixed-size SQL placeholders across batch operations. No changes to public APIs or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->