### PR TITLE
feat: add @zapo-js/store-redis package with ioredis driver

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,7 +40,8 @@ module.exports = [
                 project: [
                     './packages/store-mysql/tsconfig.json',
                     './packages/store-sqlite/tsconfig.json',
-                    './packages/store-postgres/tsconfig.json'
+                    './packages/store-postgres/tsconfig.json',
+                    './packages/store-redis/tsconfig.json'
                 ]
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1097,6 +1097,13 @@
                 }
             }
         },
+        "node_modules/@ioredis/commands": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+            "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@istanbuljs/schema": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -1268,6 +1275,16 @@
             },
             "engines": {
                 "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/@mongodb-js/saslprep": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
+            "integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sparse-bitfield": "^3.0.3"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -1482,6 +1499,23 @@
                 "@types/node": "*",
                 "pg-protocol": "*",
                 "pg-types": "^2.2.0"
+            }
+        },
+        "node_modules/@types/webidl-conversions": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+            "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/whatwg-url": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+            "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/webidl-conversions": "*"
             }
         },
         "node_modules/@types/ws": {
@@ -1738,12 +1772,20 @@
                 "typescript-eslint": "^8.12.2"
             }
         },
+        "node_modules/@zapo-js/store-mongo": {
+            "resolved": "packages/store-mongo",
+            "link": true
+        },
         "node_modules/@zapo-js/store-mysql": {
             "resolved": "packages/store-mysql",
             "link": true
         },
         "node_modules/@zapo-js/store-postgres": {
             "resolved": "packages/store-postgres",
+            "link": true
+        },
+        "node_modules/@zapo-js/store-redis": {
+            "resolved": "packages/store-redis",
             "link": true
         },
         "node_modules/@zapo-js/store-sqlite": {
@@ -2159,6 +2201,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/bson": {
+            "version": "6.10.4",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+            "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=16.20.1"
+            }
+        },
         "node_modules/buffer": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -2425,6 +2477,16 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/cluster-key-slot": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+            "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/color-convert": {
@@ -4159,6 +4221,31 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/ioredis": {
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+            "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@ioredis/commands": "1.5.1",
+                "cluster-key-slot": "^1.1.0",
+                "debug": "^4.3.4",
+                "denque": "^2.1.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.isarguments": "^3.1.0",
+                "redis-errors": "^1.2.0",
+                "redis-parser": "^3.0.0",
+                "standard-as-callback": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ioredis"
+            }
+        },
         "node_modules/is-array-buffer": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -4777,6 +4864,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.isarguments": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4862,6 +4963,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/memory-pager": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+            "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -4955,6 +5063,64 @@
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/mongodb": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
+            "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@mongodb-js/saslprep": "^1.3.0",
+                "bson": "^6.10.4",
+                "mongodb-connection-string-url": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=16.20.1"
+            },
+            "peerDependencies": {
+                "@aws-sdk/credential-providers": "^3.188.0",
+                "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+                "gcp-metadata": "^5.2.0",
+                "kerberos": "^2.0.1",
+                "mongodb-client-encryption": ">=6.0.0 <7",
+                "snappy": "^7.3.2",
+                "socks": "^2.7.1"
+            },
+            "peerDependenciesMeta": {
+                "@aws-sdk/credential-providers": {
+                    "optional": true
+                },
+                "@mongodb-js/zstd": {
+                    "optional": true
+                },
+                "gcp-metadata": {
+                    "optional": true
+                },
+                "kerberos": {
+                    "optional": true
+                },
+                "mongodb-client-encryption": {
+                    "optional": true
+                },
+                "snappy": {
+                    "optional": true
+                },
+                "socks": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/mongodb-connection-string-url": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+            "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/whatwg-url": "^11.0.2",
+                "whatwg-url": "^14.1.0 || ^13.0.0"
+            }
         },
         "node_modules/mri": {
             "version": "1.2.0",
@@ -5935,6 +6101,29 @@
                 "node": ">= 12.13.0"
             }
         },
+        "node_modules/redis-errors": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/redis-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "redis-errors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/reflect.getprototypeof": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -6439,6 +6628,16 @@
                 "atomic-sleep": "^1.0.0"
             }
         },
+        "node_modules/sparse-bitfield": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+            "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "memory-pager": "^1.0.2"
+            }
+        },
         "node_modules/spawndamnit": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
@@ -6482,6 +6681,13 @@
                 "type": "github",
                 "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
             }
+        },
+        "node_modules/standard-as-callback": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+            "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
@@ -6742,6 +6948,19 @@
             },
             "engines": {
                 "node": ">=8.0"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/ts-api-utils": {
@@ -7055,6 +7274,30 @@
                 "node": ">=10.12.0"
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7283,6 +7526,26 @@
             "resolved": "",
             "link": true
         },
