### PR TITLE
feat: add @zapo-js/store-postgres package with pg driver

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,7 +39,8 @@ module.exports = [
                 tsconfigRootDir: __dirname,
                 project: [
                     './packages/store-mysql/tsconfig.json',
-                    './packages/store-sqlite/tsconfig.json'
+                    './packages/store-sqlite/tsconfig.json',
+                    './packages/store-postgres/tsconfig.json'
                 ]
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1472,6 +1472,18 @@
                 "undici-types": "~6.21.0"
             }
         },
+        "node_modules/@types/pg": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+            "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "pg-protocol": "*",
+                "pg-types": "^2.2.0"
+            }
+        },
         "node_modules/@types/ws": {
             "version": "8.18.1",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -1728,6 +1740,10 @@
         },
         "node_modules/@zapo-js/store-mysql": {
             "resolved": "packages/store-mysql",
+            "link": true
+        },
+        "node_modules/@zapo-js/store-postgres": {
+            "resolved": "packages/store-postgres",
             "link": true
         },
         "node_modules/@zapo-js/store-sqlite": {
@@ -5369,6 +5385,104 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pg": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+            "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "pg-connection-string": "^2.12.0",
+                "pg-pool": "^3.13.0",
+                "pg-protocol": "^1.13.0",
+                "pg-types": "2.2.0",
+                "pgpass": "1.0.5"
+            },
+            "engines": {
+                "node": ">= 16.0.0"
+            },
+            "optionalDependencies": {
+                "pg-cloudflare": "^1.3.0"
+            },
+            "peerDependencies": {
+                "pg-native": ">=3.0.1"
+            },
+            "peerDependenciesMeta": {
+                "pg-native": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/pg-cloudflare": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+            "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/pg-connection-string": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+            "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pg-int8": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+            "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/pg-pool": {
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+            "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "pg": ">=8.0"
+            }
+        },
+        "node_modules/pg-protocol": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+            "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pg-types": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+            "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pg-int8": "1.0.1",
+                "postgres-array": "~2.0.0",
+                "postgres-bytea": "~1.0.0",
+                "postgres-date": "~1.0.4",
+                "postgres-interval": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pgpass": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+            "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "split2": "^4.1.0"
+            }
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5499,6 +5613,49 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/postgres-array": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+            "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/postgres-bytea": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+            "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/postgres-date": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+            "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/postgres-interval": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+            "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xtend": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/prebuild-install": {
@@ -7060,6 +7217,16 @@
                 }
             }
         },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4"
+            }
+        },
         "node_modules/y18n": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -7128,6 +7295,27 @@
             },
             "peerDependencies": {
                 "mysql2": ">=3.0.0",
+                "zapo-js": ">=0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "zapo-js": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/store-postgres": {
+            "name": "@zapo-js/store-postgres",
+            "version": "0.1.0",
+            "devDependencies": {
+                "@types/pg": "^8.11.0",
+                "pg": "^8.14.1",
+                "zapo-js": "file:../.."
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "peerDependencies": {
+                "pg": ">=8.0.0",
                 "zapo-js": ">=0.1.0"
             },
             "peerDependenciesMeta": {

--- a/packages/store-postgres/package.json
+++ b/packages/store-postgres/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "@zapo-js/store-mysql",
+    "name": "@zapo-js/store-postgres",
     "version": "0.1.0",
-    "description": "MySQL/MariaDB store provider for zapo-js",
+    "description": "PostgreSQL store provider for zapo-js",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "exports": {
@@ -24,7 +24,7 @@
     },
     "peerDependencies": {
         "zapo-js": ">=0.1.0",
-        "mysql2": ">=3.0.0"
+        "pg": ">=8.0.0"
     },
     "peerDependenciesMeta": {
         "zapo-js": {
@@ -32,7 +32,8 @@
         }
     },
     "devDependencies": {
-        "mysql2": "^3.14.0",
+        "@types/pg": "^8.11.0",
+        "pg": "^8.14.1",
         "zapo-js": "file:../.."
     },
     "engines": {

--- a/packages/store-postgres/src/BasePgStore.ts
+++ b/packages/store-postgres/src/BasePgStore.ts
@@ -1,0 +1,67 @@
+import type { Pool, PoolClient } from 'pg'
+
+import { ensurePgMigrations } from './connection'
+import { assertSafeTablePrefix } from './helpers'
+import type { WaPgMigrationDomain, WaPgStorageOptions } from './types'
+
+export abstract class BasePgStore {
+    protected readonly pool: Pool
+    protected readonly sessionId: string
+    protected readonly tablePrefix: string
+    private readonly migrationDomains: readonly WaPgMigrationDomain[]
+    private migrationPromise: Promise<void> | null
+
+    protected constructor(
+        options: WaPgStorageOptions,
+        migrationDomains: readonly WaPgMigrationDomain[]
+    ) {
+        this.pool = options.pool
+        this.sessionId = options.sessionId
+        this.tablePrefix = options.tablePrefix ?? ''
+        assertSafeTablePrefix(this.tablePrefix)
+        this.migrationDomains = migrationDomains
+        this.migrationPromise = null
+    }
+
+    protected t(name: string): string {
+        return `"${this.tablePrefix}${name}"`
+    }
+
+    protected stmtName(key: string): string {
+        return `${this.tablePrefix}${key}`
+    }
+
+    protected async ensureReady(): Promise<void> {
+        if (!this.migrationPromise) {
+            this.migrationPromise = ensurePgMigrations(
+                this.pool,
+                this.migrationDomains,
+                this.tablePrefix
+            ).catch((err) => {
+                this.migrationPromise = null
+                throw err
+            })
+        }
+        return this.migrationPromise
+    }
+
+    protected async withTransaction<T>(run: (client: PoolClient) => Promise<T>): Promise<T> {
+        await this.ensureReady()
+        const client = await this.pool.connect()
+        try {
+            await client.query('BEGIN')
+            const result = await run(client)
+            await client.query('COMMIT')
+            return result
+        } catch (err) {
+            await client.query('ROLLBACK')
+            throw err
+        } finally {
+            client.release()
+        }
+    }
+
+    public async destroy(): Promise<void> {
+        this.migrationPromise = null
+    }
+}

--- a/packages/store-postgres/src/appstate.store.ts
+++ b/packages/store-postgres/src/appstate.store.ts
@@ -1,0 +1,422 @@
+import type { PoolClient } from 'pg'
+import type {
+    AppStateCollectionName,
+    WaAppStateSyncKey,
+    WaAppStateStoreData
+} from 'zapo-js/appstate'
+import {
+    APP_STATE_EMPTY_LT_HASH,
+    encodeAppStateFingerprint,
+    decodeAppStateFingerprint,
+    keyEpoch
+} from 'zapo-js/appstate'
+import type {
+    WaAppStateStore,
+    WaAppStateCollectionStoreState,
+    WaAppStateCollectionStateUpdate
+} from 'zapo-js/store'
+
+import { BasePgStore } from './BasePgStore'
+import { queryFirst, queryRows, toBytes, toBytesOrNull, bytesToHex, uint8Equal } from './helpers'
+import type { PgParam, WaPgStorageOptions } from './types'
+
+const BATCH_SIZE = 500
+
+export class WaAppStatePgStore extends BasePgStore implements WaAppStateStore {
+    public constructor(options: WaPgStorageOptions) {
+        super(options, ['appState'])
+    }
+
+    public async exportData(): Promise<WaAppStateStoreData> {
+        return this.withTransaction(async (client) => {
+            const keyRows = queryRows(
+                await client.query({
+                    name: this.stmtName('appstate_export_keys'),
+                    text: `SELECT key_id, key_data, timestamp, fingerprint
+                     FROM ${this.t('appstate_sync_keys')}
+                     WHERE session_id = $1`,
+                    values: [this.sessionId]
+                })
+            )
+            const versionRows = queryRows(
+                await client.query({
+                    name: this.stmtName('appstate_export_versions'),
+                    text: `SELECT collection, version, hash
+                     FROM ${this.t('appstate_collection_versions')}
+                     WHERE session_id = $1`,
+                    values: [this.sessionId]
+                })
+            )
+            const valueRows = queryRows(
+                await client.query({
+                    name: this.stmtName('appstate_export_values'),
+                    text: `SELECT collection, index_mac_hex, value_mac
+                     FROM ${this.t('appstate_collection_index_values')}
+                     WHERE session_id = $1`,
+                    values: [this.sessionId]
+                })
+            )
+
+            const keys: WaAppStateSyncKey[] = keyRows.map((row) => ({
+                keyId: toBytes(row.key_id),
+                keyData: toBytes(row.key_data),
+                timestamp: Number(row.timestamp),
+                fingerprint: decodeAppStateFingerprint(toBytesOrNull(row.fingerprint))
+            }))
+
+            const collections: WaAppStateStoreData['collections'] = {}
+            for (const row of versionRows) {
+                const name = String(row.collection) as AppStateCollectionName
+                collections[name] = {
+                    version: Number(row.version),
+                    hash: toBytes(row.hash),
+                    indexValueMap: {}
+                }
+            }
+            for (const row of valueRows) {
+                const name = String(row.collection) as AppStateCollectionName
+                const entry = collections[name]
+                if (entry) {
+                    ;(entry.indexValueMap as Record<string, Uint8Array>)[
+                        String(row.index_mac_hex)
+                    ] = toBytes(row.value_mac)
+                }
+            }
+
+            return { keys, collections }
+        })
+    }
+
+    public async upsertSyncKeys(keys: readonly WaAppStateSyncKey[]): Promise<number> {
+        if (keys.length === 0) return 0
+        let inserted = 0
+        await this.withTransaction(async (client) => {
+            const keyIds = keys.map((k) => k.keyId)
+            const existingByHex = await this.selectSyncKeyDataByIds(client, keyIds)
+
+            for (const key of keys) {
+                const existing = existingByHex.get(bytesToHex(key.keyId))
+                if (existing && uint8Equal(existing, key.keyData)) {
+                    continue
+                }
+                await client.query({
+                    name: this.stmtName('appstate_upsert_sync_key'),
+                    text: `INSERT INTO ${this.t('appstate_sync_keys')} (
+                        session_id, key_id, key_data, timestamp, fingerprint, key_epoch
+                    ) VALUES ($1, $2, $3, $4, $5, $6)
+                    ON CONFLICT (session_id, key_id) DO UPDATE SET
+                        key_data = EXCLUDED.key_data,
+                        timestamp = EXCLUDED.timestamp,
+                        fingerprint = EXCLUDED.fingerprint,
+                        key_epoch = EXCLUDED.key_epoch`,
+                    values: [
+                        this.sessionId,
+                        key.keyId,
+                        key.keyData,
+                        key.timestamp,
+                        encodeAppStateFingerprint(key.fingerprint),
+                        keyEpoch(key.keyId)
+                    ]
+                })
+                inserted += 1
+            }
+        })
+        return inserted
+    }
+
+    public async getSyncKeysBatch(
+        keyIds: readonly Uint8Array[]
+    ): Promise<readonly (WaAppStateSyncKey | null)[]> {
+        if (keyIds.length === 0) return []
+        await this.ensureReady()
+        const byHex = await this.selectSyncKeysByIds(keyIds)
+        return keyIds.map((id) => byHex.get(bytesToHex(id)) ?? null)
+    }
+
+    public async getSyncKeyData(keyId: Uint8Array): Promise<Uint8Array | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('appstate_get_sync_key_data'),
+                text: `SELECT key_data
+                 FROM ${this.t('appstate_sync_keys')}
+                 WHERE session_id = $1 AND key_id = $2`,
+                values: [this.sessionId, keyId]
+            })
+        )
+        if (!row) return null
+        return toBytes(row.key_data)
+    }
+
+    public async getSyncKeyDataBatch(
+        keyIds: readonly Uint8Array[]
+    ): Promise<readonly (Uint8Array | null)[]> {
+        if (keyIds.length === 0) return []
+        await this.ensureReady()
+        const byHex = await this.selectSyncKeyDataByIds(this.pool, keyIds)
+        return keyIds.map((id) => byHex.get(bytesToHex(id)) ?? null)
+    }
+
+    public async getActiveSyncKey(): Promise<WaAppStateSyncKey | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('appstate_get_active_sync_key'),
+                text: `SELECT key_id, key_data, timestamp, fingerprint
+                 FROM ${this.t('appstate_sync_keys')}
+                 WHERE session_id = $1
+                 ORDER BY key_epoch DESC, key_id ASC
+                 LIMIT 1`,
+                values: [this.sessionId]
+            })
+        )
+        if (!row) return null
+        return {
+            keyId: toBytes(row.key_id),
+            keyData: toBytes(row.key_data),
+            timestamp: Number(row.timestamp),
+            fingerprint: decodeAppStateFingerprint(toBytesOrNull(row.fingerprint))
+        }
+    }
+
+    public async getCollectionState(
+        collection: AppStateCollectionName
+    ): Promise<WaAppStateCollectionStoreState> {
+        return this.withTransaction(async (client) => {
+            const versionRow = queryFirst(
+                await client.query({
+                    name: this.stmtName('appstate_get_collection_version'),
+                    text: `SELECT version, hash
+                     FROM ${this.t('appstate_collection_versions')}
+                     WHERE session_id = $1 AND collection = $2`,
+                    values: [this.sessionId, collection]
+                })
+            )
+            if (!versionRow) {
+                return {
+                    initialized: false,
+                    version: 0,
+                    hash: APP_STATE_EMPTY_LT_HASH,
+                    indexValueMap: new Map()
+                }
+            }
+
+            const valueRows = queryRows(
+                await client.query({
+                    name: this.stmtName('appstate_get_collection_values'),
+                    text: `SELECT index_mac_hex, value_mac
+                     FROM ${this.t('appstate_collection_index_values')}
+                     WHERE session_id = $1 AND collection = $2`,
+                    values: [this.sessionId, collection]
+                })
+            )
+            const indexValueMap = new Map<string, Uint8Array>()
+            for (const row of valueRows) {
+                indexValueMap.set(String(row.index_mac_hex), toBytes(row.value_mac))
+            }
+
+            return {
+                initialized: true,
+                version: Number(versionRow.version),
+                hash: toBytes(versionRow.hash),
+                indexValueMap
+            }
+        })
+    }
+
+    public async getCollectionStates(
+        collections: readonly AppStateCollectionName[]
+    ): Promise<readonly WaAppStateCollectionStoreState[]> {
+        if (collections.length === 0) return []
+        return this.withTransaction(async (client) => {
+            const uniqueCollections = [...new Set(collections)]
+            let paramIdx = 2
+            const placeholders = uniqueCollections.map(() => `$${paramIdx++}`).join(', ')
+            const params: PgParam[] = [this.sessionId, ...uniqueCollections]
+
+            const versionRows = queryRows(
+                await client.query(
+                    `SELECT collection, version, hash
+                     FROM ${this.t('appstate_collection_versions')}
+                     WHERE session_id = $1 AND collection IN (${placeholders})`,
+                    params
+                )
+            )
+            const valueRows = queryRows(
+                await client.query(
+                    `SELECT collection, index_mac_hex, value_mac
+                     FROM ${this.t('appstate_collection_index_values')}
+                     WHERE session_id = $1 AND collection IN (${placeholders})`,
+                    params
+                )
+            )
+
+            const versionsByCollection = new Map<
+                AppStateCollectionName,
+                { version: number; hash: Uint8Array }
+            >()
+            for (const row of versionRows) {
+                const name = String(row.collection) as AppStateCollectionName
+                versionsByCollection.set(name, {
+                    version: Number(row.version),
+                    hash: toBytes(row.hash)
+                })
+            }
+
+            const indexValueMaps = new Map<AppStateCollectionName, Map<string, Uint8Array>>()
+            for (const row of valueRows) {
+                const name = String(row.collection) as AppStateCollectionName
+                let map = indexValueMaps.get(name)
+                if (!map) {
+                    map = new Map<string, Uint8Array>()
+                    indexValueMaps.set(name, map)
+                }
+                map.set(String(row.index_mac_hex), toBytes(row.value_mac))
+            }
+
+            return collections.map((collection) => {
+                const version = versionsByCollection.get(collection)
+                if (!version) {
+                    return {
+                        initialized: false,
+                        version: 0,
+                        hash: APP_STATE_EMPTY_LT_HASH,
+                        indexValueMap: new Map()
+                    }
+                }
+                return {
+                    initialized: true,
+                    version: version.version,
+                    hash: version.hash,
+                    indexValueMap: indexValueMaps.get(collection) ?? new Map()
+                }
+            })
+        })
+    }
+
+    public async setCollectionStates(
+        updates: readonly WaAppStateCollectionStateUpdate[]
+    ): Promise<void> {
+        if (updates.length === 0) return
+        await this.withTransaction(async (client) => {
+            for (const update of updates) {
+                await client.query({
+                    name: this.stmtName('appstate_upsert_collection_version'),
+                    text: `INSERT INTO ${this.t('appstate_collection_versions')} (
+                        session_id, collection, version, hash
+                    ) VALUES ($1, $2, $3, $4)
+                    ON CONFLICT (session_id, collection) DO UPDATE SET
+                        version = EXCLUDED.version,
+                        hash = EXCLUDED.hash`,
+                    values: [this.sessionId, update.collection, update.version, update.hash]
+                })
+
+                await client.query({
+                    name: this.stmtName('appstate_delete_collection_values'),
+                    text: `DELETE FROM ${this.t('appstate_collection_index_values')}
+                     WHERE session_id = $1 AND collection = $2`,
+                    values: [this.sessionId, update.collection]
+                })
+
+                for (const [indexMacHex, valueMac] of update.indexValueMap.entries()) {
+                    await client.query({
+                        name: this.stmtName('appstate_insert_collection_value'),
+                        text: `INSERT INTO ${this.t('appstate_collection_index_values')} (
+                            session_id, collection, index_mac_hex, value_mac
+                        ) VALUES ($1, $2, $3, $4)`,
+                        values: [this.sessionId, update.collection, indexMacHex, valueMac]
+                    })
+                }
+            }
+        })
+    }
+
+    public async clear(): Promise<void> {
+        await this.withTransaction(async (client) => {
+            await client.query({
+                name: this.stmtName('appstate_clear_sync_keys'),
+                text: `DELETE FROM ${this.t('appstate_sync_keys')} WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+            await client.query({
+                name: this.stmtName('appstate_clear_collection_versions'),
+                text: `DELETE FROM ${this.t('appstate_collection_versions')} WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+            await client.query({
+                name: this.stmtName('appstate_clear_collection_values'),
+                text: `DELETE FROM ${this.t('appstate_collection_index_values')} WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+        })
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────
+
+    private async selectSyncKeyDataByIds(
+        executor: { query: PoolClient['query'] },
+        keyIds: readonly Uint8Array[]
+    ): Promise<Map<string, Uint8Array>> {
+        const uniqueByHex = new Map<string, Uint8Array>()
+        for (const keyId of keyIds) {
+            uniqueByHex.set(bytesToHex(keyId), keyId)
+        }
+        const uniqueKeyIds = Array.from(uniqueByHex.values())
+        if (uniqueKeyIds.length === 0) return new Map()
+        const byHex = new Map<string, Uint8Array>()
+        for (let start = 0; start < uniqueKeyIds.length; start += BATCH_SIZE) {
+            const batch = uniqueKeyIds.slice(start, start + BATCH_SIZE)
+            let paramIdx = 2
+            const placeholders = batch.map(() => `$${paramIdx++}`).join(', ')
+            const params: PgParam[] = [this.sessionId, ...batch]
+            const rows = queryRows(
+                await executor.query(
+                    `SELECT key_id, key_data
+                     FROM ${this.t('appstate_sync_keys')}
+                     WHERE session_id = $1 AND key_id IN (${placeholders})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                byHex.set(bytesToHex(toBytes(row.key_id)), toBytes(row.key_data))
+            }
+        }
+        return byHex
+    }
+
+    private async selectSyncKeysByIds(
+        keyIds: readonly Uint8Array[]
+    ): Promise<Map<string, WaAppStateSyncKey>> {
+        const uniqueByHex = new Map<string, Uint8Array>()
+        for (const keyId of keyIds) {
+            uniqueByHex.set(bytesToHex(keyId), keyId)
+        }
+        const uniqueKeyIds = Array.from(uniqueByHex.values())
+        if (uniqueKeyIds.length === 0) return new Map()
+        const byHex = new Map<string, WaAppStateSyncKey>()
+        for (let start = 0; start < uniqueKeyIds.length; start += BATCH_SIZE) {
+            const batch = uniqueKeyIds.slice(start, start + BATCH_SIZE)
+            let paramIdx = 2
+            const placeholders = batch.map(() => `$${paramIdx++}`).join(', ')
+            const params: PgParam[] = [this.sessionId, ...batch]
+            const rows = queryRows(
+                await this.pool.query(
+                    `SELECT key_id, key_data, timestamp, fingerprint
+                     FROM ${this.t('appstate_sync_keys')}
+                     WHERE session_id = $1 AND key_id IN (${placeholders})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                const keyId = toBytes(row.key_id)
+                byHex.set(bytesToHex(keyId), {
+                    keyId,
+                    keyData: toBytes(row.key_data),
+                    timestamp: Number(row.timestamp),
+                    fingerprint: decodeAppStateFingerprint(toBytesOrNull(row.fingerprint))
+                })
+            }
+        }
+        return byHex
+    }
+}

--- a/packages/store-postgres/src/auth.store.ts
+++ b/packages/store-postgres/src/auth.store.ts
@@ -1,0 +1,159 @@
+import type { WaAuthCredentials } from 'zapo-js/auth'
+import { proto } from 'zapo-js/proto'
+import type { WaAuthStore } from 'zapo-js/store'
+
+import { BasePgStore } from './BasePgStore'
+import { queryFirst, toBytes, toBytesOrNull } from './helpers'
+import type { WaPgStorageOptions } from './types'
+
+export class WaAuthPgStore extends BasePgStore implements WaAuthStore {
+    public constructor(options: WaPgStorageOptions) {
+        super(options, ['auth'])
+    }
+
+    public async load(): Promise<WaAuthCredentials | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('auth_load'),
+                text: `SELECT noise_pub_key, noise_priv_key, registration_id,
+                    identity_pub_key, identity_priv_key,
+                    signed_prekey_id, signed_prekey_pub_key, signed_prekey_priv_key, signed_prekey_signature,
+                    adv_secret_key, signed_identity,
+                    me_jid, me_lid, me_display_name, companion_enc_static,
+                    platform, server_static_key, server_has_prekeys, routing_info,
+                    last_success_ts, props_version, ab_props_version,
+                    connection_location, account_creation_ts
+             FROM ${this.t('auth_credentials')}
+             WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+        )
+        if (!row) return null
+
+        const signedIdentityBytes = toBytesOrNull(row.signed_identity)
+
+        return {
+            noiseKeyPair: {
+                pubKey: toBytes(row.noise_pub_key),
+                privKey: toBytes(row.noise_priv_key)
+            },
+            registrationInfo: {
+                registrationId: Number(row.registration_id),
+                identityKeyPair: {
+                    pubKey: toBytes(row.identity_pub_key),
+                    privKey: toBytes(row.identity_priv_key)
+                }
+            },
+            signedPreKey: {
+                keyId: Number(row.signed_prekey_id),
+                keyPair: {
+                    pubKey: toBytes(row.signed_prekey_pub_key),
+                    privKey: toBytes(row.signed_prekey_priv_key)
+                },
+                signature: toBytes(row.signed_prekey_signature),
+                uploaded: false
+            },
+            advSecretKey: toBytes(row.adv_secret_key),
+            signedIdentity: signedIdentityBytes
+                ? proto.ADVSignedDeviceIdentity.decode(signedIdentityBytes)
+                : undefined,
+            meJid: (row.me_jid as string | null) ?? undefined,
+            meLid: (row.me_lid as string | null) ?? undefined,
+            meDisplayName: (row.me_display_name as string | null) ?? undefined,
+            companionEncStatic: toBytesOrNull(row.companion_enc_static) ?? undefined,
+            platform: (row.platform as string | null) ?? undefined,
+            serverStaticKey: toBytesOrNull(row.server_static_key) ?? undefined,
+            serverHasPreKeys:
+                row.server_has_prekeys === null ? undefined : Boolean(row.server_has_prekeys),
+            routingInfo: toBytesOrNull(row.routing_info) ?? undefined,
+            lastSuccessTs: row.last_success_ts !== null ? Number(row.last_success_ts) : undefined,
+            propsVersion: row.props_version !== null ? Number(row.props_version) : undefined,
+            abPropsVersion:
+                row.ab_props_version !== null ? Number(row.ab_props_version) : undefined,
+            connectionLocation: (row.connection_location as string | null) ?? undefined,
+            accountCreationTs:
+                row.account_creation_ts !== null ? Number(row.account_creation_ts) : undefined
+        }
+    }
+
+    public async save(credentials: WaAuthCredentials): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('auth_save'),
+            text: `INSERT INTO ${this.t('auth_credentials')} (
+                session_id, noise_pub_key, noise_priv_key,
+                registration_id, identity_pub_key, identity_priv_key,
+                signed_prekey_id, signed_prekey_pub_key, signed_prekey_priv_key, signed_prekey_signature,
+                adv_secret_key, signed_identity,
+                me_jid, me_lid, me_display_name, companion_enc_static,
+                platform, server_static_key, server_has_prekeys, routing_info,
+                last_success_ts, props_version, ab_props_version,
+                connection_location, account_creation_ts
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)
+            ON CONFLICT (session_id) DO UPDATE SET
+                noise_pub_key = EXCLUDED.noise_pub_key,
+                noise_priv_key = EXCLUDED.noise_priv_key,
+                registration_id = EXCLUDED.registration_id,
+                identity_pub_key = EXCLUDED.identity_pub_key,
+                identity_priv_key = EXCLUDED.identity_priv_key,
+                signed_prekey_id = EXCLUDED.signed_prekey_id,
+                signed_prekey_pub_key = EXCLUDED.signed_prekey_pub_key,
+                signed_prekey_priv_key = EXCLUDED.signed_prekey_priv_key,
+                signed_prekey_signature = EXCLUDED.signed_prekey_signature,
+                adv_secret_key = EXCLUDED.adv_secret_key,
+                signed_identity = EXCLUDED.signed_identity,
+                me_jid = EXCLUDED.me_jid,
+                me_lid = EXCLUDED.me_lid,
+                me_display_name = EXCLUDED.me_display_name,
+                companion_enc_static = EXCLUDED.companion_enc_static,
+                platform = EXCLUDED.platform,
+                server_static_key = EXCLUDED.server_static_key,
+                server_has_prekeys = EXCLUDED.server_has_prekeys,
+                routing_info = EXCLUDED.routing_info,
+                last_success_ts = EXCLUDED.last_success_ts,
+                props_version = EXCLUDED.props_version,
+                ab_props_version = EXCLUDED.ab_props_version,
+                connection_location = EXCLUDED.connection_location,
+                account_creation_ts = EXCLUDED.account_creation_ts`,
+            values: [
+                this.sessionId,
+                credentials.noiseKeyPair.pubKey,
+                credentials.noiseKeyPair.privKey,
+                credentials.registrationInfo.registrationId,
+                credentials.registrationInfo.identityKeyPair.pubKey,
+                credentials.registrationInfo.identityKeyPair.privKey,
+                credentials.signedPreKey.keyId,
+                credentials.signedPreKey.keyPair.pubKey,
+                credentials.signedPreKey.keyPair.privKey,
+                credentials.signedPreKey.signature,
+                credentials.advSecretKey,
+                credentials.signedIdentity
+                    ? proto.ADVSignedDeviceIdentity.encode(credentials.signedIdentity).finish()
+                    : null,
+                credentials.meJid ?? null,
+                credentials.meLid ?? null,
+                credentials.meDisplayName ?? null,
+                credentials.companionEncStatic ?? null,
+                credentials.platform ?? null,
+                credentials.serverStaticKey ?? null,
+                credentials.serverHasPreKeys ?? null,
+                credentials.routingInfo ?? null,
+                credentials.lastSuccessTs ?? null,
+                credentials.propsVersion ?? null,
+                credentials.abPropsVersion ?? null,
+                credentials.connectionLocation ?? null,
+                credentials.accountCreationTs ?? null
+            ]
+        })
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('auth_clear'),
+            text: `DELETE FROM ${this.t('auth_credentials')} WHERE session_id = $1`,
+            values: [this.sessionId]
+        })
+    }
+}