+        "packages/store-mongo": {
+            "name": "@zapo-js/store-mongo",
+            "version": "0.1.0",
+            "devDependencies": {
+                "mongodb": "^6.16.0",
+                "zapo-js": "file:../.."
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "peerDependencies": {
+                "mongodb": ">=6.0.0",
+                "zapo-js": ">=0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "zapo-js": {
+                    "optional": true
+                }
+            }
+        },
         "packages/store-mysql": {
             "name": "@zapo-js/store-mysql",
             "version": "0.1.0",
@@ -7316,6 +7579,26 @@
             },
             "peerDependencies": {
                 "pg": ">=8.0.0",
+                "zapo-js": ">=0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "zapo-js": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/store-redis": {
+            "name": "@zapo-js/store-redis",
+            "version": "0.1.0",
+            "devDependencies": {
+                "ioredis": "^5.6.1",
+                "zapo-js": "file:../.."
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "peerDependencies": {
+                "ioredis": ">=5.0.0",
                 "zapo-js": ">=0.1.0"
             },
             "peerDependenciesMeta": {

--- a/packages/store-redis/package.json
+++ b/packages/store-redis/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "@zapo-js/store-redis",
+    "version": "0.1.0",
+    "description": "Redis store provider for zapo-js",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "require": "./dist/index.js",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": [
+        "dist"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsc -p tsconfig.build.cjs.json",
+        "typecheck": "tsc --noEmit",
+        "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
+    },
+    "peerDependencies": {
+        "zapo-js": ">=0.1.0",
+        "ioredis": ">=5.0.0"
+    },
+    "peerDependenciesMeta": {
+        "zapo-js": {
+            "optional": true
+        }
+    },
+    "devDependencies": {
+        "ioredis": "^5.6.1",
+        "zapo-js": "file:../.."
+    },
+    "engines": {
+        "node": ">=20.9.0"
+    }
+}

--- a/packages/store-redis/src/BaseRedisStore.ts
+++ b/packages/store-redis/src/BaseRedisStore.ts
@@ -1,0 +1,25 @@
+import type Redis from 'ioredis'
+
+import { assertSafeKeyPrefix } from './helpers'
+import type { WaRedisStorageOptions } from './types'
+
+export abstract class BaseRedisStore {
+    protected readonly redis: Redis
+    protected readonly sessionId: string
+    protected readonly keyPrefix: string
+
+    protected constructor(options: WaRedisStorageOptions) {
+        this.redis = options.redis
+        this.sessionId = options.sessionId
+        this.keyPrefix = options.keyPrefix ?? ''
+        assertSafeKeyPrefix(this.keyPrefix)
+    }
+
+    protected k(...parts: readonly string[]): string {
+        return `${this.keyPrefix}${parts.join(':')}`
+    }
+
+    public async destroy(): Promise<void> {
+        // Redis connection is shared, don't close
+    }
+}

--- a/packages/store-redis/src/appstate.store.ts
+++ b/packages/store-redis/src/appstate.store.ts
@@ -1,0 +1,434 @@
+import type {
+    AppStateCollectionName,
+    WaAppStateSyncKey,
+    WaAppStateStoreData
+} from 'zapo-js/appstate'
+import {
+    APP_STATE_EMPTY_LT_HASH,
+    encodeAppStateFingerprint,
+    decodeAppStateFingerprint,
+    keyEpoch
+} from 'zapo-js/appstate'
+import type {
+    WaAppStateStore,
+    WaAppStateCollectionStoreState,
+    WaAppStateCollectionStateUpdate
+} from 'zapo-js/store'
+
+import { BaseRedisStore } from './BaseRedisStore'
+import {
+    bytesToHex,
+    hexToBytes,
+    scanKeys,
+    toBytesOrNull,
+    toRedisBuffer,
+    uint8Equal
+} from './helpers'
+import type { WaRedisStorageOptions } from './types'
+
+export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateStore {
+    public constructor(options: WaRedisStorageOptions) {
+        super(options)
+    }
+
+    public async exportData(): Promise<WaAppStateStoreData> {
+        const keyPattern = this.k('appstate:key', this.sessionId, '*')
+        const colPattern = this.k('appstate:col', this.sessionId, '*')
+        const idxSetPattern = this.k('appstate:idx:set', this.sessionId, '*')
+
+        const [keyKeys, colKeys, idxSetKeys] = await Promise.all([
+            scanKeys(this.redis, keyPattern),
+            scanKeys(this.redis, colPattern),
+            scanKeys(this.redis, idxSetPattern)
+        ])
+
+        const keys: WaAppStateSyncKey[] = []
+        if (keyKeys.length > 0) {
+            // Filter out binary sub-keys (contain :data or :fp suffix)
+            const hashKeys = keyKeys.filter((k) => {
+                const afterPrefix = k.substring(this.k('appstate:key', this.sessionId, '').length)
+                return !afterPrefix.includes(':')
+            })
+
+            if (hashKeys.length > 0) {
+                const pipeline = this.redis.pipeline()
+                for (const k of hashKeys) {
+                    pipeline.hgetall(k)
+                    const prefix = this.k('appstate:key', this.sessionId, '')
+                    const keyIdHex = k.substring(prefix.length)
+                    pipeline.getBuffer(this.k('appstate:key', this.sessionId, keyIdHex, 'data'))
+                    pipeline.getBuffer(this.k('appstate:key', this.sessionId, keyIdHex, 'fp'))
+                }
+                const results = await pipeline.exec()
+                if (results) {
+                    for (let i = 0; i < hashKeys.length; i += 1) {
+                        const base = i * 3
+                        const [err, hashData] = results[base]
+                        if (err || !hashData || typeof hashData !== 'object') continue
+                        const record = hashData as Record<string, string>
+                        if (Object.keys(record).length === 0) continue
+                        const keyData = toBytesOrNull(results[base + 1][1])
+                        if (!keyData) continue
+                        const fingerprint = toBytesOrNull(results[base + 2][1])
+                        keys.push({
+                            keyId: hexToBytes(record.key_id_hex),
+                            keyData,
+                            timestamp: Number(record.timestamp),
+                            fingerprint: decodeAppStateFingerprint(fingerprint)
+                        })
+                    }
+                }
+            }
+        }
+
+        const collections: WaAppStateStoreData['collections'] = {}
+        if (colKeys.length > 0) {
+            // Filter out binary sub-keys (contain :hash suffix)
+            const hashColKeys = colKeys.filter((k) => {
+                const afterPrefix = k.substring(this.k('appstate:col', this.sessionId, '').length)
+                return !afterPrefix.includes(':')
+            })
+
+            if (hashColKeys.length > 0) {
+                const pipeline = this.redis.pipeline()
+                for (const k of hashColKeys) {
+                    const prefix = this.k('appstate:col', this.sessionId, '')
+                    const collection = k.substring(prefix.length)
+                    pipeline.hgetall(k)
+                    pipeline.getBuffer(this.k('appstate:col', this.sessionId, collection, 'hash'))
+                }
+                const results = await pipeline.exec()
+                if (results) {
+                    for (let i = 0; i < hashColKeys.length; i += 1) {
+                        const base = i * 2
+                        const [err, hashData] = results[base]
+                        if (err || !hashData || typeof hashData !== 'object') continue
+                        const record = hashData as Record<string, string>
+                        if (Object.keys(record).length === 0) continue
+                        const hashBytes = toBytesOrNull(results[base + 1][1])
+                        if (!hashBytes) continue
+                        const prefix = this.k('appstate:col', this.sessionId, '')
+                        const collection = hashColKeys[i].substring(
+                            prefix.length
+                        ) as AppStateCollectionName
+                        collections[collection] = {
+                            version: Number(record.version),
+                            hash: hashBytes,
+                            indexValueMap: {}
+                        }
+                    }
+                }
+            }
+        }
+
+        if (idxSetKeys.length > 0) {
+            for (const setKey of idxSetKeys) {
+                const prefix = this.k('appstate:idx:set', this.sessionId, '')
+                const collection = setKey.substring(prefix.length) as AppStateCollectionName
+                const entry = collections[collection]
+                if (!entry) continue
+
+                const indexMacs = await this.redis.smembers(setKey)
+                if (indexMacs.length === 0) continue
+
+                const valuePipeline = this.redis.pipeline()
+                for (const macHex of indexMacs) {
+                    valuePipeline.getBuffer(
+                        this.k('appstate:idx', this.sessionId, collection, macHex)
+                    )
+                }
+                const valueResults = await valuePipeline.exec()
+                if (valueResults) {
+                    const map = entry.indexValueMap as Record<string, Uint8Array>
+                    for (let j = 0; j < valueResults.length; j += 1) {
+                        const [err, data] = valueResults[j]
+                        if (err || !data) continue
+                        map[indexMacs[j]] = new Uint8Array(data as Uint8Array)
+                    }
+                }
+            }
+        }
+
+        return { keys, collections }
+    }
+
+    public async upsertSyncKeys(syncKeys: readonly WaAppStateSyncKey[]): Promise<number> {
+        if (syncKeys.length === 0) return 0
+
+        const idxKey = this.k('appstate:key:idx', this.sessionId)
+        let inserted = 0
+
+        const existingPipeline = this.redis.pipeline()
+        for (const sk of syncKeys) {
+            const keyIdHex = bytesToHex(sk.keyId)
+            existingPipeline.getBuffer(this.k('appstate:key', this.sessionId, keyIdHex, 'data'))
+        }
+        const existingResults = await existingPipeline.exec()
+
+        const writePipeline = this.redis.pipeline()
+        for (let i = 0; i < syncKeys.length; i += 1) {
+            const sk = syncKeys[i]
+            const keyIdHex = bytesToHex(sk.keyId)
+
+            if (existingResults) {
+                const [err, data] = existingResults[i]
+                if (!err && data) {
+                    const existingData = toBytesOrNull(data)
+                    if (existingData && uint8Equal(existingData, sk.keyData)) {
+                        continue
+                    }
+                }
+            }
+
+            const hashKey = this.k('appstate:key', this.sessionId, keyIdHex)
+            const epoch = keyEpoch(sk.keyId)
+            writePipeline.hset(hashKey, {
+                key_id_hex: keyIdHex,
+                timestamp: String(sk.timestamp),
+                key_epoch: String(epoch)
+            })
+            writePipeline.set(
+                this.k('appstate:key', this.sessionId, keyIdHex, 'data'),
+                toRedisBuffer(sk.keyData)
+            )
+            const fingerprint = encodeAppStateFingerprint(sk.fingerprint)
+            if (fingerprint) {
+                writePipeline.set(
+                    this.k('appstate:key', this.sessionId, keyIdHex, 'fp'),
+                    toRedisBuffer(fingerprint)
+                )
+            }
+            writePipeline.zadd(idxKey, epoch, keyIdHex)
+            inserted += 1
+        }
+
+        if (inserted > 0) {
+            await writePipeline.exec()
+        }
+        return inserted
+    }
+
+    public async getSyncKeysBatch(
+        keyIds: readonly Uint8Array[]
+    ): Promise<readonly (WaAppStateSyncKey | null)[]> {
+        if (keyIds.length === 0) return []
+        const pipeline = this.redis.pipeline()
+        for (const keyId of keyIds) {
+            const keyIdHex = bytesToHex(keyId)
+            pipeline.hgetall(this.k('appstate:key', this.sessionId, keyIdHex))
+            pipeline.getBuffer(this.k('appstate:key', this.sessionId, keyIdHex, 'data'))
+            pipeline.getBuffer(this.k('appstate:key', this.sessionId, keyIdHex, 'fp'))
+        }
+        const results = await pipeline.exec()
+        if (!results) return keyIds.map(() => null)
+
+        return keyIds.map((keyId, index) => {
+            const base = index * 3
+            const [err, hashData] = results[base]
+            if (err || !hashData || typeof hashData !== 'object') return null
+            const record = hashData as Record<string, string>
+            if (Object.keys(record).length === 0) return null
+            const keyData = toBytesOrNull(results[base + 1][1])
+            if (!keyData) return null
+            const fingerprint = toBytesOrNull(results[base + 2][1])
+            return {
+                keyId,
+                keyData,
+                timestamp: Number(record.timestamp),
+                fingerprint: decodeAppStateFingerprint(fingerprint)
+            }
+        })
+    }
+
+    public async getSyncKeyData(keyId: Uint8Array): Promise<Uint8Array | null> {
+        const binKey = this.k('appstate:key', this.sessionId, bytesToHex(keyId), 'data')
+        const raw = await this.redis.getBuffer(binKey)
+        if (!raw) return null
+        return new Uint8Array(raw)
+    }
+
+    public async getSyncKeyDataBatch(
+        keyIds: readonly Uint8Array[]
+    ): Promise<readonly (Uint8Array | null)[]> {
+        if (keyIds.length === 0) return []
+        const pipeline = this.redis.pipeline()
+        for (const keyId of keyIds) {
+            pipeline.getBuffer(this.k('appstate:key', this.sessionId, bytesToHex(keyId), 'data'))
+        }
+        const results = await pipeline.exec()
+        if (!results) return keyIds.map(() => null)
+        return results.map(([err, data]) => {
+            if (err || !data) return null
+            return new Uint8Array(data as Uint8Array)
+        })
+    }
+
+    public async getActiveSyncKey(): Promise<WaAppStateSyncKey | null> {
+        const idxKey = this.k('appstate:key:idx', this.sessionId)
+        const topMembers = await this.redis.zrevrange(idxKey, 0, 0)
+        if (topMembers.length === 0) return null
+
+        const keyIdHex = topMembers[0]
+        const pipeline = this.redis.pipeline()
+        pipeline.hgetall(this.k('appstate:key', this.sessionId, keyIdHex))
+        pipeline.getBuffer(this.k('appstate:key', this.sessionId, keyIdHex, 'data'))
+        pipeline.getBuffer(this.k('appstate:key', this.sessionId, keyIdHex, 'fp'))
+        const results = await pipeline.exec()
+        if (!results) return null
+
+        const [err, hashData] = results[0]
+        if (err || !hashData || typeof hashData !== 'object') return null
+        const data = hashData as Record<string, string>
+        if (Object.keys(data).length === 0) return null
+        const keyData = toBytesOrNull(results[1][1])
+        if (!keyData) return null
+        const fingerprint = toBytesOrNull(results[2][1])
+
+        return {
+            keyId: hexToBytes(keyIdHex),
+            keyData,
+            timestamp: Number(data.timestamp),
+            fingerprint: decodeAppStateFingerprint(fingerprint)
+        }
+    }
+
+    public async getCollectionState(
+        collection: AppStateCollectionName
+    ): Promise<WaAppStateCollectionStoreState> {
+        const colKey = this.k('appstate:col', this.sessionId, collection)
+        const pipeline = this.redis.pipeline()
+        pipeline.hgetall(colKey)
+        pipeline.getBuffer(this.k('appstate:col', this.sessionId, collection, 'hash'))
+        const results = await pipeline.exec()
+
+        if (!results) {
+            return {
+                initialized: false,
+                version: 0,
+                hash: APP_STATE_EMPTY_LT_HASH,
+                indexValueMap: new Map()
+            }
+        }
+
+        const [hashErr, hashData] = results[0]
+        const data = hashData as Record<string, string>
+        if (hashErr || !data || Object.keys(data).length === 0) {
+            return {
+                initialized: false,
+                version: 0,
+                hash: APP_STATE_EMPTY_LT_HASH,
+                indexValueMap: new Map()
+            }
+        }
+
+        const hashBytes = toBytesOrNull(results[1][1])
+        if (!hashBytes) {
+            return {
+                initialized: false,
+                version: 0,
+                hash: APP_STATE_EMPTY_LT_HASH,
+                indexValueMap: new Map()
+            }
+        }
+
+        const idxSetKey = this.k('appstate:idx:set', this.sessionId, collection)
+        const indexMacs = await this.redis.smembers(idxSetKey)
+        const indexValueMap = new Map<string, Uint8Array>()
+
+        if (indexMacs.length > 0) {
+            const idxPipeline = this.redis.pipeline()
+            for (const macHex of indexMacs) {
+                idxPipeline.getBuffer(this.k('appstate:idx', this.sessionId, collection, macHex))
+            }
+            const idxResults = await idxPipeline.exec()
+            if (idxResults) {
+                for (let i = 0; i < idxResults.length; i += 1) {
+                    const [err, val] = idxResults[i]
+                    if (err || !val) continue
+                    indexValueMap.set(indexMacs[i], new Uint8Array(val as Uint8Array))
+                }
+            }
+        }
+
+        return {
+            initialized: true,
+            version: Number(data.version),
+            hash: hashBytes,
+            indexValueMap
+        }
+    }
+
+    public async getCollectionStates(
+        collections: readonly AppStateCollectionName[]
+    ): Promise<readonly WaAppStateCollectionStoreState[]> {
+        if (collections.length === 0) return []
+        const results: WaAppStateCollectionStoreState[] = []
+        for (const collection of collections) {
+            results.push(await this.getCollectionState(collection))
+        }
+        return results
+    }
+
+    public async setCollectionStates(
+        updates: readonly WaAppStateCollectionStateUpdate[]
+    ): Promise<void> {
+        if (updates.length === 0) return
+
+        for (const update of updates) {
+            const colKey = this.k('appstate:col', this.sessionId, update.collection)
+            const idxSetKey = this.k('appstate:idx:set', this.sessionId, update.collection)
+
+            const oldMacs = await this.redis.smembers(idxSetKey)
+
+            const multi = this.redis.multi()
+
+            multi.hset(colKey, {
+                version: String(update.version)
+            })
+            multi.set(
+                this.k('appstate:col', this.sessionId, update.collection, 'hash'),
+                toRedisBuffer(update.hash)
+            )
+
+            if (oldMacs.length > 0) {
+                for (const macHex of oldMacs) {
+                    multi.del(this.k('appstate:idx', this.sessionId, update.collection, macHex))
+                }
+                multi.del(idxSetKey)
+            }
+
+            const newMacs: string[] = []
+            for (const [indexMacHex, valueMac] of update.indexValueMap.entries()) {
+                const idxBinKey = this.k(
+                    'appstate:idx',
+                    this.sessionId,
+                    update.collection,
+                    indexMacHex
+                )
+                multi.set(idxBinKey, toRedisBuffer(valueMac))
+                newMacs.push(indexMacHex)
+            }
+            if (newMacs.length > 0) {
+                multi.sadd(idxSetKey, ...newMacs)
+            }
+
+            await multi.exec()
+        }
+    }
+
+    public async clear(): Promise<void> {
+        const fixedKeys = [this.k('appstate:key:idx', this.sessionId)]
+        const scanPatterns = [
+            this.k('appstate:key', this.sessionId, '*'),
+            this.k('appstate:col', this.sessionId, '*'),
+            this.k('appstate:idx', this.sessionId, '*'),
+            this.k('appstate:idx:set', this.sessionId, '*')
+        ]
+
+        const scannedKeys = await Promise.all(scanPatterns.map((p) => scanKeys(this.redis, p)))
+        const allKeys = [...fixedKeys, ...scannedKeys.flat()]
+        if (allKeys.length > 0) {
+            await this.redis.del(...allKeys)
+        }
+    }
+}

--- a/packages/store-redis/src/auth.store.ts
+++ b/packages/store-redis/src/auth.store.ts
@@ -1,0 +1,209 @@
+import type { WaAuthCredentials } from 'zapo-js/auth'
+import { proto } from 'zapo-js/proto'
+import type { WaAuthStore } from 'zapo-js/store'
+
+import { BaseRedisStore } from './BaseRedisStore'
+import { scanKeys, toBytesOrNull, toRedisBuffer, toStringOrNull } from './helpers'
+import type { WaRedisStorageOptions } from './types'
+
+const BINARY_FIELDS = [
+    'noise_pub_key',
+    'noise_priv_key',
+    'identity_pub_key',
+    'identity_priv_key',
+    'signed_prekey_pub_key',
+    'signed_prekey_priv_key',
+    'signed_prekey_signature',
+    'adv_secret_key',
+    'signed_identity',
+    'companion_enc_static',
+    'server_static_key',
+    'routing_info'
+] as const
+
+export class WaAuthRedisStore extends BaseRedisStore implements WaAuthStore {
+    public constructor(options: WaRedisStorageOptions) {
+        super(options)
+    }
+
+    public async load(): Promise<WaAuthCredentials | null> {
+        const key = this.k('auth', this.sessionId)
+
+        const pipeline = this.redis.pipeline()
+        pipeline.hgetall(key)
+        for (const field of BINARY_FIELDS) {
+            pipeline.getBuffer(`${key}:${field}`)
+        }
+        const results = await pipeline.exec()
+        if (!results) return null
+
+        const data = results[0][1] as Record<string, string>
+        if (!data || Object.keys(data).length === 0) return null
+
+        const bin: Record<string, Uint8Array | null> = {}
+        for (let i = 0; i < BINARY_FIELDS.length; i += 1) {
+            bin[BINARY_FIELDS[i]] = toBytesOrNull(results[i + 1][1])
+        }
+
+        const signedIdentityBytes = bin.signed_identity
+        return {
+            noiseKeyPair: {
+                pubKey: bin.noise_pub_key!,
+                privKey: bin.noise_priv_key!
+            },
+            registrationInfo: {
+                registrationId: Number(data.registration_id),
+                identityKeyPair: {
+                    pubKey: bin.identity_pub_key!,
+                    privKey: bin.identity_priv_key!
+                }
+            },
+            signedPreKey: {
+                keyId: Number(data.signed_prekey_id),
+                keyPair: {
+                    pubKey: bin.signed_prekey_pub_key!,
+                    privKey: bin.signed_prekey_priv_key!
+                },
+                signature: bin.signed_prekey_signature!,
+                uploaded: false
+            },
+            advSecretKey: bin.adv_secret_key!,
+            signedIdentity: signedIdentityBytes
+                ? proto.ADVSignedDeviceIdentity.decode(signedIdentityBytes)
+                : undefined,
+            meJid: toStringOrNull(data.me_jid) ?? undefined,
+            meLid: toStringOrNull(data.me_lid) ?? undefined,
+            meDisplayName: toStringOrNull(data.me_display_name) ?? undefined,
+            companionEncStatic: bin.companion_enc_static ?? undefined,
+            platform: toStringOrNull(data.platform) ?? undefined,
+            serverStaticKey: bin.server_static_key ?? undefined,
+            serverHasPreKeys:
+                toStringOrNull(data.server_has_prekeys) !== null
+                    ? data.server_has_prekeys === '1'
+                    : undefined,
+            routingInfo: bin.routing_info ?? undefined,
+            lastSuccessTs:
+                toStringOrNull(data.last_success_ts) !== null
+                    ? Number(data.last_success_ts)
+                    : undefined,
+            propsVersion:
+                toStringOrNull(data.props_version) !== null
+                    ? Number(data.props_version)
+                    : undefined,
+            abPropsVersion:
+                toStringOrNull(data.ab_props_version) !== null
+                    ? Number(data.ab_props_version)
+                    : undefined,
+            connectionLocation: toStringOrNull(data.connection_location) ?? undefined,
+            accountCreationTs:
+                toStringOrNull(data.account_creation_ts) !== null
+                    ? Number(data.account_creation_ts)
+                    : undefined
+        }
+    }
+
+    public async save(credentials: WaAuthCredentials): Promise<void> {
+        const key = this.k('auth', this.sessionId)
+        const fields: Record<string, string> = {
+            registration_id: String(credentials.registrationInfo.registrationId),
+            signed_prekey_id: String(credentials.signedPreKey.keyId)
+        }
+
+        if (credentials.meJid !== undefined) {
+            fields.me_jid = credentials.meJid
+        }
+        if (credentials.meLid !== undefined) {
+            fields.me_lid = credentials.meLid
+        }
+        if (credentials.meDisplayName !== undefined) {
+            fields.me_display_name = credentials.meDisplayName
+        }
+        if (credentials.platform !== undefined) {
+            fields.platform = credentials.platform
+        }
+        if (credentials.serverHasPreKeys !== undefined) {
+            fields.server_has_prekeys = credentials.serverHasPreKeys ? '1' : '0'
+        }
+        if (credentials.lastSuccessTs !== undefined) {
+            fields.last_success_ts = String(credentials.lastSuccessTs)
+        }
+        if (credentials.propsVersion !== undefined) {
+            fields.props_version = String(credentials.propsVersion)
+        }
+        if (credentials.abPropsVersion !== undefined) {
+            fields.ab_props_version = String(credentials.abPropsVersion)
+        }
+        if (credentials.connectionLocation !== undefined) {
+            fields.connection_location = credentials.connectionLocation
+        }
+        if (credentials.accountCreationTs !== undefined) {
+            fields.account_creation_ts = String(credentials.accountCreationTs)
+        }
+
+        const pipeline = this.redis.pipeline()
+        // Delete existing hash and all binary sub-keys first for a full snapshot rewrite
+        pipeline.del(key)
+        for (const field of BINARY_FIELDS) {
+            pipeline.del(`${key}:${field}`)
+        }
+        pipeline.hset(key, fields)
+
+        // Required binary fields
+        pipeline.set(`${key}:noise_pub_key`, toRedisBuffer(credentials.noiseKeyPair.pubKey))
+        pipeline.set(`${key}:noise_priv_key`, toRedisBuffer(credentials.noiseKeyPair.privKey))
+        pipeline.set(
+            `${key}:identity_pub_key`,
+            toRedisBuffer(credentials.registrationInfo.identityKeyPair.pubKey)
+        )
+        pipeline.set(
+            `${key}:identity_priv_key`,
+            toRedisBuffer(credentials.registrationInfo.identityKeyPair.privKey)
+        )
+        pipeline.set(
+            `${key}:signed_prekey_pub_key`,
+            toRedisBuffer(credentials.signedPreKey.keyPair.pubKey)
+        )
+        pipeline.set(
+            `${key}:signed_prekey_priv_key`,
+            toRedisBuffer(credentials.signedPreKey.keyPair.privKey)
+        )
+        pipeline.set(
+            `${key}:signed_prekey_signature`,
+            toRedisBuffer(credentials.signedPreKey.signature)
+        )
+        pipeline.set(`${key}:adv_secret_key`, toRedisBuffer(credentials.advSecretKey))
+
+        // Optional binary fields
+        if (credentials.signedIdentity) {
+            pipeline.set(
+                `${key}:signed_identity`,
+                toRedisBuffer(
+                    proto.ADVSignedDeviceIdentity.encode(credentials.signedIdentity).finish()
+                )
+            )
+        }
+        if (credentials.companionEncStatic !== undefined) {
+            pipeline.set(
+                `${key}:companion_enc_static`,
+                toRedisBuffer(credentials.companionEncStatic)
+            )
+        }
+        if (credentials.serverStaticKey !== undefined) {
+            pipeline.set(`${key}:server_static_key`, toRedisBuffer(credentials.serverStaticKey))
+        }
+        if (credentials.routingInfo !== undefined) {
+            pipeline.set(`${key}:routing_info`, toRedisBuffer(credentials.routingInfo))
+        }
+
+        await pipeline.exec()
+    }
+
+    public async clear(): Promise<void> {
+        const baseKey = this.k('auth', this.sessionId)
+        const subKeys = await scanKeys(this.redis, `${baseKey}:*`)
+        if (subKeys.length > 0) {
+            await this.redis.del(...subKeys)
+        }
+        await this.redis.del(baseKey)
+    }
+}

--- a/packages/store-redis/src/contact.store.ts
+++ b/packages/store-redis/src/contact.store.ts
@@ -1,0 +1,93 @@
+import type { WaContactStore, WaStoredContactRecord } from 'zapo-js/store'
+
+import { BaseRedisStore } from './BaseRedisStore'
+import { scanKeys, toStringOrNull } from './helpers'
+import type { WaRedisStorageOptions } from './types'
+
+function hashToRecord(data: Record<string, string>): WaStoredContactRecord {
+    return {
+        jid: data.jid,
+        displayName: toStringOrNull(data.display_name) ?? undefined,
+        pushName: toStringOrNull(data.push_name) ?? undefined,
+        lid: toStringOrNull(data.lid) ?? undefined,
+        phoneNumber: toStringOrNull(data.phone_number) ?? undefined,
+        lastUpdatedMs: Number(data.last_updated_ms)
+    }
+}
+
+function recordToHash(record: WaStoredContactRecord): Record<string, string> {
+    const fields: Record<string, string> = {
+        jid: record.jid,
+        last_updated_ms: String(record.lastUpdatedMs)
+    }
+
+    if (record.displayName !== undefined) {
+        fields.display_name = record.displayName
+    }
+    if (record.pushName !== undefined) {
+        fields.push_name = record.pushName
+    }
+    if (record.lid !== undefined) {
+        fields.lid = record.lid
+    }
+    if (record.phoneNumber !== undefined) {
+        fields.phone_number = record.phoneNumber
+    }
+
+    return fields
+}
+
+export class WaContactRedisStore extends BaseRedisStore implements WaContactStore {
+    public constructor(options: WaRedisStorageOptions) {
+        super(options)
+    }
+
+    private contactKey(jid: string): string {
+        return this.k('contact', this.sessionId, jid)
+    }
+
+    public async upsert(record: WaStoredContactRecord): Promise<void> {
+        const key = this.contactKey(record.jid)
+        const existing = await this.redis.hgetall(key)
+        const newFields = recordToHash(record)
+
+        if (existing && Object.keys(existing).length > 0) {
+            const merged: Record<string, string> = { ...existing }
+            for (const [field, value] of Object.entries(newFields)) {
+                merged[field] = value
+            }
+            await this.redis.hset(key, merged)
+        } else {
+            await this.redis.hset(key, newFields)
+        }
+    }
+
+    public async upsertBatch(records: readonly WaStoredContactRecord[]): Promise<void> {
+        if (records.length === 0) return
+
+        for (const record of records) {
+            await this.upsert(record)
+        }
+    }
+
+    public async getByJid(jid: string): Promise<WaStoredContactRecord | null> {
+        const data = await this.redis.hgetall(this.contactKey(jid))
+        if (!data || Object.keys(data).length === 0) return null
+        return hashToRecord(data)
+    }
+
+    public async deleteByJid(jid: string): Promise<number> {
+        return this.redis.del(this.contactKey(jid))
+    }
+
+    public async clear(): Promise<void> {
+        const keys = await scanKeys(this.redis, this.k('contact', this.sessionId, '*'))
+        if (keys.length === 0) return
+
+        const pipeline = this.redis.pipeline()
+        for (const key of keys) {
+            pipeline.del(key)
+        }
+        await pipeline.exec()
+    }
+}

--- a/packages/store-redis/src/createRedisStore.ts
+++ b/packages/store-redis/src/createRedisStore.ts
@@ -1,0 +1,89 @@
+import Redis from 'ioredis'
+import type { RedisOptions } from 'ioredis'
+
+import { WaAppStateRedisStore } from './appstate.store'
+import { WaAuthRedisStore } from './auth.store'
+import { WaContactRedisStore } from './contact.store'
+import { WaDeviceListRedisStore } from './device-list.store'
+import { WaMessageRedisStore } from './message.store'
+import { WaParticipantsRedisStore } from './participants.store'
+import { WaPrivacyTokenRedisStore } from './privacy-token.store'
+import { WaRetryRedisStore } from './retry.store'
+import { WaSenderKeyRedisStore } from './sender-key.store'
+import { WaSignalRedisStore } from './signal.store'
+import { WaThreadRedisStore } from './thread.store'
+import type { WaRedisStorageOptions } from './types'
+
+export interface WaRedisStoreConfig {
+    readonly redis: Redis | RedisOptions
+    readonly keyPrefix?: string
+    readonly cacheTtlMs?: {
+        readonly retryMs?: number
+        readonly participantsMs?: number
+        readonly deviceListMs?: number
+    }
+}
+
+export interface WaRedisStoreResult {
+    readonly redis: Redis
+    readonly stores: {
+        readonly auth: (sessionId: string) => WaAuthRedisStore
+        readonly signal: (sessionId: string) => WaSignalRedisStore
+        readonly senderKey: (sessionId: string) => WaSenderKeyRedisStore
+        readonly appState: (sessionId: string) => WaAppStateRedisStore
+        readonly messages: (sessionId: string) => WaMessageRedisStore
+        readonly threads: (sessionId: string) => WaThreadRedisStore
+        readonly contacts: (sessionId: string) => WaContactRedisStore
+        readonly privacyToken: (sessionId: string) => WaPrivacyTokenRedisStore
+    }
+    readonly caches: {
+        readonly retry: (sessionId: string) => WaRetryRedisStore
+        readonly participants: (sessionId: string) => WaParticipantsRedisStore
+        readonly deviceList: (sessionId: string) => WaDeviceListRedisStore
+    }
+    destroy(): Promise<void>
+}
+
+function isRedis(value: Redis | RedisOptions): value is Redis {
+    return typeof (value as Redis).get === 'function'
+}
+
+export function createRedisStore(config: WaRedisStoreConfig): WaRedisStoreResult {
+    const redis = isRedis(config.redis) ? config.redis : new Redis(config.redis)
+    const keyPrefix = config.keyPrefix ?? ''
+    const retryTtlMs = config.cacheTtlMs?.retryMs
+    const participantsTtlMs = config.cacheTtlMs?.participantsMs
+    const deviceListTtlMs = config.cacheTtlMs?.deviceListMs
+    const ownsRedis = !isRedis(config.redis)
+
+    const opts = (sessionId: string): WaRedisStorageOptions => ({
+        redis,
+        sessionId,
+        keyPrefix
+    })
+
+    return {
+        redis,
+        stores: {
+            auth: (sessionId) => new WaAuthRedisStore(opts(sessionId)),
+            signal: (sessionId) => new WaSignalRedisStore(opts(sessionId)),
+            senderKey: (sessionId) => new WaSenderKeyRedisStore(opts(sessionId)),
+            appState: (sessionId) => new WaAppStateRedisStore(opts(sessionId)),
+            messages: (sessionId) => new WaMessageRedisStore(opts(sessionId)),
+            threads: (sessionId) => new WaThreadRedisStore(opts(sessionId)),
+            contacts: (sessionId) => new WaContactRedisStore(opts(sessionId)),
+            privacyToken: (sessionId) => new WaPrivacyTokenRedisStore(opts(sessionId))
+        },
+        caches: {
+            retry: (sessionId) => new WaRetryRedisStore(opts(sessionId), retryTtlMs),
+            participants: (sessionId) =>
+                new WaParticipantsRedisStore(opts(sessionId), participantsTtlMs),
+            deviceList: (sessionId) => new WaDeviceListRedisStore(opts(sessionId), deviceListTtlMs)
+        },
+        async destroy(): Promise<void> {
+            if (ownsRedis) {
+                redis.disconnect()
+            }
+        }
+    }
+}

--- a/packages/store-redis/src/device-list.store.ts
+++ b/packages/store-redis/src/device-list.store.ts
@@ -1,0 +1,82 @@
+import type { WaDeviceListSnapshot, WaDeviceListStore } from 'zapo-js/store'
+
+import { BaseRedisStore } from './BaseRedisStore'
+import { scanKeys } from './helpers'
+import type { WaRedisStorageOptions } from './types'
+
+const DEFAULT_DEVICE_LIST_TTL_MS = 5 * 60 * 1000
+
+export class WaDeviceListRedisStore extends BaseRedisStore implements WaDeviceListStore {
+    private readonly ttlMs: number
+
+    public constructor(options: WaRedisStorageOptions, ttlMs = DEFAULT_DEVICE_LIST_TTL_MS) {
+        super(options)
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('device-list ttlMs must be a non-negative finite number')
+        }
+        this.ttlMs = ttlMs
+    }
+
+    public async upsertUserDevicesBatch(snapshots: readonly WaDeviceListSnapshot[]): Promise<void> {
+        if (snapshots.length === 0) return
+        const pipeline = this.redis.pipeline()
+        for (const snapshot of snapshots) {
+            const key = this.k('devlist', this.sessionId, snapshot.userJid)
+            pipeline.hset(key, {
+                device_jids_json: JSON.stringify(snapshot.deviceJids),
+                updated_at_ms: String(snapshot.updatedAtMs)
+            })
+            pipeline.pexpire(key, this.ttlMs)
+        }
+        await pipeline.exec()
+    }
+
+    public async getUserDevicesBatch(
+        userJids: readonly string[],
+        _nowMs?: number
+    ): Promise<readonly (WaDeviceListSnapshot | null)[]> {
+        if (userJids.length === 0) return []
+
+        const pipeline = this.redis.pipeline()
+        for (const userJid of userJids) {
+            pipeline.hgetall(this.k('devlist', this.sessionId, userJid))
+        }
+        const results = await pipeline.exec()
+        if (!results) return userJids.map(() => null)
+
+        return userJids.map((userJid, index) => {
+            const [err, data] = results[index]
+            if (err || !data || typeof data !== 'object') return null
+            const record = data as Record<string, string>
+            if (Object.keys(record).length === 0) return null
+
+            const parsed: unknown = JSON.parse(record.device_jids_json)
+            if (!Array.isArray(parsed)) {
+                throw new Error('device_jids_json must be an array')
+            }
+
+            return {
+                userJid,
+                deviceJids: parsed.map((entry: unknown) => String(entry)),
+                updatedAtMs: Number(record.updated_at_ms)
+            }
+        })
+    }
+
+    public async deleteUserDevices(userJid: string): Promise<number> {
+        const key = this.k('devlist', this.sessionId, userJid)
+        return this.redis.del(key)
+    }
+
+    public async cleanupExpired(_nowMs: number): Promise<number> {
+        return 0
+    }
+
+    public async clear(): Promise<void> {
+        const pattern = this.k('devlist', this.sessionId, '*')
+        const keys = await scanKeys(this.redis, pattern)
+        if (keys.length > 0) {
+            await this.redis.del(...keys)
+        }
+    }
+}

--- a/packages/store-redis/src/helpers.ts
+++ b/packages/store-redis/src/helpers.ts
@@ -1,0 +1,50 @@
+import type Redis from 'ioredis'
+import { bytesToHex, hexToBytes, normalizeQueryLimit, toBytesView, uint8Equal } from 'zapo-js/util'
+
+export function toBytes(value: unknown): Uint8Array {
+    if (value instanceof Uint8Array) return value
+    if (value instanceof ArrayBuffer) return new Uint8Array(value)
+    if (ArrayBuffer.isView(value)) return toBytesView(value)
+    throw new Error('expected binary data')
+}
+
+export function toBytesOrNull(value: unknown): Uint8Array | null {
+    if (value === null || value === undefined) return null
+    if (typeof value === 'string' && value.length === 0) return null
+    return toBytes(value)
+}
+
+export function toStringOrNull(value: string | null | undefined): string | null {
+    if (value === null || value === undefined || value.length === 0) return null
+    return value
+}
+
+export function toNumberOrNull(value: string | null | undefined): number | null {
+    if (value === null || value === undefined || value.length === 0) return null
+    return Number(value)
+}
+
+const SAFE_PREFIX_RE = /^[A-Za-z0-9_:]*$/
+
+export function assertSafeKeyPrefix(prefix: string): void {
+    if (!SAFE_PREFIX_RE.test(prefix)) {
+        throw new Error('keyPrefix must contain only letters, numbers, underscores, and colons')
+    }
+}
+
+export async function scanKeys(redis: Redis, pattern: string): Promise<string[]> {
+    const keys: string[] = []
+    let cursor = '0'
+    do {
+        const [nextCursor, batch] = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', 200)
+        cursor = nextCursor
+        keys.push(...batch)
+    } while (cursor !== '0')
+    return keys
+}
+
+export function toRedisBuffer(bytes: Uint8Array): Buffer {
+    return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+}
+
+export { bytesToHex, hexToBytes, normalizeQueryLimit as safeLimit, uint8Equal }

--- a/packages/store-redis/src/index.ts
+++ b/packages/store-redis/src/index.ts
@@ -1,0 +1,18 @@
+export type { WaRedisCreateStoreOptions, WaRedisStorageOptions } from './types'
+export { BaseRedisStore } from './BaseRedisStore'
+export { WaAuthRedisStore } from './auth.store'
+export { WaSignalRedisStore } from './signal.store'
+export { WaSenderKeyRedisStore } from './sender-key.store'
+export { WaAppStateRedisStore } from './appstate.store'
+export { WaRetryRedisStore } from './retry.store'
+export { WaParticipantsRedisStore } from './participants.store'
+export { WaDeviceListRedisStore } from './device-list.store'
+export { WaMessageRedisStore } from './message.store'
+export { WaThreadRedisStore } from './thread.store'
+export { WaContactRedisStore } from './contact.store'
+export { WaPrivacyTokenRedisStore } from './privacy-token.store'
+export {
+    createRedisStore,
+    type WaRedisStoreConfig,
+    type WaRedisStoreResult
+} from './createRedisStore'

--- a/packages/store-redis/src/message.store.ts
+++ b/packages/store-redis/src/message.store.ts
@@ -1,0 +1,234 @@
+import type { WaMessageStore, WaStoredMessageRecord } from 'zapo-js/store'
+
+import { BaseRedisStore } from './BaseRedisStore'
+import { safeLimit, scanKeys, toBytesOrNull, toRedisBuffer, toStringOrNull } from './helpers'
+import type { WaRedisStorageOptions } from './types'
+
+const BINARY_FIELDS = ['plaintext', 'message_bytes'] as const
+
+export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStore {
+    public constructor(options: WaRedisStorageOptions) {
+        super(options)
+    }
+
+    private msgKey(messageId: string): string {
+        return this.k('msg', this.sessionId, messageId)
+    }
+
+    private idxKey(threadJid: string): string {
+        return this.k('msg:idx', this.sessionId, threadJid)
+    }
+
+    public async upsert(record: WaStoredMessageRecord): Promise<void> {
+        const key = this.msgKey(record.id)
+        const idxKey = this.idxKey(record.threadJid)
+        const score = record.timestampMs ?? 0
+
+        // Check if thread changed to remove stale index entry
+        const existing = await this.redis.hget(key, 'thread_jid')
+
+        const pipeline = this.redis.pipeline()
+        if (existing && existing !== record.threadJid) {
+            pipeline.zrem(this.idxKey(existing), record.id)
+        }
+        pipeline.hset(key, recordToHash(record))
+        pipeline.zadd(idxKey, String(score), record.id)
+
+        if (record.plaintext !== undefined) {
+            pipeline.set(`${key}:plaintext`, toRedisBuffer(record.plaintext))
+        }
+        if (record.messageBytes !== undefined) {
+            pipeline.set(`${key}:message_bytes`, toRedisBuffer(record.messageBytes))
+        }
+
+        await pipeline.exec()
+    }
+
+    public async upsertBatch(records: readonly WaStoredMessageRecord[]): Promise<void> {
+        if (records.length === 0) return
+
+        // Read existing thread_jid for each record to detect changes
+        const readPipeline = this.redis.pipeline()
+        for (const record of records) {
+            readPipeline.hget(this.msgKey(record.id), 'thread_jid')
+        }
+        const existingResults = await readPipeline.exec()
+
+        const pipeline = this.redis.pipeline()
+        for (let i = 0; i < records.length; i += 1) {
+            const record = records[i]
+            const key = this.msgKey(record.id)
+            const idxKey = this.idxKey(record.threadJid)
+            const score = record.timestampMs ?? 0
+
+            // Remove stale thread index entry if thread changed
+            if (existingResults) {
+                const [err, oldThreadJid] = existingResults[i]
+                if (!err && oldThreadJid && oldThreadJid !== record.threadJid) {
+                    pipeline.zrem(this.idxKey(oldThreadJid as string), record.id)
+                }
+            }
+
+            pipeline.hset(key, recordToHash(record))
+            pipeline.zadd(idxKey, String(score), record.id)
+
+            if (record.plaintext !== undefined) {
+                pipeline.set(`${key}:plaintext`, toRedisBuffer(record.plaintext))
+            }
+            if (record.messageBytes !== undefined) {
+                pipeline.set(`${key}:message_bytes`, toRedisBuffer(record.messageBytes))
+            }
+        }
+        await pipeline.exec()
+    }
+
+    public async getById(id: string): Promise<WaStoredMessageRecord | null> {
+        const key = this.msgKey(id)
+
+        const pipeline = this.redis.pipeline()
+        pipeline.hgetall(key)
+        for (const field of BINARY_FIELDS) {
+            pipeline.getBuffer(`${key}:${field}`)
+        }
+        const results = await pipeline.exec()
+        if (!results) return null
+
+        const data = results[0][1] as Record<string, string>
+        if (!data || Object.keys(data).length === 0) return null
+
+        return hashToRecord(data, toBytesOrNull(results[1][1]), toBytesOrNull(results[2][1]))
+    }
+
+    public async listByThread(
+        threadJid: string,
+        limit?: number,
+        beforeTimestampMs?: number
+    ): Promise<readonly WaStoredMessageRecord[]> {
+        const resolved = safeLimit(limit, 50)
+        const idxKey = this.idxKey(threadJid)
+
+        let messageIds: string[]
+        if (beforeTimestampMs !== undefined) {
+            messageIds = await this.redis.zrevrangebyscore(
+                idxKey,
+                String(beforeTimestampMs - 1),
+                '-inf',
+                'LIMIT',
+                0,
+                resolved
+            )
+        } else {
+            messageIds = await this.redis.zrevrangebyscore(
+                idxKey,
+                '+inf',
+                '-inf',
+                'LIMIT',
+                0,
+                resolved
+            )
+        }
+
+        if (messageIds.length === 0) return []
+
+        const pipeline = this.redis.pipeline()
+        for (const msgId of messageIds) {
+            const key = this.msgKey(msgId)
+            pipeline.hgetall(key)
+            for (const field of BINARY_FIELDS) {
+                pipeline.getBuffer(`${key}:${field}`)
+            }
+        }
+        const results = await pipeline.exec()
+
+        const stride = 1 + BINARY_FIELDS.length
+        const records: WaStoredMessageRecord[] = []
+        if (results) {
+            for (let i = 0; i < results.length; i += stride) {
+                const [err, data] = results[i]
+                if (err) continue
+                const hash = data as Record<string, string>
+                if (hash && Object.keys(hash).length > 0) {
+                    records.push(
+                        hashToRecord(
+                            hash,
+                            toBytesOrNull(results[i + 1][1]),
+                            toBytesOrNull(results[i + 2][1])
+                        )
+                    )
+                }
+            }
+        }
+        return records
+    }
+
+    public async deleteById(id: string): Promise<number> {
+        const key = this.msgKey(id)
+        const data = await this.redis.hgetall(key)
+        if (!data || Object.keys(data).length === 0) return 0
+
+        const threadJid = data.thread_jid
+        const pipeline = this.redis.pipeline()
+        pipeline.del(key)
+        for (const field of BINARY_FIELDS) {
+            pipeline.del(`${key}:${field}`)
+        }
+        pipeline.zrem(this.idxKey(threadJid), id)
+        await pipeline.exec()
+        return 1
+    }
+
+    public async clear(): Promise<void> {
+        const msgKeys = await scanKeys(this.redis, this.k('msg', this.sessionId, '*'))
+        const idxKeys = await scanKeys(this.redis, this.k('msg:idx', this.sessionId, '*'))
+        const allKeys = [...msgKeys, ...idxKeys]
+        if (allKeys.length === 0) return
+
+        const pipeline = this.redis.pipeline()
+        for (const key of allKeys) {
+            pipeline.del(key)
+        }
+        await pipeline.exec()
+    }
+}
+
+function recordToHash(record: WaStoredMessageRecord): Record<string, string> {
+    const fields: Record<string, string> = {
+        id: record.id,
+        thread_jid: record.threadJid,
+        from_me: record.fromMe ? '1' : '0'
+    }
+
+    if (record.senderJid !== undefined) {
+        fields.sender_jid = record.senderJid
+    }
+    if (record.participantJid !== undefined) {
+        fields.participant_jid = record.participantJid
+    }
+    if (record.timestampMs !== undefined) {
+        fields.timestamp_ms = String(record.timestampMs)
+    }
+    if (record.encType !== undefined) {
+        fields.enc_type = record.encType
+    }
+
+    return fields
+}
+
+function hashToRecord(
+    data: Record<string, string>,
+    plaintext: Uint8Array | null,
+    messageBytes: Uint8Array | null
+): WaStoredMessageRecord {
+    return {
+        id: data.id,
+        threadJid: data.thread_jid,
+        senderJid: toStringOrNull(data.sender_jid) ?? undefined,
+        participantJid: toStringOrNull(data.participant_jid) ?? undefined,
+        fromMe: data.from_me === '1',
+        timestampMs:
+            toStringOrNull(data.timestamp_ms) !== null ? Number(data.timestamp_ms) : undefined,
+        encType: toStringOrNull(data.enc_type) ?? undefined,
+        plaintext: plaintext ?? undefined,
+        messageBytes: messageBytes ?? undefined
+    }
+}

--- a/packages/store-redis/src/participants.store.ts
+++ b/packages/store-redis/src/participants.store.ts
@@ -1,0 +1,67 @@
+import type { WaParticipantsSnapshot, WaParticipantsStore } from 'zapo-js/store'
+
+import { BaseRedisStore } from './BaseRedisStore'
+import { scanKeys } from './helpers'
+import type { WaRedisStorageOptions } from './types'
+
+const DEFAULT_PARTICIPANTS_TTL_MS = 5 * 60 * 1000
+
+export class WaParticipantsRedisStore extends BaseRedisStore implements WaParticipantsStore {
+    private readonly ttlMs: number
+
+    public constructor(options: WaRedisStorageOptions, ttlMs = DEFAULT_PARTICIPANTS_TTL_MS) {
+        super(options)
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('participants ttlMs must be a non-negative finite number')
+        }
+        this.ttlMs = ttlMs
+    }
+
+    public async upsertGroupParticipants(snapshot: WaParticipantsSnapshot): Promise<void> {
+        const key = this.k('participants', this.sessionId, snapshot.groupJid)
+        const pipeline = this.redis.pipeline()
+        pipeline.hset(key, {
+            participants_json: JSON.stringify(snapshot.participants),
+            updated_at_ms: String(snapshot.updatedAtMs)
+        })
+        pipeline.pexpire(key, this.ttlMs)
+        await pipeline.exec()
+    }
+
+    public async getGroupParticipants(
+        groupJid: string,
+        _nowMs?: number
+    ): Promise<WaParticipantsSnapshot | null> {
+        const key = this.k('participants', this.sessionId, groupJid)
+        const data = await this.redis.hgetall(key)
+        if (!data || Object.keys(data).length === 0) return null
+
+        const parsed: unknown = JSON.parse(data.participants_json)
+        if (!Array.isArray(parsed)) {
+            throw new Error('participants_json must be an array')
+        }
+
+        return {
+            groupJid,
+            participants: parsed.map((entry: unknown) => String(entry)),
+            updatedAtMs: Number(data.updated_at_ms)
+        }
+    }
+
+    public async deleteGroupParticipants(groupJid: string): Promise<number> {
+        const key = this.k('participants', this.sessionId, groupJid)
+        return this.redis.del(key)
+    }
+
+    public async cleanupExpired(_nowMs: number): Promise<number> {
+        return 0
+    }
+
+    public async clear(): Promise<void> {
+        const pattern = this.k('participants', this.sessionId, '*')
+        const keys = await scanKeys(this.redis, pattern)
+        if (keys.length > 0) {
+            await this.redis.del(...keys)
+        }
+    }
+}

--- a/packages/store-redis/src/privacy-token.store.ts
+++ b/packages/store-redis/src/privacy-token.store.ts
@@ -1,0 +1,130 @@
+import type { WaPrivacyTokenStore, WaStoredPrivacyTokenRecord } from 'zapo-js/store'
+
+import { BaseRedisStore } from './BaseRedisStore'
+import { scanKeys, toBytesOrNull, toRedisBuffer, toStringOrNull } from './helpers'
+import type { WaRedisStorageOptions } from './types'
+
+const BINARY_FIELDS = ['tc_token', 'nct_salt'] as const
+
+export class WaPrivacyTokenRedisStore extends BaseRedisStore implements WaPrivacyTokenStore {
+    public constructor(options: WaRedisStorageOptions) {
+        super(options)
+    }
+
+    private tokenKey(jid: string): string {
+        return this.k('privtoken', this.sessionId, jid)
+    }
+
+    public async upsert(record: WaStoredPrivacyTokenRecord): Promise<void> {
+        const key = this.tokenKey(record.jid)
+
+        const existing = await this.redis.hgetall(key)
+        const newFields = recordToHash(record)
+
+        const pipeline = this.redis.pipeline()
+
+        if (existing && Object.keys(existing).length > 0) {
+            const merged: Record<string, string> = { ...existing }
+            for (const [field, value] of Object.entries(newFields)) {
+                merged[field] = value
+            }
+            pipeline.hset(key, merged)
+        } else {
+            pipeline.hset(key, newFields)
+        }
+
+        if (record.tcToken !== undefined) {
+            pipeline.set(`${key}:tc_token`, toRedisBuffer(record.tcToken))
+        }
+        if (record.nctSalt !== undefined) {
+            pipeline.set(`${key}:nct_salt`, toRedisBuffer(record.nctSalt))
+        }
+
+        await pipeline.exec()
+    }
+
+    public async upsertBatch(records: readonly WaStoredPrivacyTokenRecord[]): Promise<void> {
+        if (records.length === 0) return
+
+        for (const record of records) {
+            await this.upsert(record)
+        }
+    }
+
+    public async getByJid(jid: string): Promise<WaStoredPrivacyTokenRecord | null> {
+        const key = this.tokenKey(jid)
+
+        const pipeline = this.redis.pipeline()
+        pipeline.hgetall(key)
+        for (const field of BINARY_FIELDS) {
+            pipeline.getBuffer(`${key}:${field}`)
+        }
+        const results = await pipeline.exec()
+        if (!results) return null
+
+        const data = results[0][1] as Record<string, string>
+        if (!data || Object.keys(data).length === 0) return null
+
+        return hashToRecord(data, toBytesOrNull(results[1][1]), toBytesOrNull(results[2][1]))
+    }
+
+    public async deleteByJid(jid: string): Promise<number> {
+        const key = this.tokenKey(jid)
+        const pipeline = this.redis.pipeline()
+        pipeline.del(key)
+        for (const field of BINARY_FIELDS) {
+            pipeline.del(`${key}:${field}`)
+        }
+        const results = await pipeline.exec()
+        if (!results) return 0
+        return (results[0][1] as number) > 0 ? 1 : 0
+    }
+
+    public async clear(): Promise<void> {
+        const keys = await scanKeys(this.redis, this.k('privtoken', this.sessionId, '*'))
+        if (keys.length === 0) return
+
+        const pipeline = this.redis.pipeline()
+        for (const key of keys) {
+            pipeline.del(key)
+        }
+        await pipeline.exec()
+    }
+}
+
+function recordToHash(record: WaStoredPrivacyTokenRecord): Record<string, string> {
+    const fields: Record<string, string> = {
+        jid: record.jid,
+        updated_at_ms: String(record.updatedAtMs)
+    }
+
+    if (record.tcTokenTimestamp !== undefined) {
+        fields.tc_token_timestamp = String(record.tcTokenTimestamp)
+    }
+    if (record.tcTokenSenderTimestamp !== undefined) {
+        fields.tc_token_sender_timestamp = String(record.tcTokenSenderTimestamp)
+    }
+
+    return fields
+}
+
+function hashToRecord(
+    data: Record<string, string>,
+    tcToken: Uint8Array | null,
+    nctSalt: Uint8Array | null
+): WaStoredPrivacyTokenRecord {
+    return {
+        jid: data.jid,
+        tcToken: tcToken ?? undefined,
+        tcTokenTimestamp:
+            toStringOrNull(data.tc_token_timestamp) !== null
+                ? Number(data.tc_token_timestamp)
+                : undefined,
+        tcTokenSenderTimestamp:
+            toStringOrNull(data.tc_token_sender_timestamp) !== null
+                ? Number(data.tc_token_sender_timestamp)
+                : undefined,
+        nctSalt: nctSalt ?? undefined,
+        updatedAtMs: Number(data.updated_at_ms)
+    }
+}