--- a/packages/store-postgres/src/cleanup.ts
+++ b/packages/store-postgres/src/cleanup.ts
@@ -1,0 +1,93 @@
+import type { WaDeviceListStore, WaParticipantsStore, WaRetryStore } from 'zapo-js/store'
+
+export interface PgCleanupPollerOptions {
+    readonly intervalMs?: number
+    readonly retry?: WaRetryStore
+    readonly participants?: WaParticipantsStore
+    readonly deviceList?: WaDeviceListStore
+    readonly onError?: (error: Error) => void
+}
+
+const DEFAULT_INTERVAL_MS = 60_000
+
+export class PgCleanupPoller {
+    private readonly intervalMs: number
+    private readonly retry: WaRetryStore | undefined
+    private readonly participants: WaParticipantsStore | undefined
+    private readonly deviceList: WaDeviceListStore | undefined
+    private readonly onError: ((error: Error) => void) | undefined
+    private timer: ReturnType<typeof setInterval> | null
+    private inFlight: boolean
+
+    public constructor(options: PgCleanupPollerOptions) {
+        const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS
+        if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+            throw new Error('cleanup intervalMs must be a positive finite number')
+        }
+        this.intervalMs = intervalMs
+        this.retry = options.retry
+        this.participants = options.participants
+        this.deviceList = options.deviceList
+        this.onError = options.onError
+        this.timer = null
+        this.inFlight = false
+    }
+
+    public start(): void {
+        if (this.timer) return
+        this.timer = setInterval(() => {
+            if (this.inFlight) return
+            this.inFlight = true
+            this.cleanup()
+                .catch((error: unknown) => {
+                    if (this.onError) {
+                        this.onError(error instanceof Error ? error : new Error(String(error)))
+                    }
+                })
+                .finally(() => {
+                    this.inFlight = false
+                })
+        }, this.intervalMs)
+        if (typeof this.timer === 'object' && 'unref' in this.timer) {
+            this.timer.unref()
+        }
+    }
+
+    public stop(): void {
+        if (!this.timer) return
+        clearInterval(this.timer)
+        this.timer = null
+    }
+
+    public async cleanup(): Promise<number> {
+        const nowMs = Date.now()
+        const tasks: Promise<number>[] = []
+        if (this.retry) tasks.push(this.retry.cleanupExpired(nowMs))
+        if (this.participants) tasks.push(this.participants.cleanupExpired(nowMs))
+        if (this.deviceList) tasks.push(this.deviceList.cleanupExpired(nowMs))
+
+        const results = await Promise.allSettled(tasks)
+        let total = 0
+        const errors: Error[] = []
+        for (const result of results) {
+            if (result.status === 'fulfilled') {
+                total += result.value
+            } else {
+                errors.push(
+                    result.reason instanceof Error
+                        ? result.reason
+                        : new Error(String(result.reason))
+                )
+            }
+        }
+        if (errors.length === 1) {
+            throw errors[0]
+        }
+        if (errors.length > 1) {
+            throw new Error(
+                `${errors.length} cleanup tasks failed: ${errors.map((e) => e.message).join('; ')}`
+            )
+        }
+        return total
+    }
+}