--- a/packages/store-redis/src/retry.store.ts
+++ b/packages/store-redis/src/retry.store.ts
@@ -1,0 +1,345 @@
+import type { WaRetryOutboundMessageRecord, WaRetryOutboundState } from 'zapo-js/retry'
+import type { WaRetryStore } from 'zapo-js/store'
+
+import { BaseRedisStore } from './BaseRedisStore'
+import { scanKeys, toBytesOrNull, toRedisBuffer, toStringOrNull } from './helpers'
+import type { WaRedisStorageOptions } from './types'
+
+interface RetryRequesterStatusPayload {
+    readonly eligible: readonly string[]
+    readonly delivered: readonly string[]
+}
+
+const DEFAULT_RETRY_TTL_MS = 60 * 1000
+
+const LUA_INCREMENT_INBOUND = `
+local key = KEYS[1]
+local count = redis.call('HINCRBY', key, 'retry_count', 1)
+redis.call('HSET', key, 'updated_at_ms', ARGV[1])
+redis.call('PEXPIREAT', key, tonumber(ARGV[2]))
+return count
+`
+
+const LUA_MARK_DELIVERED = `
+local key = KEYS[1]
+local replayKey = KEYS[2]
+local requester = ARGV[1]
+local updatedAtMs = ARGV[2]
+local expiresAtMs = tonumber(ARGV[3])
+local raw = redis.call('HGET', key, 'requesters_json')
+if not raw then
+    return 0
+end
+local requesters = cjson.decode(raw)
+if not requesters.eligible then
+    return 0
+end
+local isEligible = false
+for _, v in ipairs(requesters.eligible) do
+    if v == requester then
+        isEligible = true
+        break
+    end
+end
+if not isEligible then
+    return 0
+end
+if not requesters.delivered then
+    requesters.delivered = {}
+end
+for _, v in ipairs(requesters.delivered) do
+    if v == requester then
+        return 0
+    end
+end
+table.insert(requesters.delivered, requester)
+redis.call('HSET', key, 'requesters_json', cjson.encode(requesters))
+redis.call('HSET', key, 'updated_at_ms', updatedAtMs)
+redis.call('PEXPIREAT', key, expiresAtMs)
+redis.call('PEXPIREAT', replayKey, expiresAtMs)
+return 1
+`
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+export class WaRetryRedisStore extends BaseRedisStore implements WaRetryStore {
+    private readonly ttlMs: number
+
+    public constructor(options: WaRedisStorageOptions, ttlMs = DEFAULT_RETRY_TTL_MS) {
+        super(options)
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('retry ttlMs must be a non-negative finite number')
+        }
+        this.ttlMs = ttlMs
+    }
+
+    public getTtlMs(): number {
+        return this.ttlMs
+    }
+
+    public supportsRawReplayPayload(): boolean {
+        return false
+    }
+
+    public async getOutboundRequesterStatus(
+        messageId: string,
+        requesterDeviceJid: string
+    ): Promise<{
+        readonly eligible: boolean
+        readonly delivered: boolean
+    } | null> {
+        const key = this.k('retry:out', this.sessionId, messageId)
+        const raw = await this.redis.hget(key, 'requesters_json')
+        if (!raw) return null
+
+        const requesters = this.parseRequesterStatusPayload(raw)
+        if (requesters.eligible.length === 0) return null
+
+        let isEligible = false
+        for (let index = 0; index < requesters.eligible.length; index += 1) {
+            if (requesters.eligible[index] === requesterDeviceJid) {
+                isEligible = true
+                break
+            }
+        }
+        if (!isEligible) {
+            return { eligible: false, delivered: false }
+        }
+        for (let index = 0; index < requesters.delivered.length; index += 1) {
+            if (requesters.delivered[index] === requesterDeviceJid) {
+                return { eligible: true, delivered: true }
+            }
+        }
+        return { eligible: true, delivered: false }
+    }
+
+    public async upsertOutboundMessage(record: WaRetryOutboundMessageRecord): Promise<void> {
+        const key = this.k('retry:out', this.sessionId, record.messageId)
+        if (!(record.replayPayload instanceof Uint8Array)) {
+            throw new Error('retry_outbound_messages.replay_payload must be Uint8Array')
+        }
+        const requestersJson = this.serializeRequesterStatusPayload(
+            record.eligibleRequesterDeviceJids,
+            record.deliveredRequesterDeviceJids
+        )
+        const fields: Record<string, string> = {
+            message_id: record.messageId,
+            to_jid: record.toJid,
+            message_type: record.messageType,
+            replay_mode: record.replayMode,
+            state: record.state,
+            created_at_ms: String(record.createdAtMs),
+            updated_at_ms: String(record.updatedAtMs),
+            expires_at_ms: String(record.expiresAtMs)
+        }
+        if (record.participantJid !== undefined) {
+            fields.participant_jid = record.participantJid
+        }
+        if (record.recipientJid !== undefined) {
+            fields.recipient_jid = record.recipientJid
+        }
+        if (requestersJson !== null) {
+            fields.requesters_json = requestersJson
+        }
+
+        const ttl = record.expiresAtMs - Date.now()
+        if (ttl <= 0) {
+            const pipeline = this.redis.pipeline()
+            pipeline.del(key)
+            pipeline.del(`${key}:replay_payload`)
+            await pipeline.exec()
+            return
+        }
+
+        const pipeline = this.redis.pipeline()
+        pipeline.hset(key, fields)
+        pipeline.set(`${key}:replay_payload`, toRedisBuffer(record.replayPayload))
+        pipeline.pexpire(key, ttl)
+        pipeline.pexpire(`${key}:replay_payload`, ttl)
+        await pipeline.exec()
+    }
+
+    public async deleteOutboundMessage(messageId: string): Promise<number> {
+        const key = this.k('retry:out', this.sessionId, messageId)
+        const pipeline = this.redis.pipeline()
+        pipeline.del(key)
+        pipeline.del(`${key}:replay_payload`)
+        const results = await pipeline.exec()
+        if (!results) return 0
+        return (results[0][1] as number) > 0 ? 1 : 0
+    }
+
+    public async getOutboundMessage(
+        messageId: string
+    ): Promise<WaRetryOutboundMessageRecord | null> {
+        const key = this.k('retry:out', this.sessionId, messageId)
+
+        const pipeline = this.redis.pipeline()
+        pipeline.hgetall(key)
+        pipeline.getBuffer(`${key}:replay_payload`)
+        const results = await pipeline.exec()
+        if (!results) return null
+
+        const data = results[0][1] as Record<string, string>
+        if (!data || Object.keys(data).length === 0) return null
+
+        const replayPayload = toBytesOrNull(results[1][1])
+        if (!replayPayload) return null
+
+        const requestersJson = toStringOrNull(data.requesters_json)
+        const requesters = requestersJson
+            ? this.parseRequesterStatusPayload(requestersJson)
+            : { eligible: [] as readonly string[], delivered: [] as readonly string[] }
+
+        return {
+            messageId: data.message_id,
+            toJid: data.to_jid,
+            participantJid: toStringOrNull(data.participant_jid) ?? undefined,
+            recipientJid: toStringOrNull(data.recipient_jid) ?? undefined,
+            eligibleRequesterDeviceJids:
+                requesters.eligible.length > 0 ? requesters.eligible : undefined,
+            deliveredRequesterDeviceJids:
+                requesters.delivered.length > 0 ? requesters.delivered : undefined,
+            messageType: data.message_type,
+            replayMode: data.replay_mode as WaRetryOutboundMessageRecord['replayMode'],
+            replayPayload,
+            state: data.state as WaRetryOutboundState,
+            createdAtMs: Number(data.created_at_ms),
+            updatedAtMs: Number(data.updated_at_ms),
+            expiresAtMs: Number(data.expires_at_ms)
+        }
+    }
+
+    public async updateOutboundMessageState(
+        messageId: string,
+        state: WaRetryOutboundState,
+        updatedAtMs: number,
+        expiresAtMs: number
+    ): Promise<void> {
+        const key = this.k('retry:out', this.sessionId, messageId)
+        const exists = await this.redis.exists(key)
+        if (!exists) return
+
+        const ttl = expiresAtMs - Date.now()
+        const pipeline = this.redis.pipeline()
+        pipeline.hset(key, {
+            state,
+            updated_at_ms: String(updatedAtMs),
+            expires_at_ms: String(expiresAtMs)
+        })
+        if (ttl > 0) {
+            pipeline.pexpire(key, ttl)
+            pipeline.pexpire(`${key}:replay_payload`, ttl)
+        }
+        await pipeline.exec()
+    }
+
+    public async markOutboundRequesterDelivered(
+        messageId: string,
+        requesterDeviceJid: string,
+        updatedAtMs: number,
+        expiresAtMs: number
+    ): Promise<void> {
+        const key = this.k('retry:out', this.sessionId, messageId)
+        const replayKey = `${key}:replay_payload`
+        await this.redis.eval(
+            LUA_MARK_DELIVERED,
+            2,
+            key,
+            replayKey,
+            requesterDeviceJid,
+            String(updatedAtMs),
+            String(expiresAtMs)
+        )
+    }
+
+    public async incrementInboundCounter(
+        messageId: string,
+        requesterJid: string,
+        updatedAtMs: number,
+        expiresAtMs: number
+    ): Promise<number> {
+        const key = this.k('retry:in', this.sessionId, messageId, requesterJid)
+        const count = await this.redis.eval(
+            LUA_INCREMENT_INBOUND,
+            1,
+            key,
+            String(updatedAtMs),
+            String(expiresAtMs)
+        )
+        return Number(count)
+    }
+
+    public async cleanupExpired(_nowMs: number): Promise<number> {
+        return 0
+    }
+
+    public async clear(): Promise<void> {
+        const outPattern = this.k('retry:out', this.sessionId, '*')
+        const inPattern = this.k('retry:in', this.sessionId, '*')
+        const [outKeys, inKeys] = await Promise.all([
+            scanKeys(this.redis, outPattern),
+            scanKeys(this.redis, inPattern)
+        ])
+        const allKeys = [...outKeys, ...inKeys]
+        if (allKeys.length > 0) {
+            await this.redis.del(...allKeys)
+        }
+    }
+
+    private serializeRequesterStatusPayload(
+        eligibleRequesterDeviceJids: readonly string[] | undefined,
+        deliveredRequesterDeviceJids: readonly string[] | undefined
+    ): string | null {
+        const eligible = this.toUniqueStrings(
+            eligibleRequesterDeviceJids ?? [],
+            'requesters_json.eligible'
+        )
+        if (eligible.length === 0) return null
+        const eligibleSet = new Set(eligible)
+        const delivered = this.toUniqueStrings(
+            deliveredRequesterDeviceJids ?? [],
+            'requesters_json.delivered'
+        ).filter((jid) => eligibleSet.has(jid))
+        const payload = delivered.length > 0 ? { eligible, delivered } : { eligible }
+        return JSON.stringify(payload)
+    }
+
+    private parseRequesterStatusPayload(raw: string): RetryRequesterStatusPayload {
+        const parsed = JSON.parse(raw)
+        if (!isObjectRecord(parsed)) {
+            throw new Error('requesters_json must be an object')
+        }
+        const eligibleRaw = parsed.eligible
+        if (!Array.isArray(eligibleRaw)) {
+            throw new Error('requesters_json.eligible must be an array')
+        }
+        const eligible = this.toUniqueStrings(eligibleRaw, 'requesters_json.eligible')
+        const deliveredRaw = parsed.delivered
+        if (deliveredRaw !== undefined && !Array.isArray(deliveredRaw)) {
+            throw new Error('requesters_json.delivered must be an array')
+        }
+        const eligibleSet = new Set(eligible)
+        const delivered = this.toUniqueStrings(
+            Array.isArray(deliveredRaw) ? deliveredRaw : [],
+            'requesters_json.delivered'
+        ).filter((jid) => eligibleSet.has(jid))
+        return { eligible, delivered }
+    }
+
+    private toUniqueStrings(values: readonly unknown[], field: string): readonly string[] {
+        const deduped = new Set<string>()
+        for (let index = 0; index < values.length; index += 1) {
+            const rawValue = values[index]
+            if (typeof rawValue !== 'string') {
+                throw new Error(`${field} must contain only strings`)
+            }
+            const normalized = rawValue.trim()
+            if (!normalized) continue
+            deduped.add(normalized)
+        }
+        return Array.from(deduped)
+    }
+}

--- a/packages/store-redis/src/sender-key.store.ts
+++ b/packages/store-redis/src/sender-key.store.ts
@@ -1,0 +1,322 @@
+import type { SenderKeyDistributionRecord, SenderKeyRecord, SignalAddress } from 'zapo-js/signal'
+import { encodeSenderKeyRecord, decodeSenderKeyRecord, toSignalAddressParts } from 'zapo-js/signal'
+import type { WaSenderKeyStore } from 'zapo-js/store'
+
+import { BaseRedisStore } from './BaseRedisStore'
+import { scanKeys, toRedisBuffer } from './helpers'
+import type { WaRedisStorageOptions } from './types'
+
+export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKeyStore {
+    public constructor(options: WaRedisStorageOptions) {
+        super(options)
+    }
+
+    public async upsertSenderKey(record: SenderKeyRecord): Promise<void> {
+        const sender = toSignalAddressParts(record.sender)
+        const key = this.k(
+            'sk',
+            this.sessionId,
+            record.groupId,
+            sender.user,
+            sender.server,
+            String(sender.device)
+        )
+        const encoded = encodeSenderKeyRecord(record)
+        await this.redis.set(key, toRedisBuffer(encoded))
+
+        const groupIdxKey = this.k('sk:grp', this.sessionId, record.groupId)
+        await this.redis.sadd(groupIdxKey, `${sender.user}:${sender.server}:${sender.device}`)
+    }
+
+    public async upsertSenderKeyDistribution(record: SenderKeyDistributionRecord): Promise<void> {
+        const sender = toSignalAddressParts(record.sender)
+        const key = this.k(
+            'skd',
+            this.sessionId,
+            record.groupId,
+            sender.user,
+            sender.server,
+            String(sender.device)
+        )
+        await this.redis.hset(key, {
+            key_id: String(record.keyId),
+            timestamp_ms: String(record.timestampMs)
+        })
+
+        const groupIdxKey = this.k('sk:grp', this.sessionId, record.groupId)
+        await this.redis.sadd(groupIdxKey, `${sender.user}:${sender.server}:${sender.device}`)
+    }
+
+    public async upsertSenderKeyDistributions(
+        records: readonly SenderKeyDistributionRecord[]
+    ): Promise<void> {
+        if (records.length === 0) return
+        const pipeline = this.redis.pipeline()
+        for (const record of records) {
+            const sender = toSignalAddressParts(record.sender)
+            const key = this.k(
+                'skd',
+                this.sessionId,
+                record.groupId,
+                sender.user,
+                sender.server,
+                String(sender.device)
+            )
+            pipeline.hset(key, {
+                key_id: String(record.keyId),
+                timestamp_ms: String(record.timestampMs)
+            })
+            const groupIdxKey = this.k('sk:grp', this.sessionId, record.groupId)
+            pipeline.sadd(groupIdxKey, `${sender.user}:${sender.server}:${sender.device}`)
+        }
+        await pipeline.exec()
+    }
+
+    public async getGroupSenderKeyList(groupId: string): Promise<{
+        readonly skList: readonly SenderKeyRecord[]
+        readonly skDistribList: readonly SenderKeyDistributionRecord[]
+    }> {
+        const groupIdxKey = this.k('sk:grp', this.sessionId, groupId)
+        const members = await this.redis.smembers(groupIdxKey)
+        if (members.length === 0) {
+            return { skList: [], skDistribList: [] }
+        }
+
+        const skPipeline = this.redis.pipeline()
+        const skdPipeline = this.redis.pipeline()
+        const parsedMembers: { user: string; server: string; device: number }[] = []
+
+        for (const member of members) {
+            const parts = member.split(':')
+            const user = parts[0]
+            const server = parts[1]
+            const device = Number(parts[2])
+            parsedMembers.push({ user, server, device })
+            skPipeline.getBuffer(
+                this.k('sk', this.sessionId, groupId, user, server, String(device))
+            )
+            skdPipeline.hgetall(
+                this.k('skd', this.sessionId, groupId, user, server, String(device))
+            )
+        }
+
+        const [skResults, skdResults] = await Promise.all([skPipeline.exec(), skdPipeline.exec()])
+
+        const skList: SenderKeyRecord[] = []
+        const skDistribList: SenderKeyDistributionRecord[] = []
+
+        if (skResults) {
+            for (let i = 0; i < skResults.length; i += 1) {
+                const [err, data] = skResults[i]
+                if (err || !data) continue
+                const m = parsedMembers[i]
+                skList.push(
+                    decodeSenderKeyRecord(new Uint8Array(data as Uint8Array), groupId, {
+                        user: m.user,
+                        server: m.server,
+                        device: m.device
+                    })
+                )
+            }
+        }
+
+        if (skdResults) {
+            for (let i = 0; i < skdResults.length; i += 1) {
+                const [err, data] = skdResults[i]
+                if (err || !data || typeof data !== 'object') continue
+                const record = data as Record<string, string>
+                if (Object.keys(record).length === 0) continue
+                const m = parsedMembers[i]
+                skDistribList.push({
+                    groupId,
+                    sender: { user: m.user, server: m.server, device: m.device },
+                    keyId: Number(record.key_id),
+                    timestampMs: Number(record.timestamp_ms)
+                })
+            }
+        }
+
+        return { skList, skDistribList }
+    }
+
+    public async getDeviceSenderKey(
+        groupId: string,
+        sender: SignalAddress
+    ): Promise<SenderKeyRecord | null> {
+        const target = toSignalAddressParts(sender)
+        const key = this.k(
+            'sk',
+            this.sessionId,
+            groupId,
+            target.user,
+            target.server,
+            String(target.device)
+        )
+        const data = await this.redis.getBuffer(key)
+        if (!data) return null
+        return decodeSenderKeyRecord(new Uint8Array(data), groupId, {
+            user: target.user,
+            server: target.server,
+            device: target.device
+        })
+    }
+
+    public async getDeviceSenderKeyDistributions(
+        groupId: string,
+        senders: readonly SignalAddress[]
+    ): Promise<readonly (SenderKeyDistributionRecord | null)[]> {
+        if (senders.length === 0) return []
+        const targets = senders.map((s) => toSignalAddressParts(s))
+        const pipeline = this.redis.pipeline()
+        for (const t of targets) {
+            pipeline.hgetall(
+                this.k('skd', this.sessionId, groupId, t.user, t.server, String(t.device))
+            )
+        }
+        const results = await pipeline.exec()
+        if (!results) return senders.map(() => null)
+
+        return targets.map((t, index) => {
+            const [err, data] = results[index]
+            if (err || !data || typeof data !== 'object') return null
+            const record = data as Record<string, string>
+            if (Object.keys(record).length === 0) return null
+            return {
+                groupId,
+                sender: { user: t.user, server: t.server, device: t.device },
+                keyId: Number(record.key_id),
+                timestampMs: Number(record.timestamp_ms)
+            }
+        })
+    }
+
+    public async deleteDeviceSenderKey(target: SignalAddress, groupId?: string): Promise<number> {
+        const sender = toSignalAddressParts(target)
+        const memberKey = `${sender.user}:${sender.server}:${sender.device}`
+
+        if (groupId !== undefined) {
+            const skKey = this.k(
+                'sk',
+                this.sessionId,
+                groupId,
+                sender.user,
+                sender.server,
+                String(sender.device)
+            )
+            const skdKey = this.k(
+                'skd',
+                this.sessionId,
+                groupId,
+                sender.user,
+                sender.server,
+                String(sender.device)
+            )
+            const groupIdxKey = this.k('sk:grp', this.sessionId, groupId)
+            const pipeline = this.redis.pipeline()
+            pipeline.del(skKey)
+            pipeline.del(skdKey)
+            pipeline.srem(groupIdxKey, memberKey)
+            const results = await pipeline.exec()
+            if (!results) return 0
+            let total = 0
+            for (const [err, val] of results.slice(0, 2)) {
+                if (!err) total += Number(val)
+            }
+            return total
+        }
+
+        const pattern = this.k('sk:grp', this.sessionId, '*')
+        const groupIdxKeys = await scanKeys(this.redis, pattern)
+        const grpPrefix = this.k('sk:grp', this.sessionId, '')
+        let total = 0
+        for (const idxKey of groupIdxKeys) {
+            const isMember = await this.redis.sismember(idxKey, memberKey)
+            if (!isMember) continue
+            const grpId = idxKey.substring(grpPrefix.length)
+            const skKey = this.k(
+                'sk',
+                this.sessionId,
+                grpId,
+                sender.user,
+                sender.server,
+                String(sender.device)
+            )
+            const skdKey = this.k(
+                'skd',
+                this.sessionId,
+                grpId,
+                sender.user,
+                sender.server,
+                String(sender.device)
+            )
+            const pipeline = this.redis.pipeline()
+            pipeline.del(skKey)
+            pipeline.del(skdKey)
+            pipeline.srem(idxKey, memberKey)
+            const results = await pipeline.exec()
+            if (results) {
+                for (const [err, val] of results.slice(0, 2)) {
+                    if (!err) total += Number(val)
+                }
+            }
+        }
+        return total
+    }
+
+    public async markForgetSenderKey(
+        groupId: string,
+        participants: readonly SignalAddress[]
+    ): Promise<number> {
+        if (participants.length === 0) return 0
+        const groupIdxKey = this.k('sk:grp', this.sessionId, groupId)
+        let total = 0
+        const pipeline = this.redis.pipeline()
+        for (const participant of participants) {
+            const sender = toSignalAddressParts(participant)
+            const skKey = this.k(
+                'sk',
+                this.sessionId,
+                groupId,
+                sender.user,
+                sender.server,
+                String(sender.device)
+            )
+            const skdKey = this.k(
+                'skd',
+                this.sessionId,
+                groupId,
+                sender.user,
+                sender.server,
+                String(sender.device)
+            )
+            const memberKey = `${sender.user}:${sender.server}:${sender.device}`
+            pipeline.del(skKey)
+            pipeline.del(skdKey)
+            pipeline.srem(groupIdxKey, memberKey)
+        }
+        const results = await pipeline.exec()
+        if (results) {
+            for (let i = 0; i < results.length; i += 1) {
+                const step = i % 3
+                if (step < 2) {
+                    const [err, val] = results[i]
+                    if (!err) total += Number(val)
+                }
+            }
+        }
+        return total
+    }
+
+    public async clear(): Promise<void> {
+        const patterns = [
+            this.k('sk', this.sessionId, '*'),
+            this.k('skd', this.sessionId, '*'),
+            this.k('sk:grp', this.sessionId, '*')
+        ]
+        const scannedKeys = await Promise.all(patterns.map((p) => scanKeys(this.redis, p)))
+        const allKeys = scannedKeys.flat()
+        if (allKeys.length > 0) {
+            await this.redis.del(...allKeys)
+        }
+    }
+}