--- a/packages/store-postgres/src/connection.ts
+++ b/packages/store-postgres/src/connection.ts
@@ -1,0 +1,358 @@
+import pg from 'pg'
+import type { Pool, PoolConfig } from 'pg'
+
+import { assertSafeTablePrefix, queryRows } from './helpers'
+import type { WaPgMigrationDomain } from './types'
+
+// pg returns bytea as Buffer which extends Uint8Array — zero-copy on read
+
+interface Migration {
+    readonly name: string
+    readonly domain: WaPgMigrationDomain
+    readonly sql: string
+}
+
+const MIGRATIONS: readonly Migration[] = [
+    {
+        name: '0001_auth_credentials',
+        domain: 'auth',
+        sql: `
+            CREATE TABLE IF NOT EXISTS "__PREFIX__auth_credentials" (
+                session_id TEXT NOT NULL,
+                noise_pub_key BYTEA NOT NULL,
+                noise_priv_key BYTEA NOT NULL,
+                registration_id BIGINT NOT NULL,
+                identity_pub_key BYTEA NOT NULL,
+                identity_priv_key BYTEA NOT NULL,
+                signed_prekey_id BIGINT NOT NULL,
+                signed_prekey_pub_key BYTEA NOT NULL,
+                signed_prekey_priv_key BYTEA NOT NULL,
+                signed_prekey_signature BYTEA NOT NULL,
+                adv_secret_key BYTEA NOT NULL,
+                signed_identity BYTEA,
+                me_jid TEXT,
+                me_lid TEXT,
+                me_display_name TEXT,
+                companion_enc_static BYTEA,
+                platform TEXT,
+                server_static_key BYTEA,
+                server_has_prekeys BOOLEAN,
+                routing_info BYTEA,
+                last_success_ts BIGINT,
+                props_version BIGINT,
+                ab_props_version BIGINT,
+                connection_location TEXT,
+                account_creation_ts BIGINT,
+                PRIMARY KEY (session_id)
+            )
+        `
+    },
+    {
+        name: '0002_signal_schema',
+        domain: 'signal',
+        sql: `
+            CREATE TABLE IF NOT EXISTS "__PREFIX__signal_meta" (
+                session_id TEXT NOT NULL,
+                server_has_prekeys BOOLEAN NOT NULL DEFAULT FALSE,
+                next_prekey_id BIGINT NOT NULL DEFAULT 1,
+                signed_prekey_rotation_ts BIGINT,
+                PRIMARY KEY (session_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS "__PREFIX__signal_registration" (
+                session_id TEXT NOT NULL,
+                registration_id BIGINT NOT NULL,
+                identity_pub_key BYTEA NOT NULL,
+                identity_priv_key BYTEA NOT NULL,
+                PRIMARY KEY (session_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS "__PREFIX__signal_signed_prekey" (
+                session_id TEXT NOT NULL,
+                key_id BIGINT NOT NULL,
+                pub_key BYTEA NOT NULL,
+                priv_key BYTEA NOT NULL,
+                signature BYTEA NOT NULL,
+                uploaded BOOLEAN NOT NULL DEFAULT FALSE,
+                PRIMARY KEY (session_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS "__PREFIX__signal_prekey" (
+                session_id TEXT NOT NULL,
+                key_id BIGINT NOT NULL,
+                pub_key BYTEA NOT NULL,
+                priv_key BYTEA NOT NULL,
+                uploaded BOOLEAN NOT NULL DEFAULT FALSE,
+                PRIMARY KEY (session_id, key_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS "__PREFIX__signal_session" (
+                session_id TEXT NOT NULL,
+                "user" TEXT NOT NULL,
+                server TEXT NOT NULL,
+                device INT NOT NULL,
+                record BYTEA NOT NULL,
+                PRIMARY KEY (session_id, "user", server, device)
+            );
+
+            CREATE TABLE IF NOT EXISTS "__PREFIX__signal_identity" (
+                session_id TEXT NOT NULL,
+                "user" TEXT NOT NULL,
+                server TEXT NOT NULL,
+                device INT NOT NULL,
+                identity_key BYTEA NOT NULL,
+                PRIMARY KEY (session_id, "user", server, device)
+            )
+        `
+    },
+    {
+        name: '0003_sender_key_schema',
+        domain: 'senderKey',
+        sql: `
+            CREATE TABLE IF NOT EXISTS "__PREFIX__sender_keys" (
+                session_id TEXT NOT NULL,
+                group_id TEXT NOT NULL,
+                sender_user TEXT NOT NULL,
+                sender_server TEXT NOT NULL,
+                sender_device INT NOT NULL,
+                record BYTEA NOT NULL,
+                PRIMARY KEY (session_id, group_id, sender_user, sender_server, sender_device)
+            );
+
+            CREATE TABLE IF NOT EXISTS "__PREFIX__sender_key_distribution" (
+                session_id TEXT NOT NULL,
+                group_id TEXT NOT NULL,
+                sender_user TEXT NOT NULL,
+                sender_server TEXT NOT NULL,
+                sender_device INT NOT NULL,
+                key_id BIGINT NOT NULL,
+                timestamp_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, group_id, sender_user, sender_server, sender_device)
+            )
+        `
+    },
+    {
+        name: '0004_appstate_schema',
+        domain: 'appState',
+        sql: `
+            CREATE TABLE IF NOT EXISTS "__PREFIX__appstate_sync_keys" (
+                session_id TEXT NOT NULL,
+                key_id BYTEA NOT NULL,
+                key_data BYTEA NOT NULL,
+                "timestamp" BIGINT NOT NULL,
+                fingerprint BYTEA,
+                key_epoch INT NOT NULL DEFAULT 0,
+                PRIMARY KEY (session_id, key_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS "__PREFIX__appstate_collection_versions" (
+                session_id TEXT NOT NULL,
+                collection TEXT NOT NULL,
+                version BIGINT NOT NULL,
+                hash BYTEA NOT NULL,
+                PRIMARY KEY (session_id, collection)
+            );
+
+            CREATE TABLE IF NOT EXISTS "__PREFIX__appstate_collection_index_values" (
+                session_id TEXT NOT NULL,
+                collection TEXT NOT NULL,
+                index_mac_hex TEXT NOT NULL,
+                value_mac BYTEA NOT NULL,
+                PRIMARY KEY (session_id, collection, index_mac_hex)
+            )
+        `
+    },
+    {
+        name: '0005_retry_schema',
+        domain: 'retry',
+        sql: `
+            CREATE TABLE IF NOT EXISTS "__PREFIX__retry_outbound_messages" (
+                session_id TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                to_jid TEXT NOT NULL,
+                participant_jid TEXT,
+                recipient_jid TEXT,
+                message_type TEXT NOT NULL,
+                replay_mode TEXT NOT NULL,
+                replay_payload BYTEA NOT NULL,
+                requesters_json TEXT,
+                state TEXT NOT NULL,
+                created_at_ms BIGINT NOT NULL,
+                updated_at_ms BIGINT NOT NULL,
+                expires_at_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, message_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS "__PREFIX__idx_retry_outbound_expires"
+                ON "__PREFIX__retry_outbound_messages" (session_id, expires_at_ms);
+
+            CREATE INDEX IF NOT EXISTS "__PREFIX__idx_retry_outbound_state"
+                ON "__PREFIX__retry_outbound_messages" (session_id, state);
+
+            CREATE TABLE IF NOT EXISTS "__PREFIX__retry_inbound_counters" (
+                session_id TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                requester_jid TEXT NOT NULL,
+                retry_count INT NOT NULL DEFAULT 0,
+                updated_at_ms BIGINT NOT NULL,
+                expires_at_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, message_id, requester_jid)
+            );
+
+            CREATE INDEX IF NOT EXISTS "__PREFIX__idx_retry_inbound_expires"
+                ON "__PREFIX__retry_inbound_counters" (session_id, expires_at_ms)
+        `
+    },
+    {
+        name: '0006_mailbox_schema',
+        domain: 'mailbox',
+        sql: `
+            CREATE TABLE IF NOT EXISTS "__PREFIX__mailbox_messages" (
+                session_id TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                thread_jid TEXT NOT NULL,
+                sender_jid TEXT,
+                participant_jid TEXT,
+                from_me BOOLEAN NOT NULL DEFAULT FALSE,
+                timestamp_ms BIGINT,
+                enc_type TEXT,
+                plaintext BYTEA,
+                message_bytes BYTEA,
+                PRIMARY KEY (session_id, message_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS "__PREFIX__idx_messages_thread_ts"
+                ON "__PREFIX__mailbox_messages" (session_id, thread_jid, timestamp_ms DESC, message_id DESC);
+
+            CREATE TABLE IF NOT EXISTS "__PREFIX__mailbox_threads" (
+                session_id TEXT NOT NULL,
+                jid TEXT NOT NULL,
+                name TEXT,
+                unread_count INT,
+                archived BOOLEAN,
+                pinned INT,
+                mute_end_ms BIGINT,
+                marked_as_unread BOOLEAN,
+                ephemeral_expiration INT,
+                PRIMARY KEY (session_id, jid)
+            );
+
+            CREATE TABLE IF NOT EXISTS "__PREFIX__mailbox_contacts" (
+                session_id TEXT NOT NULL,
+                jid TEXT NOT NULL,
+                display_name TEXT,
+                push_name TEXT,
+                lid TEXT,
+                phone_number TEXT,
+                last_updated_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, jid)
+            )
+        `
+    },
+    {
+        name: '0007_participants_cache_schema',
+        domain: 'participants',
+        sql: `
+            CREATE TABLE IF NOT EXISTS "__PREFIX__group_participants_cache" (
+                session_id TEXT NOT NULL,
+                group_jid TEXT NOT NULL,
+                participants_json TEXT NOT NULL,
+                updated_at_ms BIGINT NOT NULL,
+                expires_at_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, group_jid)
+            );
+
+            CREATE INDEX IF NOT EXISTS "__PREFIX__idx_participants_expires"
+                ON "__PREFIX__group_participants_cache" (session_id, expires_at_ms)
+        `
+    },
+    {
+        name: '0008_device_list_cache_schema',
+        domain: 'deviceList',
+        sql: `
+            CREATE TABLE IF NOT EXISTS "__PREFIX__device_list_cache" (
+                session_id TEXT NOT NULL,
+                user_jid TEXT NOT NULL,
+                device_jids_json TEXT NOT NULL,
+                updated_at_ms BIGINT NOT NULL,
+                expires_at_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, user_jid)
+            );
+
+            CREATE INDEX IF NOT EXISTS "__PREFIX__idx_device_list_expires"
+                ON "__PREFIX__device_list_cache" (session_id, expires_at_ms)
+        `
+    },
+    {
+        name: '0009_privacy_token_schema',
+        domain: 'privacyToken',
+        sql: `
+            CREATE TABLE IF NOT EXISTS "__PREFIX__privacy_tokens" (
+                session_id TEXT NOT NULL,
+                jid TEXT NOT NULL,
+                tc_token BYTEA,
+                tc_token_timestamp BIGINT,
+                tc_token_sender_timestamp BIGINT,
+                nct_salt BYTEA,
+                updated_at_ms BIGINT NOT NULL,
+                PRIMARY KEY (session_id, jid)
+            )
+        `
+    }
+]
+
+export function createPgPool(options: PoolConfig): pg.Pool {
+    return new pg.Pool(options)
+}
+
+export async function ensurePgMigrations(
+    pool: Pool,
+    domains: readonly WaPgMigrationDomain[],
+    tablePrefix = ''
+): Promise<void> {
+    assertSafeTablePrefix(tablePrefix)
+    const t = (name: string) => `${tablePrefix}${name}`
+    const domainSet = new Set(domains)
+    const pending = MIGRATIONS.filter((m) => domainSet.has(m.domain))
+    if (pending.length === 0) return
+
+    await pool.query(`
+        CREATE TABLE IF NOT EXISTS "${t('_migrations')}" (
+            name TEXT PRIMARY KEY,
+            applied_at BIGINT NOT NULL
+        )
+    `)
+
+    const applied = new Set(
+        queryRows(await pool.query(`SELECT name FROM "${t('_migrations')}"`)).map(
+            (r) => r.name as string
+        )
+    )
+
+    for (const migration of pending) {
+        if (applied.has(migration.name)) continue
+
+        const client = await pool.connect()
+        try {
+            await client.query('BEGIN')
+            const sql = migration.sql.replace(/__PREFIX__/g, tablePrefix)
+            const statements = sql
+                .split(';')
+                .map((s) => s.trim())
+                .filter(Boolean)
+            for (const stmt of statements) {
+                await client.query(stmt)
+            }
+            await client.query(
+                `INSERT INTO "${t('_migrations')}" (name, applied_at) VALUES ($1, $2) ON CONFLICT (name) DO NOTHING`,
+                [migration.name, Date.now()]
+            )
+            await client.query('COMMIT')
+        } catch (err) {
+            await client.query('ROLLBACK')
+            throw err
+        } finally {
+            client.release()
+        }
+    }
+}

--- a/packages/store-postgres/src/contact.store.ts
+++ b/packages/store-postgres/src/contact.store.ts
@@ -1,0 +1,112 @@
+import type { WaContactStore, WaStoredContactRecord } from 'zapo-js/store'
+
+import { BasePgStore } from './BasePgStore'
+import { affectedRows, queryFirst } from './helpers'
+import type { WaPgStorageOptions } from './types'
+
+export class WaContactPgStore extends BasePgStore implements WaContactStore {
+    public constructor(options: WaPgStorageOptions) {
+        super(options, ['mailbox'])
+    }
+
+    public async upsert(record: WaStoredContactRecord): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('contact_upsert'),
+            text: `INSERT INTO ${this.t('mailbox_contacts')} (
+                session_id, jid, display_name, push_name, lid,
+                phone_number, last_updated_ms
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (session_id, jid) DO UPDATE SET
+                display_name = COALESCE(EXCLUDED.display_name, ${this.t('mailbox_contacts')}.display_name),
+                push_name = COALESCE(EXCLUDED.push_name, ${this.t('mailbox_contacts')}.push_name),
+                lid = COALESCE(EXCLUDED.lid, ${this.t('mailbox_contacts')}.lid),
+                phone_number = COALESCE(EXCLUDED.phone_number, ${this.t('mailbox_contacts')}.phone_number),
+                last_updated_ms = EXCLUDED.last_updated_ms`,
+            values: [
+                this.sessionId,
+                record.jid,
+                record.displayName ?? null,
+                record.pushName ?? null,
+                record.lid ?? null,
+                record.phoneNumber ?? null,
+                record.lastUpdatedMs
+            ]
+        })
+    }
+
+    public async upsertBatch(records: readonly WaStoredContactRecord[]): Promise<void> {
+        if (records.length === 0) return
+
+        await this.withTransaction(async (client) => {
+            for (const record of records) {
+                await client.query({
+                    name: this.stmtName('contact_upsert'),
+                    text: `INSERT INTO ${this.t('mailbox_contacts')} (
+                        session_id, jid, display_name, push_name, lid,
+                        phone_number, last_updated_ms
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+                    ON CONFLICT (session_id, jid) DO UPDATE SET
+                        display_name = COALESCE(EXCLUDED.display_name, ${this.t('mailbox_contacts')}.display_name),
+                        push_name = COALESCE(EXCLUDED.push_name, ${this.t('mailbox_contacts')}.push_name),
+                        lid = COALESCE(EXCLUDED.lid, ${this.t('mailbox_contacts')}.lid),
+                        phone_number = COALESCE(EXCLUDED.phone_number, ${this.t('mailbox_contacts')}.phone_number),
+                        last_updated_ms = EXCLUDED.last_updated_ms`,
+                    values: [
+                        this.sessionId,
+                        record.jid,
+                        record.displayName ?? null,
+                        record.pushName ?? null,
+                        record.lid ?? null,
+                        record.phoneNumber ?? null,
+                        record.lastUpdatedMs
+                    ]
+                })
+            }
+        })
+    }
+
+    public async getByJid(jid: string): Promise<WaStoredContactRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('contact_get_by_jid'),
+                text: `SELECT jid, display_name, push_name, lid,
+                    phone_number, last_updated_ms
+             FROM ${this.t('mailbox_contacts')}
+             WHERE session_id = $1 AND jid = $2`,
+                values: [this.sessionId, jid]
+            })
+        )
+        if (!row) return null
+        return {
+            jid: row.jid as string,
+            displayName: (row.display_name as string | null) ?? undefined,
+            pushName: (row.push_name as string | null) ?? undefined,
+            lid: (row.lid as string | null) ?? undefined,
+            phoneNumber: (row.phone_number as string | null) ?? undefined,
+            lastUpdatedMs: Number(row.last_updated_ms)
+        }
+    }
+
+    public async deleteByJid(jid: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.query({
+                name: this.stmtName('contact_delete_by_jid'),
+                text: `DELETE FROM ${this.t('mailbox_contacts')}
+             WHERE session_id = $1 AND jid = $2`,
+                values: [this.sessionId, jid]
+            })
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('contact_clear'),
+            text: `DELETE FROM ${this.t('mailbox_contacts')} WHERE session_id = $1`,
+            values: [this.sessionId]
+        })
+    }
+}

--- a/packages/store-postgres/src/createPostgresStore.ts
+++ b/packages/store-postgres/src/createPostgresStore.ts
@@ -1,0 +1,114 @@
+import type { Pool, PoolConfig } from 'pg'
+
+import { WaAppStatePgStore } from './appstate.store'
+import { WaAuthPgStore } from './auth.store'
+import { PgCleanupPoller } from './cleanup'
+import { createPgPool } from './connection'
+import { WaContactPgStore } from './contact.store'
+import { WaDeviceListPgStore } from './device-list.store'
+import { WaMessagePgStore } from './message.store'
+import { WaParticipantsPgStore } from './participants.store'
+import { WaPrivacyTokenPgStore } from './privacy-token.store'
+import { WaRetryPgStore } from './retry.store'
+import { WaSenderKeyPgStore } from './sender-key.store'
+import { WaSignalPgStore } from './signal.store'
+import { WaThreadPgStore } from './thread.store'
+import type { WaPgStorageOptions } from './types'
+
+export interface WaPgStoreConfig {
+    readonly pool: Pool | PoolConfig
+    readonly tablePrefix?: string
+    readonly cacheTtlMs?: {
+        readonly retryMs?: number
+        readonly participantsMs?: number
+        readonly deviceListMs?: number
+    }
+    readonly cleanup?: {
+        readonly intervalMs?: number
+        readonly onError?: (error: Error) => void
+    }
+}
+
+export interface WaPgStoreResult {
+    readonly pool: Pool
+    readonly stores: {
+        readonly auth: (sessionId: string) => WaAuthPgStore
+        readonly signal: (sessionId: string) => WaSignalPgStore
+        readonly senderKey: (sessionId: string) => WaSenderKeyPgStore
+        readonly appState: (sessionId: string) => WaAppStatePgStore
+        readonly messages: (sessionId: string) => WaMessagePgStore
+        readonly threads: (sessionId: string) => WaThreadPgStore
+        readonly contacts: (sessionId: string) => WaContactPgStore
+        readonly privacyToken: (sessionId: string) => WaPrivacyTokenPgStore
+    }
+    readonly caches: {
+        readonly retry: (sessionId: string) => WaRetryPgStore
+        readonly participants: (sessionId: string) => WaParticipantsPgStore
+        readonly deviceList: (sessionId: string) => WaDeviceListPgStore
+    }
+    startCleanup(sessionId: string): PgCleanupPoller
+    destroy(): Promise<void>
+}
+
+function isPool(value: Pool | PoolConfig): value is Pool {
+    return typeof (value as Pool).connect === 'function'
+}
+
+export function createPostgresStore(config: WaPgStoreConfig): WaPgStoreResult {
+    const pool = isPool(config.pool) ? config.pool : createPgPool(config.pool)
+    const tablePrefix = config.tablePrefix ?? ''
+    const retryTtlMs = config.cacheTtlMs?.retryMs
+    const participantsTtlMs = config.cacheTtlMs?.participantsMs
+    const deviceListTtlMs = config.cacheTtlMs?.deviceListMs
+    const ownsPool = !isPool(config.pool)
+
+    const opts = (sessionId: string): WaPgStorageOptions => ({
+        pool,
+        sessionId,
+        tablePrefix
+    })
+
+    const cleanupPollers = new Set<PgCleanupPoller>()
+
+    return {
+        pool,
+        stores: {
+            auth: (sessionId) => new WaAuthPgStore(opts(sessionId)),
+            signal: (sessionId) => new WaSignalPgStore(opts(sessionId)),
+            senderKey: (sessionId) => new WaSenderKeyPgStore(opts(sessionId)),
+            appState: (sessionId) => new WaAppStatePgStore(opts(sessionId)),
+            messages: (sessionId) => new WaMessagePgStore(opts(sessionId)),
+            threads: (sessionId) => new WaThreadPgStore(opts(sessionId)),
+            contacts: (sessionId) => new WaContactPgStore(opts(sessionId)),
+            privacyToken: (sessionId) => new WaPrivacyTokenPgStore(opts(sessionId))
+        },
+        caches: {
+            retry: (sessionId) => new WaRetryPgStore(opts(sessionId), retryTtlMs),
+            participants: (sessionId) =>
+                new WaParticipantsPgStore(opts(sessionId), participantsTtlMs),
+            deviceList: (sessionId) => new WaDeviceListPgStore(opts(sessionId), deviceListTtlMs)
+        },
+        startCleanup(sessionId: string): PgCleanupPoller {
+            const o = opts(sessionId)
+            const poller = new PgCleanupPoller({
+                intervalMs: config.cleanup?.intervalMs,
+                retry: new WaRetryPgStore(o, retryTtlMs),
+                participants: new WaParticipantsPgStore(o, participantsTtlMs),
+                deviceList: new WaDeviceListPgStore(o, deviceListTtlMs),
+                onError: config.cleanup?.onError
+            })
+            poller.start()
+            cleanupPollers.add(poller)
+            return poller
+        },
+        async destroy(): Promise<void> {
+            for (const poller of cleanupPollers) {
+                poller.stop()
+            }
+            cleanupPollers.clear()
+            if (ownsPool) {
+                await pool.end()
+            }
+        }
+    }
+}