--- a/packages/store-redis/src/signal.store.ts
+++ b/packages/store-redis/src/signal.store.ts
@@ -1,0 +1,775 @@
+import type {
+    PreKeyRecord,
+    RegistrationInfo,
+    SignalAddress,
+    SignalSessionRecord,
+    SignedPreKeyRecord
+} from 'zapo-js/signal'
+import {
+    encodeSignalSessionRecord,
+    decodeSignalSessionRecord,
+    toSignalAddressParts
+} from 'zapo-js/signal'
+import type { WaSignalStore, WaSignalMetaSnapshot } from 'zapo-js/store'
+
+import { BaseRedisStore } from './BaseRedisStore'
+import { safeLimit, scanKeys, toBytesOrNull, toRedisBuffer, toStringOrNull } from './helpers'
+import type { WaRedisStorageOptions } from './types'
+
+const LUA_CONSUME_PREKEY = `
+local hashKey = KEYS[1]
+local pubKey  = KEYS[2]
+local privKey = KEYS[3]
+local idsKey  = KEYS[4]
+local availKey = KEYS[5]
+local keyId   = ARGV[1]
+local data = redis.call('HGETALL', hashKey)
+if #data == 0 then
+    return nil
+end
+redis.call('DEL', hashKey, pubKey, privKey)
+redis.call('SREM', idsKey, keyId)
+redis.call('ZREM', availKey, keyId)
+return data
+`
+
+const LUA_RESERVE_PREKEY_IDS = `
+local metaKey = KEYS[1]
+local count = tonumber(ARGV[1])
+local nextId = tonumber(redis.call('HGET', metaKey, 'next_prekey_id') or '1')
+local ids = {}
+for i = 0, count - 1 do
+    ids[i + 1] = nextId + i
+end
+redis.call('HSET', metaKey, 'next_prekey_id', tostring(nextId + count))
+return ids
+`
+
+export class WaSignalRedisStore extends BaseRedisStore implements WaSignalStore {
+    public constructor(options: WaRedisStorageOptions) {
+        super(options)
+    }
+
+    // ── Registration ──────────────────────────────────────────────────
+
+    public async getRegistrationInfo(): Promise<RegistrationInfo | null> {
+        const baseKey = this.k('signal:reg', this.sessionId)
+        const pipeline = this.redis.pipeline()
+        pipeline.hgetall(baseKey)
+        pipeline.getBuffer(this.k('signal:reg', this.sessionId, 'pub'))
+        pipeline.getBuffer(this.k('signal:reg', this.sessionId, 'priv'))
+        const results = await pipeline.exec()
+        if (!results) return null
+        const [, hashData] = results[0]
+        const data = hashData as Record<string, string>
+        if (!data || Object.keys(data).length === 0) return null
+        const pubKey = toBytesOrNull(results[1][1])
+        const privKey = toBytesOrNull(results[2][1])
+        if (!pubKey || !privKey) return null
+        return {
+            registrationId: Number(data.registration_id),
+            identityKeyPair: { pubKey, privKey }
+        }
+    }
+
+    public async setRegistrationInfo(info: RegistrationInfo): Promise<void> {
+        const baseKey = this.k('signal:reg', this.sessionId)
+        const pipeline = this.redis.pipeline()
+        pipeline.hset(baseKey, { registration_id: String(info.registrationId) })
+        pipeline.set(
+            this.k('signal:reg', this.sessionId, 'pub'),
+            toRedisBuffer(info.identityKeyPair.pubKey)
+        )
+        pipeline.set(
+            this.k('signal:reg', this.sessionId, 'priv'),
+            toRedisBuffer(info.identityKeyPair.privKey)
+        )
+        await pipeline.exec()
+    }
+
+    // ── Signed PreKey ─────────────────────────────────────────────────
+
+    public async getSignedPreKey(): Promise<SignedPreKeyRecord | null> {
+        return this.readSignedPreKey()
+    }
+
+    public async setSignedPreKey(record: SignedPreKeyRecord): Promise<void> {
+        const baseKey = this.k('signal:spk', this.sessionId)
+        const pipeline = this.redis.pipeline()
+        pipeline.hset(baseKey, {
+            key_id: String(record.keyId),
+            uploaded: record.uploaded === true ? '1' : '0'
+        })
+        pipeline.set(
+            this.k('signal:spk', this.sessionId, 'pub'),
+            toRedisBuffer(record.keyPair.pubKey)
+        )
+        pipeline.set(
+            this.k('signal:spk', this.sessionId, 'priv'),
+            toRedisBuffer(record.keyPair.privKey)
+        )
+        pipeline.set(this.k('signal:spk', this.sessionId, 'sig'), toRedisBuffer(record.signature))
+        await pipeline.exec()
+    }
+
+    public async getSignedPreKeyById(keyId: number): Promise<SignedPreKeyRecord | null> {
+        const result = await this.readSignedPreKey()
+        if (!result || result.keyId !== keyId) return null
+        return result
+    }
+
+    public async setSignedPreKeyRotationTs(value: number | null): Promise<void> {
+        const metaKey = this.k('signal:meta', this.sessionId)
+        await this.ensureMetaHash()
+        if (value !== null) {
+            await this.redis.hset(metaKey, 'signed_prekey_rotation_ts', String(value))
+        } else {
+            await this.redis.hdel(metaKey, 'signed_prekey_rotation_ts')
+        }
+    }
+
+    public async getSignedPreKeyRotationTs(): Promise<number | null> {
+        const metaKey = this.k('signal:meta', this.sessionId)
+        const raw = await this.redis.hget(metaKey, 'signed_prekey_rotation_ts')
+        if (raw === null || raw === '') return null
+        return Number(raw)
+    }
+
+    // ── PreKeys ───────────────────────────────────────────────────────
+
+    public async putPreKey(record: PreKeyRecord): Promise<void> {
+        await this.ensureMetaHash()
+        await this.upsertPreKey(record)
+        const metaKey = this.k('signal:meta', this.sessionId)
+        const current = await this.redis.hget(metaKey, 'next_prekey_id')
+        const currentId = current ? Number(current) : 1
+        if (record.keyId + 1 > currentId) {
+            await this.redis.hset(metaKey, 'next_prekey_id', String(record.keyId + 1))
+        }
+    }
+
+    public async getOrGenPreKeys(
+        count: number,
+        generator: (keyId: number) => PreKeyRecord | Promise<PreKeyRecord>
+    ): Promise<readonly PreKeyRecord[]> {
+        if (!Number.isSafeInteger(count) || count <= 0) {
+            throw new Error(`invalid prekey count: ${count}`)
+        }
+
+        while (true) {
+            await this.ensureMetaHash()
+            const availKey = this.k('signal:pk:avail', this.sessionId)
+            const resolved = safeLimit(count, 100)
+
+            const availableIds = await this.redis.zrangebyscore(
+                availKey,
+                '-inf',
+                '+inf',
+                'LIMIT',
+                0,
+                resolved
+            )
+            const available: PreKeyRecord[] = []
+            if (availableIds.length > 0) {
+                const pipeline = this.redis.pipeline()
+                for (const id of availableIds) {
+                    pipeline.hgetall(this.k('signal:pk', this.sessionId, id))
+                    pipeline.getBuffer(this.k('signal:pk', this.sessionId, id, 'pub'))
+                    pipeline.getBuffer(this.k('signal:pk', this.sessionId, id, 'priv'))
+                }
+                const results = await pipeline.exec()
+                if (results) {
+                    for (let i = 0; i < availableIds.length; i += 1) {
+                        const base = i * 3
+                        const [hashErr, hashData] = results[base]
+                        const record = hashData as Record<string, string>
+                        if (hashErr || !record || Object.keys(record).length === 0) continue
+                        const pubKey = toBytesOrNull(results[base + 1][1])
+                        const privKey = toBytesOrNull(results[base + 2][1])
+                        if (!pubKey || !privKey) continue
+                        available.push({
+                            keyId: Number(availableIds[i]),
+                            keyPair: { pubKey, privKey },
+                            uploaded:
+                                record.uploaded !== undefined ? record.uploaded === '1' : undefined
+                        })
+                    }
+                }
+            }
+
+            const missing = count - available.length
+            if (missing <= 0) {
+                return available.slice(0, count)
+            }
+
+            const metaKey = this.k('signal:meta', this.sessionId)
+            const reservedIds = (await this.redis.eval(
+                LUA_RESERVE_PREKEY_IDS,
+                1,
+                metaKey,
+                String(missing)
+            )) as number[]
+
+            const generated: PreKeyRecord[] = []
+            let maxId = reservedIds[reservedIds.length - 1]
+            for (const keyId of reservedIds) {
+                const record = await generator(keyId)
+                generated.push(record)
+                if (record.keyId > maxId) {
+                    maxId = record.keyId
+                }
+            }
+
+            const pipeline = this.redis.pipeline()
+            const idsKey = this.k('signal:pk:ids', this.sessionId)
+            for (const record of generated) {
+                const idStr = String(record.keyId)
+                const pkKey = this.k('signal:pk', this.sessionId, idStr)
+                pipeline.hset(pkKey, {
+                    uploaded: record.uploaded === true ? '1' : '0'
+                })
+                pipeline.set(
+                    this.k('signal:pk', this.sessionId, idStr, 'pub'),
+                    toRedisBuffer(record.keyPair.pubKey)
+                )
+                pipeline.set(
+                    this.k('signal:pk', this.sessionId, idStr, 'priv'),
+                    toRedisBuffer(record.keyPair.privKey)
+                )
+                pipeline.sadd(idsKey, idStr)
+                if (record.uploaded !== true) {
+                    pipeline.zadd(availKey, record.keyId, idStr)
+                }
+            }
+            // next_prekey_id is already atomically updated by LUA_RESERVE_PREKEY_IDS;
+            // only reconcile if the generator produced IDs beyond the reserved range
+            if (maxId + 1 > reservedIds[reservedIds.length - 1] + 1) {
+                pipeline.hset(metaKey, 'next_prekey_id', String(maxId + 1))
+            }
+            await pipeline.exec()
+
+            const recheckIds = await this.redis.zrangebyscore(
+                availKey,
+                '-inf',
+                '+inf',
+                'LIMIT',
+                0,
+                resolved
+            )
+            if (recheckIds.length >= count) {
+                const fetchPipeline = this.redis.pipeline()
+                for (const id of recheckIds.slice(0, count)) {
+                    fetchPipeline.hgetall(this.k('signal:pk', this.sessionId, id))
+                    fetchPipeline.getBuffer(this.k('signal:pk', this.sessionId, id, 'pub'))
+                    fetchPipeline.getBuffer(this.k('signal:pk', this.sessionId, id, 'priv'))
+                }
+                const fetchResults = await fetchPipeline.exec()
+                const finalKeys: PreKeyRecord[] = []
+                if (fetchResults) {
+                    for (let i = 0; i < Math.min(recheckIds.length, count); i += 1) {
+                        const base = i * 3
+                        const [hashErr, hashData] = fetchResults[base]
+                        const record = hashData as Record<string, string>
+                        if (hashErr || !record || Object.keys(record).length === 0) continue
+                        const pubKey = toBytesOrNull(fetchResults[base + 1][1])
+                        const privKey = toBytesOrNull(fetchResults[base + 2][1])
+                        if (!pubKey || !privKey) continue
+                        finalKeys.push({
+                            keyId: Number(recheckIds[i]),
+                            keyPair: { pubKey, privKey },
+                            uploaded:
+                                record.uploaded !== undefined ? record.uploaded === '1' : undefined
+                        })
+                    }
+                }
+                if (finalKeys.length >= count) {
+                    return finalKeys.slice(0, count)
+                }
+            }
+        }
+    }
+
+    public async getPreKeyById(keyId: number): Promise<PreKeyRecord | null> {
+        const idStr = String(keyId)
+        const pipeline = this.redis.pipeline()
+        pipeline.hgetall(this.k('signal:pk', this.sessionId, idStr))
+        pipeline.getBuffer(this.k('signal:pk', this.sessionId, idStr, 'pub'))
+        pipeline.getBuffer(this.k('signal:pk', this.sessionId, idStr, 'priv'))
+        const results = await pipeline.exec()
+        if (!results) return null
+        const [hashErr, hashData] = results[0]
+        const data = hashData as Record<string, string>
+        if (hashErr || !data || Object.keys(data).length === 0) return null
+        const pubKey = toBytesOrNull(results[1][1])
+        const privKey = toBytesOrNull(results[2][1])
+        if (!pubKey || !privKey) return null
+        return {
+            keyId,
+            keyPair: { pubKey, privKey },
+            uploaded: data.uploaded !== undefined ? data.uploaded === '1' : undefined
+        }
+    }
+
+    public async getPreKeysById(
+        keyIds: readonly number[]
+    ): Promise<readonly (PreKeyRecord | null)[]> {
+        if (keyIds.length === 0) return []
+        const pipeline = this.redis.pipeline()
+        for (const keyId of keyIds) {
+            const idStr = String(keyId)
+            pipeline.hgetall(this.k('signal:pk', this.sessionId, idStr))
+            pipeline.getBuffer(this.k('signal:pk', this.sessionId, idStr, 'pub'))
+            pipeline.getBuffer(this.k('signal:pk', this.sessionId, idStr, 'priv'))
+        }
+        const results = await pipeline.exec()
+        if (!results) return keyIds.map(() => null)
+        return keyIds.map((keyId, index) => {
+            const base = index * 3
+            const [hashErr, hashData] = results[base]
+            const data = hashData as Record<string, string>
+            if (hashErr || !data || Object.keys(data).length === 0) return null
+            const pubKey = toBytesOrNull(results[base + 1][1])
+            const privKey = toBytesOrNull(results[base + 2][1])
+            if (!pubKey || !privKey) return null
+            return {
+                keyId,
+                keyPair: { pubKey, privKey },
+                uploaded: data.uploaded !== undefined ? data.uploaded === '1' : undefined
+            }
+        })
+    }
+
+    public async consumePreKeyById(keyId: number): Promise<PreKeyRecord | null> {
+        const idStr = String(keyId)
+        const hashKey = this.k('signal:pk', this.sessionId, idStr)
+        const pubBinKey = this.k('signal:pk', this.sessionId, idStr, 'pub')
+        const privBinKey = this.k('signal:pk', this.sessionId, idStr, 'priv')
+        const idsKey = this.k('signal:pk:ids', this.sessionId)
+        const availKey = this.k('signal:pk:avail', this.sessionId)
+
+        // Read binary keys before the Lua script deletes them
+        const binPipeline = this.redis.pipeline()
+        binPipeline.getBuffer(pubBinKey)
+        binPipeline.getBuffer(privBinKey)
+        const binResults = await binPipeline.exec()
+        if (!binResults) return null
+        const pubKey = toBytesOrNull(binResults[0][1])
+        const privKey = toBytesOrNull(binResults[1][1])
+
+        const raw = (await this.redis.eval(
+            LUA_CONSUME_PREKEY,
+            5,
+            hashKey,
+            pubBinKey,
+            privBinKey,
+            idsKey,
+            availKey,
+            idStr
+        )) as string[] | null
+        if (!raw || raw.length === 0) return null
+        if (!pubKey || !privKey) return null
+
+        const data: Record<string, string> = {}
+        for (let i = 0; i < raw.length; i += 2) {
+            data[raw[i]] = raw[i + 1]
+        }
+        return {
+            keyId,
+            keyPair: { pubKey, privKey },
+            uploaded: data.uploaded !== undefined ? data.uploaded === '1' : undefined
+        }
+    }
+
+    public async getOrGenSinglePreKey(
+        generator: (keyId: number) => PreKeyRecord | Promise<PreKeyRecord>
+    ): Promise<PreKeyRecord> {
+        const records = await this.getOrGenPreKeys(1, generator)
+        return records[0]
+    }
+
+    public async markKeyAsUploaded(keyId: number): Promise<void> {
+        const metaKey = this.k('signal:meta', this.sessionId)
+        const raw = await this.redis.hget(metaKey, 'next_prekey_id')
+        const nextId = raw ? Number(raw) : 1
+        if (keyId < 0 || keyId >= nextId) {
+            throw new Error(`prekey ${keyId} is out of boundary`)
+        }
+
+        const idsKey = this.k('signal:pk:ids', this.sessionId)
+        const allIds = await this.redis.smembers(idsKey)
+        const availKey = this.k('signal:pk:avail', this.sessionId)
+        const pipeline = this.redis.pipeline()
+        for (const idStr of allIds) {
+            const id = Number(idStr)
+            if (id <= keyId) {
+                const pkKey = this.k('signal:pk', this.sessionId, idStr)
+                pipeline.hset(pkKey, 'uploaded', '1')
+                pipeline.zrem(availKey, idStr)
+            }
+        }
+        await pipeline.exec()
+    }
+
+    // ── Server State ──────────────────────────────────────────────────
+
+    public async setServerHasPreKeys(value: boolean): Promise<void> {
+        await this.ensureMetaHash()
+        const metaKey = this.k('signal:meta', this.sessionId)
+        await this.redis.hset(metaKey, 'server_has_prekeys', value ? '1' : '0')
+    }
+
+    public async getServerHasPreKeys(): Promise<boolean> {
+        const metaKey = this.k('signal:meta', this.sessionId)
+        const raw = await this.redis.hget(metaKey, 'server_has_prekeys')
+        return raw === '1'
+    }
+
+    // ── Meta ──────────────────────────────────────────────────────────
+
+    public async getSignalMeta(): Promise<WaSignalMetaSnapshot> {
+        await this.ensureMetaHash()
+
+        const pipeline = this.redis.pipeline()
+        pipeline.hgetall(this.k('signal:meta', this.sessionId))
+        pipeline.hgetall(this.k('signal:reg', this.sessionId))
+        pipeline.getBuffer(this.k('signal:reg', this.sessionId, 'pub'))
+        pipeline.getBuffer(this.k('signal:reg', this.sessionId, 'priv'))
+        pipeline.hgetall(this.k('signal:spk', this.sessionId))
+        pipeline.getBuffer(this.k('signal:spk', this.sessionId, 'pub'))
+        pipeline.getBuffer(this.k('signal:spk', this.sessionId, 'priv'))
+        pipeline.getBuffer(this.k('signal:spk', this.sessionId, 'sig'))
+        const results = await pipeline.exec()
+        if (!results) {
+            return {
+                serverHasPreKeys: false,
+                signedPreKeyRotationTs: null,
+                registrationInfo: null,
+                signedPreKey: null
+            }
+        }
+
+        const metaData = results[0][1] as Record<string, string>
+        const serverHasPreKeys = metaData.server_has_prekeys === '1'
+        const signedPreKeyRotationTs =
+            toStringOrNull(metaData.signed_prekey_rotation_ts) !== null
+                ? Number(metaData.signed_prekey_rotation_ts)
+                : null
+
+        const regData = results[1][1] as Record<string, string>
+        let registrationInfo: RegistrationInfo | null = null
+        if (regData && Object.keys(regData).length > 0) {
+            const regPub = toBytesOrNull(results[2][1])
+            const regPriv = toBytesOrNull(results[3][1])
+            if (regPub && regPriv) {
+                registrationInfo = {
+                    registrationId: Number(regData.registration_id),
+                    identityKeyPair: { pubKey: regPub, privKey: regPriv }
+                }
+            }
+        }
+
+        const spkData = results[4][1] as Record<string, string>
+        let signedPreKey: SignedPreKeyRecord | null = null
+        if (spkData && Object.keys(spkData).length > 0) {
+            const spkPub = toBytesOrNull(results[5][1])
+            const spkPriv = toBytesOrNull(results[6][1])
+            const spkSig = toBytesOrNull(results[7][1])
+            if (spkPub && spkPriv && spkSig) {
+                signedPreKey = {
+                    keyId: Number(spkData.key_id),
+                    keyPair: { pubKey: spkPub, privKey: spkPriv },
+                    signature: spkSig,
+                    uploaded: spkData.uploaded !== undefined ? spkData.uploaded === '1' : undefined
+                }
+            }
+        }
+
+        return {
+            serverHasPreKeys,
+            signedPreKeyRotationTs,
+            registrationInfo,
+            signedPreKey
+        }
+    }
+
+    // ── Sessions ──────────────────────────────────────────────────────
+
+    public async hasSession(address: SignalAddress): Promise<boolean> {
+        const target = toSignalAddressParts(address)
+        const key = this.k(
+            'signal:sess',
+            this.sessionId,
+            target.user,
+            target.server,
+            String(target.device)
+        )
+        return (await this.redis.exists(key)) === 1
+    }
+
+    public async hasSessions(addresses: readonly SignalAddress[]): Promise<readonly boolean[]> {
+        if (addresses.length === 0) return []
+        const pipeline = this.redis.pipeline()
+        for (const address of addresses) {
+            const target = toSignalAddressParts(address)
+            pipeline.exists(
+                this.k(
+                    'signal:sess',
+                    this.sessionId,
+                    target.user,
+                    target.server,
+                    String(target.device)
+                )
+            )
+        }
+        const results = await pipeline.exec()
+        if (!results) return addresses.map(() => false)
+        return results.map(([err, val]) => !err && val === 1)
+    }
+
+    public async getSession(address: SignalAddress): Promise<SignalSessionRecord | null> {
+        const target = toSignalAddressParts(address)
+        const key = this.k(
+            'signal:sess',
+            this.sessionId,
+            target.user,
+            target.server,
+            String(target.device)
+        )
+        const data = await this.redis.getBuffer(key)
+        if (!data) return null
+        return decodeSignalSessionRecord(new Uint8Array(data))
+    }
+
+    public async getSessionsBatch(
+        addresses: readonly SignalAddress[]
+    ): Promise<readonly (SignalSessionRecord | null)[]> {
+        if (addresses.length === 0) return []
+        const pipeline = this.redis.pipeline()
+        for (const address of addresses) {
+            const target = toSignalAddressParts(address)
+            pipeline.getBuffer(
+                this.k(
+                    'signal:sess',
+                    this.sessionId,
+                    target.user,
+                    target.server,
+                    String(target.device)
+                )
+            )
+        }
+        const results = await pipeline.exec()
+        if (!results) return addresses.map(() => null)
+        return results.map(([err, data]) => {
+            if (err || !data) return null
+            return decodeSignalSessionRecord(new Uint8Array(data as Uint8Array))
+        })
+    }
+
+    public async setSession(address: SignalAddress, session: SignalSessionRecord): Promise<void> {
+        const target = toSignalAddressParts(address)
+        const key = this.k(
+            'signal:sess',
+            this.sessionId,
+            target.user,
+            target.server,
+            String(target.device)
+        )
+        const encoded = encodeSignalSessionRecord(session)
+        await this.redis.set(key, toRedisBuffer(encoded))
+    }
+
+    public async setSessionsBatch(
+        entries: readonly {
+            readonly address: SignalAddress
+            readonly session: SignalSessionRecord
+        }[]
+    ): Promise<void> {
+        if (entries.length === 0) return
+        const pipeline = this.redis.pipeline()
+        for (const entry of entries) {
+            const target = toSignalAddressParts(entry.address)
+            const key = this.k(
+                'signal:sess',
+                this.sessionId,
+                target.user,
+                target.server,
+                String(target.device)
+            )
+            const encoded = encodeSignalSessionRecord(entry.session)
+            pipeline.set(key, toRedisBuffer(encoded))
+        }
+        await pipeline.exec()
+    }
+
+    public async deleteSession(address: SignalAddress): Promise<void> {
+        const target = toSignalAddressParts(address)
+        const key = this.k(
+            'signal:sess',
+            this.sessionId,
+            target.user,
+            target.server,
+            String(target.device)
+        )
+        await this.redis.del(key)
+    }
+
+    // ── Identities ────────────────────────────────────────────────────
+
+    public async getRemoteIdentity(address: SignalAddress): Promise<Uint8Array | null> {
+        const target = toSignalAddressParts(address)
+        const key = this.k(
+            'signal:ident',
+            this.sessionId,
+            target.user,
+            target.server,
+            String(target.device)
+        )
+        const data = await this.redis.getBuffer(key)
+        if (!data) return null
+        return new Uint8Array(data)
+    }
+
+    public async getRemoteIdentities(
+        addresses: readonly SignalAddress[]
+    ): Promise<readonly (Uint8Array | null)[]> {
+        if (addresses.length === 0) return []
+        const pipeline = this.redis.pipeline()
+        for (const address of addresses) {
+            const target = toSignalAddressParts(address)
+            pipeline.getBuffer(
+                this.k(
+                    'signal:ident',
+                    this.sessionId,
+                    target.user,
+                    target.server,
+                    String(target.device)
+                )
+            )
+        }
+        const results = await pipeline.exec()
+        if (!results) return addresses.map(() => null)
+        return results.map(([err, data]) => {
+            if (err || !data) return null
+            return new Uint8Array(data as Uint8Array)
+        })
+    }
+
+    public async setRemoteIdentity(address: SignalAddress, identityKey: Uint8Array): Promise<void> {
+        const target = toSignalAddressParts(address)
+        const key = this.k(
+            'signal:ident',
+            this.sessionId,
+            target.user,
+            target.server,
+            String(target.device)
+        )
+        await this.redis.set(key, toRedisBuffer(identityKey))
+    }
+
+    public async setRemoteIdentities(
+        entries: readonly {
+            readonly address: SignalAddress
+            readonly identityKey: Uint8Array
+        }[]
+    ): Promise<void> {
+        if (entries.length === 0) return
+        const pipeline = this.redis.pipeline()
+        for (const entry of entries) {
+            const target = toSignalAddressParts(entry.address)
+            const key = this.k(
+                'signal:ident',
+                this.sessionId,
+                target.user,
+                target.server,
+                String(target.device)
+            )
+            pipeline.set(key, toRedisBuffer(entry.identityKey))
+        }
+        await pipeline.exec()
+    }
+
+    // ── Clear ─────────────────────────────────────────────────────────
+
+    public async clear(): Promise<void> {
+        const patterns = [
+            this.k('signal:meta', this.sessionId),
+            this.k('signal:reg', this.sessionId),
+            this.k('signal:spk', this.sessionId),
+            this.k('signal:pk:ids', this.sessionId),
+            this.k('signal:pk:avail', this.sessionId)
+        ]
+        const scanPatterns = [
+            this.k('signal:reg', this.sessionId, '*'),
+            this.k('signal:spk', this.sessionId, '*'),
+            this.k('signal:pk', this.sessionId, '*'),
+            this.k('signal:sess', this.sessionId, '*'),
+            this.k('signal:ident', this.sessionId, '*')
+        ]
+        const scannedKeys = await Promise.all(scanPatterns.map((p) => scanKeys(this.redis, p)))
+        const allKeys = [...patterns, ...scannedKeys.flat()]
+        if (allKeys.length > 0) {
+            await this.redis.del(...allKeys)
+        }
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────
+
+    private async ensureMetaHash(): Promise<void> {
+        const metaKey = this.k('signal:meta', this.sessionId)
+        const exists = await this.redis.exists(metaKey)
+        if (!exists) {
+            await this.redis.hsetnx(metaKey, 'server_has_prekeys', '0')
+            await this.redis.hsetnx(metaKey, 'next_prekey_id', '1')
+        }
+    }
+
+    private async upsertPreKey(record: PreKeyRecord): Promise<void> {
+        const idStr = String(record.keyId)
+        const pkKey = this.k('signal:pk', this.sessionId, idStr)
+        const idsKey = this.k('signal:pk:ids', this.sessionId)
+        const availKey = this.k('signal:pk:avail', this.sessionId)
+        const pipeline = this.redis.pipeline()
+        pipeline.hset(pkKey, {
+            uploaded: record.uploaded === true ? '1' : '0'
+        })
+        pipeline.set(
+            this.k('signal:pk', this.sessionId, idStr, 'pub'),
+            toRedisBuffer(record.keyPair.pubKey)
+        )
+        pipeline.set(
+            this.k('signal:pk', this.sessionId, idStr, 'priv'),
+            toRedisBuffer(record.keyPair.privKey)
+        )
+        pipeline.sadd(idsKey, idStr)
+        if (record.uploaded !== true) {
+            pipeline.zadd(availKey, record.keyId, idStr)
+        } else {
+            pipeline.zrem(availKey, idStr)
+        }
+        await pipeline.exec()
+    }
+
+    private async readSignedPreKey(): Promise<SignedPreKeyRecord | null> {
+        const baseKey = this.k('signal:spk', this.sessionId)
+        const pipeline = this.redis.pipeline()
+        pipeline.hgetall(baseKey)
+        pipeline.getBuffer(this.k('signal:spk', this.sessionId, 'pub'))
+        pipeline.getBuffer(this.k('signal:spk', this.sessionId, 'priv'))
+        pipeline.getBuffer(this.k('signal:spk', this.sessionId, 'sig'))
+        const results = await pipeline.exec()
+        if (!results) return null
+        const [, hashData] = results[0]
+        const data = hashData as Record<string, string>
+        if (!data || Object.keys(data).length === 0) return null
+        const pubKey = toBytesOrNull(results[1][1])
+        const privKey = toBytesOrNull(results[2][1])
+        const signature = toBytesOrNull(results[3][1])
+        if (!pubKey || !privKey || !signature) return null
+        return {
+            keyId: Number(data.key_id),
+            keyPair: { pubKey, privKey },
+            signature,
+            uploaded: data.uploaded !== undefined ? data.uploaded === '1' : undefined
+        }
+    }
+}

--- a/packages/store-redis/src/thread.store.ts
+++ b/packages/store-redis/src/thread.store.ts
@@ -1,0 +1,125 @@
+import type { WaThreadStore, WaStoredThreadRecord } from 'zapo-js/store'
+
+import { BaseRedisStore } from './BaseRedisStore'
+import { safeLimit, scanKeys, toStringOrNull } from './helpers'
+import type { WaRedisStorageOptions } from './types'
+
+function hashToRecord(data: Record<string, string>): WaStoredThreadRecord {
+    return {
+        jid: data.jid,
+        name: toStringOrNull(data.name) ?? undefined,
+        unreadCount:
+            toStringOrNull(data.unread_count) !== null ? Number(data.unread_count) : undefined,
+        archived: toStringOrNull(data.archived) !== null ? data.archived === '1' : undefined,
+        pinned: toStringOrNull(data.pinned) !== null ? Number(data.pinned) : undefined,
+        muteEndMs: toStringOrNull(data.mute_end_ms) !== null ? Number(data.mute_end_ms) : undefined,
+        markedAsUnread:
+            toStringOrNull(data.marked_as_unread) !== null
+                ? data.marked_as_unread === '1'
+                : undefined,
+        ephemeralExpiration:
+            toStringOrNull(data.ephemeral_expiration) !== null
+                ? Number(data.ephemeral_expiration)
+                : undefined
+    }
+}
+
+function recordToHash(record: WaStoredThreadRecord): Record<string, string> {
+    const fields: Record<string, string> = {
+        jid: record.jid
+    }
+
+    if (record.name !== undefined) {
+        fields.name = record.name
+    }
+    if (record.unreadCount !== undefined) {
+        fields.unread_count = String(record.unreadCount)
+    }
+    if (record.archived !== undefined) {
+        fields.archived = record.archived ? '1' : '0'
+    }
+    if (record.pinned !== undefined) {
+        fields.pinned = String(record.pinned)
+    }
+    if (record.muteEndMs !== undefined) {
+        fields.mute_end_ms = String(record.muteEndMs)
+    }
+    if (record.markedAsUnread !== undefined) {
+        fields.marked_as_unread = record.markedAsUnread ? '1' : '0'
+    }
+    if (record.ephemeralExpiration !== undefined) {
+        fields.ephemeral_expiration = String(record.ephemeralExpiration)
+    }
+
+    return fields
+}
+
+export class WaThreadRedisStore extends BaseRedisStore implements WaThreadStore {
+    public constructor(options: WaRedisStorageOptions) {
+        super(options)
+    }
+
+    private threadKey(jid: string): string {
+        return this.k('thread', this.sessionId, jid)
+    }
+
+    public async upsert(record: WaStoredThreadRecord): Promise<void> {
+        const key = this.threadKey(record.jid)
+        const existing = await this.redis.hgetall(key)
+        const newFields = recordToHash(record)
+
+        if (existing && Object.keys(existing).length > 0) {
+            const merged: Record<string, string> = { ...existing }
+            for (const [field, value] of Object.entries(newFields)) {
+                merged[field] = value
+            }
+            await this.redis.hset(key, merged)
+        } else {
+            await this.redis.hset(key, newFields)
+        }
+    }
+
+    public async upsertBatch(records: readonly WaStoredThreadRecord[]): Promise<void> {
+        if (records.length === 0) return
+
+        for (const record of records) {
+            await this.upsert(record)
+        }
+    }
+
+    public async getByJid(jid: string): Promise<WaStoredThreadRecord | null> {
+        const data = await this.redis.hgetall(this.threadKey(jid))
+        if (!data || Object.keys(data).length === 0) return null
+        return hashToRecord(data)
+    }
+
+    public async list(limit?: number): Promise<readonly WaStoredThreadRecord[]> {
+        const resolved = safeLimit(limit, 100)
+        const keys = await scanKeys(this.redis, this.k('thread', this.sessionId, '*'))
+
+        const records: WaStoredThreadRecord[] = []
+        for (const key of keys) {
+            if (records.length >= resolved) break
+            const data = await this.redis.hgetall(key)
+            if (data && Object.keys(data).length > 0) {
+                records.push(hashToRecord(data))
+            }
+        }
+        return records
+    }
+
+    public async deleteByJid(jid: string): Promise<number> {
+        return this.redis.del(this.threadKey(jid))
+    }
+
+    public async clear(): Promise<void> {
+        const keys = await scanKeys(this.redis, this.k('thread', this.sessionId, '*'))
+        if (keys.length === 0) return
+
+        const pipeline = this.redis.pipeline()
+        for (const key of keys) {
+            pipeline.del(key)
+        }
+        await pipeline.exec()
+    }
+}

--- a/packages/store-redis/src/types.ts
+++ b/packages/store-redis/src/types.ts
@@ -1,0 +1,13 @@
+import type Redis from 'ioredis'
+import type { RedisOptions } from 'ioredis'
+
+export interface WaRedisStorageOptions {
+    readonly redis: Redis
+    readonly sessionId: string
+    readonly keyPrefix?: string
+}
+
+export interface WaRedisCreateStoreOptions {
+    readonly redis: Redis | RedisOptions
+    readonly keyPrefix?: string
+}

--- a/packages/store-redis/tsconfig.build.cjs.json
+++ b/packages/store-redis/tsconfig.build.cjs.json
@@ -1,0 +1,27 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "baseUrl": "../..",
+        "paths": {
+            "zapo-js": ["dist/types/index.d.ts"],
+            "zapo-js/store": ["dist/types/store/index.d.ts"],
+            "zapo-js/signal": ["dist/types/signal/index.d.ts"],
+            "zapo-js/auth": ["dist/types/auth/index.d.ts"],
+            "zapo-js/appstate": ["dist/types/appstate/index.d.ts"],
+            "zapo-js/retry": ["dist/types/retry/index.d.ts"],
+            "zapo-js/proto": ["dist/types/proto.d.ts"],
+            "zapo-js/protocol": ["dist/types/protocol/index.d.ts"],
+            "zapo-js/crypto": ["dist/types/crypto/index.d.ts"],
+            "zapo-js/util": ["dist/types/util/index.d.ts"]
+        }
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/store-redis/tsconfig.json
+++ b/packages/store-redis/tsconfig.json
@@ -1,0 +1,42 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "types": ["node"],
+        "rootDir": "../..",
+        "baseUrl": "../..",
+        "paths": {
+            "zapo-js": ["src/index.ts"],
+            "zapo-js/store": ["src/store/index.ts"],
+            "zapo-js/signal": ["src/signal/index.ts"],
+            "zapo-js/auth": ["src/auth/index.ts"],
+            "zapo-js/appstate": ["src/appstate/index.ts"],
+            "zapo-js/retry": ["src/retry/index.ts"],
+            "zapo-js/proto": ["src/proto.ts"],
+            "zapo-js/protocol": ["src/protocol/index.ts"],
+            "zapo-js/crypto": ["src/crypto/index.ts"],
+            "zapo-js/util": ["src/util/index.ts"],
+            "@appstate": ["src/appstate/index.ts"],
+            "@appstate/*": ["src/appstate/*"],
+            "@auth": ["src/auth/index.ts"],
+            "@auth/*": ["src/auth/*"],
+            "@crypto": ["src/crypto/index.ts"],
+            "@crypto/*": ["src/crypto/*"],
+            "@infra/*": ["src/infra/*"],
+            "@protocol": ["src/protocol/index.ts"],
+            "@protocol/*": ["src/protocol/*"],
+            "@proto": ["src/proto.ts"],
+            "@retry": ["src/retry/index.ts"],
+            "@retry/*": ["src/retry/*"],
+            "@signal": ["src/signal/index.ts"],
+            "@signal/*": ["src/signal/*"],
+            "@store": ["src/store/index.ts"],
+            "@store/*": ["src/store/*"],
+            "@transport": ["src/transport/index.ts"],
+            "@transport/*": ["src/transport/*"],
+            "@util/*": ["src/util/*"]
+        },
+        "noEmit": true
+    },
+    "include": ["src"],
+    "exclude": ["dist", "node_modules"]
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,4 +1,4 @@
-export { bytesToHex, toBytesView, uint8Equal } from '@util/bytes'
+export { bytesToHex, hexToBytes, toBytesView, uint8Equal } from '@util/bytes'
 export {
     asBytes,
     asNumber,


### PR DESCRIPTION
- implement all 11 store contracts backed by Redis via ioredis
- zero-copy binary reads via getBuffer (Buffer extends Uint8Array)
- zero-copy binary writes via toRedisBuffer (Buffer view, no allocation)
- store binary fields as separate keys with set/getBuffer instead of hex in hashes
- use Lua scripts for atomic consumePreKeyById and incrementInboundCounter
- use Redis pipelines for all batch operations (sessions, prekeys, identities)
- use sorted sets for message ordering (listByThread with zrevrangebyscore)
- use native Redis TTL (pexpire) for cache stores instead of manual expiry tracking
- use SCAN (not KEYS) for all key enumeration (production-safe)
- add createRedisStore() helper for plug-and-play backend registration
- add RedisCleanupPoller with in-flight guard and allSettled error handling
- validate keyPrefix in constructor
- no migrations needed (Redis creates keys on write)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Redis storage backend with full support for messages, threads, contacts, auth, Signal state, sender keys, app state, retry, participants, device lists, and privacy tokens; includes store factory, export/clear, and configurable cache TTLs.

* **Chores**
  * Added package manifest and TypeScript build/configuration plus ESLint updates to enable the new storage package; minor utility re-exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->