--- a/packages/store-postgres/src/device-list.store.ts
+++ b/packages/store-postgres/src/device-list.store.ts
@@ -1,0 +1,138 @@
+import type { WaDeviceListSnapshot, WaDeviceListStore } from 'zapo-js/store'
+
+import { BasePgStore } from './BasePgStore'
+import { affectedRows, queryRows } from './helpers'
+import type { PgParam, WaPgStorageOptions } from './types'
+
+const DEFAULT_DEVICE_LIST_TTL_MS = 5 * 60 * 1000
+const BATCH_SIZE = 500
+
+export class WaDeviceListPgStore extends BasePgStore implements WaDeviceListStore {
+    private readonly ttlMs: number
+
+    public constructor(options: WaPgStorageOptions, ttlMs = DEFAULT_DEVICE_LIST_TTL_MS) {
+        super(options, ['deviceList'])
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('device-list ttlMs must be a non-negative finite number')
+        }
+        this.ttlMs = ttlMs
+    }
+
+    public async upsertUserDevicesBatch(snapshots: readonly WaDeviceListSnapshot[]): Promise<void> {
+        if (snapshots.length === 0) return
+        await this.withTransaction(async (client) => {
+            for (const snapshot of snapshots) {
+                await client.query({
+                    name: this.stmtName('devlist_upsert'),
+                    text: `INSERT INTO ${this.t('device_list_cache')} (
+                        session_id, user_jid, device_jids_json, updated_at_ms, expires_at_ms
+                    ) VALUES ($1, $2, $3, $4, $5)
+                    ON CONFLICT (session_id, user_jid) DO UPDATE SET
+                        device_jids_json = EXCLUDED.device_jids_json,
+                        updated_at_ms = EXCLUDED.updated_at_ms,
+                        expires_at_ms = EXCLUDED.expires_at_ms`,
+                    values: [
+                        this.sessionId,
+                        snapshot.userJid,
+                        JSON.stringify(snapshot.deviceJids),
+                        snapshot.updatedAtMs,
+                        snapshot.updatedAtMs + this.ttlMs
+                    ]
+                })
+            }
+        })
+    }
+
+    public async getUserDevicesBatch(
+        userJids: readonly string[],
+        nowMs = Date.now()
+    ): Promise<readonly (WaDeviceListSnapshot | null)[]> {
+        if (userJids.length === 0) return []
+        await this.ensureReady()
+
+        const uniqueUserJids = [...new Set(userJids)]
+        const activeByUserJid = new Map<string, WaDeviceListSnapshot>()
+        const expiredUserJids: string[] = []
+
+        for (let start = 0; start < uniqueUserJids.length; start += BATCH_SIZE) {
+            const batch = uniqueUserJids.slice(start, start + BATCH_SIZE)
+            let paramIdx = 2
+            const placeholders = batch.map(() => `$${paramIdx++}`).join(', ')
+            const params: PgParam[] = [this.sessionId, ...batch]
+            const rows = queryRows(
+                await this.pool.query(
+                    `SELECT user_jid, device_jids_json, updated_at_ms, expires_at_ms
+                     FROM ${this.t('device_list_cache')}
+                     WHERE session_id = $1 AND user_jid IN (${placeholders})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                const userJid = String(row.user_jid)
+                const expiresAtMs = Number(row.expires_at_ms)
+                if (expiresAtMs <= nowMs) {
+                    expiredUserJids.push(userJid)
+                    continue
+                }
+                const parsed: unknown = JSON.parse(row.device_jids_json as string)
+                if (!Array.isArray(parsed)) {
+                    throw new Error('device_list_cache.device_jids_json must be an array')
+                }
+                activeByUserJid.set(userJid, {
+                    userJid,
+                    deviceJids: parsed.map((entry: unknown) => String(entry)),
+                    updatedAtMs: Number(row.updated_at_ms)
+                })
+            }
+        }
+
+        if (expiredUserJids.length > 0) {
+            for (let start = 0; start < expiredUserJids.length; start += BATCH_SIZE) {
+                const batch = expiredUserJids.slice(start, start + BATCH_SIZE)
+                let paramIdx = 3
+                const placeholders = batch.map(() => `$${paramIdx++}`).join(', ')
+                const params: PgParam[] = [this.sessionId, nowMs, ...batch]
+                await this.pool.query(
+                    `DELETE FROM ${this.t('device_list_cache')}
+                     WHERE session_id = $1 AND expires_at_ms <= $2 AND user_jid IN (${placeholders})`,
+                    params
+                )
+            }
+        }
+
+        return userJids.map((jid) => activeByUserJid.get(jid) ?? null)
+    }
+
+    public async deleteUserDevices(userJid: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.query({
+                name: this.stmtName('devlist_delete_user'),
+                text: `DELETE FROM ${this.t('device_list_cache')}
+                 WHERE session_id = $1 AND user_jid = $2`,
+                values: [this.sessionId, userJid]
+            })
+        )
+    }
+
+    public async cleanupExpired(nowMs: number): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.query({
+                name: this.stmtName('devlist_cleanup'),
+                text: `DELETE FROM ${this.t('device_list_cache')}
+                 WHERE session_id = $1 AND expires_at_ms <= $2`,
+                values: [this.sessionId, nowMs]
+            })
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('devlist_clear'),
+            text: `DELETE FROM ${this.t('device_list_cache')} WHERE session_id = $1`,
+            values: [this.sessionId]
+        })
+    }
+}

--- a/packages/store-postgres/src/helpers.ts
+++ b/packages/store-postgres/src/helpers.ts
@@ -1,0 +1,38 @@
+import type { QueryResult } from 'pg'
+import { bytesToHex, normalizeQueryLimit, toBytesView, uint8Equal } from 'zapo-js/util'
+
+export type PgRow = Record<string, unknown>
+
+export function queryRows(result: QueryResult): PgRow[] {
+    return result.rows
+}
+
+export function queryFirst(result: QueryResult): PgRow | undefined {
+    return result.rows[0]
+}
+
+export function affectedRows(result: QueryResult): number {
+    return result.rowCount ?? 0
+}
+
+export function toBytes(value: unknown): Uint8Array {
+    if (value instanceof Uint8Array) return value
+    if (value instanceof ArrayBuffer) return new Uint8Array(value)
+    if (ArrayBuffer.isView(value)) return toBytesView(value)
+    throw new Error('expected binary data')
+}
+
+export function toBytesOrNull(value: unknown): Uint8Array | null {
+    if (value === null || value === undefined) return null
+    return toBytes(value)
+}
+
+const SAFE_PREFIX_RE = /^[A-Za-z0-9_]*$/
+
+export function assertSafeTablePrefix(prefix: string): void {
+    if (!SAFE_PREFIX_RE.test(prefix)) {
+        throw new Error('tablePrefix must contain only letters, numbers, and underscores')
+    }
+}
+
+export { bytesToHex, normalizeQueryLimit as safeLimit, uint8Equal }

--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -1,0 +1,25 @@
+export type {
+    PgParam,
+    WaPgCreateStoreOptions,
+    WaPgMigrationDomain,
+    WaPgStorageOptions
+} from './types'
+export { createPgPool, ensurePgMigrations } from './connection'
+export { BasePgStore } from './BasePgStore'
+export { WaAuthPgStore } from './auth.store'
+export { WaSignalPgStore } from './signal.store'
+export { WaSenderKeyPgStore } from './sender-key.store'
+export { WaAppStatePgStore } from './appstate.store'
+export { WaRetryPgStore } from './retry.store'
+export { WaParticipantsPgStore } from './participants.store'
+export { WaDeviceListPgStore } from './device-list.store'
+export { WaMessagePgStore } from './message.store'
+export { WaThreadPgStore } from './thread.store'
+export { WaContactPgStore } from './contact.store'
+export { WaPrivacyTokenPgStore } from './privacy-token.store'
+export { PgCleanupPoller, type PgCleanupPollerOptions } from './cleanup'
+export {
+    createPostgresStore,
+    type WaPgStoreConfig,
+    type WaPgStoreResult
+} from './createPostgresStore'

--- a/packages/store-postgres/src/message.store.ts
+++ b/packages/store-postgres/src/message.store.ts
@@ -1,0 +1,175 @@
+import type { WaMessageStore, WaStoredMessageRecord } from 'zapo-js/store'
+
+import { BasePgStore } from './BasePgStore'
+import {
+    affectedRows,
+    queryFirst,
+    queryRows,
+    safeLimit,
+    toBytesOrNull,
+    type PgRow
+} from './helpers'
+import type { WaPgStorageOptions } from './types'
+
+function rowToRecord(row: PgRow): WaStoredMessageRecord {
+    return {
+        id: row.message_id as string,
+        threadJid: row.thread_jid as string,
+        senderJid: (row.sender_jid as string | null) ?? undefined,
+        participantJid: (row.participant_jid as string | null) ?? undefined,
+        fromMe: Boolean(row.from_me),
+        timestampMs: row.timestamp_ms !== null ? Number(row.timestamp_ms) : undefined,
+        encType: (row.enc_type as string | null) ?? undefined,
+        plaintext: toBytesOrNull(row.plaintext) ?? undefined,
+        messageBytes: toBytesOrNull(row.message_bytes) ?? undefined
+    }
+}
+
+export class WaMessagePgStore extends BasePgStore implements WaMessageStore {
+    public constructor(options: WaPgStorageOptions) {
+        super(options, ['mailbox'])
+    }
+
+    public async upsert(record: WaStoredMessageRecord): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('msg_upsert'),
+            text: `INSERT INTO ${this.t('mailbox_messages')} (
+                session_id, message_id, thread_jid, sender_jid, participant_jid,
+                from_me, timestamp_ms, enc_type, plaintext, message_bytes
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            ON CONFLICT (session_id, message_id) DO UPDATE SET
+                thread_jid = EXCLUDED.thread_jid,
+                sender_jid = EXCLUDED.sender_jid,
+                participant_jid = EXCLUDED.participant_jid,
+                from_me = EXCLUDED.from_me,
+                timestamp_ms = EXCLUDED.timestamp_ms,
+                enc_type = EXCLUDED.enc_type,
+                plaintext = EXCLUDED.plaintext,
+                message_bytes = EXCLUDED.message_bytes`,
+            values: [
+                this.sessionId,
+                record.id,
+                record.threadJid,
+                record.senderJid ?? null,
+                record.participantJid ?? null,
+                record.fromMe,
+                record.timestampMs ?? null,
+                record.encType ?? null,
+                record.plaintext ?? null,
+                record.messageBytes ?? null
+            ]
+        })
+    }
+
+    public async upsertBatch(records: readonly WaStoredMessageRecord[]): Promise<void> {
+        if (records.length === 0) return
+
+        await this.withTransaction(async (client) => {
+            for (const record of records) {
+                await client.query({
+                    name: this.stmtName('msg_upsert'),
+                    text: `INSERT INTO ${this.t('mailbox_messages')} (
+                        session_id, message_id, thread_jid, sender_jid, participant_jid,
+                        from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                    ON CONFLICT (session_id, message_id) DO UPDATE SET
+                        thread_jid = EXCLUDED.thread_jid,
+                        sender_jid = EXCLUDED.sender_jid,
+                        participant_jid = EXCLUDED.participant_jid,
+                        from_me = EXCLUDED.from_me,
+                        timestamp_ms = EXCLUDED.timestamp_ms,
+                        enc_type = EXCLUDED.enc_type,
+                        plaintext = EXCLUDED.plaintext,
+                        message_bytes = EXCLUDED.message_bytes`,
+                    values: [
+                        this.sessionId,
+                        record.id,
+                        record.threadJid,
+                        record.senderJid ?? null,
+                        record.participantJid ?? null,
+                        record.fromMe,
+                        record.timestampMs ?? null,
+                        record.encType ?? null,
+                        record.plaintext ?? null,
+                        record.messageBytes ?? null
+                    ]
+                })
+            }
+        })
+    }
+
+    public async getById(id: string): Promise<WaStoredMessageRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('msg_get_by_id'),
+                text: `SELECT message_id, thread_jid, sender_jid, participant_jid,
+                    from_me, timestamp_ms, enc_type, plaintext, message_bytes
+             FROM ${this.t('mailbox_messages')}
+             WHERE session_id = $1 AND message_id = $2`,
+                values: [this.sessionId, id]
+            })
+        )
+        if (!row) return null
+        return rowToRecord(row)
+    }
+
+    public async listByThread(
+        threadJid: string,
+        limit?: number,
+        beforeTimestampMs?: number
+    ): Promise<readonly WaStoredMessageRecord[]> {
+        await this.ensureReady()
+        const resolved = safeLimit(limit, 50)
+
+        if (beforeTimestampMs !== undefined) {
+            return queryRows(
+                await this.pool.query({
+                    name: this.stmtName('msg_list_thread_before'),
+                    text: `SELECT message_id, thread_jid, sender_jid, participant_jid,
+                        from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                 FROM ${this.t('mailbox_messages')}
+                 WHERE session_id = $1 AND thread_jid = $2 AND timestamp_ms < $3
+                 ORDER BY timestamp_ms DESC, message_id DESC
+                 LIMIT $4`,
+                    values: [this.sessionId, threadJid, beforeTimestampMs, resolved]
+                })
+            ).map(rowToRecord)
+        }
+
+        return queryRows(
+            await this.pool.query({
+                name: this.stmtName('msg_list_thread'),
+                text: `SELECT message_id, thread_jid, sender_jid, participant_jid,
+                    from_me, timestamp_ms, enc_type, plaintext, message_bytes
+             FROM ${this.t('mailbox_messages')}
+             WHERE session_id = $1 AND thread_jid = $2
+             ORDER BY timestamp_ms DESC, message_id DESC
+             LIMIT $3`,
+                values: [this.sessionId, threadJid, resolved]
+            })
+        ).map(rowToRecord)
+    }
+
+    public async deleteById(id: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.query({
+                name: this.stmtName('msg_delete_by_id'),
+                text: `DELETE FROM ${this.t('mailbox_messages')}
+             WHERE session_id = $1 AND message_id = $2`,
+                values: [this.sessionId, id]
+            })
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('msg_clear'),
+            text: `DELETE FROM ${this.t('mailbox_messages')} WHERE session_id = $1`,
+            values: [this.sessionId]
+        })
+    }
+}

--- a/packages/store-postgres/src/participants.store.ts
+++ b/packages/store-postgres/src/participants.store.ts
@@ -1,0 +1,111 @@
+import type { WaParticipantsSnapshot, WaParticipantsStore } from 'zapo-js/store'
+
+import { BasePgStore } from './BasePgStore'
+import { affectedRows, queryFirst } from './helpers'
+import type { WaPgStorageOptions } from './types'
+
+const DEFAULT_PARTICIPANTS_TTL_MS = 5 * 60 * 1000
+
+export class WaParticipantsPgStore extends BasePgStore implements WaParticipantsStore {
+    private readonly ttlMs: number
+
+    public constructor(options: WaPgStorageOptions, ttlMs = DEFAULT_PARTICIPANTS_TTL_MS) {
+        super(options, ['participants'])
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('participants ttlMs must be a non-negative finite number')
+        }
+        this.ttlMs = ttlMs
+    }
+
+    public async upsertGroupParticipants(snapshot: WaParticipantsSnapshot): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('participants_upsert'),
+            text: `INSERT INTO ${this.t('group_participants_cache')} (
+                session_id, group_jid, participants_json, updated_at_ms, expires_at_ms
+            ) VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (session_id, group_jid) DO UPDATE SET
+                participants_json = EXCLUDED.participants_json,
+                updated_at_ms = EXCLUDED.updated_at_ms,
+                expires_at_ms = EXCLUDED.expires_at_ms`,
+            values: [
+                this.sessionId,
+                snapshot.groupJid,
+                JSON.stringify(snapshot.participants),
+                snapshot.updatedAtMs,
+                snapshot.updatedAtMs + this.ttlMs
+            ]
+        })
+    }
+
+    public async getGroupParticipants(
+        groupJid: string,
+        nowMs = Date.now()
+    ): Promise<WaParticipantsSnapshot | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('participants_get'),
+                text: `SELECT group_jid, participants_json, updated_at_ms, expires_at_ms
+                 FROM ${this.t('group_participants_cache')}
+                 WHERE session_id = $1 AND group_jid = $2`,
+                values: [this.sessionId, groupJid]
+            })
+        )
+        if (!row) return null
+
+        if (Number(row.expires_at_ms) <= nowMs) {
+            await this.pool.query({
+                name: this.stmtName('participants_delete_expired'),
+                text: `DELETE FROM ${this.t('group_participants_cache')}
+                 WHERE session_id = $1 AND group_jid = $2 AND expires_at_ms <= $3`,
+                values: [this.sessionId, groupJid, nowMs]
+            })
+            return null
+        }
+
+        const parsed: unknown = JSON.parse(row.participants_json as string)
+        if (!Array.isArray(parsed)) {
+            throw new Error('group_participants_cache.participants_json must be an array')
+        }
+
+        return {
+            groupJid: String(row.group_jid),
+            participants: parsed.map((entry: unknown) => String(entry)),
+            updatedAtMs: Number(row.updated_at_ms)
+        }
+    }
+
+    public async deleteGroupParticipants(groupJid: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.query({
+                name: this.stmtName('participants_delete_group'),
+                text: `DELETE FROM ${this.t('group_participants_cache')}
+                 WHERE session_id = $1 AND group_jid = $2`,
+                values: [this.sessionId, groupJid]
+            })
+        )
+    }
+
+    public async cleanupExpired(nowMs: number): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.query({
+                name: this.stmtName('participants_cleanup'),
+                text: `DELETE FROM ${this.t('group_participants_cache')}
+                 WHERE session_id = $1 AND expires_at_ms <= $2`,
+                values: [this.sessionId, nowMs]
+            })
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('participants_clear'),
+            text: `DELETE FROM ${this.t('group_participants_cache')} WHERE session_id = $1`,
+            values: [this.sessionId]
+        })
+    }
+}

--- a/packages/store-postgres/src/privacy-token.store.ts
+++ b/packages/store-postgres/src/privacy-token.store.ts
@@ -1,0 +1,120 @@
+import type { WaPrivacyTokenStore, WaStoredPrivacyTokenRecord } from 'zapo-js/store'
+
+import { BasePgStore } from './BasePgStore'
+import { affectedRows, queryFirst, toBytesOrNull } from './helpers'
+import type { WaPgStorageOptions } from './types'
+
+export class WaPrivacyTokenPgStore extends BasePgStore implements WaPrivacyTokenStore {
+    public constructor(options: WaPgStorageOptions) {
+        super(options, ['privacyToken'])
+    }
+
+    public async upsert(record: WaStoredPrivacyTokenRecord): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('privtoken_upsert'),
+            text: `INSERT INTO ${this.t('privacy_tokens')} (
+                session_id, jid, tc_token, tc_token_timestamp,
+                tc_token_sender_timestamp, nct_salt, updated_at_ms
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (session_id, jid) DO UPDATE SET
+                tc_token = COALESCE(EXCLUDED.tc_token, ${this.t('privacy_tokens')}.tc_token),
+                tc_token_timestamp = COALESCE(EXCLUDED.tc_token_timestamp, ${this.t('privacy_tokens')}.tc_token_timestamp),
+                tc_token_sender_timestamp = COALESCE(EXCLUDED.tc_token_sender_timestamp, ${this.t('privacy_tokens')}.tc_token_sender_timestamp),
+                nct_salt = COALESCE(EXCLUDED.nct_salt, ${this.t('privacy_tokens')}.nct_salt),
+                updated_at_ms = EXCLUDED.updated_at_ms`,
+            values: [
+                this.sessionId,
+                record.jid,
+                record.tcToken ?? null,
+                record.tcTokenTimestamp ?? null,
+                record.tcTokenSenderTimestamp ?? null,
+                record.nctSalt ?? null,
+                record.updatedAtMs
+            ]
+        })
+    }
+
+    public async upsertBatch(records: readonly WaStoredPrivacyTokenRecord[]): Promise<void> {
+        if (records.length === 0) return
+
+        await this.withTransaction(async (client) => {
+            for (const record of records) {
+                await client.query({
+                    name: this.stmtName('privtoken_upsert'),
+                    text: `INSERT INTO ${this.t('privacy_tokens')} (
+                        session_id, jid, tc_token, tc_token_timestamp,
+                        tc_token_sender_timestamp, nct_salt, updated_at_ms
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+                    ON CONFLICT (session_id, jid) DO UPDATE SET
+                        tc_token = COALESCE(EXCLUDED.tc_token, ${this.t('privacy_tokens')}.tc_token),
+                        tc_token_timestamp = COALESCE(EXCLUDED.tc_token_timestamp, ${this.t('privacy_tokens')}.tc_token_timestamp),
+                        tc_token_sender_timestamp = COALESCE(EXCLUDED.tc_token_sender_timestamp, ${this.t('privacy_tokens')}.tc_token_sender_timestamp),
+                        nct_salt = COALESCE(EXCLUDED.nct_salt, ${this.t('privacy_tokens')}.nct_salt),
+                        updated_at_ms = EXCLUDED.updated_at_ms`,
+                    values: [
+                        this.sessionId,
+                        record.jid,
+                        record.tcToken ?? null,
+                        record.tcTokenTimestamp ?? null,
+                        record.tcTokenSenderTimestamp ?? null,
+                        record.nctSalt ?? null,
+                        record.updatedAtMs
+                    ]
+                })
+            }
+        })
+    }
+
+    public async getByJid(jid: string): Promise<WaStoredPrivacyTokenRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('privtoken_get_by_jid'),
+                text: `SELECT jid, tc_token, tc_token_timestamp,
+                    tc_token_sender_timestamp, nct_salt, updated_at_ms
+             FROM ${this.t('privacy_tokens')}
+             WHERE session_id = $1 AND jid = $2`,
+                values: [this.sessionId, jid]
+            })
+        )
+        if (!row) return null
+        return {
+            jid: row.jid as string,
+            tcToken: toBytesOrNull(row.tc_token) ?? undefined,
+            tcTokenTimestamp:
+                row.tc_token_timestamp !== null ? Number(row.tc_token_timestamp) : undefined,
+            tcTokenSenderTimestamp:
+                row.tc_token_sender_timestamp !== null
+                    ? Number(row.tc_token_sender_timestamp)
+                    : undefined,
+            nctSalt: toBytesOrNull(row.nct_salt) ?? undefined,
+            updatedAtMs: Number(row.updated_at_ms)
+        }
+    }
+
+    public async deleteByJid(jid: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.query({
+                name: this.stmtName('privtoken_delete_by_jid'),
+                text: `DELETE FROM ${this.t('privacy_tokens')}
+             WHERE session_id = $1 AND jid = $2`,
+                values: [this.sessionId, jid]
+            })
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('privtoken_clear'),
+            text: `DELETE FROM ${this.t('privacy_tokens')} WHERE session_id = $1`,
+            values: [this.sessionId]
+        })
+    }
+
+    public async destroy(): Promise<void> {
+        // no-op
+    }
+}

--- a/packages/store-postgres/src/retry.store.ts
+++ b/packages/store-postgres/src/retry.store.ts
@@ -1,0 +1,414 @@
+import type { WaRetryOutboundMessageRecord, WaRetryOutboundState } from 'zapo-js/retry'
+import type { WaRetryStore } from 'zapo-js/store'
+
+import { BasePgStore } from './BasePgStore'
+import { affectedRows, queryFirst, toBytes } from './helpers'
+import type { WaPgStorageOptions } from './types'
+
+interface RetryRequesterStatusPayload {
+    readonly eligible: readonly string[]
+    readonly delivered: readonly string[]
+}
+
+const DEFAULT_RETRY_TTL_MS = 60 * 1000
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+export class WaRetryPgStore extends BasePgStore implements WaRetryStore {
+    private readonly ttlMs: number
+
+    public constructor(options: WaPgStorageOptions, ttlMs = DEFAULT_RETRY_TTL_MS) {
+        super(options, ['retry'])
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('retry ttlMs must be a non-negative finite number')
+        }
+        this.ttlMs = ttlMs
+    }
+
+    public getTtlMs(): number {
+        return this.ttlMs
+    }
+
+    public supportsRawReplayPayload(): boolean {
+        return false
+    }
+
+    public async getOutboundRequesterStatus(
+        messageId: string,
+        requesterDeviceJid: string
+    ): Promise<{
+        readonly eligible: boolean
+        readonly delivered: boolean
+    } | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('retry_get_requester_status'),
+                text: `SELECT requesters_json
+                 FROM ${this.t('retry_outbound_messages')}
+                 WHERE session_id = $1 AND message_id = $2
+                 LIMIT 1`,
+                values: [this.sessionId, messageId]
+            })
+        )
+        if (!row) {
+            return null
+        }
+        const requestersJson = row.requesters_json !== null ? String(row.requesters_json) : null
+        if (!requestersJson) {
+            return null
+        }
+        const requesters = this.parseRequesterStatusPayload(requestersJson)
+        if (requesters.eligible.length === 0) {
+            return null
+        }
+        let isEligible = false
+        for (let index = 0; index < requesters.eligible.length; index += 1) {
+            if (requesters.eligible[index] === requesterDeviceJid) {
+                isEligible = true
+                break
+            }
+        }
+        if (!isEligible) {
+            return {
+                eligible: false,
+                delivered: false
+            }
+        }
+        for (let index = 0; index < requesters.delivered.length; index += 1) {
+            if (requesters.delivered[index] === requesterDeviceJid) {
+                return {
+                    eligible: true,
+                    delivered: true
+                }
+            }
+        }
+        return {
+            eligible: true,
+            delivered: false
+        }
+    }
+
+    public async upsertOutboundMessage(record: WaRetryOutboundMessageRecord): Promise<void> {
+        await this.ensureReady()
+        const requestersJson = this.serializeRequesterStatusPayload(
+            record.eligibleRequesterDeviceJids,
+            record.deliveredRequesterDeviceJids
+        )
+        if (!(record.replayPayload instanceof Uint8Array)) {
+            throw new Error('retry_outbound_messages.replay_payload must be Uint8Array')
+        }
+        const replayPayload = record.replayPayload
+        await this.pool.query({
+            name: this.stmtName('retry_upsert_outbound'),
+            text: `INSERT INTO ${this.t('retry_outbound_messages')} (
+                session_id,
+                message_id,
+                to_jid,
+                participant_jid,
+                recipient_jid,
+                message_type,
+                replay_mode,
+                replay_payload,
+                requesters_json,
+                state,
+                created_at_ms,
+                updated_at_ms,
+                expires_at_ms
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            ON CONFLICT (session_id, message_id) DO UPDATE SET
+                to_jid = EXCLUDED.to_jid,
+                participant_jid = EXCLUDED.participant_jid,
+                recipient_jid = EXCLUDED.recipient_jid,
+                message_type = EXCLUDED.message_type,
+                replay_mode = EXCLUDED.replay_mode,
+                replay_payload = EXCLUDED.replay_payload,
+                requesters_json = EXCLUDED.requesters_json,
+                state = EXCLUDED.state,
+                created_at_ms = EXCLUDED.created_at_ms,
+                updated_at_ms = EXCLUDED.updated_at_ms,
+                expires_at_ms = EXCLUDED.expires_at_ms`,
+            values: [
+                this.sessionId,
+                record.messageId,
+                record.toJid,
+                record.participantJid ?? null,
+                record.recipientJid ?? null,
+                record.messageType,
+                record.replayMode,
+                replayPayload,
+                requestersJson,
+                record.state,
+                record.createdAtMs,
+                record.updatedAtMs,
+                record.expiresAtMs
+            ]
+        })
+    }
+
+    public async deleteOutboundMessage(messageId: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.query({
+                name: this.stmtName('retry_delete_outbound'),
+                text: `DELETE FROM ${this.t('retry_outbound_messages')}
+                 WHERE session_id = $1 AND message_id = $2`,
+                values: [this.sessionId, messageId]
+            })
+        )
+    }
+
+    public async getOutboundMessage(
+        messageId: string
+    ): Promise<WaRetryOutboundMessageRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('retry_get_outbound'),
+                text: `SELECT
+                    message_id,
+                    to_jid,
+                    participant_jid,
+                    recipient_jid,
+                    message_type,
+                    replay_mode,
+                    replay_payload,
+                    requesters_json,
+                    state,
+                    created_at_ms,
+                    updated_at_ms,
+                    expires_at_ms
+                FROM ${this.t('retry_outbound_messages')}
+                WHERE session_id = $1 AND message_id = $2`,
+                values: [this.sessionId, messageId]
+            })
+        )
+        if (!row) {
+            return null
+        }
+        const requestersJson = row.requesters_json !== null ? String(row.requesters_json) : null
+        const requesters = requestersJson
+            ? this.parseRequesterStatusPayload(requestersJson)
+            : {
+                  eligible: [] as readonly string[],
+                  delivered: [] as readonly string[]
+              }
+        return {
+            messageId: String(row.message_id),
+            toJid: String(row.to_jid),
+            participantJid: row.participant_jid !== null ? String(row.participant_jid) : undefined,
+            recipientJid: row.recipient_jid !== null ? String(row.recipient_jid) : undefined,
+            eligibleRequesterDeviceJids:
+                requesters.eligible.length > 0 ? requesters.eligible : undefined,
+            deliveredRequesterDeviceJids:
+                requesters.delivered.length > 0 ? requesters.delivered : undefined,
+            messageType: String(row.message_type),
+            replayMode: String(row.replay_mode) as WaRetryOutboundMessageRecord['replayMode'],
+            replayPayload: toBytes(row.replay_payload),
+            state: String(row.state) as WaRetryOutboundState,
+            createdAtMs: Number(row.created_at_ms),
+            updatedAtMs: Number(row.updated_at_ms),
+            expiresAtMs: Number(row.expires_at_ms)
+        }
+    }
+
+    public async updateOutboundMessageState(
+        messageId: string,
+        state: WaRetryOutboundState,
+        updatedAtMs: number,
+        expiresAtMs: number
+    ): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('retry_update_outbound_state'),
+            text: `UPDATE ${this.t('retry_outbound_messages')}
+             SET state = $1, updated_at_ms = $2, expires_at_ms = $3
+             WHERE session_id = $4 AND message_id = $5`,
+            values: [state, updatedAtMs, expiresAtMs, this.sessionId, messageId]
+        })
+    }
+
+    public async markOutboundRequesterDelivered(
+        messageId: string,
+        requesterDeviceJid: string,
+        updatedAtMs: number,
+        expiresAtMs: number
+    ): Promise<void> {
+        await this.withTransaction(async (client) => {
+            const row = queryFirst(
+                await client.query({
+                    name: this.stmtName('retry_select_requesters_for_update'),
+                    text: `SELECT requesters_json
+                     FROM ${this.t('retry_outbound_messages')}
+                     WHERE session_id = $1 AND message_id = $2
+                     FOR UPDATE`,
+                    values: [this.sessionId, messageId]
+                })
+            )
+            if (!row) {
+                return
+            }
+            const requestersJson = row.requesters_json !== null ? String(row.requesters_json) : null
+            if (!requestersJson) {
+                return
+            }
+            const requesters = this.parseRequesterStatusPayload(requestersJson)
+            let isEligible = false
+            for (let index = 0; index < requesters.eligible.length; index += 1) {
+                if (requesters.eligible[index] === requesterDeviceJid) {
+                    isEligible = true
+                    break
+                }
+            }
+            if (!isEligible) {
+                return
+            }
+            for (let index = 0; index < requesters.delivered.length; index += 1) {
+                if (requesters.delivered[index] === requesterDeviceJid) {
+                    return
+                }
+            }
+            const nextRequestersJson = this.serializeRequesterStatusPayload(requesters.eligible, [
+                ...requesters.delivered,
+                requesterDeviceJid
+            ])
+            await client.query({
+                name: this.stmtName('retry_update_requesters'),
+                text: `UPDATE ${this.t('retry_outbound_messages')}
+                 SET requesters_json = $1, updated_at_ms = $2, expires_at_ms = $3
+                 WHERE session_id = $4 AND message_id = $5`,
+                values: [nextRequestersJson, updatedAtMs, expiresAtMs, this.sessionId, messageId]
+            })
+        })
+    }
+
+    public async incrementInboundCounter(
+        messageId: string,
+        requesterJid: string,
+        updatedAtMs: number,
+        expiresAtMs: number
+    ): Promise<number> {
+        await this.ensureReady()
+        const tbl = this.t('retry_inbound_counters')
+        const result = await this.pool.query({
+            name: this.stmtName('retry_inc_inbound'),
+            text: `INSERT INTO ${tbl} (
+                session_id, message_id, requester_jid, retry_count, updated_at_ms, expires_at_ms
+            ) VALUES ($1, $2, $3, 1, $4, $5)
+            ON CONFLICT (session_id, message_id, requester_jid) DO UPDATE SET
+                retry_count = ${tbl}.retry_count + 1,
+                updated_at_ms = EXCLUDED.updated_at_ms,
+                expires_at_ms = EXCLUDED.expires_at_ms
+            RETURNING retry_count`,
+            values: [this.sessionId, messageId, requesterJid, updatedAtMs, expiresAtMs]
+        })
+        const row = queryFirst(result)
+        return row ? Number(row.retry_count) : 1
+    }
+
+    public async cleanupExpired(nowMs: number): Promise<number> {
+        await this.ensureReady()
+        const outboundCount = affectedRows(
+            await this.pool.query({
+                name: this.stmtName('retry_cleanup_outbound'),
+                text: `DELETE FROM ${this.t('retry_outbound_messages')}
+                 WHERE session_id = $1 AND expires_at_ms <= $2`,
+                values: [this.sessionId, nowMs]
+            })
+        )
+        const inboundCount = affectedRows(
+            await this.pool.query({
+                name: this.stmtName('retry_cleanup_inbound'),
+                text: `DELETE FROM ${this.t('retry_inbound_counters')}
+                 WHERE session_id = $1 AND expires_at_ms <= $2`,
+                values: [this.sessionId, nowMs]
+            })
+        )
+        return outboundCount + inboundCount
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('retry_clear_outbound'),
+            text: `DELETE FROM ${this.t('retry_outbound_messages')} WHERE session_id = $1`,
+            values: [this.sessionId]
+        })
+        await this.pool.query({
+            name: this.stmtName('retry_clear_inbound'),
+            text: `DELETE FROM ${this.t('retry_inbound_counters')} WHERE session_id = $1`,
+            values: [this.sessionId]
+        })
+    }
+
+    private serializeRequesterStatusPayload(
+        eligibleRequesterDeviceJids: readonly string[] | undefined,
+        deliveredRequesterDeviceJids: readonly string[] | undefined
+    ): string | null {
+        const eligible = this.toUniqueStrings(
+            eligibleRequesterDeviceJids ?? [],
+            'requesters_json.eligible'
+        )
+        if (eligible.length === 0) {
+            return null
+        }
+        const eligibleSet = new Set(eligible)
+        const delivered = this.toUniqueStrings(
+            deliveredRequesterDeviceJids ?? [],
+            'requesters_json.delivered'
+        ).filter((jid) => eligibleSet.has(jid))
+        const payload =
+            delivered.length > 0
+                ? {
+                      eligible,
+                      delivered
+                  }
+                : {
+                      eligible
+                  }
+        return JSON.stringify(payload)
+    }
+
+    private parseRequesterStatusPayload(raw: string): RetryRequesterStatusPayload {
+        const parsed = JSON.parse(raw)
+        if (!isObjectRecord(parsed)) {
+            throw new Error('retry_outbound_messages.requesters_json must be an object')
+        }
+        const eligibleRaw = parsed.eligible
+        if (!Array.isArray(eligibleRaw)) {
+            throw new Error('retry_outbound_messages.requesters_json.eligible must be an array')
+        }
+        const eligible = this.toUniqueStrings(eligibleRaw, 'requesters_json.eligible')
+        const deliveredRaw = parsed.delivered
+        if (deliveredRaw !== undefined && !Array.isArray(deliveredRaw)) {
+            throw new Error('retry_outbound_messages.requesters_json.delivered must be an array')
+        }
+        const eligibleSet = new Set(eligible)
+        const delivered = this.toUniqueStrings(
+            Array.isArray(deliveredRaw) ? deliveredRaw : [],
+            'requesters_json.delivered'
+        ).filter((jid) => eligibleSet.has(jid))
+        return {
+            eligible,
+            delivered
+        }
+    }
+
+    private toUniqueStrings(values: readonly unknown[], field: string): readonly string[] {
+        const deduped = new Set<string>()
+        for (let index = 0; index < values.length; index += 1) {
+            const rawValue = values[index]
+            if (typeof rawValue !== 'string') {
+                throw new Error(`${field} must contain only strings`)
+            }
+            const normalized = rawValue.trim()
+            if (!normalized) {
+                continue
+            }
+            deduped.add(normalized)
+        }
+        return Array.from(deduped)
+    }
+}

--- a/packages/store-postgres/src/sender-key.store.ts
+++ b/packages/store-postgres/src/sender-key.store.ts
@@ -1,0 +1,313 @@
+import type { PoolClient } from 'pg'
+import type { SenderKeyDistributionRecord, SenderKeyRecord, SignalAddress } from 'zapo-js/signal'
+import {
+    encodeSenderKeyRecord,
+    decodeSenderKeyRecord,
+    toSignalAddressParts,
+    type SignalAddressParts
+} from 'zapo-js/signal'
+import type { WaSenderKeyStore } from 'zapo-js/store'
+
+import { BasePgStore } from './BasePgStore'
+import { affectedRows, queryFirst, queryRows, toBytes } from './helpers'
+import type { PgParam, WaPgStorageOptions } from './types'
+
+const BATCH_SIZE = 250
+
+export class WaSenderKeyPgStore extends BasePgStore implements WaSenderKeyStore {
+    public constructor(options: WaPgStorageOptions) {
+        super(options, ['senderKey'])
+    }
+
+    public async upsertSenderKey(record: SenderKeyRecord): Promise<void> {
+        await this.ensureReady()
+        const sender = toSignalAddressParts(record.sender)
+        await this.pool.query({
+            name: this.stmtName('sk_upsert'),
+            text: `INSERT INTO ${this.t('sender_keys')} (
+                session_id, group_id, sender_user, sender_server, sender_device, record
+            ) VALUES ($1, $2, $3, $4, $5, $6)
+            ON CONFLICT (session_id, group_id, sender_user, sender_server, sender_device) DO UPDATE SET
+                record = EXCLUDED.record`,
+            values: [
+                this.sessionId,
+                record.groupId,
+                sender.user,
+                sender.server,
+                sender.device,
+                encodeSenderKeyRecord(record)
+            ]
+        })
+    }
+
+    public async upsertSenderKeyDistribution(record: SenderKeyDistributionRecord): Promise<void> {
+        await this.ensureReady()
+        const sender = toSignalAddressParts(record.sender)
+        await this.upsertSenderKeyDistributionRow(this.pool, record, sender)
+    }
+
+    public async upsertSenderKeyDistributions(
+        records: readonly SenderKeyDistributionRecord[]
+    ): Promise<void> {
+        if (records.length === 0) return
+        await this.withTransaction(async (client) => {
+            for (const record of records) {
+                const sender = toSignalAddressParts(record.sender)
+                await this.upsertSenderKeyDistributionRow(client, record, sender)
+            }
+        })
+    }
+
+    public async getGroupSenderKeyList(groupId: string): Promise<{
+        readonly skList: readonly SenderKeyRecord[]
+        readonly skDistribList: readonly SenderKeyDistributionRecord[]
+    }> {
+        return this.withTransaction(async (client) => {
+            const senderRows = queryRows(
+                await client.query({
+                    name: this.stmtName('sk_list_by_group'),
+                    text: `SELECT group_id, sender_user, sender_server, sender_device, record
+                     FROM ${this.t('sender_keys')}
+                     WHERE session_id = $1 AND group_id = $2`,
+                    values: [this.sessionId, groupId]
+                })
+            )
+            const distributionRows = queryRows(
+                await client.query({
+                    name: this.stmtName('sk_distrib_list_by_group'),
+                    text: `SELECT group_id, sender_user, sender_server, sender_device, key_id, timestamp_ms
+                     FROM ${this.t('sender_key_distribution')}
+                     WHERE session_id = $1 AND group_id = $2`,
+                    values: [this.sessionId, groupId]
+                })
+            )
+
+            const skList: SenderKeyRecord[] = senderRows.map((row) =>
+                decodeSenderKeyRecord(toBytes(row.record), String(row.group_id), {
+                    user: String(row.sender_user),
+                    server: String(row.sender_server),
+                    device: Number(row.sender_device)
+                })
+            )
+
+            const skDistribList: SenderKeyDistributionRecord[] = distributionRows.map((row) => ({
+                groupId: String(row.group_id),
+                sender: {
+                    user: String(row.sender_user),
+                    server: String(row.sender_server),
+                    device: Number(row.sender_device)
+                },
+                keyId: Number(row.key_id),
+                timestampMs: Number(row.timestamp_ms)
+            }))
+
+            return { skList, skDistribList }
+        })
+    }
+
+    public async getDeviceSenderKey(
+        groupId: string,
+        sender: SignalAddress
+    ): Promise<SenderKeyRecord | null> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(sender)
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('sk_get_device'),
+                text: `SELECT group_id, sender_user, sender_server, sender_device, record
+                 FROM ${this.t('sender_keys')}
+                 WHERE session_id = $1
+                   AND group_id = $2
+                   AND sender_user = $3
+                   AND sender_server = $4
+                   AND sender_device = $5`,
+                values: [this.sessionId, groupId, target.user, target.server, target.device]
+            })
+        )
+        if (!row) return null
+        return decodeSenderKeyRecord(toBytes(row.record), String(row.group_id), {
+            user: String(row.sender_user),
+            server: String(row.sender_server),
+            device: Number(row.sender_device)
+        })
+    }
+
+    public async getDeviceSenderKeyDistributions(
+        groupId: string,
+        senders: readonly SignalAddress[]
+    ): Promise<readonly (SenderKeyDistributionRecord | null)[]> {
+        if (senders.length === 0) return []
+        await this.ensureReady()
+        const targets = senders.map((s) => toSignalAddressParts(s))
+        const byKey = new Map<string, SenderKeyDistributionRecord>()
+        for (let start = 0; start < targets.length; start += BATCH_SIZE) {
+            const batch = targets.slice(start, start + BATCH_SIZE)
+            let paramIdx = 3
+            const senderClauses = batch
+                .map(() => {
+                    const clause = `(sender_user = $${paramIdx} AND sender_server = $${paramIdx + 1} AND sender_device = $${paramIdx + 2})`
+                    paramIdx += 3
+                    return clause
+                })
+                .join(' OR ')
+            const params: PgParam[] = [
+                this.sessionId,
+                groupId,
+                ...batch.flatMap((t) => [t.user, t.server, t.device])
+            ]
+            const rows = queryRows(
+                await this.pool.query(
+                    `SELECT group_id, sender_user, sender_server, sender_device, key_id, timestamp_ms
+                     FROM ${this.t('sender_key_distribution')}
+                     WHERE session_id = $1 AND group_id = $2 AND (${senderClauses})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                const key = this.distributionTargetKey(
+                    String(row.sender_user),
+                    String(row.sender_server),
+                    Number(row.sender_device)
+                )
+                byKey.set(key, {
+                    groupId: String(row.group_id),
+                    sender: {
+                        user: String(row.sender_user),
+                        server: String(row.sender_server),
+                        device: Number(row.sender_device)
+                    },
+                    keyId: Number(row.key_id),
+                    timestampMs: Number(row.timestamp_ms)
+                })
+            }
+        }
+        return targets.map(
+            (t) => byKey.get(this.distributionTargetKey(t.user, t.server, t.device)) ?? null
+        )
+    }
+
+    public async deleteDeviceSenderKey(target: SignalAddress, groupId?: string): Promise<number> {
+        const sender = toSignalAddressParts(target)
+        return this.withTransaction(async (client) => {
+            const senderCount = await this.countDelete(client, 'sender_keys', sender, groupId)
+            const distributionCount = await this.countDelete(
+                client,
+                'sender_key_distribution',
+                sender,
+                groupId
+            )
+            return senderCount + distributionCount
+        })
+    }
+
+    public async markForgetSenderKey(
+        groupId: string,
+        participants: readonly SignalAddress[]
+    ): Promise<number> {
+        if (participants.length === 0) return 0
+        return this.withTransaction(async (client) => {
+            let total = 0
+            for (let start = 0; start < participants.length; start += BATCH_SIZE) {
+                const batch = participants.slice(start, start + BATCH_SIZE)
+                let paramIdx = 3
+                const senderClauses = batch
+                    .map(() => {
+                        const clause = `(sender_user = $${paramIdx} AND sender_server = $${paramIdx + 1} AND sender_device = $${paramIdx + 2})`
+                        paramIdx += 3
+                        return clause
+                    })
+                    .join(' OR ')
+                const senderParams: PgParam[] = batch.flatMap((p) => {
+                    const sender = toSignalAddressParts(p)
+                    return [sender.user, sender.server, sender.device]
+                })
+                const where = `session_id = $1 AND group_id = $2 AND (${senderClauses})`
+                const params: PgParam[] = [this.sessionId, groupId, ...senderParams]
+                total += affectedRows(
+                    await client.query(
+                        `DELETE FROM ${this.t('sender_keys')} WHERE ${where}`,
+                        params
+                    )
+                )
+                total += affectedRows(
+                    await client.query(
+                        `DELETE FROM ${this.t('sender_key_distribution')} WHERE ${where}`,
+                        params
+                    )
+                )
+            }
+            return total
+        })
+    }
+
+    public async clear(): Promise<void> {
+        await this.withTransaction(async (client) => {
+            await client.query({
+                name: this.stmtName('sk_clear_keys'),
+                text: `DELETE FROM ${this.t('sender_keys')} WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+            await client.query({
+                name: this.stmtName('sk_clear_distrib'),
+                text: `DELETE FROM ${this.t('sender_key_distribution')} WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+        })
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────
+
+    private async upsertSenderKeyDistributionRow(
+        executor: { query: PoolClient['query'] },
+        record: SenderKeyDistributionRecord,
+        sender: SignalAddressParts
+    ): Promise<void> {
+        await executor.query({
+            name: this.stmtName('sk_upsert_distrib'),
+            text: `INSERT INTO ${this.t('sender_key_distribution')} (
+                session_id, group_id, sender_user, sender_server, sender_device,
+                key_id, timestamp_ms
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (session_id, group_id, sender_user, sender_server, sender_device) DO UPDATE SET
+                key_id = EXCLUDED.key_id,
+                timestamp_ms = EXCLUDED.timestamp_ms`,
+            values: [
+                this.sessionId,
+                record.groupId,
+                sender.user,
+                sender.server,
+                sender.device,
+                record.keyId,
+                record.timestampMs
+            ]
+        })
+    }
+
+    private async countDelete(
+        client: PoolClient,
+        table: 'sender_keys' | 'sender_key_distribution',
+        target: SignalAddressParts,
+        groupId?: string
+    ): Promise<number> {
+        const whereBase =
+            'session_id = $1 AND sender_user = $2 AND sender_server = $3 AND sender_device = $4'
+        const where = groupId ? `${whereBase} AND group_id = $5` : whereBase
+        const params: PgParam[] = groupId
+            ? [this.sessionId, target.user, target.server, target.device, groupId]
+            : [this.sessionId, target.user, target.server, target.device]
+        const suffix = table === 'sender_keys' ? 'keys' : 'distrib'
+        const variant = groupId ? 'group' : 'all'
+
+        return affectedRows(
+            await client.query({
+                name: this.stmtName(`sk_delete_device_${suffix}_${variant}`),
+                text: `DELETE FROM ${this.t(table)} WHERE ${where}`,
+                values: params
+            })
+        )
+    }
+
+    private distributionTargetKey(user: string, server: string, device: number): string {
+        return `${user}|${server}|${device}`
+    }
+}

--- a/packages/store-postgres/src/signal.store.ts
+++ b/packages/store-postgres/src/signal.store.ts
@@ -1,0 +1,833 @@
+import type { PoolClient } from 'pg'
+import { signalAddressKey } from 'zapo-js/protocol'
+import type {
+    PreKeyRecord,
+    RegistrationInfo,
+    SignalAddress,
+    SignalSessionRecord,
+    SignedPreKeyRecord
+} from 'zapo-js/signal'
+import {
+    encodeSignalSessionRecord,
+    decodeSignalSessionRecord,
+    toSignalAddressParts,
+    type SignalAddressParts
+} from 'zapo-js/signal'
+import type { WaSignalStore, WaSignalMetaSnapshot } from 'zapo-js/store'
+
+import { BasePgStore } from './BasePgStore'
+import { queryFirst, queryRows, safeLimit, toBytes, toBytesOrNull, type PgRow } from './helpers'
+import type { PgParam, WaPgStorageOptions } from './types'
+
+const BATCH_SIZE = 250
+
+export class WaSignalPgStore extends BasePgStore implements WaSignalStore {
+    public constructor(options: WaPgStorageOptions) {
+        super(options, ['signal'])
+    }
+
+    // ── Registration ──────────────────────────────────────────────────
+
+    public async getRegistrationInfo(): Promise<RegistrationInfo | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('signal_get_reg'),
+                text: `SELECT registration_id, identity_pub_key, identity_priv_key
+                 FROM ${this.t('signal_registration')}
+                 WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+        )
+        if (!row) return null
+        return {
+            registrationId: Number(row.registration_id),
+            identityKeyPair: {
+                pubKey: toBytes(row.identity_pub_key),
+                privKey: toBytes(row.identity_priv_key)
+            }
+        }
+    }
+
+    public async setRegistrationInfo(info: RegistrationInfo): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('signal_set_reg'),
+            text: `INSERT INTO ${this.t('signal_registration')} (
+                session_id, registration_id, identity_pub_key, identity_priv_key
+            ) VALUES ($1, $2, $3, $4)
+            ON CONFLICT (session_id) DO UPDATE SET
+                registration_id = EXCLUDED.registration_id,
+                identity_pub_key = EXCLUDED.identity_pub_key,
+                identity_priv_key = EXCLUDED.identity_priv_key`,
+            values: [
+                this.sessionId,
+                info.registrationId,
+                info.identityKeyPair.pubKey,
+                info.identityKeyPair.privKey
+            ]
+        })
+    }
+
+    // ── Signed PreKey ─────────────────────────────────────────────────
+
+    public async getSignedPreKey(): Promise<SignedPreKeyRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('signal_get_signed_pk'),
+                text: `SELECT key_id, pub_key, priv_key, signature, uploaded
+                 FROM ${this.t('signal_signed_prekey')}
+                 WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+        )
+        if (!row) return null
+        return this.decodeSignedPreKeyRow(row)
+    }
+
+    public async setSignedPreKey(record: SignedPreKeyRecord): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('signal_set_signed_pk'),
+            text: `INSERT INTO ${this.t('signal_signed_prekey')} (
+                session_id, key_id, pub_key, priv_key, signature, uploaded
+            ) VALUES ($1, $2, $3, $4, $5, $6)
+            ON CONFLICT (session_id) DO UPDATE SET
+                key_id = EXCLUDED.key_id,
+                pub_key = EXCLUDED.pub_key,
+                priv_key = EXCLUDED.priv_key,
+                signature = EXCLUDED.signature,
+                uploaded = EXCLUDED.uploaded`,
+            values: [
+                this.sessionId,
+                record.keyId,
+                record.keyPair.pubKey,
+                record.keyPair.privKey,
+                record.signature,
+                record.uploaded === true ? 1 : 0
+            ]
+        })
+    }
+
+    public async getSignedPreKeyById(keyId: number): Promise<SignedPreKeyRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('signal_get_signed_pk_by_id'),
+                text: `SELECT key_id, pub_key, priv_key, signature, uploaded
+                 FROM ${this.t('signal_signed_prekey')}
+                 WHERE session_id = $1 AND key_id = $2`,
+                values: [this.sessionId, keyId]
+            })
+        )
+        if (!row) return null
+        return this.decodeSignedPreKeyRow(row)
+    }
+
+    public async setSignedPreKeyRotationTs(value: number | null): Promise<void> {
+        await this.withTransaction(async (client) => {
+            await this.ensureMetaRow(client)
+            await client.query({
+                name: this.stmtName('signal_set_spk_rotation_ts'),
+                text: `UPDATE ${this.t('signal_meta')}
+                 SET signed_prekey_rotation_ts = $1
+                 WHERE session_id = $2`,
+                values: [value, this.sessionId]
+            })
+        })
+    }
+
+    public async getSignedPreKeyRotationTs(): Promise<number | null> {
+        const meta = await this.withTransaction(async (client) => this.getMeta(client))
+        return meta.signedPreKeyRotationTs
+    }
+
+    // ── PreKeys ───────────────────────────────────────────────────────
+
+    public async putPreKey(record: PreKeyRecord): Promise<void> {
+        await this.withTransaction(async (client) => {
+            await this.ensureMetaRow(client)
+            await this.upsertPreKey(client, record)
+            await client.query({
+                name: this.stmtName('signal_update_next_prekey_id'),
+                text: `UPDATE ${this.t('signal_meta')}
+                 SET next_prekey_id = GREATEST(next_prekey_id, $1)
+                 WHERE session_id = $2`,
+                values: [record.keyId + 1, this.sessionId]
+            })
+        })
+    }
+
+    public async getOrGenPreKeys(
+        count: number,
+        generator: (keyId: number) => PreKeyRecord | Promise<PreKeyRecord>
+    ): Promise<readonly PreKeyRecord[]> {
+        if (!Number.isSafeInteger(count) || count <= 0) {
+            throw new Error(`invalid prekey count: ${count}`)
+        }
+
+        while (true) {
+            const reservation = await this.withTransaction(async (client) => {
+                await this.ensureMetaRow(client)
+                const available = await this.selectAvailablePreKeys(client, count)
+                const missing = count - available.length
+                if (missing <= 0) {
+                    return { available, reservedKeyIds: [] as number[] }
+                }
+                const meta = await this.getMeta(client)
+                const reservedKeyIds = Array.from(
+                    { length: missing },
+                    (_, i) => meta.nextPreKeyId + i
+                )
+                await client.query({
+                    name: this.stmtName('signal_update_next_prekey_id'),
+                    text: `UPDATE ${this.t('signal_meta')}
+                     SET next_prekey_id = GREATEST(next_prekey_id, $1)
+                     WHERE session_id = $2`,
+                    values: [meta.nextPreKeyId + missing, this.sessionId]
+                })
+                return { available, reservedKeyIds }
+            })
+
+            if (reservation.reservedKeyIds.length === 0) {
+                return reservation.available
+            }
+
+            const generated: PreKeyRecord[] = []
+            let maxId = reservation.reservedKeyIds[reservation.reservedKeyIds.length - 1]
+            for (const keyId of reservation.reservedKeyIds) {
+                const record = await generator(keyId)
+                generated.push(record)
+                if (record.keyId > maxId) {
+                    maxId = record.keyId
+                }
+            }
+
+            await this.withTransaction(async (client) => {
+                await this.ensureMetaRow(client)
+                for (const record of generated) {
+                    await client.query({
+                        name: this.stmtName('signal_insert_prekey_noop'),
+                        text: `INSERT INTO ${this.t('signal_prekey')} (
+                            session_id, key_id, pub_key, priv_key, uploaded
+                        ) VALUES ($1, $2, $3, $4, $5)
+                        ON CONFLICT (session_id, key_id) DO NOTHING`,
+                        values: [
+                            this.sessionId,
+                            record.keyId,
+                            record.keyPair.pubKey,
+                            record.keyPair.privKey,
+                            record.uploaded === true ? 1 : 0
+                        ]
+                    })
+                }
+                await client.query({
+                    name: this.stmtName('signal_update_next_prekey_id'),
+                    text: `UPDATE ${this.t('signal_meta')}
+                     SET next_prekey_id = GREATEST(next_prekey_id, $1)
+                     WHERE session_id = $2`,
+                    values: [maxId + 1, this.sessionId]
+                })
+            })
+
+            const available = await this.withTransaction(async (client) =>
+                this.selectAvailablePreKeys(client, count)
+            )
+            if (available.length >= count) {
+                return available
+            }
+        }
+    }
+
+    public async getPreKeyById(keyId: number): Promise<PreKeyRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('signal_get_prekey_by_id'),
+                text: `SELECT key_id, pub_key, priv_key, uploaded
+                 FROM ${this.t('signal_prekey')}
+                 WHERE session_id = $1 AND key_id = $2`,
+                values: [this.sessionId, keyId]
+            })
+        )
+        if (!row) return null
+        return this.decodePreKeyRow(row)
+    }
+
+    public async getPreKeysById(
+        keyIds: readonly number[]
+    ): Promise<readonly (PreKeyRecord | null)[]> {
+        if (keyIds.length === 0) return []
+        await this.ensureReady()
+        const uniqueKeyIds = [...new Set(keyIds)]
+        const byId = new Map<number, PreKeyRecord>()
+        for (let start = 0; start < uniqueKeyIds.length; start += BATCH_SIZE) {
+            const batch = uniqueKeyIds.slice(start, start + BATCH_SIZE)
+            let paramIdx = 2
+            const placeholders = batch.map(() => `$${paramIdx++}`).join(', ')
+            const params: PgParam[] = [this.sessionId, ...batch]
+            const rows = queryRows(
+                await this.pool.query(
+                    `SELECT key_id, pub_key, priv_key, uploaded
+                     FROM ${this.t('signal_prekey')}
+                     WHERE session_id = $1 AND key_id IN (${placeholders})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                const record = this.decodePreKeyRow(row)
+                byId.set(record.keyId, record)
+            }
+        }
+        return keyIds.map((id) => byId.get(id) ?? null)
+    }
+
+    public async consumePreKeyById(keyId: number): Promise<PreKeyRecord | null> {
+        return this.withTransaction(async (client) => {
+            const row = queryFirst(
+                await client.query({
+                    name: this.stmtName('signal_consume_prekey_select'),
+                    text: `SELECT key_id, pub_key, priv_key, uploaded
+                     FROM ${this.t('signal_prekey')}
+                     WHERE session_id = $1 AND key_id = $2
+                     FOR UPDATE`,
+                    values: [this.sessionId, keyId]
+                })
+            )
+            if (!row) return null
+            await client.query({
+                name: this.stmtName('signal_consume_prekey_delete'),
+                text: `DELETE FROM ${this.t('signal_prekey')}
+                 WHERE session_id = $1 AND key_id = $2`,
+                values: [this.sessionId, keyId]
+            })
+            return this.decodePreKeyRow(row)
+        })
+    }
+
+    public async getOrGenSinglePreKey(
+        generator: (keyId: number) => PreKeyRecord | Promise<PreKeyRecord>
+    ): Promise<PreKeyRecord> {
+        const records = await this.getOrGenPreKeys(1, generator)
+        return records[0]
+    }
+
+    public async markKeyAsUploaded(keyId: number): Promise<void> {
+        await this.ensureReady()
+        const meta = await this.withTransaction(async (client) => this.getMeta(client))
+        if (keyId < 0 || keyId >= meta.nextPreKeyId) {
+            throw new Error(`prekey ${keyId} is out of boundary`)
+        }
+        await this.pool.query({
+            name: this.stmtName('signal_mark_key_uploaded'),
+            text: `UPDATE ${this.t('signal_prekey')}
+             SET uploaded = 1
+             WHERE session_id = $1 AND key_id <= $2`,
+            values: [this.sessionId, keyId]
+        })
+    }
+
+    // ── Server State ──────────────────────────────────────────────────
+
+    public async setServerHasPreKeys(value: boolean): Promise<void> {
+        await this.withTransaction(async (client) => {
+            await this.ensureMetaRow(client)
+            await client.query({
+                name: this.stmtName('signal_set_server_has_prekeys'),
+                text: `UPDATE ${this.t('signal_meta')}
+                 SET server_has_prekeys = $1
+                 WHERE session_id = $2`,
+                values: [value ? 1 : 0, this.sessionId]
+            })
+        })
+    }
+
+    public async getServerHasPreKeys(): Promise<boolean> {
+        const meta = await this.withTransaction(async (client) => this.getMeta(client))
+        return meta.serverHasPreKeys
+    }
+
+    // ── Meta ──────────────────────────────────────────────────────────
+
+    public async getSignalMeta(): Promise<WaSignalMetaSnapshot> {
+        return this.withTransaction(async (client) => {
+            await this.ensureMetaRow(client)
+            const row = queryFirst(
+                await client.query({
+                    name: this.stmtName('signal_get_meta_snapshot'),
+                    text: `SELECT
+                        m.server_has_prekeys AS server_has_prekeys,
+                        m.signed_prekey_rotation_ts AS signed_prekey_rotation_ts,
+                        r.registration_id AS registration_id,
+                        r.identity_pub_key AS identity_pub_key,
+                        r.identity_priv_key AS identity_priv_key,
+                        s.key_id AS signed_key_id,
+                        s.pub_key AS signed_pub_key,
+                        s.priv_key AS signed_priv_key,
+                        s.signature AS signed_signature,
+                        s.uploaded AS signed_uploaded
+                     FROM ${this.t('signal_meta')} AS m
+                     LEFT JOIN ${this.t('signal_registration')} AS r
+                        ON r.session_id = m.session_id
+                     LEFT JOIN ${this.t('signal_signed_prekey')} AS s
+                        ON s.session_id = m.session_id
+                     WHERE m.session_id = $1`,
+                    values: [this.sessionId]
+                })
+            )
+            if (!row) {
+                throw new Error('signal meta row not found')
+            }
+
+            const registrationId =
+                row.registration_id !== null ? Number(row.registration_id) : undefined
+            const registrationPubKey = toBytesOrNull(row.identity_pub_key)
+            const registrationPrivKey = toBytesOrNull(row.identity_priv_key)
+            const registrationInfo: RegistrationInfo | null =
+                registrationId !== undefined && registrationPubKey && registrationPrivKey
+                    ? {
+                          registrationId,
+                          identityKeyPair: {
+                              pubKey: registrationPubKey,
+                              privKey: registrationPrivKey
+                          }
+                      }
+                    : null
+
+            const signedKeyId = row.signed_key_id !== null ? Number(row.signed_key_id) : undefined
+            const signedPubKey = toBytesOrNull(row.signed_pub_key)
+            const signedPrivKey = toBytesOrNull(row.signed_priv_key)
+            const signedSignature = toBytesOrNull(row.signed_signature)
+            const signedPreKey: SignedPreKeyRecord | null =
+                signedKeyId !== undefined && signedPubKey && signedPrivKey && signedSignature
+                    ? {
+                          keyId: signedKeyId,
+                          keyPair: { pubKey: signedPubKey, privKey: signedPrivKey },
+                          signature: signedSignature,
+                          uploaded:
+                              row.signed_uploaded !== null
+                                  ? Number(row.signed_uploaded) === 1
+                                  : undefined
+                      }
+                    : null
+
+            return {
+                serverHasPreKeys: Number(row.server_has_prekeys) === 1,
+                signedPreKeyRotationTs:
+                    row.signed_prekey_rotation_ts !== null
+                        ? Number(row.signed_prekey_rotation_ts)
+                        : null,
+                registrationInfo,
+                signedPreKey
+            }
+        })
+    }
+
+    // ── Sessions ──────────────────────────────────────────────────────
+
+    public async hasSession(address: SignalAddress): Promise<boolean> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(address)
+        return (
+            queryRows(
+                await this.pool.query({
+                    name: this.stmtName('signal_has_session'),
+                    text: `SELECT 1 AS has_session
+                     FROM ${this.t('signal_session')}
+                     WHERE session_id = $1 AND "user" = $2 AND server = $3 AND device = $4
+                     LIMIT 1`,
+                    values: [this.sessionId, target.user, target.server, target.device]
+                })
+            ).length > 0
+        )
+    }
+
+    public async hasSessions(addresses: readonly SignalAddress[]): Promise<readonly boolean[]> {
+        if (addresses.length === 0) return []
+        await this.ensureReady()
+        const targets = addresses.map((a) => toSignalAddressParts(a))
+        const existingKeys = new Set<string>()
+        for (let start = 0; start < targets.length; start += BATCH_SIZE) {
+            const batch = targets.slice(start, start + BATCH_SIZE)
+            let paramIdx = 2
+            const addrClauses = batch
+                .map(() => {
+                    const clause = `("user" = $${paramIdx} AND server = $${paramIdx + 1} AND device = $${paramIdx + 2})`
+                    paramIdx += 3
+                    return clause
+                })
+                .join(' OR ')
+            const params: PgParam[] = [
+                this.sessionId,
+                ...batch.flatMap((t) => [t.user, t.server, t.device])
+            ]
+            const rows = queryRows(
+                await this.pool.query(
+                    `SELECT "user", server, device
+                     FROM ${this.t('signal_session')}
+                     WHERE session_id = $1 AND (${addrClauses})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                existingKeys.add(
+                    signalAddressKey({
+                        user: String(row.user),
+                        server: String(row.server),
+                        device: Number(row.device)
+                    })
+                )
+            }
+        }
+        return targets.map((t) => existingKeys.has(signalAddressKey(t)))
+    }
+
+    public async getSession(address: SignalAddress): Promise<SignalSessionRecord | null> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(address)
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('signal_get_session'),
+                text: `SELECT record
+                 FROM ${this.t('signal_session')}
+                 WHERE session_id = $1 AND "user" = $2 AND server = $3 AND device = $4`,
+                values: [this.sessionId, target.user, target.server, target.device]
+            })
+        )
+        if (!row) return null
+        return decodeSignalSessionRecord(toBytes(row.record))
+    }
+
+    public async getSessionsBatch(
+        addresses: readonly SignalAddress[]
+    ): Promise<readonly (SignalSessionRecord | null)[]> {
+        if (addresses.length === 0) return []
+        await this.ensureReady()
+        const targets = addresses.map((a) => toSignalAddressParts(a))
+        const byKey = new Map<string, SignalSessionRecord>()
+        for (let start = 0; start < targets.length; start += BATCH_SIZE) {
+            const batch = targets.slice(start, start + BATCH_SIZE)
+            let paramIdx = 2
+            const addrClauses = batch
+                .map(() => {
+                    const clause = `("user" = $${paramIdx} AND server = $${paramIdx + 1} AND device = $${paramIdx + 2})`
+                    paramIdx += 3
+                    return clause
+                })
+                .join(' OR ')
+            const params: PgParam[] = [
+                this.sessionId,
+                ...batch.flatMap((t) => [t.user, t.server, t.device])
+            ]
+            const rows = queryRows(
+                await this.pool.query(
+                    `SELECT "user", server, device, record
+                     FROM ${this.t('signal_session')}
+                     WHERE session_id = $1 AND (${addrClauses})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                byKey.set(
+                    signalAddressKey({
+                        user: String(row.user),
+                        server: String(row.server),
+                        device: Number(row.device)
+                    }),
+                    decodeSignalSessionRecord(toBytes(row.record))
+                )
+            }
+        }
+        return targets.map((t) => byKey.get(signalAddressKey(t)) ?? null)
+    }
+
+    public async setSession(address: SignalAddress, session: SignalSessionRecord): Promise<void> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(address)
+        await this.upsertSession(this.pool, target, session)
+    }
+
+    public async setSessionsBatch(
+        entries: readonly {
+            readonly address: SignalAddress
+            readonly session: SignalSessionRecord
+        }[]
+    ): Promise<void> {
+        if (entries.length === 0) return
+        await this.withTransaction(async (client) => {
+            for (const entry of entries) {
+                const target = toSignalAddressParts(entry.address)
+                await this.upsertSession(client, target, entry.session)
+            }
+        })
+    }
+
+    public async deleteSession(address: SignalAddress): Promise<void> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(address)
+        await this.pool.query({
+            name: this.stmtName('signal_delete_session'),
+            text: `DELETE FROM ${this.t('signal_session')}
+             WHERE session_id = $1 AND "user" = $2 AND server = $3 AND device = $4`,
+            values: [this.sessionId, target.user, target.server, target.device]
+        })
+    }
+
+    // ── Identities ────────────────────────────────────────────────────
+
+    public async getRemoteIdentity(address: SignalAddress): Promise<Uint8Array | null> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(address)
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('signal_get_remote_identity'),
+                text: `SELECT identity_key
+                 FROM ${this.t('signal_identity')}
+                 WHERE session_id = $1 AND "user" = $2 AND server = $3 AND device = $4`,
+                values: [this.sessionId, target.user, target.server, target.device]
+            })
+        )
+        if (!row) return null
+        return toBytes(row.identity_key)
+    }
+
+    public async getRemoteIdentities(
+        addresses: readonly SignalAddress[]
+    ): Promise<readonly (Uint8Array | null)[]> {
+        if (addresses.length === 0) return []
+        await this.ensureReady()
+        const targets = addresses.map((a) => toSignalAddressParts(a))
+        const byKey = new Map<string, Uint8Array>()
+        for (let start = 0; start < targets.length; start += BATCH_SIZE) {
+            const batch = targets.slice(start, start + BATCH_SIZE)
+            let paramIdx = 2
+            const addrClauses = batch
+                .map(() => {
+                    const clause = `("user" = $${paramIdx} AND server = $${paramIdx + 1} AND device = $${paramIdx + 2})`
+                    paramIdx += 3
+                    return clause
+                })
+                .join(' OR ')
+            const params: PgParam[] = [
+                this.sessionId,
+                ...batch.flatMap((t) => [t.user, t.server, t.device])
+            ]
+            const rows = queryRows(
+                await this.pool.query(
+                    `SELECT "user", server, device, identity_key
+                     FROM ${this.t('signal_identity')}
+                     WHERE session_id = $1 AND (${addrClauses})`,
+                    params
+                )
+            )
+            for (const row of rows) {
+                byKey.set(
+                    signalAddressKey({
+                        user: String(row.user),
+                        server: String(row.server),
+                        device: Number(row.device)
+                    }),
+                    toBytes(row.identity_key)
+                )
+            }
+        }
+        return targets.map((t) => byKey.get(signalAddressKey(t)) ?? null)
+    }
+
+    public async setRemoteIdentity(address: SignalAddress, identityKey: Uint8Array): Promise<void> {
+        await this.ensureReady()
+        const target = toSignalAddressParts(address)
+        await this.upsertRemoteIdentity(this.pool, target, identityKey)
+    }
+
+    public async setRemoteIdentities(
+        entries: readonly {
+            readonly address: SignalAddress
+            readonly identityKey: Uint8Array
+        }[]
+    ): Promise<void> {
+        if (entries.length === 0) return
+        await this.withTransaction(async (client) => {
+            for (const entry of entries) {
+                const target = toSignalAddressParts(entry.address)
+                await this.upsertRemoteIdentity(client, target, entry.identityKey)
+            }
+        })
+    }
+
+    // ── Clear ─────────────────────────────────────────────────────────
+
+    public async clear(): Promise<void> {
+        await this.withTransaction(async (client) => {
+            await client.query({
+                name: this.stmtName('signal_clear_registration'),
+                text: `DELETE FROM ${this.t('signal_registration')} WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+            await client.query({
+                name: this.stmtName('signal_clear_signed_prekey'),
+                text: `DELETE FROM ${this.t('signal_signed_prekey')} WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+            await client.query({
+                name: this.stmtName('signal_clear_prekey'),
+                text: `DELETE FROM ${this.t('signal_prekey')} WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+            await client.query({
+                name: this.stmtName('signal_clear_session'),
+                text: `DELETE FROM ${this.t('signal_session')} WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+            await client.query({
+                name: this.stmtName('signal_clear_identity'),
+                text: `DELETE FROM ${this.t('signal_identity')} WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+            await client.query({
+                name: this.stmtName('signal_clear_meta'),
+                text: `DELETE FROM ${this.t('signal_meta')} WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+        })
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────
+
+    private async ensureMetaRow(client: PoolClient): Promise<void> {
+        await client.query({
+            name: this.stmtName('signal_ensure_meta'),
+            text: `INSERT INTO ${this.t('signal_meta')} (
+                session_id, server_has_prekeys, next_prekey_id
+            ) VALUES ($1, 0, 1)
+            ON CONFLICT (session_id) DO NOTHING`,
+            values: [this.sessionId]
+        })
+    }
+
+    private async getMeta(client: PoolClient): Promise<{
+        serverHasPreKeys: boolean
+        nextPreKeyId: number
+        signedPreKeyRotationTs: number | null
+    }> {
+        await this.ensureMetaRow(client)
+        const row = queryFirst(
+            await client.query({
+                name: this.stmtName('signal_get_meta'),
+                text: `SELECT server_has_prekeys, next_prekey_id, signed_prekey_rotation_ts
+                 FROM ${this.t('signal_meta')}
+                 WHERE session_id = $1`,
+                values: [this.sessionId]
+            })
+        )
+        if (!row) throw new Error('signal meta row not found')
+        return {
+            serverHasPreKeys: Number(row.server_has_prekeys) === 1,
+            nextPreKeyId: Number(row.next_prekey_id),
+            signedPreKeyRotationTs:
+                row.signed_prekey_rotation_ts !== null
+                    ? Number(row.signed_prekey_rotation_ts)
+                    : null
+        }
+    }
+
+    private async selectAvailablePreKeys(
+        client: PoolClient,
+        limit: number
+    ): Promise<PreKeyRecord[]> {
+        const resolved = safeLimit(limit, 100)
+        return queryRows(
+            await client.query({
+                name: this.stmtName('signal_select_available_prekeys'),
+                text: `SELECT key_id, pub_key, priv_key, uploaded
+                 FROM ${this.t('signal_prekey')}
+                 WHERE session_id = $1 AND uploaded = 0
+                 ORDER BY key_id ASC
+                 LIMIT $2`,
+                values: [this.sessionId, resolved]
+            })
+        ).map((row) => this.decodePreKeyRow(row))
+    }
+
+    private async upsertPreKey(client: PoolClient, record: PreKeyRecord): Promise<void> {
+        await client.query({
+            name: this.stmtName('signal_upsert_prekey'),
+            text: `INSERT INTO ${this.t('signal_prekey')} (
+                session_id, key_id, pub_key, priv_key, uploaded
+            ) VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (session_id, key_id) DO UPDATE SET
+                pub_key = EXCLUDED.pub_key,
+                priv_key = EXCLUDED.priv_key,
+                uploaded = EXCLUDED.uploaded`,
+            values: [
+                this.sessionId,
+                record.keyId,
+                record.keyPair.pubKey,
+                record.keyPair.privKey,
+                record.uploaded === true ? 1 : 0
+            ]
+        })
+    }
+
+    private async upsertSession(
+        executor: { query: PoolClient['query'] },
+        target: SignalAddressParts,
+        session: SignalSessionRecord
+    ): Promise<void> {
+        await executor.query({
+            name: this.stmtName('signal_upsert_session'),
+            text: `INSERT INTO ${this.t('signal_session')} (
+                session_id, "user", server, device, record
+            ) VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (session_id, "user", server, device) DO UPDATE SET
+                record = EXCLUDED.record`,
+            values: [
+                this.sessionId,
+                target.user,
+                target.server,
+                target.device,
+                encodeSignalSessionRecord(session)
+            ]
+        })
+    }
+
+    private async upsertRemoteIdentity(
+        executor: { query: PoolClient['query'] },
+        target: SignalAddressParts,
+        identityKey: Uint8Array
+    ): Promise<void> {
+        await executor.query({
+            name: this.stmtName('signal_upsert_remote_identity'),
+            text: `INSERT INTO ${this.t('signal_identity')} (
+                session_id, "user", server, device, identity_key
+            ) VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (session_id, "user", server, device) DO UPDATE SET
+                identity_key = EXCLUDED.identity_key`,
+            values: [this.sessionId, target.user, target.server, target.device, identityKey]
+        })
+    }
+
+    private decodePreKeyRow(row: PgRow): PreKeyRecord {
+        return {
+            keyId: Number(row.key_id),
+            keyPair: {
+                pubKey: toBytes(row.pub_key),
+                privKey: toBytes(row.priv_key)
+            },
+            uploaded: row.uploaded !== null ? Number(row.uploaded) === 1 : undefined
+        }
+    }
+
+    private decodeSignedPreKeyRow(row: PgRow): SignedPreKeyRecord {
+        return {
+            keyId: Number(row.key_id),
+            keyPair: {
+                pubKey: toBytes(row.pub_key),
+                privKey: toBytes(row.priv_key)
+            },
+            signature: toBytes(row.signature),
+            uploaded: row.uploaded !== null ? Number(row.uploaded) === 1 : undefined
+        }
+    }
+}

--- a/packages/store-postgres/src/thread.store.ts
+++ b/packages/store-postgres/src/thread.store.ts
@@ -1,0 +1,143 @@
+import type { WaThreadStore, WaStoredThreadRecord } from 'zapo-js/store'
+
+import { BasePgStore } from './BasePgStore'
+import { affectedRows, queryFirst, queryRows, safeLimit, type PgRow } from './helpers'
+import type { WaPgStorageOptions } from './types'
+
+function rowToRecord(row: PgRow): WaStoredThreadRecord {
+    return {
+        jid: row.jid as string,
+        name: (row.name as string | null) ?? undefined,
+        unreadCount: row.unread_count !== null ? Number(row.unread_count) : undefined,
+        archived: row.archived === null ? undefined : Boolean(row.archived),
+        pinned: row.pinned !== null ? Number(row.pinned) : undefined,
+        muteEndMs: row.mute_end_ms !== null ? Number(row.mute_end_ms) : undefined,
+        markedAsUnread: row.marked_as_unread === null ? undefined : Boolean(row.marked_as_unread),
+        ephemeralExpiration:
+            row.ephemeral_expiration !== null ? Number(row.ephemeral_expiration) : undefined
+    }
+}
+
+export class WaThreadPgStore extends BasePgStore implements WaThreadStore {
+    public constructor(options: WaPgStorageOptions) {
+        super(options, ['mailbox'])
+    }
+
+    public async upsert(record: WaStoredThreadRecord): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('thread_upsert'),
+            text: `INSERT INTO ${this.t('mailbox_threads')} (
+                session_id, jid, name, unread_count, archived, pinned,
+                mute_end_ms, marked_as_unread, ephemeral_expiration
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (session_id, jid) DO UPDATE SET
+                name = COALESCE(EXCLUDED.name, ${this.t('mailbox_threads')}.name),
+                unread_count = COALESCE(EXCLUDED.unread_count, ${this.t('mailbox_threads')}.unread_count),
+                archived = COALESCE(EXCLUDED.archived, ${this.t('mailbox_threads')}.archived),
+                pinned = COALESCE(EXCLUDED.pinned, ${this.t('mailbox_threads')}.pinned),
+                mute_end_ms = COALESCE(EXCLUDED.mute_end_ms, ${this.t('mailbox_threads')}.mute_end_ms),
+                marked_as_unread = COALESCE(EXCLUDED.marked_as_unread, ${this.t('mailbox_threads')}.marked_as_unread),
+                ephemeral_expiration = COALESCE(EXCLUDED.ephemeral_expiration, ${this.t('mailbox_threads')}.ephemeral_expiration)`,
+            values: [
+                this.sessionId,
+                record.jid,
+                record.name ?? null,
+                record.unreadCount ?? null,
+                record.archived ?? null,
+                record.pinned ?? null,
+                record.muteEndMs ?? null,
+                record.markedAsUnread ?? null,
+                record.ephemeralExpiration ?? null
+            ]
+        })
+    }
+
+    public async upsertBatch(records: readonly WaStoredThreadRecord[]): Promise<void> {
+        if (records.length === 0) return
+
+        await this.withTransaction(async (client) => {
+            for (const record of records) {
+                await client.query({
+                    name: this.stmtName('thread_upsert'),
+                    text: `INSERT INTO ${this.t('mailbox_threads')} (
+                        session_id, jid, name, unread_count, archived, pinned,
+                        mute_end_ms, marked_as_unread, ephemeral_expiration
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                    ON CONFLICT (session_id, jid) DO UPDATE SET
+                        name = COALESCE(EXCLUDED.name, ${this.t('mailbox_threads')}.name),
+                        unread_count = COALESCE(EXCLUDED.unread_count, ${this.t('mailbox_threads')}.unread_count),
+                        archived = COALESCE(EXCLUDED.archived, ${this.t('mailbox_threads')}.archived),
+                        pinned = COALESCE(EXCLUDED.pinned, ${this.t('mailbox_threads')}.pinned),
+                        mute_end_ms = COALESCE(EXCLUDED.mute_end_ms, ${this.t('mailbox_threads')}.mute_end_ms),
+                        marked_as_unread = COALESCE(EXCLUDED.marked_as_unread, ${this.t('mailbox_threads')}.marked_as_unread),
+                        ephemeral_expiration = COALESCE(EXCLUDED.ephemeral_expiration, ${this.t('mailbox_threads')}.ephemeral_expiration)`,
+                    values: [
+                        this.sessionId,
+                        record.jid,
+                        record.name ?? null,
+                        record.unreadCount ?? null,
+                        record.archived ?? null,
+                        record.pinned ?? null,
+                        record.muteEndMs ?? null,
+                        record.markedAsUnread ?? null,
+                        record.ephemeralExpiration ?? null
+                    ]
+                })
+            }
+        })
+    }
+
+    public async getByJid(jid: string): Promise<WaStoredThreadRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('thread_get_by_jid'),
+                text: `SELECT jid, name, unread_count, archived, pinned,
+                    mute_end_ms, marked_as_unread, ephemeral_expiration
+             FROM ${this.t('mailbox_threads')}
+             WHERE session_id = $1 AND jid = $2`,
+                values: [this.sessionId, jid]
+            })
+        )
+        if (!row) return null
+        return rowToRecord(row)
+    }
+
+    public async list(limit?: number): Promise<readonly WaStoredThreadRecord[]> {
+        await this.ensureReady()
+        const resolved = safeLimit(limit, 100)
+        return queryRows(
+            await this.pool.query({
+                name: this.stmtName('thread_list'),
+                text: `SELECT jid, name, unread_count, archived, pinned,
+                    mute_end_ms, marked_as_unread, ephemeral_expiration
+             FROM ${this.t('mailbox_threads')}
+             WHERE session_id = $1
+             LIMIT $2`,
+                values: [this.sessionId, resolved]
+            })
+        ).map(rowToRecord)
+    }
+
+    public async deleteByJid(jid: string): Promise<number> {
+        await this.ensureReady()
+        return affectedRows(
+            await this.pool.query({
+                name: this.stmtName('thread_delete_by_jid'),
+                text: `DELETE FROM ${this.t('mailbox_threads')}
+             WHERE session_id = $1 AND jid = $2`,
+                values: [this.sessionId, jid]
+            })
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureReady()
+        await this.pool.query({
+            name: this.stmtName('thread_clear'),
+            text: `DELETE FROM ${this.t('mailbox_threads')} WHERE session_id = $1`,
+            values: [this.sessionId]
+        })
+    }
+}

--- a/packages/store-postgres/src/types.ts
+++ b/packages/store-postgres/src/types.ts
@@ -1,0 +1,25 @@
+import type { Pool, PoolConfig } from 'pg'
+
+export type PgParam = string | number | bigint | Uint8Array | boolean | null
+
+export type WaPgMigrationDomain =
+    | 'auth'
+    | 'signal'
+    | 'senderKey'
+    | 'appState'
+    | 'retry'
+    | 'mailbox'
+    | 'participants'
+    | 'deviceList'
+    | 'privacyToken'
+
+export interface WaPgStorageOptions {
+    readonly pool: Pool
+    readonly sessionId: string
+    readonly tablePrefix?: string
+}
+
+export interface WaPgCreateStoreOptions {
+    readonly pool: Pool | PoolConfig
+    readonly tablePrefix?: string
+}

--- a/packages/store-postgres/tsconfig.build.cjs.json
+++ b/packages/store-postgres/tsconfig.build.cjs.json
@@ -1,0 +1,27 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "baseUrl": "../..",
+        "paths": {
+            "zapo-js": ["dist/types/index.d.ts"],
+            "zapo-js/store": ["dist/types/store/index.d.ts"],
+            "zapo-js/signal": ["dist/types/signal/index.d.ts"],
+            "zapo-js/auth": ["dist/types/auth/index.d.ts"],
+            "zapo-js/appstate": ["dist/types/appstate/index.d.ts"],
+            "zapo-js/retry": ["dist/types/retry/index.d.ts"],
+            "zapo-js/proto": ["dist/types/proto.d.ts"],
+            "zapo-js/protocol": ["dist/types/protocol/index.d.ts"],
+            "zapo-js/crypto": ["dist/types/crypto/index.d.ts"],
+            "zapo-js/util": ["dist/types/util/index.d.ts"]
+        }
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/store-postgres/tsconfig.json
+++ b/packages/store-postgres/tsconfig.json
@@ -1,0 +1,42 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "types": ["node"],
+        "rootDir": "../..",
+        "baseUrl": "../..",
+        "paths": {
+            "zapo-js": ["src/index.ts"],
+            "zapo-js/store": ["src/store/index.ts"],
+            "zapo-js/signal": ["src/signal/index.ts"],
+            "zapo-js/auth": ["src/auth/index.ts"],
+            "zapo-js/appstate": ["src/appstate/index.ts"],
+            "zapo-js/retry": ["src/retry/index.ts"],
+            "zapo-js/proto": ["src/proto.ts"],
+            "zapo-js/protocol": ["src/protocol/index.ts"],
+            "zapo-js/crypto": ["src/crypto/index.ts"],
+            "zapo-js/util": ["src/util/index.ts"],
+            "@appstate": ["src/appstate/index.ts"],
+            "@appstate/*": ["src/appstate/*"],
+            "@auth": ["src/auth/index.ts"],
+            "@auth/*": ["src/auth/*"],
+            "@crypto": ["src/crypto/index.ts"],
+            "@crypto/*": ["src/crypto/*"],
+            "@infra/*": ["src/infra/*"],
+            "@protocol": ["src/protocol/index.ts"],
+            "@protocol/*": ["src/protocol/*"],
+            "@proto": ["src/proto.ts"],
+            "@retry": ["src/retry/index.ts"],
+            "@retry/*": ["src/retry/*"],
+            "@signal": ["src/signal/index.ts"],
+            "@signal/*": ["src/signal/*"],
+            "@store": ["src/store/index.ts"],
+            "@store/*": ["src/store/*"],
+            "@transport": ["src/transport/index.ts"],
+            "@transport/*": ["src/transport/*"],
+            "@util/*": ["src/util/*"]
+        },
+        "noEmit": true
+    },
+    "include": ["src"],
+    "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
- implement all 11 store contracts backed by PostgreSQL via node-postgres (pg)
- use native PG features: ON CONFLICT DO UPDATE/NOTHING, RETURNING, parameterized LIMIT, BOOLEAN
- add prepared/named statements for all fixed-SQL queries (92 cached statements)
- zero-copy bytea reads via native Buffer (extends Uint8Array)
- lazy per-domain migrations with concurrency-safe tracking
- batch-chunked queries with BATCH_SIZE to avoid oversized IN/OR clauses
- quote "user" as reserved keyword in all SQL
- add createPostgresStore() helper for plug-and-play backend registration
- add PgCleanupPoller with in-flight guard, allSettled, intervalMs validation
- validate tablePrefix and ttlMs in constructors
- wrap multi-table reads in transactions for snapshot isolation
- use SELECT FOR UPDATE on consumePreKeyById to prevent double-consume
- atomic incrementInboundCounter via RETURNING clause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full PostgreSQL storage provider: auth, signal/sender-key, messages, threads, contacts, app state, retry/participants/device-list caches, privacy tokens, and a factory to create per-session stores.
  * Automatic schema migrations and a background cleanup poller for TTL-based cache expiration.

* **Chores**
  * Updated MySQL store description to note MariaDB support.
  * Extended ESLint TypeScript project config to include the new Postgres package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->