### PR TITLE
feat: add @zapo-js/store-mongo package with mongodb driver

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,7 +41,8 @@ module.exports = [
                     './packages/store-mysql/tsconfig.json',
                     './packages/store-sqlite/tsconfig.json',
                     './packages/store-postgres/tsconfig.json',
-                    './packages/store-redis/tsconfig.json'
+                    './packages/store-redis/tsconfig.json',
+                    './packages/store-mongo/tsconfig.json'
                 ]
             }
         }

--- a/packages/store-mongo/package.json
+++ b/packages/store-mongo/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "@zapo-js/store-mongo",
+    "version": "0.1.0",
+    "description": "MongoDB store provider for zapo-js",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "require": "./dist/index.js",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": [
+        "dist"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsc -p tsconfig.build.cjs.json",
+        "typecheck": "tsc --noEmit",
+        "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
+    },
+    "peerDependencies": {
+        "zapo-js": ">=0.1.0",
+        "mongodb": ">=6.0.0"
+    },
+    "peerDependenciesMeta": {
+        "zapo-js": {
+            "optional": true
+        }
+    },
+    "devDependencies": {
+        "mongodb": "^6.16.0",
+        "zapo-js": "file:../.."
+    },
+    "engines": {
+        "node": ">=20.9.0"
+    }
+}

--- a/packages/store-mongo/src/BaseMongoStore.ts
+++ b/packages/store-mongo/src/BaseMongoStore.ts
@@ -1,0 +1,55 @@
+import type { ClientSession, Collection, Db, Document } from 'mongodb'
+
+import { assertSafeCollectionPrefix } from './helpers'
+import type { WaMongoStorageOptions } from './types'
+
+export abstract class BaseMongoStore {
+    protected readonly db: Db
+    protected readonly sessionId: string
+    protected readonly collectionPrefix: string
+    private indexPromise: Promise<void> | null
+
+    protected constructor(options: WaMongoStorageOptions) {
+        this.db = options.db
+        this.sessionId = options.sessionId
+        this.collectionPrefix = options.collectionPrefix ?? ''
+        assertSafeCollectionPrefix(this.collectionPrefix)
+        this.indexPromise = null
+    }
+
+    protected col<T extends Document = Document>(name: string): Collection<T> {
+        return this.db.collection<T>(`${this.collectionPrefix}${name}`)
+    }
+
+    protected async ensureIndexes(): Promise<void> {
+        if (!this.indexPromise) {
+            this.indexPromise = this.createIndexes().catch((err) => {
+                this.indexPromise = null
+                throw err
+            })
+        }
+        return this.indexPromise
+    }
+
+    protected async createIndexes(): Promise<void> {
+        // Override in subclasses that need indexes
+    }
+
+    protected async withSession<T>(run: (session: ClientSession) => Promise<T>): Promise<T> {
+        await this.ensureIndexes()
+        const session = this.db.client.startSession()
+        try {
+            let result: T
+            await session.withTransaction(async () => {
+                result = await run(session)
+            })
+            return result!
+        } finally {
+            await session.endSession()
+        }
+    }
+
+    public async destroy(): Promise<void> {
+        this.indexPromise = null
+    }
+}

--- a/packages/store-mongo/src/appstate.store.ts
+++ b/packages/store-mongo/src/appstate.store.ts
@@ -1,0 +1,407 @@
+import type { AnyBulkWriteOperation, Binary } from 'mongodb'
+import type {
+    AppStateCollectionName,
+    WaAppStateSyncKey,
+    WaAppStateStoreData
+} from 'zapo-js/appstate'
+import {
+    APP_STATE_EMPTY_LT_HASH,
+    encodeAppStateFingerprint,
+    decodeAppStateFingerprint,
+    keyEpoch
+} from 'zapo-js/appstate'
+import type {
+    WaAppStateStore,
+    WaAppStateCollectionStoreState,
+    WaAppStateCollectionStateUpdate
+} from 'zapo-js/store'
+
+import { BaseMongoStore } from './BaseMongoStore'
+import { fromBinary, fromBinaryOrNull, toBinary, bytesToHex, uint8Equal } from './helpers'
+import type { WaMongoStorageOptions } from './types'
+
+interface SyncKeyDoc {
+    _id: { session_id: string; key_id: Binary }
+    key_data: Binary
+    timestamp: number
+    fingerprint: Binary | null
+    key_epoch: number
+}
+
+interface CollectionVersionDoc {
+    _id: { session_id: string; collection: string }
+    version: number
+    hash: Binary
+}
+
+interface IndexValueDoc {
+    _id: { session_id: string; collection: string; index_mac_hex: string }
+    value_mac: Binary
+}
+
+export class WaAppStateMongoStore extends BaseMongoStore implements WaAppStateStore {
+    public constructor(options: WaMongoStorageOptions) {
+        super(options)
+    }
+
+    protected override async createIndexes(): Promise<void> {
+        const syncKeys = this.col<SyncKeyDoc>('appstate_sync_keys')
+        await syncKeys.createIndex({ '_id.session_id': 1, key_epoch: -1 })
+    }
+
+    public async exportData(): Promise<WaAppStateStoreData> {
+        return this.withSession(async (session) => {
+            const syncKeysCol = this.col<SyncKeyDoc>('appstate_sync_keys')
+            const versionsCol = this.col<CollectionVersionDoc>('appstate_collection_versions')
+            const valuesCol = this.col<IndexValueDoc>('appstate_collection_index_values')
+
+            const [keyDocs, versionDocs, valueDocs] = await Promise.all([
+                syncKeysCol.find({ '_id.session_id': this.sessionId }, { session }).toArray(),
+                versionsCol.find({ '_id.session_id': this.sessionId }, { session }).toArray(),
+                valuesCol.find({ '_id.session_id': this.sessionId }, { session }).toArray()
+            ])
+
+            const keys: WaAppStateSyncKey[] = keyDocs.map((doc) => ({
+                keyId: fromBinary(doc._id.key_id),
+                keyData: fromBinary(doc.key_data),
+                timestamp: doc.timestamp,
+                fingerprint: decodeAppStateFingerprint(fromBinaryOrNull(doc.fingerprint))
+            }))
+
+            const collections: WaAppStateStoreData['collections'] = {}
+            for (const doc of versionDocs) {
+                const name = doc._id.collection as AppStateCollectionName
+                collections[name] = {
+                    version: doc.version,
+                    hash: fromBinary(doc.hash),
+                    indexValueMap: {}
+                }
+            }
+            for (const doc of valueDocs) {
+                const name = doc._id.collection as AppStateCollectionName
+                const entry = collections[name]
+                if (entry) {
+                    ;(entry.indexValueMap as Record<string, Uint8Array>)[doc._id.index_mac_hex] =
+                        fromBinary(doc.value_mac)
+                }
+            }
+
+            return { keys, collections }
+        })
+    }
+
+    public async upsertSyncKeys(keys: readonly WaAppStateSyncKey[]): Promise<number> {
+        if (keys.length === 0) return 0
+        await this.ensureIndexes()
+        const col = this.col<SyncKeyDoc>('appstate_sync_keys')
+
+        const keyIds = keys.map((k) => toBinary(k.keyId))
+        const existingDocs = await col
+            .find({
+                '_id.session_id': this.sessionId,
+                '_id.key_id': { $in: keyIds }
+            })
+            .toArray()
+        const existingByHex = new Map<string, Uint8Array>()
+        for (const doc of existingDocs) {
+            existingByHex.set(bytesToHex(fromBinary(doc._id.key_id)), fromBinary(doc.key_data))
+        }
+
+        let inserted = 0
+        const ops: AnyBulkWriteOperation<SyncKeyDoc>[] = []
+        for (const key of keys) {
+            const existing = existingByHex.get(bytesToHex(key.keyId))
+            if (existing && uint8Equal(existing, key.keyData)) {
+                continue
+            }
+            const fp = key.fingerprint ? encodeAppStateFingerprint(key.fingerprint) : null
+            ops.push({
+                updateOne: {
+                    filter: {
+                        _id: { session_id: this.sessionId, key_id: toBinary(key.keyId) }
+                    },
+                    update: {
+                        $set: {
+                            key_data: toBinary(key.keyData),
+                            timestamp: key.timestamp,
+                            fingerprint: fp ? toBinary(fp) : null,
+                            key_epoch: keyEpoch(key.keyId)
+                        }
+                    },
+                    upsert: true
+                }
+            })
+            inserted += 1
+        }
+        if (ops.length > 0) {
+            await col.bulkWrite(ops)
+        }
+        return inserted
+    }
+
+    public async getSyncKeysBatch(
+        keyIds: readonly Uint8Array[]
+    ): Promise<readonly (WaAppStateSyncKey | null)[]> {
+        if (keyIds.length === 0) return []
+        await this.ensureIndexes()
+        const col = this.col<SyncKeyDoc>('appstate_sync_keys')
+        const binaryIds = keyIds.map((k) => toBinary(k))
+        const docs = await col
+            .find({
+                '_id.session_id': this.sessionId,
+                '_id.key_id': { $in: binaryIds }
+            })
+            .toArray()
+        const byHex = new Map<string, WaAppStateSyncKey>()
+        for (const doc of docs) {
+            const keyId = fromBinary(doc._id.key_id)
+            byHex.set(bytesToHex(keyId), {
+                keyId,
+                keyData: fromBinary(doc.key_data),
+                timestamp: doc.timestamp,
+                fingerprint: decodeAppStateFingerprint(fromBinaryOrNull(doc.fingerprint))
+            })
+        }
+        return keyIds.map((id) => byHex.get(bytesToHex(id)) ?? null)
+    }
+
+    public async getSyncKeyData(keyId: Uint8Array): Promise<Uint8Array | null> {
+        await this.ensureIndexes()
+        const col = this.col<SyncKeyDoc>('appstate_sync_keys')
+        const doc = await col.findOne({
+            _id: { session_id: this.sessionId, key_id: toBinary(keyId) }
+        })
+        if (!doc) return null
+        return fromBinary(doc.key_data)
+    }
+
+    public async getSyncKeyDataBatch(
+        keyIds: readonly Uint8Array[]
+    ): Promise<readonly (Uint8Array | null)[]> {
+        if (keyIds.length === 0) return []
+        await this.ensureIndexes()
+        const col = this.col<SyncKeyDoc>('appstate_sync_keys')
+        const binaryIds = keyIds.map((k) => toBinary(k))
+        const docs = await col
+            .find({
+                '_id.session_id': this.sessionId,
+                '_id.key_id': { $in: binaryIds }
+            })
+            .toArray()
+        const byHex = new Map<string, Uint8Array>()
+        for (const doc of docs) {
+            byHex.set(bytesToHex(fromBinary(doc._id.key_id)), fromBinary(doc.key_data))
+        }
+        return keyIds.map((id) => byHex.get(bytesToHex(id)) ?? null)
+    }
+
+    public async getActiveSyncKey(): Promise<WaAppStateSyncKey | null> {
+        await this.ensureIndexes()
+        const col = this.col<SyncKeyDoc>('appstate_sync_keys')
+        const docs = await col
+            .find({ '_id.session_id': this.sessionId })
+            .sort({ key_epoch: -1, '_id.key_id': 1 })
+            .limit(1)
+            .toArray()
+        if (docs.length === 0) return null
+        const doc = docs[0]
+        return {
+            keyId: fromBinary(doc._id.key_id),
+            keyData: fromBinary(doc.key_data),
+            timestamp: doc.timestamp,
+            fingerprint: decodeAppStateFingerprint(fromBinaryOrNull(doc.fingerprint))
+        }
+    }
+
+    public async getCollectionState(
+        collection: AppStateCollectionName
+    ): Promise<WaAppStateCollectionStoreState> {
+        return this.withSession(async (session) => {
+            const versionsCol = this.col<CollectionVersionDoc>('appstate_collection_versions')
+            const valuesCol = this.col<IndexValueDoc>('appstate_collection_index_values')
+
+            const versionDoc = await versionsCol.findOne(
+                { _id: { session_id: this.sessionId, collection } },
+                { session }
+            )
+            if (!versionDoc) {
+                return {
+                    initialized: false,
+                    version: 0,
+                    hash: APP_STATE_EMPTY_LT_HASH,
+                    indexValueMap: new Map()
+                }
+            }
+
+            const valueDocs = await valuesCol
+                .find(
+                    {
+                        '_id.session_id': this.sessionId,
+                        '_id.collection': collection
+                    },
+                    { session }
+                )
+                .toArray()
+            const indexValueMap = new Map<string, Uint8Array>()
+            for (const doc of valueDocs) {
+                indexValueMap.set(doc._id.index_mac_hex, fromBinary(doc.value_mac))
+            }
+
+            return {
+                initialized: true,
+                version: versionDoc.version,
+                hash: fromBinary(versionDoc.hash),
+                indexValueMap
+            }
+        })
+    }
+
+    public async getCollectionStates(
+        collections: readonly AppStateCollectionName[]
+    ): Promise<readonly WaAppStateCollectionStoreState[]> {
+        if (collections.length === 0) return []
+        return this.withSession(async (session) => {
+            const versionsCol = this.col<CollectionVersionDoc>('appstate_collection_versions')
+            const valuesCol = this.col<IndexValueDoc>('appstate_collection_index_values')
+            const uniqueCollections = [...new Set(collections)]
+
+            const [versionDocs, valueDocs] = await Promise.all([
+                versionsCol
+                    .find(
+                        {
+                            '_id.session_id': this.sessionId,
+                            '_id.collection': { $in: uniqueCollections }
+                        },
+                        { session }
+                    )
+                    .toArray(),
+                valuesCol
+                    .find(
+                        {
+                            '_id.session_id': this.sessionId,
+                            '_id.collection': { $in: uniqueCollections }
+                        },
+                        { session }
+                    )
+                    .toArray()
+            ])
+
+            const versionsByCollection = new Map<
+                AppStateCollectionName,
+                { version: number; hash: Uint8Array }
+            >()
+            for (const doc of versionDocs) {
+                const name = doc._id.collection as AppStateCollectionName
+                versionsByCollection.set(name, {
+                    version: doc.version,
+                    hash: fromBinary(doc.hash)
+                })
+            }
+
+            const indexValueMaps = new Map<AppStateCollectionName, Map<string, Uint8Array>>()
+            for (const doc of valueDocs) {
+                const name = doc._id.collection as AppStateCollectionName
+                let map = indexValueMaps.get(name)
+                if (!map) {
+                    map = new Map<string, Uint8Array>()
+                    indexValueMaps.set(name, map)
+                }
+                map.set(doc._id.index_mac_hex, fromBinary(doc.value_mac))
+            }
+
+            return collections.map((collection) => {
+                const version = versionsByCollection.get(collection)
+                if (!version) {
+                    return {
+                        initialized: false,
+                        version: 0,
+                        hash: APP_STATE_EMPTY_LT_HASH,
+                        indexValueMap: new Map()
+                    }
+                }
+                return {
+                    initialized: true,
+                    version: version.version,
+                    hash: version.hash,
+                    indexValueMap: indexValueMaps.get(collection) ?? new Map()
+                }
+            })
+        })
+    }
+
+    public async setCollectionStates(
+        updates: readonly WaAppStateCollectionStateUpdate[]
+    ): Promise<void> {
+        if (updates.length === 0) return
+        await this.withSession(async (session) => {
+            const versionsCol = this.col<CollectionVersionDoc>('appstate_collection_versions')
+            const valuesCol = this.col<IndexValueDoc>('appstate_collection_index_values')
+
+            const versionOps: AnyBulkWriteOperation<CollectionVersionDoc>[] = []
+            for (const update of updates) {
+                versionOps.push({
+                    updateOne: {
+                        filter: {
+                            _id: { session_id: this.sessionId, collection: update.collection }
+                        },
+                        update: {
+                            $set: {
+                                version: update.version,
+                                hash: toBinary(update.hash)
+                            }
+                        },
+                        upsert: true
+                    }
+                })
+            }
+            await versionsCol.bulkWrite(versionOps, { session })
+
+            for (const update of updates) {
+                await valuesCol.deleteMany(
+                    {
+                        '_id.session_id': this.sessionId,
+                        '_id.collection': update.collection
+                    },
+                    { session }
+                )
+
+                const valueOps: AnyBulkWriteOperation<IndexValueDoc>[] = []
+                for (const [indexMacHex, valueMac] of update.indexValueMap.entries()) {
+                    valueOps.push({
+                        updateOne: {
+                            filter: {
+                                _id: {
+                                    session_id: this.sessionId,
+                                    collection: update.collection,
+                                    index_mac_hex: indexMacHex
+                                }
+                            },
+                            update: {
+                                $set: { value_mac: toBinary(valueMac) }
+                            },
+                            upsert: true
+                        }
+                    })
+                }
+                if (valueOps.length > 0) {
+                    await valuesCol.bulkWrite(valueOps, { session })
+                }
+            }
+        })
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureIndexes()
+        await Promise.all([
+            this.col<SyncKeyDoc>('appstate_sync_keys').deleteMany({
+                '_id.session_id': this.sessionId
+            }),
+            this.col<CollectionVersionDoc>('appstate_collection_versions').deleteMany({
+                '_id.session_id': this.sessionId
+            }),
+            this.col<IndexValueDoc>('appstate_collection_index_values').deleteMany({
+                '_id.session_id': this.sessionId
+            })
+        ])
+    }
+}

--- a/packages/store-mongo/src/auth.store.ts
+++ b/packages/store-mongo/src/auth.store.ts
@@ -1,0 +1,152 @@
+import type { Binary } from 'mongodb'
+import type { WaAuthCredentials } from 'zapo-js/auth'
+import { proto } from 'zapo-js/proto'
+import type { WaAuthStore } from 'zapo-js/store'
+
+import { BaseMongoStore } from './BaseMongoStore'
+import { fromBinary, fromBinaryOrNull, toBinary } from './helpers'
+import type { WaMongoStorageOptions } from './types'
+
+interface AuthDoc {
+    _id: string
+    noise_pub_key: Binary
+    noise_priv_key: Binary
+    registration_id: number
+    identity_pub_key: Binary
+    identity_priv_key: Binary
+    signed_prekey_id: number
+    signed_prekey_pub_key: Binary
+    signed_prekey_priv_key: Binary
+    signed_prekey_signature: Binary
+    adv_secret_key: Binary
+    signed_identity: Binary | null
+    me_jid: string | null
+    me_lid: string | null
+    me_display_name: string | null
+    companion_enc_static: Binary | null
+    platform: string | null
+    server_static_key: Binary | null
+    server_has_prekeys: boolean | null
+    routing_info: Binary | null
+    last_success_ts: number | null
+    props_version: number | null
+    ab_props_version: number | null
+    connection_location: string | null
+    account_creation_ts: number | null
+}
+
+const COLLECTION = 'auth_credentials'
+
+export class WaAuthMongoStore extends BaseMongoStore implements WaAuthStore {
+    public constructor(options: WaMongoStorageOptions) {
+        super(options)
+    }
+
+    public async load(): Promise<WaAuthCredentials | null> {
+        await this.ensureIndexes()
+        const doc = await this.col<AuthDoc>(COLLECTION).findOne({ _id: this.sessionId })
+        if (!doc) return null
+
+        const signedIdentityBytes = fromBinaryOrNull(doc.signed_identity)
+
+        return {
+            noiseKeyPair: {
+                pubKey: fromBinary(doc.noise_pub_key),
+                privKey: fromBinary(doc.noise_priv_key)
+            },
+            registrationInfo: {
+                registrationId: Number(doc.registration_id),
+                identityKeyPair: {
+                    pubKey: fromBinary(doc.identity_pub_key),
+                    privKey: fromBinary(doc.identity_priv_key)
+                }
+            },
+            signedPreKey: {
+                keyId: Number(doc.signed_prekey_id),
+                keyPair: {
+                    pubKey: fromBinary(doc.signed_prekey_pub_key),
+                    privKey: fromBinary(doc.signed_prekey_priv_key)
+                },
+                signature: fromBinary(doc.signed_prekey_signature),
+                uploaded: false
+            },
+            advSecretKey: fromBinary(doc.adv_secret_key),
+            signedIdentity: signedIdentityBytes
+                ? proto.ADVSignedDeviceIdentity.decode(signedIdentityBytes)
+                : undefined,
+            meJid: doc.me_jid ?? undefined,
+            meLid: doc.me_lid ?? undefined,
+            meDisplayName: doc.me_display_name ?? undefined,
+            companionEncStatic: fromBinaryOrNull(doc.companion_enc_static) ?? undefined,
+            platform: doc.platform ?? undefined,
+            serverStaticKey: fromBinaryOrNull(doc.server_static_key) ?? undefined,
+            serverHasPreKeys:
+                doc.server_has_prekeys === null || doc.server_has_prekeys === undefined
+                    ? undefined
+                    : Boolean(doc.server_has_prekeys),
+            routingInfo: fromBinaryOrNull(doc.routing_info) ?? undefined,
+            lastSuccessTs: doc.last_success_ts !== null ? Number(doc.last_success_ts) : undefined,
+            propsVersion: doc.props_version !== null ? Number(doc.props_version) : undefined,
+            abPropsVersion:
+                doc.ab_props_version !== null ? Number(doc.ab_props_version) : undefined,
+            connectionLocation: doc.connection_location ?? undefined,
+            accountCreationTs:
+                doc.account_creation_ts !== null ? Number(doc.account_creation_ts) : undefined
+        }
+    }
+
+    public async save(credentials: WaAuthCredentials): Promise<void> {
+        await this.ensureIndexes()
+        await this.col<AuthDoc>(COLLECTION).updateOne(
+            { _id: this.sessionId },
+            {
+                $set: {
+                    noise_pub_key: toBinary(credentials.noiseKeyPair.pubKey),
+                    noise_priv_key: toBinary(credentials.noiseKeyPair.privKey),
+                    registration_id: credentials.registrationInfo.registrationId,
+                    identity_pub_key: toBinary(credentials.registrationInfo.identityKeyPair.pubKey),
+                    identity_priv_key: toBinary(
+                        credentials.registrationInfo.identityKeyPair.privKey
+                    ),
+                    signed_prekey_id: credentials.signedPreKey.keyId,
+                    signed_prekey_pub_key: toBinary(credentials.signedPreKey.keyPair.pubKey),
+                    signed_prekey_priv_key: toBinary(credentials.signedPreKey.keyPair.privKey),
+                    signed_prekey_signature: toBinary(credentials.signedPreKey.signature),
+                    adv_secret_key: toBinary(credentials.advSecretKey),
+                    signed_identity: credentials.signedIdentity
+                        ? toBinary(
+                              proto.ADVSignedDeviceIdentity.encode(
+                                  credentials.signedIdentity
+                              ).finish()
+                          )
+                        : null,
+                    me_jid: credentials.meJid ?? null,
+                    me_lid: credentials.meLid ?? null,
+                    me_display_name: credentials.meDisplayName ?? null,
+                    companion_enc_static: credentials.companionEncStatic
+                        ? toBinary(credentials.companionEncStatic)
+                        : null,
+                    platform: credentials.platform ?? null,
+                    server_static_key: credentials.serverStaticKey
+                        ? toBinary(credentials.serverStaticKey)
+                        : null,
+                    server_has_prekeys: credentials.serverHasPreKeys ?? null,
+                    routing_info: credentials.routingInfo
+                        ? toBinary(credentials.routingInfo)
+                        : null,
+                    last_success_ts: credentials.lastSuccessTs ?? null,
+                    props_version: credentials.propsVersion ?? null,
+                    ab_props_version: credentials.abPropsVersion ?? null,
+                    connection_location: credentials.connectionLocation ?? null,
+                    account_creation_ts: credentials.accountCreationTs ?? null
+                }
+            },
+            { upsert: true }
+        )
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureIndexes()
+        await this.col<AuthDoc>(COLLECTION).deleteOne({ _id: this.sessionId })
+    }
+}

--- a/packages/store-mongo/src/contact.store.ts
+++ b/packages/store-mongo/src/contact.store.ts
@@ -1,0 +1,90 @@
+import type { WaContactStore, WaStoredContactRecord } from 'zapo-js/store'
+
+import { BaseMongoStore } from './BaseMongoStore'
+import type { WaMongoStorageOptions } from './types'
+
+const COLLECTION = 'mailbox_contacts'
+
+interface ContactDoc {
+    _id: { session_id: string; jid: string }
+    display_name: string | null
+    push_name: string | null
+    lid: string | null
+    phone_number: string | null
+    last_updated_ms: number
+}
+
+function docToRecord(doc: ContactDoc): WaStoredContactRecord {
+    return {
+        jid: doc._id.jid,
+        displayName: doc.display_name ?? undefined,
+        pushName: doc.push_name ?? undefined,
+        lid: doc.lid ?? undefined,
+        phoneNumber: doc.phone_number ?? undefined,
+        lastUpdatedMs: doc.last_updated_ms
+    }
+}
+
+function buildCoalesceSet(record: WaStoredContactRecord): Partial<ContactDoc> {
+    const set: Partial<ContactDoc> = {
+        last_updated_ms: record.lastUpdatedMs
+    }
+    if (record.displayName !== undefined) set.display_name = record.displayName
+    if (record.pushName !== undefined) set.push_name = record.pushName
+    if (record.lid !== undefined) set.lid = record.lid
+    if (record.phoneNumber !== undefined) set.phone_number = record.phoneNumber
+    return set
+}
+
+export class WaContactMongoStore extends BaseMongoStore implements WaContactStore {
+    public constructor(options: WaMongoStorageOptions) {
+        super(options)
+    }
+
+    private makeId(jid: string): ContactDoc['_id'] {
+        return { session_id: this.sessionId, jid }
+    }
+
+    public async upsert(record: WaStoredContactRecord): Promise<void> {
+        await this.ensureIndexes()
+        const set = buildCoalesceSet(record)
+        await this.col<ContactDoc>(COLLECTION).updateOne(
+            { _id: this.makeId(record.jid) },
+            { $set: set },
+            { upsert: true }
+        )
+    }
+
+    public async upsertBatch(records: readonly WaStoredContactRecord[]): Promise<void> {
+        if (records.length === 0) return
+        await this.ensureIndexes()
+
+        const ops = records.map((record) => ({
+            updateOne: {
+                filter: { _id: this.makeId(record.jid) },
+                update: { $set: buildCoalesceSet(record) },
+                upsert: true
+            }
+        }))
+
+        await this.col<ContactDoc>(COLLECTION).bulkWrite(ops, { ordered: false })
+    }
+
+    public async getByJid(jid: string): Promise<WaStoredContactRecord | null> {
+        await this.ensureIndexes()
+        const doc = await this.col<ContactDoc>(COLLECTION).findOne({ _id: this.makeId(jid) })
+        if (!doc) return null
+        return docToRecord(doc)
+    }
+
+    public async deleteByJid(jid: string): Promise<number> {
+        await this.ensureIndexes()
+        const result = await this.col<ContactDoc>(COLLECTION).deleteOne({ _id: this.makeId(jid) })
+        return result.deletedCount
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureIndexes()
+        await this.col<ContactDoc>(COLLECTION).deleteMany({ '_id.session_id': this.sessionId })
+    }
+}

--- a/packages/store-mongo/src/createMongoStore.ts
+++ b/packages/store-mongo/src/createMongoStore.ts
@@ -1,0 +1,103 @@
+import { MongoClient } from 'mongodb'
+import type { Db, MongoClientOptions } from 'mongodb'
+
+import { WaAppStateMongoStore } from './appstate.store'
+import { WaAuthMongoStore } from './auth.store'
+import { WaContactMongoStore } from './contact.store'
+import { WaDeviceListMongoStore } from './device-list.store'
+import { WaMessageMongoStore } from './message.store'
+import { WaParticipantsMongoStore } from './participants.store'
+import { WaPrivacyTokenMongoStore } from './privacy-token.store'
+import { WaRetryMongoStore } from './retry.store'
+import { WaSenderKeyMongoStore } from './sender-key.store'
+import { WaSignalMongoStore } from './signal.store'
+import { WaThreadMongoStore } from './thread.store'
+import type { WaMongoStorageOptions } from './types'
+
+export interface WaMongoStoreConfig {
+    readonly db:
+        | Db
+        | {
+              readonly uri: string
+              readonly database: string
+              readonly options?: MongoClientOptions
+          }
+    readonly collectionPrefix?: string
+    readonly cacheTtlMs?: {
+        readonly retryMs?: number
+        readonly participantsMs?: number
+        readonly deviceListMs?: number
+    }
+}
+
+export interface WaMongoStoreResult {
+    readonly db: Db
+    readonly stores: {
+        readonly auth: (sessionId: string) => WaAuthMongoStore
+        readonly signal: (sessionId: string) => WaSignalMongoStore
+        readonly senderKey: (sessionId: string) => WaSenderKeyMongoStore
+        readonly appState: (sessionId: string) => WaAppStateMongoStore
+        readonly messages: (sessionId: string) => WaMessageMongoStore
+        readonly threads: (sessionId: string) => WaThreadMongoStore
+        readonly contacts: (sessionId: string) => WaContactMongoStore
+        readonly privacyToken: (sessionId: string) => WaPrivacyTokenMongoStore
+    }
+    readonly caches: {
+        readonly retry: (sessionId: string) => WaRetryMongoStore
+        readonly participants: (sessionId: string) => WaParticipantsMongoStore
+        readonly deviceList: (sessionId: string) => WaDeviceListMongoStore
+    }
+    destroy(): Promise<void>
+}
+
+function isDb(value: WaMongoStoreConfig['db']): value is Db {
+    return typeof (value as Db).collection === 'function'
+}
+
+export function createMongoStore(config: WaMongoStoreConfig): WaMongoStoreResult {
+    let db: Db
+    let client: MongoClient | null = null
+
+    if (isDb(config.db)) {
+        db = config.db
+    } else {
+        client = new MongoClient(config.db.uri, config.db.options)
+        db = client.db(config.db.database)
+    }
+
+    const collectionPrefix = config.collectionPrefix ?? ''
+    const retryTtlMs = config.cacheTtlMs?.retryMs
+    const participantsTtlMs = config.cacheTtlMs?.participantsMs
+    const deviceListTtlMs = config.cacheTtlMs?.deviceListMs
+
+    const opts = (sessionId: string): WaMongoStorageOptions => ({
+        db,
+        sessionId,
+        collectionPrefix
+    })
+
+    return {
+        db,
+        stores: {
+            auth: (sessionId) => new WaAuthMongoStore(opts(sessionId)),
+            signal: (sessionId) => new WaSignalMongoStore(opts(sessionId)),
+            senderKey: (sessionId) => new WaSenderKeyMongoStore(opts(sessionId)),
+            appState: (sessionId) => new WaAppStateMongoStore(opts(sessionId)),
+            messages: (sessionId) => new WaMessageMongoStore(opts(sessionId)),
+            threads: (sessionId) => new WaThreadMongoStore(opts(sessionId)),
+            contacts: (sessionId) => new WaContactMongoStore(opts(sessionId)),
+            privacyToken: (sessionId) => new WaPrivacyTokenMongoStore(opts(sessionId))
+        },
+        caches: {
+            retry: (sessionId) => new WaRetryMongoStore(opts(sessionId), retryTtlMs),
+            participants: (sessionId) =>
+                new WaParticipantsMongoStore(opts(sessionId), participantsTtlMs),
+            deviceList: (sessionId) => new WaDeviceListMongoStore(opts(sessionId), deviceListTtlMs)
+        },
+        async destroy(): Promise<void> {
+            if (client) {
+                await client.close()
+            }
+        }
+    }
+}

--- a/packages/store-mongo/src/device-list.store.ts
+++ b/packages/store-mongo/src/device-list.store.ts
@@ -1,0 +1,95 @@
+import type { WaDeviceListSnapshot, WaDeviceListStore } from 'zapo-js/store'
+
+import { BaseMongoStore } from './BaseMongoStore'
+import type { WaMongoStorageOptions } from './types'
+
+interface DeviceListDoc {
+    _id: { session_id: string; user_jid: string }
+    device_jids: string[]
+    updated_at_ms: number
+    expires_at: Date
+}
+
+const DEFAULT_DEVICE_LIST_TTL_MS = 5 * 60 * 1000
+
+export class WaDeviceListMongoStore extends BaseMongoStore implements WaDeviceListStore {
+    private readonly ttlMs: number
+
+    public constructor(options: WaMongoStorageOptions, ttlMs = DEFAULT_DEVICE_LIST_TTL_MS) {
+        super(options)
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('device-list ttlMs must be a non-negative finite number')
+        }
+        this.ttlMs = ttlMs
+    }
+
+    protected override async createIndexes(): Promise<void> {
+        const col = this.col<DeviceListDoc>('device_list_cache')
+        await col.createIndex({ expires_at: 1 }, { expireAfterSeconds: 0 })
+    }
+
+    public async upsertUserDevicesBatch(snapshots: readonly WaDeviceListSnapshot[]): Promise<void> {
+        if (snapshots.length === 0) return
+        await this.ensureIndexes()
+        const col = this.col<DeviceListDoc>('device_list_cache')
+        const ops = snapshots.map((snapshot) => ({
+            updateOne: {
+                filter: { _id: { session_id: this.sessionId, user_jid: snapshot.userJid } },
+                update: {
+                    $set: {
+                        device_jids: snapshot.deviceJids as string[],
+                        updated_at_ms: snapshot.updatedAtMs,
+                        expires_at: new Date(snapshot.updatedAtMs + this.ttlMs)
+                    }
+                },
+                upsert: true
+            }
+        }))
+        await col.bulkWrite(ops)
+    }
+
+    public async getUserDevicesBatch(
+        userJids: readonly string[],
+        _nowMs?: number
+    ): Promise<readonly (WaDeviceListSnapshot | null)[]> {
+        if (userJids.length === 0) return []
+        await this.ensureIndexes()
+        const col = this.col<DeviceListDoc>('device_list_cache')
+        const uniqueUserJids = [...new Set(userJids)]
+        const docs = await col
+            .find({
+                '_id.session_id': this.sessionId,
+                '_id.user_jid': { $in: uniqueUserJids }
+            })
+            .toArray()
+
+        const byUserJid = new Map<string, WaDeviceListSnapshot>()
+        for (const doc of docs) {
+            byUserJid.set(doc._id.user_jid, {
+                userJid: doc._id.user_jid,
+                deviceJids: doc.device_jids,
+                updatedAtMs: doc.updated_at_ms
+            })
+        }
+        return userJids.map((jid) => byUserJid.get(jid) ?? null)
+    }
+
+    public async deleteUserDevices(userJid: string): Promise<number> {
+        await this.ensureIndexes()
+        const col = this.col<DeviceListDoc>('device_list_cache')
+        const result = await col.deleteOne({
+            _id: { session_id: this.sessionId, user_jid: userJid }
+        })
+        return result.deletedCount
+    }
+
+    public async cleanupExpired(_nowMs: number): Promise<number> {
+        return 0
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<DeviceListDoc>('device_list_cache')
+        await col.deleteMany({ '_id.session_id': this.sessionId })
+    }
+}

--- a/packages/store-mongo/src/helpers.ts
+++ b/packages/store-mongo/src/helpers.ts
@@ -1,0 +1,32 @@
+import { Binary } from 'mongodb'
+import { bytesToHex, normalizeQueryLimit, toBytesView, uint8Equal } from 'zapo-js/util'
+
+export function toBinary(bytes: Uint8Array): Binary {
+    return new Binary(bytes)
+}
+
+export function fromBinary(value: unknown): Uint8Array {
+    if (value instanceof Binary) {
+        const buf = value.buffer
+        return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+    }
+    if (value instanceof Uint8Array) return value
+    if (value instanceof ArrayBuffer) return new Uint8Array(value)
+    if (ArrayBuffer.isView(value)) return toBytesView(value)
+    throw new Error('expected binary data')
+}
+
+export function fromBinaryOrNull(value: unknown): Uint8Array | null {
+    if (value === null || value === undefined) return null
+    return fromBinary(value)
+}
+
+const SAFE_PREFIX_RE = /^[A-Za-z0-9_]*$/
+
+export function assertSafeCollectionPrefix(prefix: string): void {
+    if (!SAFE_PREFIX_RE.test(prefix)) {
+        throw new Error('collectionPrefix must contain only letters, numbers, and underscores')
+    }
+}
+
+export { bytesToHex, normalizeQueryLimit as safeLimit, uint8Equal }

--- a/packages/store-mongo/src/index.ts
+++ b/packages/store-mongo/src/index.ts
@@ -1,0 +1,18 @@
+export type { WaMongoStorageOptions } from './types'
+export { BaseMongoStore } from './BaseMongoStore'
+export { WaAuthMongoStore } from './auth.store'
+export { WaSignalMongoStore } from './signal.store'
+export { WaSenderKeyMongoStore } from './sender-key.store'
+export { WaAppStateMongoStore } from './appstate.store'
+export { WaRetryMongoStore } from './retry.store'
+export { WaParticipantsMongoStore } from './participants.store'
+export { WaDeviceListMongoStore } from './device-list.store'
+export { WaMessageMongoStore } from './message.store'
+export { WaThreadMongoStore } from './thread.store'
+export { WaContactMongoStore } from './contact.store'
+export { WaPrivacyTokenMongoStore } from './privacy-token.store'
+export {
+    createMongoStore,
+    type WaMongoStoreConfig,
+    type WaMongoStoreResult
+} from './createMongoStore'

--- a/packages/store-mongo/src/message.store.ts
+++ b/packages/store-mongo/src/message.store.ts
@@ -1,0 +1,139 @@
+import type { Binary, Document } from 'mongodb'
+import type { WaMessageStore, WaStoredMessageRecord } from 'zapo-js/store'
+
+import { BaseMongoStore } from './BaseMongoStore'
+import { fromBinaryOrNull, safeLimit, toBinary } from './helpers'
+import type { WaMongoStorageOptions } from './types'
+
+const COLLECTION = 'mailbox_messages'
+
+interface MessageDoc {
+    _id: { session_id: string; message_id: string }
+    thread_jid: string
+    sender_jid: string | null
+    participant_jid: string | null
+    from_me: boolean
+    timestamp_ms: number | null
+    enc_type: string | null
+    plaintext: Binary | null
+    message_bytes: Binary | null
+}
+
+function docToRecord(doc: MessageDoc): WaStoredMessageRecord {
+    return {
+        id: doc._id.message_id,
+        threadJid: doc.thread_jid,
+        senderJid: doc.sender_jid ?? undefined,
+        participantJid: doc.participant_jid ?? undefined,
+        fromMe: doc.from_me,
+        timestampMs: doc.timestamp_ms ?? undefined,
+        encType: doc.enc_type ?? undefined,
+        plaintext: fromBinaryOrNull(doc.plaintext) ?? undefined,
+        messageBytes: fromBinaryOrNull(doc.message_bytes) ?? undefined
+    }
+}
+
+export class WaMessageMongoStore extends BaseMongoStore implements WaMessageStore {
+    public constructor(options: WaMongoStorageOptions) {
+        super(options)
+    }
+
+    protected override async createIndexes(): Promise<void> {
+        await this.col<MessageDoc>(COLLECTION).createIndex(
+            { '_id.session_id': 1, thread_jid: 1, timestamp_ms: -1 },
+            { background: true }
+        )
+    }
+
+    private makeId(messageId: string): MessageDoc['_id'] {
+        return { session_id: this.sessionId, message_id: messageId }
+    }
+
+    private toDoc(record: WaStoredMessageRecord): MessageDoc {
+        return {
+            _id: this.makeId(record.id),
+            thread_jid: record.threadJid,
+            sender_jid: record.senderJid ?? null,
+            participant_jid: record.participantJid ?? null,
+            from_me: record.fromMe,
+            timestamp_ms: record.timestampMs ?? null,
+            enc_type: record.encType ?? null,
+            plaintext: record.plaintext ? toBinary(record.plaintext) : null,
+            message_bytes: record.messageBytes ? toBinary(record.messageBytes) : null
+        }
+    }
+
+    public async upsert(record: WaStoredMessageRecord): Promise<void> {
+        await this.ensureIndexes()
+        const doc = this.toDoc(record)
+        const { _id, ...fields } = doc
+        await this.col<MessageDoc>(COLLECTION).updateOne(
+            { _id },
+            { $set: fields },
+            { upsert: true }
+        )
+    }
+
+    public async upsertBatch(records: readonly WaStoredMessageRecord[]): Promise<void> {
+        if (records.length === 0) return
+        await this.ensureIndexes()
+
+        const ops = records.map((record) => {
+            const doc = this.toDoc(record)
+            const { _id, ...fields } = doc
+            return {
+                updateOne: {
+                    filter: { _id },
+                    update: { $set: fields },
+                    upsert: true
+                }
+            }
+        })
+
+        await this.col<MessageDoc>(COLLECTION).bulkWrite(ops, { ordered: false })
+    }
+
+    public async getById(id: string): Promise<WaStoredMessageRecord | null> {
+        await this.ensureIndexes()
+        const doc = await this.col<MessageDoc>(COLLECTION).findOne({ _id: this.makeId(id) })
+        if (!doc) return null
+        return docToRecord(doc)
+    }
+
+    public async listByThread(
+        threadJid: string,
+        limit?: number,
+        beforeTimestampMs?: number
+    ): Promise<readonly WaStoredMessageRecord[]> {
+        await this.ensureIndexes()
+        const resolved = safeLimit(limit, 50)
+
+        const filter: Document = {
+            '_id.session_id': this.sessionId,
+            thread_jid: threadJid
+        }
+
+        if (beforeTimestampMs !== undefined) {
+            filter.timestamp_ms = { $lt: beforeTimestampMs }
+        }
+
+        const docs = await this.col<MessageDoc>(COLLECTION)
+            .find(filter)
+            .sort({ timestamp_ms: -1, '_id.message_id': -1 })
+            .limit(resolved)
+            .toArray()
+
+        return docs.map(docToRecord)
+    }
+
+    public async deleteById(id: string): Promise<number> {
+        await this.ensureIndexes()
+        const result = await this.col<MessageDoc>(COLLECTION).deleteOne({ _id: this.makeId(id) })
+        return result.deletedCount
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureIndexes()
+        await this.col<MessageDoc>(COLLECTION).deleteMany({ '_id.session_id': this.sessionId })
+    }
+}

--- a/packages/store-mongo/src/participants.store.ts
+++ b/packages/store-mongo/src/participants.store.ts
@@ -1,0 +1,82 @@
+import type { WaParticipantsSnapshot, WaParticipantsStore } from 'zapo-js/store'
+
+import { BaseMongoStore } from './BaseMongoStore'
+import type { WaMongoStorageOptions } from './types'
+
+interface ParticipantsDoc {
+    _id: { session_id: string; group_jid: string }
+    participants: string[]
+    updated_at_ms: number
+    expires_at: Date
+}
+
+const DEFAULT_PARTICIPANTS_TTL_MS = 5 * 60 * 1000
+
+export class WaParticipantsMongoStore extends BaseMongoStore implements WaParticipantsStore {
+    private readonly ttlMs: number
+
+    public constructor(options: WaMongoStorageOptions, ttlMs = DEFAULT_PARTICIPANTS_TTL_MS) {
+        super(options)
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('participants ttlMs must be a non-negative finite number')
+        }
+        this.ttlMs = ttlMs
+    }
+
+    protected override async createIndexes(): Promise<void> {
+        const col = this.col<ParticipantsDoc>('group_participants_cache')
+        await col.createIndex({ expires_at: 1 }, { expireAfterSeconds: 0 })
+    }
+
+    public async upsertGroupParticipants(snapshot: WaParticipantsSnapshot): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<ParticipantsDoc>('group_participants_cache')
+        await col.updateOne(
+            { _id: { session_id: this.sessionId, group_jid: snapshot.groupJid } },
+            {
+                $set: {
+                    participants: snapshot.participants as string[],
+                    updated_at_ms: snapshot.updatedAtMs,
+                    expires_at: new Date(snapshot.updatedAtMs + this.ttlMs)
+                }
+            },
+            { upsert: true }
+        )
+    }
+
+    public async getGroupParticipants(
+        groupJid: string,
+        _nowMs?: number
+    ): Promise<WaParticipantsSnapshot | null> {
+        await this.ensureIndexes()
+        const col = this.col<ParticipantsDoc>('group_participants_cache')
+        const doc = await col.findOne({
+            _id: { session_id: this.sessionId, group_jid: groupJid }
+        })
+        if (!doc) return null
+        return {
+            groupJid,
+            participants: doc.participants,
+            updatedAtMs: doc.updated_at_ms
+        }
+    }
+
+    public async deleteGroupParticipants(groupJid: string): Promise<number> {
+        await this.ensureIndexes()
+        const col = this.col<ParticipantsDoc>('group_participants_cache')
+        const result = await col.deleteOne({
+            _id: { session_id: this.sessionId, group_jid: groupJid }
+        })
+        return result.deletedCount
+    }
+
+    public async cleanupExpired(_nowMs: number): Promise<number> {
+        return 0
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<ParticipantsDoc>('group_participants_cache')
+        await col.deleteMany({ '_id.session_id': this.sessionId })
+    }
+}

--- a/packages/store-mongo/src/privacy-token.store.ts
+++ b/packages/store-mongo/src/privacy-token.store.ts
@@ -1,0 +1,100 @@
+import type { Binary } from 'mongodb'
+import type { WaPrivacyTokenStore, WaStoredPrivacyTokenRecord } from 'zapo-js/store'
+
+import { BaseMongoStore } from './BaseMongoStore'
+import { fromBinaryOrNull, toBinary } from './helpers'
+import type { WaMongoStorageOptions } from './types'
+
+const COLLECTION = 'privacy_tokens'
+
+interface PrivacyTokenDoc {
+    _id: { session_id: string; jid: string }
+    tc_token: Binary | null
+    tc_token_timestamp: number | null
+    tc_token_sender_timestamp: number | null
+    nct_salt: Binary | null
+    updated_at_ms: number
+}
+
+function docToRecord(doc: PrivacyTokenDoc): WaStoredPrivacyTokenRecord {
+    return {
+        jid: doc._id.jid,
+        tcToken: fromBinaryOrNull(doc.tc_token) ?? undefined,
+        tcTokenTimestamp: doc.tc_token_timestamp ?? undefined,
+        tcTokenSenderTimestamp: doc.tc_token_sender_timestamp ?? undefined,
+        nctSalt: fromBinaryOrNull(doc.nct_salt) ?? undefined,
+        updatedAtMs: doc.updated_at_ms
+    }
+}
+
+function buildCoalesceSet(record: WaStoredPrivacyTokenRecord): Partial<PrivacyTokenDoc> {
+    const set: Partial<PrivacyTokenDoc> = {
+        updated_at_ms: record.updatedAtMs
+    }
+    if (record.tcToken !== undefined) set.tc_token = toBinary(record.tcToken)
+    if (record.tcTokenTimestamp !== undefined) set.tc_token_timestamp = record.tcTokenTimestamp
+    if (record.tcTokenSenderTimestamp !== undefined) {
+        set.tc_token_sender_timestamp = record.tcTokenSenderTimestamp
+    }
+    if (record.nctSalt !== undefined) set.nct_salt = toBinary(record.nctSalt)
+    return set
+}
+
+export class WaPrivacyTokenMongoStore extends BaseMongoStore implements WaPrivacyTokenStore {
+    public constructor(options: WaMongoStorageOptions) {
+        super(options)
+    }
+
+    private makeId(jid: string): PrivacyTokenDoc['_id'] {
+        return { session_id: this.sessionId, jid }
+    }
+
+    public async upsert(record: WaStoredPrivacyTokenRecord): Promise<void> {
+        await this.ensureIndexes()
+        const set = buildCoalesceSet(record)
+        await this.col<PrivacyTokenDoc>(COLLECTION).updateOne(
+            { _id: this.makeId(record.jid) },
+            { $set: set },
+            { upsert: true }
+        )
+    }
+
+    public async upsertBatch(records: readonly WaStoredPrivacyTokenRecord[]): Promise<void> {
+        if (records.length === 0) return
+        await this.ensureIndexes()
+
+        const ops = records.map((record) => ({
+            updateOne: {
+                filter: { _id: this.makeId(record.jid) },
+                update: { $set: buildCoalesceSet(record) },
+                upsert: true
+            }
+        }))
+
+        await this.col<PrivacyTokenDoc>(COLLECTION).bulkWrite(ops, { ordered: false })
+    }
+
+    public async getByJid(jid: string): Promise<WaStoredPrivacyTokenRecord | null> {
+        await this.ensureIndexes()
+        const doc = await this.col<PrivacyTokenDoc>(COLLECTION).findOne({ _id: this.makeId(jid) })
+        if (!doc) return null
+        return docToRecord(doc)
+    }
+
+    public async deleteByJid(jid: string): Promise<number> {
+        await this.ensureIndexes()
+        const result = await this.col<PrivacyTokenDoc>(COLLECTION).deleteOne({
+            _id: this.makeId(jid)
+        })
+        return result.deletedCount
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureIndexes()
+        await this.col<PrivacyTokenDoc>(COLLECTION).deleteMany({ '_id.session_id': this.sessionId })
+    }
+
+    public override async destroy(): Promise<void> {
+        await super.destroy()
+    }
+}

--- a/packages/store-mongo/src/retry.store.ts
+++ b/packages/store-mongo/src/retry.store.ts
@@ -1,0 +1,333 @@
+import type { Binary } from 'mongodb'
+import type { WaRetryOutboundMessageRecord, WaRetryOutboundState } from 'zapo-js/retry'
+import type { WaRetryStore } from 'zapo-js/store'
+
+import { BaseMongoStore } from './BaseMongoStore'
+import { fromBinary, toBinary } from './helpers'
+import type { WaMongoStorageOptions } from './types'
+
+interface RetryRequesterStatusPayload {
+    readonly eligible: readonly string[]
+    readonly delivered: readonly string[]
+}
+
+interface OutboundDoc {
+    _id: { session_id: string; message_id: string }
+    to_jid: string
+    participant_jid: string | null
+    recipient_jid: string | null
+    message_type: string
+    replay_mode: string
+    replay_payload: Binary
+    requesters_json: string | null
+    state: string
+    created_at_ms: number
+    updated_at_ms: number
+    expires_at: Date
+}
+
+interface InboundDoc {
+    _id: { session_id: string; message_id: string; requester_jid: string }
+    retry_count: number
+    expires_at: Date
+}
+
+const DEFAULT_RETRY_TTL_MS = 60 * 1000
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+export class WaRetryMongoStore extends BaseMongoStore implements WaRetryStore {
+    private readonly ttlMs: number
+
+    public constructor(options: WaMongoStorageOptions, ttlMs = DEFAULT_RETRY_TTL_MS) {
+        super(options)
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('retry ttlMs must be a non-negative finite number')
+        }
+        this.ttlMs = ttlMs
+    }
+
+    protected override async createIndexes(): Promise<void> {
+        const outbound = this.col<OutboundDoc>('retry_outbound_messages')
+        const inbound = this.col<InboundDoc>('retry_inbound_counters')
+        await Promise.all([
+            outbound.createIndex({ expires_at: 1 }, { expireAfterSeconds: 0 }),
+            inbound.createIndex({ expires_at: 1 }, { expireAfterSeconds: 0 })
+        ])
+    }
+
+    public getTtlMs(): number {
+        return this.ttlMs
+    }
+
+    public supportsRawReplayPayload(): boolean {
+        return false
+    }
+
+    public async getOutboundRequesterStatus(
+        messageId: string,
+        requesterDeviceJid: string
+    ): Promise<{
+        readonly eligible: boolean
+        readonly delivered: boolean
+    } | null> {
+        await this.ensureIndexes()
+        const col = this.col<OutboundDoc>('retry_outbound_messages')
+        const doc = await col.findOne({
+            _id: { session_id: this.sessionId, message_id: messageId }
+        })
+        if (!doc) return null
+        if (!doc.requesters_json) return null
+        const requesters = this.parseRequesterStatusPayload(doc.requesters_json)
+        if (requesters.eligible.length === 0) return null
+
+        let isEligible = false
+        for (let index = 0; index < requesters.eligible.length; index += 1) {
+            if (requesters.eligible[index] === requesterDeviceJid) {
+                isEligible = true
+                break
+            }
+        }
+        if (!isEligible) {
+            return { eligible: false, delivered: false }
+        }
+        for (let index = 0; index < requesters.delivered.length; index += 1) {
+            if (requesters.delivered[index] === requesterDeviceJid) {
+                return { eligible: true, delivered: true }
+            }
+        }
+        return { eligible: true, delivered: false }
+    }
+
+    public async upsertOutboundMessage(record: WaRetryOutboundMessageRecord): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<OutboundDoc>('retry_outbound_messages')
+        if (!(record.replayPayload instanceof Uint8Array)) {
+            throw new Error('retry_outbound_messages.replay_payload must be Uint8Array')
+        }
+        const requestersJson = this.serializeRequesterStatusPayload(
+            record.eligibleRequesterDeviceJids,
+            record.deliveredRequesterDeviceJids
+        )
+        await col.updateOne(
+            { _id: { session_id: this.sessionId, message_id: record.messageId } },
+            {
+                $set: {
+                    to_jid: record.toJid,
+                    participant_jid: record.participantJid ?? null,
+                    recipient_jid: record.recipientJid ?? null,
+                    message_type: record.messageType,
+                    replay_mode: record.replayMode,
+                    replay_payload: toBinary(record.replayPayload),
+                    requesters_json: requestersJson,
+                    state: record.state,
+                    created_at_ms: record.createdAtMs,
+                    updated_at_ms: record.updatedAtMs,
+                    expires_at: new Date(record.expiresAtMs)
+                }
+            },
+            { upsert: true }
+        )
+    }
+
+    public async deleteOutboundMessage(messageId: string): Promise<number> {
+        await this.ensureIndexes()
+        const col = this.col<OutboundDoc>('retry_outbound_messages')
+        const result = await col.deleteOne({
+            _id: { session_id: this.sessionId, message_id: messageId }
+        })
+        return result.deletedCount
+    }
+
+    public async getOutboundMessage(
+        messageId: string
+    ): Promise<WaRetryOutboundMessageRecord | null> {
+        await this.ensureIndexes()
+        const col = this.col<OutboundDoc>('retry_outbound_messages')
+        const doc = await col.findOne({
+            _id: { session_id: this.sessionId, message_id: messageId }
+        })
+        if (!doc) return null
+        const requesters = doc.requesters_json
+            ? this.parseRequesterStatusPayload(doc.requesters_json)
+            : { eligible: [] as readonly string[], delivered: [] as readonly string[] }
+        return {
+            messageId: doc._id.message_id,
+            toJid: doc.to_jid,
+            participantJid: doc.participant_jid ?? undefined,
+            recipientJid: doc.recipient_jid ?? undefined,
+            eligibleRequesterDeviceJids:
+                requesters.eligible.length > 0 ? requesters.eligible : undefined,
+            deliveredRequesterDeviceJids:
+                requesters.delivered.length > 0 ? requesters.delivered : undefined,
+            messageType: doc.message_type,
+            replayMode: doc.replay_mode as WaRetryOutboundMessageRecord['replayMode'],
+            replayPayload: fromBinary(doc.replay_payload),
+            state: doc.state as WaRetryOutboundState,
+            createdAtMs: doc.created_at_ms,
+            updatedAtMs: doc.updated_at_ms,
+            expiresAtMs: doc.expires_at.getTime()
+        }
+    }
+
+    public async updateOutboundMessageState(
+        messageId: string,
+        state: WaRetryOutboundState,
+        updatedAtMs: number,
+        expiresAtMs: number
+    ): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<OutboundDoc>('retry_outbound_messages')
+        await col.updateOne(
+            { _id: { session_id: this.sessionId, message_id: messageId } },
+            {
+                $set: {
+                    state,
+                    updated_at_ms: updatedAtMs,
+                    expires_at: new Date(expiresAtMs)
+                }
+            }
+        )
+    }
+
+    public async markOutboundRequesterDelivered(
+        messageId: string,
+        requesterDeviceJid: string,
+        updatedAtMs: number,
+        expiresAtMs: number
+    ): Promise<void> {
+        await this.withSession(async (session) => {
+            const col = this.col<OutboundDoc>('retry_outbound_messages')
+            const doc = await col.findOne(
+                { _id: { session_id: this.sessionId, message_id: messageId } },
+                { session }
+            )
+            if (!doc) return
+            if (!doc.requesters_json) return
+            const requesters = this.parseRequesterStatusPayload(doc.requesters_json)
+            let isEligible = false
+            for (let index = 0; index < requesters.eligible.length; index += 1) {
+                if (requesters.eligible[index] === requesterDeviceJid) {
+                    isEligible = true
+                    break
+                }
+            }
+            if (!isEligible) return
+            for (let index = 0; index < requesters.delivered.length; index += 1) {
+                if (requesters.delivered[index] === requesterDeviceJid) {
+                    return
+                }
+            }
+            const nextRequestersJson = this.serializeRequesterStatusPayload(requesters.eligible, [
+                ...requesters.delivered,
+                requesterDeviceJid
+            ])
+            await col.updateOne(
+                { _id: { session_id: this.sessionId, message_id: messageId } },
+                {
+                    $set: {
+                        requesters_json: nextRequestersJson,
+                        updated_at_ms: updatedAtMs,
+                        expires_at: new Date(expiresAtMs)
+                    }
+                },
+                { session }
+            )
+        })
+    }
+
+    public async incrementInboundCounter(
+        messageId: string,
+        requesterJid: string,
+        _updatedAtMs: number,
+        expiresAtMs: number
+    ): Promise<number> {
+        await this.ensureIndexes()
+        const col = this.col<InboundDoc>('retry_inbound_counters')
+        const result = await col.findOneAndUpdate(
+            {
+                _id: {
+                    session_id: this.sessionId,
+                    message_id: messageId,
+                    requester_jid: requesterJid
+                }
+            },
+            {
+                $inc: { retry_count: 1 },
+                $set: { expires_at: new Date(expiresAtMs) }
+            },
+            { upsert: true, returnDocument: 'after' }
+        )
+        return result?.retry_count ?? 1
+    }
+
+    public async cleanupExpired(_nowMs: number): Promise<number> {
+        return 0
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureIndexes()
+        const outbound = this.col<OutboundDoc>('retry_outbound_messages')
+        const inbound = this.col<InboundDoc>('retry_inbound_counters')
+        await Promise.all([
+            outbound.deleteMany({ '_id.session_id': this.sessionId }),
+            inbound.deleteMany({ '_id.session_id': this.sessionId })
+        ])
+    }
+
+    private serializeRequesterStatusPayload(
+        eligibleRequesterDeviceJids: readonly string[] | undefined,
+        deliveredRequesterDeviceJids: readonly string[] | undefined
+    ): string | null {
+        const eligible = this.toUniqueStrings(
+            eligibleRequesterDeviceJids ?? [],
+            'requesters_json.eligible'
+        )
+        if (eligible.length === 0) return null
+        const eligibleSet = new Set(eligible)
+        const delivered = this.toUniqueStrings(
+            deliveredRequesterDeviceJids ?? [],
+            'requesters_json.delivered'
+        ).filter((jid) => eligibleSet.has(jid))
+        const payload = delivered.length > 0 ? { eligible, delivered } : { eligible }
+        return JSON.stringify(payload)
+    }
+
+    private parseRequesterStatusPayload(raw: string): RetryRequesterStatusPayload {
+        const parsed = JSON.parse(raw)
+        if (!isObjectRecord(parsed)) {
+            throw new Error('retry_outbound_messages.requesters_json must be an object')
+        }
+        const eligibleRaw = parsed.eligible
+        if (!Array.isArray(eligibleRaw)) {
+            throw new Error('retry_outbound_messages.requesters_json.eligible must be an array')
+        }
+        const eligible = this.toUniqueStrings(eligibleRaw, 'requesters_json.eligible')
+        const deliveredRaw = parsed.delivered
+        if (deliveredRaw !== undefined && !Array.isArray(deliveredRaw)) {
+            throw new Error('retry_outbound_messages.requesters_json.delivered must be an array')
+        }
+        const eligibleSet = new Set(eligible)
+        const delivered = this.toUniqueStrings(
+            Array.isArray(deliveredRaw) ? deliveredRaw : [],
+            'requesters_json.delivered'
+        ).filter((jid) => eligibleSet.has(jid))
+        return { eligible, delivered }
+    }
+
+    private toUniqueStrings(values: readonly unknown[], field: string): readonly string[] {
+        const deduped = new Set<string>()
+        for (let index = 0; index < values.length; index += 1) {
+            const rawValue = values[index]
+            if (typeof rawValue !== 'string') {
+                throw new Error(`${field} must contain only strings`)
+            }
+            const normalized = rawValue.trim()
+            if (!normalized) continue
+            deduped.add(normalized)
+        }
+        return Array.from(deduped)
+    }
+}

--- a/packages/store-mongo/src/sender-key.store.ts
+++ b/packages/store-mongo/src/sender-key.store.ts
@@ -1,0 +1,276 @@
+import type { Binary } from 'mongodb'
+import type { SenderKeyDistributionRecord, SenderKeyRecord, SignalAddress } from 'zapo-js/signal'
+import { encodeSenderKeyRecord, decodeSenderKeyRecord, toSignalAddressParts } from 'zapo-js/signal'
+import type { WaSenderKeyStore } from 'zapo-js/store'
+
+import { BaseMongoStore } from './BaseMongoStore'
+import { fromBinary, toBinary } from './helpers'
+import type { WaMongoStorageOptions } from './types'
+
+interface SenderKeyDoc {
+    _id: {
+        session_id: string
+        group_id: string
+        sender_user: string
+        sender_server: string
+        sender_device: number
+    }
+    record: Binary
+}
+
+interface DistributionDoc {
+    _id: {
+        session_id: string
+        group_id: string
+        sender_user: string
+        sender_server: string
+        sender_device: number
+    }
+    key_id: number
+    timestamp_ms: number
+}
+
+export class WaSenderKeyMongoStore extends BaseMongoStore implements WaSenderKeyStore {
+    public constructor(options: WaMongoStorageOptions) {
+        super(options)
+    }
+
+    public async upsertSenderKey(record: SenderKeyRecord): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<SenderKeyDoc>('sender_keys')
+        const sender = toSignalAddressParts(record.sender)
+        await col.updateOne(
+            {
+                _id: {
+                    session_id: this.sessionId,
+                    group_id: record.groupId,
+                    sender_user: sender.user,
+                    sender_server: sender.server,
+                    sender_device: sender.device
+                }
+            },
+            { $set: { record: toBinary(encodeSenderKeyRecord(record)) } },
+            { upsert: true }
+        )
+    }
+
+    public async upsertSenderKeyDistribution(record: SenderKeyDistributionRecord): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<DistributionDoc>('sender_key_distribution')
+        const sender = toSignalAddressParts(record.sender)
+        await col.updateOne(
+            {
+                _id: {
+                    session_id: this.sessionId,
+                    group_id: record.groupId,
+                    sender_user: sender.user,
+                    sender_server: sender.server,
+                    sender_device: sender.device
+                }
+            },
+            {
+                $set: {
+                    key_id: record.keyId,
+                    timestamp_ms: record.timestampMs
+                }
+            },
+            { upsert: true }
+        )
+    }
+
+    public async upsertSenderKeyDistributions(
+        records: readonly SenderKeyDistributionRecord[]
+    ): Promise<void> {
+        if (records.length === 0) return
+        await this.ensureIndexes()
+        const col = this.col<DistributionDoc>('sender_key_distribution')
+        const ops = records.map((record) => {
+            const sender = toSignalAddressParts(record.sender)
+            return {
+                updateOne: {
+                    filter: {
+                        _id: {
+                            session_id: this.sessionId,
+                            group_id: record.groupId,
+                            sender_user: sender.user,
+                            sender_server: sender.server,
+                            sender_device: sender.device
+                        }
+                    },
+                    update: {
+                        $set: {
+                            key_id: record.keyId,
+                            timestamp_ms: record.timestampMs
+                        }
+                    },
+                    upsert: true
+                }
+            }
+        })
+        await col.bulkWrite(ops)
+    }
+
+    public async getGroupSenderKeyList(groupId: string): Promise<{
+        readonly skList: readonly SenderKeyRecord[]
+        readonly skDistribList: readonly SenderKeyDistributionRecord[]
+    }> {
+        await this.ensureIndexes()
+        const skCol = this.col<SenderKeyDoc>('sender_keys')
+        const distCol = this.col<DistributionDoc>('sender_key_distribution')
+
+        const [senderDocs, distDocs] = await Promise.all([
+            skCol
+                .find({
+                    '_id.session_id': this.sessionId,
+                    '_id.group_id': groupId
+                })
+                .toArray(),
+            distCol
+                .find({
+                    '_id.session_id': this.sessionId,
+                    '_id.group_id': groupId
+                })
+                .toArray()
+        ])
+
+        const skList: SenderKeyRecord[] = senderDocs.map((doc) =>
+            decodeSenderKeyRecord(fromBinary(doc.record), doc._id.group_id, {
+                user: doc._id.sender_user,
+                server: doc._id.sender_server,
+                device: doc._id.sender_device
+            })
+        )
+
+        const skDistribList: SenderKeyDistributionRecord[] = distDocs.map((doc) => ({
+            groupId: doc._id.group_id,
+            sender: {
+                user: doc._id.sender_user,
+                server: doc._id.sender_server,
+                device: doc._id.sender_device
+            },
+            keyId: doc.key_id,
+            timestampMs: doc.timestamp_ms
+        }))
+
+        return { skList, skDistribList }
+    }
+
+    public async getDeviceSenderKey(
+        groupId: string,
+        sender: SignalAddress
+    ): Promise<SenderKeyRecord | null> {
+        await this.ensureIndexes()
+        const col = this.col<SenderKeyDoc>('sender_keys')
+        const target = toSignalAddressParts(sender)
+        const doc = await col.findOne({
+            _id: {
+                session_id: this.sessionId,
+                group_id: groupId,
+                sender_user: target.user,
+                sender_server: target.server,
+                sender_device: target.device
+            }
+        })
+        if (!doc) return null
+        return decodeSenderKeyRecord(fromBinary(doc.record), doc._id.group_id, {
+            user: doc._id.sender_user,
+            server: doc._id.sender_server,
+            device: doc._id.sender_device
+        })
+    }
+
+    public async getDeviceSenderKeyDistributions(
+        groupId: string,
+        senders: readonly SignalAddress[]
+    ): Promise<readonly (SenderKeyDistributionRecord | null)[]> {
+        if (senders.length === 0) return []
+        await this.ensureIndexes()
+        const col = this.col<DistributionDoc>('sender_key_distribution')
+        const targets = senders.map((s) => toSignalAddressParts(s))
+        const orFilters = targets.map((t) => ({
+            '_id.session_id': this.sessionId,
+            '_id.group_id': groupId,
+            '_id.sender_user': t.user,
+            '_id.sender_server': t.server,
+            '_id.sender_device': t.device
+        }))
+        const docs = await col.find({ $or: orFilters }).toArray()
+        const byKey = new Map<string, SenderKeyDistributionRecord>()
+        for (const doc of docs) {
+            const key = this.senderKey(
+                doc._id.sender_user,
+                doc._id.sender_server,
+                doc._id.sender_device
+            )
+            byKey.set(key, {
+                groupId: doc._id.group_id,
+                sender: {
+                    user: doc._id.sender_user,
+                    server: doc._id.sender_server,
+                    device: doc._id.sender_device
+                },
+                keyId: doc.key_id,
+                timestampMs: doc.timestamp_ms
+            })
+        }
+        return targets.map((t) => byKey.get(this.senderKey(t.user, t.server, t.device)) ?? null)
+    }
+
+    public async deleteDeviceSenderKey(target: SignalAddress, groupId?: string): Promise<number> {
+        await this.ensureIndexes()
+        const sender = toSignalAddressParts(target)
+        const baseFilter: Record<string, unknown> = {
+            '_id.session_id': this.sessionId,
+            '_id.sender_user': sender.user,
+            '_id.sender_server': sender.server,
+            '_id.sender_device': sender.device
+        }
+        if (groupId !== undefined) {
+            baseFilter['_id.group_id'] = groupId
+        }
+        const skCol = this.col<SenderKeyDoc>('sender_keys')
+        const distCol = this.col<DistributionDoc>('sender_key_distribution')
+        const [skResult, distResult] = await Promise.all([
+            skCol.deleteMany(baseFilter),
+            distCol.deleteMany(baseFilter)
+        ])
+        return skResult.deletedCount + distResult.deletedCount
+    }
+
+    public async markForgetSenderKey(
+        groupId: string,
+        participants: readonly SignalAddress[]
+    ): Promise<number> {
+        if (participants.length === 0) return 0
+        await this.ensureIndexes()
+        const targets = participants.map((p) => toSignalAddressParts(p))
+        const orFilters = targets.map((t) => ({
+            '_id.session_id': this.sessionId,
+            '_id.group_id': groupId,
+            '_id.sender_user': t.user,
+            '_id.sender_server': t.server,
+            '_id.sender_device': t.device
+        }))
+        const skCol = this.col<SenderKeyDoc>('sender_keys')
+        const distCol = this.col<DistributionDoc>('sender_key_distribution')
+        const [skResult, distResult] = await Promise.all([
+            skCol.deleteMany({ $or: orFilters }),
+            distCol.deleteMany({ $or: orFilters })
+        ])
+        return skResult.deletedCount + distResult.deletedCount
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureIndexes()
+        const skCol = this.col<SenderKeyDoc>('sender_keys')
+        const distCol = this.col<DistributionDoc>('sender_key_distribution')
+        await Promise.all([
+            skCol.deleteMany({ '_id.session_id': this.sessionId }),
+            distCol.deleteMany({ '_id.session_id': this.sessionId })
+        ])
+    }
+
+    private senderKey(user: string, server: string, device: number): string {
+        return `${user}|${server}|${device}`
+    }
+}

--- a/packages/store-mongo/src/signal.store.ts
+++ b/packages/store-mongo/src/signal.store.ts
@@ -1,0 +1,734 @@
+import type { Binary } from 'mongodb'
+import { signalAddressKey } from 'zapo-js/protocol'
+import type {
+    PreKeyRecord,
+    RegistrationInfo,
+    SignalAddress,
+    SignalSessionRecord,
+    SignedPreKeyRecord
+} from 'zapo-js/signal'
+import {
+    encodeSignalSessionRecord,
+    decodeSignalSessionRecord,
+    toSignalAddressParts
+} from 'zapo-js/signal'
+import type { WaSignalStore, WaSignalMetaSnapshot } from 'zapo-js/store'
+
+import { BaseMongoStore } from './BaseMongoStore'
+import { fromBinary, toBinary, safeLimit } from './helpers'
+import type { WaMongoStorageOptions } from './types'
+
+interface MetaDoc {
+    _id: string
+    server_has_prekeys: boolean
+    next_prekey_id: number
+    signed_prekey_rotation_ts: number | null
+}
+
+interface RegistrationDoc {
+    _id: string
+    registration_id: number
+    identity_pub_key: Binary
+    identity_priv_key: Binary
+}
+
+interface SignedPreKeyDoc {
+    _id: string
+    key_id: number
+    pub_key: Binary
+    priv_key: Binary
+    signature: Binary
+    uploaded: boolean
+}
+
+interface PreKeyDoc {
+    _id: { session_id: string; key_id: number }
+    pub_key: Binary
+    priv_key: Binary
+    uploaded: boolean
+}
+
+interface SessionDoc {
+    _id: { session_id: string; user: string; server: string; device: number }
+    record: Binary
+}
+
+interface IdentityDoc {
+    _id: { session_id: string; user: string; server: string; device: number }
+    identity_key: Binary
+}
+
+export class WaSignalMongoStore extends BaseMongoStore implements WaSignalStore {
+    public constructor(options: WaMongoStorageOptions) {
+        super(options)
+    }
+
+    protected override async createIndexes(): Promise<void> {
+        const prekeys = this.col<PreKeyDoc>('signal_prekeys')
+        await prekeys.createIndex({ '_id.session_id': 1, uploaded: 1, '_id.key_id': 1 })
+    }
+
+    // ── Registration ──────────────────────────────────────────────────
+
+    public async getRegistrationInfo(): Promise<RegistrationInfo | null> {
+        await this.ensureIndexes()
+        const col = this.col<RegistrationDoc>('signal_registration')
+        const doc = await col.findOne({ _id: this.sessionId })
+        if (!doc) return null
+        return {
+            registrationId: doc.registration_id,
+            identityKeyPair: {
+                pubKey: fromBinary(doc.identity_pub_key),
+                privKey: fromBinary(doc.identity_priv_key)
+            }
+        }
+    }
+
+    public async setRegistrationInfo(info: RegistrationInfo): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<RegistrationDoc>('signal_registration')
+        await col.updateOne(
+            { _id: this.sessionId },
+            {
+                $set: {
+                    registration_id: info.registrationId,
+                    identity_pub_key: toBinary(info.identityKeyPair.pubKey),
+                    identity_priv_key: toBinary(info.identityKeyPair.privKey)
+                }
+            },
+            { upsert: true }
+        )
+    }
+
+    // ── Signed PreKey ─────────────────────────────────────────────────
+
+    public async getSignedPreKey(): Promise<SignedPreKeyRecord | null> {
+        await this.ensureIndexes()
+        const col = this.col<SignedPreKeyDoc>('signal_signed_prekey')
+        const doc = await col.findOne({ _id: this.sessionId })
+        if (!doc) return null
+        return this.decodeSignedPreKeyDoc(doc)
+    }
+
+    public async setSignedPreKey(record: SignedPreKeyRecord): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<SignedPreKeyDoc>('signal_signed_prekey')
+        await col.updateOne(
+            { _id: this.sessionId },
+            {
+                $set: {
+                    key_id: record.keyId,
+                    pub_key: toBinary(record.keyPair.pubKey),
+                    priv_key: toBinary(record.keyPair.privKey),
+                    signature: toBinary(record.signature),
+                    uploaded: record.uploaded === true
+                }
+            },
+            { upsert: true }
+        )
+    }
+
+    public async getSignedPreKeyById(keyId: number): Promise<SignedPreKeyRecord | null> {
+        await this.ensureIndexes()
+        const col = this.col<SignedPreKeyDoc>('signal_signed_prekey')
+        const doc = await col.findOne({ _id: this.sessionId, key_id: keyId })
+        if (!doc) return null
+        return this.decodeSignedPreKeyDoc(doc)
+    }
+
+    public async setSignedPreKeyRotationTs(value: number | null): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<MetaDoc>('signal_meta')
+        await col.updateOne(
+            { _id: this.sessionId },
+            {
+                $set: { signed_prekey_rotation_ts: value },
+                $setOnInsert: { server_has_prekeys: false, next_prekey_id: 1 }
+            },
+            { upsert: true }
+        )
+    }
+
+    public async getSignedPreKeyRotationTs(): Promise<number | null> {
+        const meta = await this.getMeta()
+        return meta.signedPreKeyRotationTs
+    }
+
+    // ── PreKeys ───────────────────────────────────────────────────────
+
+    public async putPreKey(record: PreKeyRecord): Promise<void> {
+        await this.ensureIndexes()
+        const prekeys = this.col<PreKeyDoc>('signal_prekeys')
+        const metaCol = this.col<MetaDoc>('signal_meta')
+        await prekeys.updateOne(
+            { _id: { session_id: this.sessionId, key_id: record.keyId } },
+            {
+                $set: {
+                    pub_key: toBinary(record.keyPair.pubKey),
+                    priv_key: toBinary(record.keyPair.privKey),
+                    uploaded: record.uploaded === true
+                }
+            },
+            { upsert: true }
+        )
+        await metaCol.updateOne(
+            { _id: this.sessionId },
+            {
+                $max: { next_prekey_id: record.keyId + 1 },
+                $setOnInsert: {
+                    server_has_prekeys: false,
+                    signed_prekey_rotation_ts: null
+                }
+            },
+            { upsert: true }
+        )
+    }
+
+    public async getOrGenPreKeys(
+        count: number,
+        generator: (keyId: number) => PreKeyRecord | Promise<PreKeyRecord>
+    ): Promise<readonly PreKeyRecord[]> {
+        if (!Number.isSafeInteger(count) || count <= 0) {
+            throw new Error(`invalid prekey count: ${count}`)
+        }
+
+        while (true) {
+            await this.ensureIndexes()
+            const metaCol = this.col<MetaDoc>('signal_meta')
+
+            // Ensure meta exists
+            await metaCol.updateOne(
+                { _id: this.sessionId },
+                {
+                    $setOnInsert: {
+                        server_has_prekeys: false,
+                        next_prekey_id: 1,
+                        signed_prekey_rotation_ts: null
+                    }
+                },
+                { upsert: true }
+            )
+
+            const available = await this.selectAvailablePreKeys(count)
+            const missing = count - available.length
+            if (missing <= 0) {
+                return available
+            }
+
+            // Atomically reserve key IDs
+            const metaResult = await metaCol.findOneAndUpdate(
+                { _id: this.sessionId },
+                { $inc: { next_prekey_id: missing } },
+                { returnDocument: 'before' }
+            )
+            if (!metaResult) {
+                throw new Error('signal meta row not found')
+            }
+            const startKeyId = metaResult.next_prekey_id
+
+            const reservedKeyIds = Array.from({ length: missing }, (_, i) => startKeyId + i)
+
+            const generated: PreKeyRecord[] = []
+            let maxId = reservedKeyIds[reservedKeyIds.length - 1]
+            for (const keyId of reservedKeyIds) {
+                const record = await generator(keyId)
+                generated.push(record)
+                if (record.keyId > maxId) {
+                    maxId = record.keyId
+                }
+            }
+
+            const prekeys = this.col<PreKeyDoc>('signal_prekeys')
+            if (generated.length > 0) {
+                const ops = generated.map((record) => ({
+                    updateOne: {
+                        filter: {
+                            _id: { session_id: this.sessionId, key_id: record.keyId }
+                        },
+                        update: {
+                            $setOnInsert: {
+                                pub_key: toBinary(record.keyPair.pubKey),
+                                priv_key: toBinary(record.keyPair.privKey),
+                                uploaded: record.uploaded === true
+                            }
+                        },
+                        upsert: true
+                    }
+                }))
+                await prekeys.bulkWrite(ops)
+            }
+
+            await metaCol.updateOne(
+                { _id: this.sessionId },
+                { $max: { next_prekey_id: maxId + 1 } }
+            )
+
+            const finalAvailable = await this.selectAvailablePreKeys(count)
+            if (finalAvailable.length >= count) {
+                return finalAvailable
+            }
+        }
+    }
+
+    public async getPreKeyById(keyId: number): Promise<PreKeyRecord | null> {
+        await this.ensureIndexes()
+        const col = this.col<PreKeyDoc>('signal_prekeys')
+        const doc = await col.findOne({
+            _id: { session_id: this.sessionId, key_id: keyId }
+        })
+        if (!doc) return null
+        return this.decodePreKeyDoc(doc)
+    }
+
+    public async getPreKeysById(
+        keyIds: readonly number[]
+    ): Promise<readonly (PreKeyRecord | null)[]> {
+        if (keyIds.length === 0) return []
+        await this.ensureIndexes()
+        const col = this.col<PreKeyDoc>('signal_prekeys')
+        const uniqueKeyIds = [...new Set(keyIds)]
+        const docs = await col
+            .find({
+                '_id.session_id': this.sessionId,
+                '_id.key_id': { $in: uniqueKeyIds }
+            })
+            .toArray()
+        const byId = new Map<number, PreKeyRecord>()
+        for (const doc of docs) {
+            byId.set(doc._id.key_id, this.decodePreKeyDoc(doc))
+        }
+        return keyIds.map((id) => byId.get(id) ?? null)
+    }
+
+    public async consumePreKeyById(keyId: number): Promise<PreKeyRecord | null> {
+        await this.ensureIndexes()
+        const col = this.col<PreKeyDoc>('signal_prekeys')
+        const doc = await col.findOneAndDelete({
+            _id: { session_id: this.sessionId, key_id: keyId }
+        })
+        if (!doc) return null
+        return this.decodePreKeyDoc(doc)
+    }
+
+    public async getOrGenSinglePreKey(
+        generator: (keyId: number) => PreKeyRecord | Promise<PreKeyRecord>
+    ): Promise<PreKeyRecord> {
+        const records = await this.getOrGenPreKeys(1, generator)
+        return records[0]
+    }
+
+    public async markKeyAsUploaded(keyId: number): Promise<void> {
+        await this.ensureIndexes()
+        const meta = await this.getMeta()
+        if (keyId < 0 || keyId >= meta.nextPreKeyId) {
+            throw new Error(`prekey ${keyId} is out of boundary`)
+        }
+        const col = this.col<PreKeyDoc>('signal_prekeys')
+        await col.updateMany(
+            {
+                '_id.session_id': this.sessionId,
+                '_id.key_id': { $lte: keyId }
+            },
+            { $set: { uploaded: true } }
+        )
+    }
+
+    // ── Server State ──────────────────────────────────────────────────
+
+    public async setServerHasPreKeys(value: boolean): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<MetaDoc>('signal_meta')
+        await col.updateOne(
+            { _id: this.sessionId },
+            {
+                $set: { server_has_prekeys: value },
+                $setOnInsert: {
+                    next_prekey_id: 1,
+                    signed_prekey_rotation_ts: null
+                }
+            },
+            { upsert: true }
+        )
+    }
+
+    public async getServerHasPreKeys(): Promise<boolean> {
+        const meta = await this.getMeta()
+        return meta.serverHasPreKeys
+    }
+
+    // ── Meta ──────────────────────────────────────────────────────────
+
+    public async getSignalMeta(): Promise<WaSignalMetaSnapshot> {
+        await this.ensureIndexes()
+        const metaCol = this.col<MetaDoc>('signal_meta')
+        await metaCol.updateOne(
+            { _id: this.sessionId },
+            {
+                $setOnInsert: {
+                    server_has_prekeys: false,
+                    next_prekey_id: 1,
+                    signed_prekey_rotation_ts: null
+                }
+            },
+            { upsert: true }
+        )
+        const meta = await metaCol.findOne({ _id: this.sessionId })
+        if (!meta) throw new Error('signal meta row not found')
+
+        const regCol = this.col<RegistrationDoc>('signal_registration')
+        const regDoc = await regCol.findOne({ _id: this.sessionId })
+        const registrationInfo: RegistrationInfo | null = regDoc
+            ? {
+                  registrationId: regDoc.registration_id,
+                  identityKeyPair: {
+                      pubKey: fromBinary(regDoc.identity_pub_key),
+                      privKey: fromBinary(regDoc.identity_priv_key)
+                  }
+              }
+            : null
+
+        const signedCol = this.col<SignedPreKeyDoc>('signal_signed_prekey')
+        const signedDoc = await signedCol.findOne({ _id: this.sessionId })
+        const signedPreKey: SignedPreKeyRecord | null = signedDoc
+            ? this.decodeSignedPreKeyDoc(signedDoc)
+            : null
+
+        return {
+            serverHasPreKeys: meta.server_has_prekeys,
+            signedPreKeyRotationTs: meta.signed_prekey_rotation_ts,
+            registrationInfo,
+            signedPreKey
+        }
+    }
+
+    // ── Sessions ──────────────────────────────────────────────────────
+
+    public async hasSession(address: SignalAddress): Promise<boolean> {
+        await this.ensureIndexes()
+        const col = this.col<SessionDoc>('signal_sessions')
+        const target = toSignalAddressParts(address)
+        const count = await col.countDocuments(
+            {
+                _id: {
+                    session_id: this.sessionId,
+                    user: target.user,
+                    server: target.server,
+                    device: target.device
+                }
+            },
+            { limit: 1 }
+        )
+        return count > 0
+    }
+
+    public async hasSessions(addresses: readonly SignalAddress[]): Promise<readonly boolean[]> {
+        if (addresses.length === 0) return []
+        await this.ensureIndexes()
+        const col = this.col<SessionDoc>('signal_sessions')
+        const targets = addresses.map((a) => toSignalAddressParts(a))
+        const idFilters = targets.map((t) => ({
+            session_id: this.sessionId,
+            user: t.user,
+            server: t.server,
+            device: t.device
+        }))
+        const docs = await col
+            .find({ _id: { $in: idFilters } }, { projection: { _id: 1 } })
+            .toArray()
+        const existingKeys = new Set<string>()
+        for (const doc of docs) {
+            existingKeys.add(
+                signalAddressKey({
+                    user: doc._id.user,
+                    server: doc._id.server,
+                    device: doc._id.device
+                })
+            )
+        }
+        return targets.map((t) => existingKeys.has(signalAddressKey(t)))
+    }
+
+    public async getSession(address: SignalAddress): Promise<SignalSessionRecord | null> {
+        await this.ensureIndexes()
+        const col = this.col<SessionDoc>('signal_sessions')
+        const target = toSignalAddressParts(address)
+        const doc = await col.findOne({
+            _id: {
+                session_id: this.sessionId,
+                user: target.user,
+                server: target.server,
+                device: target.device
+            }
+        })
+        if (!doc) return null
+        return decodeSignalSessionRecord(fromBinary(doc.record))
+    }
+
+    public async getSessionsBatch(
+        addresses: readonly SignalAddress[]
+    ): Promise<readonly (SignalSessionRecord | null)[]> {
+        if (addresses.length === 0) return []
+        await this.ensureIndexes()
+        const col = this.col<SessionDoc>('signal_sessions')
+        const targets = addresses.map((a) => toSignalAddressParts(a))
+        const orFilters = targets.map((t) => ({
+            '_id.session_id': this.sessionId,
+            '_id.user': t.user,
+            '_id.server': t.server,
+            '_id.device': t.device
+        }))
+        const docs = await col.find({ $or: orFilters }).toArray()
+        const byKey = new Map<string, SignalSessionRecord>()
+        for (const doc of docs) {
+            byKey.set(
+                signalAddressKey({
+                    user: doc._id.user,
+                    server: doc._id.server,
+                    device: doc._id.device
+                }),
+                decodeSignalSessionRecord(fromBinary(doc.record))
+            )
+        }
+        return targets.map((t) => byKey.get(signalAddressKey(t)) ?? null)
+    }
+
+    public async setSession(address: SignalAddress, session: SignalSessionRecord): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<SessionDoc>('signal_sessions')
+        const target = toSignalAddressParts(address)
+        await col.updateOne(
+            {
+                _id: {
+                    session_id: this.sessionId,
+                    user: target.user,
+                    server: target.server,
+                    device: target.device
+                }
+            },
+            { $set: { record: toBinary(encodeSignalSessionRecord(session)) } },
+            { upsert: true }
+        )
+    }
+
+    public async setSessionsBatch(
+        entries: readonly {
+            readonly address: SignalAddress
+            readonly session: SignalSessionRecord
+        }[]
+    ): Promise<void> {
+        if (entries.length === 0) return
+        await this.ensureIndexes()
+        const col = this.col<SessionDoc>('signal_sessions')
+        const ops = entries.map((entry) => {
+            const target = toSignalAddressParts(entry.address)
+            return {
+                updateOne: {
+                    filter: {
+                        _id: {
+                            session_id: this.sessionId,
+                            user: target.user,
+                            server: target.server,
+                            device: target.device
+                        }
+                    },
+                    update: {
+                        $set: { record: toBinary(encodeSignalSessionRecord(entry.session)) }
+                    },
+                    upsert: true
+                }
+            }
+        })
+        await col.bulkWrite(ops)
+    }
+
+    public async deleteSession(address: SignalAddress): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<SessionDoc>('signal_sessions')
+        const target = toSignalAddressParts(address)
+        await col.deleteOne({
+            _id: {
+                session_id: this.sessionId,
+                user: target.user,
+                server: target.server,
+                device: target.device
+            }
+        })
+    }
+
+    // ── Identities ────────────────────────────────────────────────────
+
+    public async getRemoteIdentity(address: SignalAddress): Promise<Uint8Array | null> {
+        await this.ensureIndexes()
+        const col = this.col<IdentityDoc>('signal_identities')
+        const target = toSignalAddressParts(address)
+        const doc = await col.findOne({
+            _id: {
+                session_id: this.sessionId,
+                user: target.user,
+                server: target.server,
+                device: target.device
+            }
+        })
+        if (!doc) return null
+        return fromBinary(doc.identity_key)
+    }
+
+    public async getRemoteIdentities(
+        addresses: readonly SignalAddress[]
+    ): Promise<readonly (Uint8Array | null)[]> {
+        if (addresses.length === 0) return []
+        await this.ensureIndexes()
+        const col = this.col<IdentityDoc>('signal_identities')
+        const targets = addresses.map((a) => toSignalAddressParts(a))
+        const orFilters = targets.map((t) => ({
+            '_id.session_id': this.sessionId,
+            '_id.user': t.user,
+            '_id.server': t.server,
+            '_id.device': t.device
+        }))
+        const docs = await col.find({ $or: orFilters }).toArray()
+        const byKey = new Map<string, Uint8Array>()
+        for (const doc of docs) {
+            byKey.set(
+                signalAddressKey({
+                    user: doc._id.user,
+                    server: doc._id.server,
+                    device: doc._id.device
+                }),
+                fromBinary(doc.identity_key)
+            )
+        }
+        return targets.map((t) => byKey.get(signalAddressKey(t)) ?? null)
+    }
+
+    public async setRemoteIdentity(address: SignalAddress, identityKey: Uint8Array): Promise<void> {
+        await this.ensureIndexes()
+        const col = this.col<IdentityDoc>('signal_identities')
+        const target = toSignalAddressParts(address)
+        await col.updateOne(
+            {
+                _id: {
+                    session_id: this.sessionId,
+                    user: target.user,
+                    server: target.server,
+                    device: target.device
+                }
+            },
+            { $set: { identity_key: toBinary(identityKey) } },
+            { upsert: true }
+        )
+    }
+
+    public async setRemoteIdentities(
+        entries: readonly {
+            readonly address: SignalAddress
+            readonly identityKey: Uint8Array
+        }[]
+    ): Promise<void> {
+        if (entries.length === 0) return
+        await this.ensureIndexes()
+        const col = this.col<IdentityDoc>('signal_identities')
+        const ops = entries.map((entry) => {
+            const target = toSignalAddressParts(entry.address)
+            return {
+                updateOne: {
+                    filter: {
+                        _id: {
+                            session_id: this.sessionId,
+                            user: target.user,
+                            server: target.server,
+                            device: target.device
+                        }
+                    },
+                    update: { $set: { identity_key: toBinary(entry.identityKey) } },
+                    upsert: true
+                }
+            }
+        })
+        await col.bulkWrite(ops)
+    }
+
+    // ── Clear ─────────────────────────────────────────────────────────
+
+    public async clear(): Promise<void> {
+        await this.ensureIndexes()
+        await Promise.all([
+            this.col<MetaDoc>('signal_meta').deleteMany({ _id: this.sessionId }),
+            this.col<RegistrationDoc>('signal_registration').deleteMany({ _id: this.sessionId }),
+            this.col<SignedPreKeyDoc>('signal_signed_prekey').deleteMany({ _id: this.sessionId }),
+            this.col<PreKeyDoc>('signal_prekeys').deleteMany({ '_id.session_id': this.sessionId }),
+            this.col<SessionDoc>('signal_sessions').deleteMany({
+                '_id.session_id': this.sessionId
+            }),
+            this.col<IdentityDoc>('signal_identities').deleteMany({
+                '_id.session_id': this.sessionId
+            })
+        ])
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────
+
+    private async getMeta(): Promise<{
+        serverHasPreKeys: boolean
+        nextPreKeyId: number
+        signedPreKeyRotationTs: number | null
+    }> {
+        await this.ensureIndexes()
+        const col = this.col<MetaDoc>('signal_meta')
+        await col.updateOne(
+            { _id: this.sessionId },
+            {
+                $setOnInsert: {
+                    server_has_prekeys: false,
+                    next_prekey_id: 1,
+                    signed_prekey_rotation_ts: null
+                }
+            },
+            { upsert: true }
+        )
+        const doc = await col.findOne({ _id: this.sessionId })
+        if (!doc) throw new Error('signal meta row not found')
+        return {
+            serverHasPreKeys: doc.server_has_prekeys,
+            nextPreKeyId: doc.next_prekey_id,
+            signedPreKeyRotationTs: doc.signed_prekey_rotation_ts
+        }
+    }
+
+    private async selectAvailablePreKeys(limit: number): Promise<PreKeyRecord[]> {
+        const resolved = safeLimit(limit, 100)
+        const col = this.col<PreKeyDoc>('signal_prekeys')
+        const docs = await col
+            .find({
+                '_id.session_id': this.sessionId,
+                uploaded: false
+            })
+            .sort({ '_id.key_id': 1 })
+            .limit(resolved)
+            .toArray()
+        return docs.map((doc) => this.decodePreKeyDoc(doc))
+    }
+
+    private decodePreKeyDoc(doc: PreKeyDoc): PreKeyRecord {
+        return {
+            keyId: doc._id.key_id,
+            keyPair: {
+                pubKey: fromBinary(doc.pub_key),
+                privKey: fromBinary(doc.priv_key)
+            },
+            uploaded: doc.uploaded
+        }
+    }
+
+    private decodeSignedPreKeyDoc(doc: SignedPreKeyDoc): SignedPreKeyRecord {
+        return {
+            keyId: doc.key_id,
+            keyPair: {
+                pubKey: fromBinary(doc.pub_key),
+                privKey: fromBinary(doc.priv_key)
+            },
+            signature: fromBinary(doc.signature),
+            uploaded: doc.uploaded
+        }
+    }
+}

--- a/packages/store-mongo/src/thread.store.ts
+++ b/packages/store-mongo/src/thread.store.ts
@@ -1,0 +1,107 @@
+import type { WaStoredThreadRecord, WaThreadStore } from 'zapo-js/store'
+
+import { BaseMongoStore } from './BaseMongoStore'
+import { safeLimit } from './helpers'
+import type { WaMongoStorageOptions } from './types'
+
+const COLLECTION = 'mailbox_threads'
+
+interface ThreadDoc {
+    _id: { session_id: string; jid: string }
+    name: string | null
+    unread_count: number | null
+    archived: boolean | null
+    pinned: number | null
+    mute_end_ms: number | null
+    marked_as_unread: boolean | null
+    ephemeral_expiration: number | null
+}
+
+function docToRecord(doc: ThreadDoc): WaStoredThreadRecord {
+    return {
+        jid: doc._id.jid,
+        name: doc.name ?? undefined,
+        unreadCount: doc.unread_count ?? undefined,
+        archived: doc.archived ?? undefined,
+        pinned: doc.pinned ?? undefined,
+        muteEndMs: doc.mute_end_ms ?? undefined,
+        markedAsUnread: doc.marked_as_unread ?? undefined,
+        ephemeralExpiration: doc.ephemeral_expiration ?? undefined
+    }
+}
+
+function buildCoalesceSet(record: WaStoredThreadRecord): Partial<ThreadDoc> {
+    const set: Partial<ThreadDoc> = {}
+    if (record.name !== undefined) set.name = record.name
+    if (record.unreadCount !== undefined) set.unread_count = record.unreadCount
+    if (record.archived !== undefined) set.archived = record.archived
+    if (record.pinned !== undefined) set.pinned = record.pinned
+    if (record.muteEndMs !== undefined) set.mute_end_ms = record.muteEndMs
+    if (record.markedAsUnread !== undefined) set.marked_as_unread = record.markedAsUnread
+    if (record.ephemeralExpiration !== undefined)
+        set.ephemeral_expiration = record.ephemeralExpiration
+    return set
+}
+
+export class WaThreadMongoStore extends BaseMongoStore implements WaThreadStore {
+    public constructor(options: WaMongoStorageOptions) {
+        super(options)
+    }
+
+    private makeId(jid: string): ThreadDoc['_id'] {
+        return { session_id: this.sessionId, jid }
+    }
+
+    public async upsert(record: WaStoredThreadRecord): Promise<void> {
+        await this.ensureIndexes()
+        const set = buildCoalesceSet(record)
+        await this.col<ThreadDoc>(COLLECTION).updateOne(
+            { _id: this.makeId(record.jid) },
+            { $set: set },
+            { upsert: true }
+        )
+    }
+
+    public async upsertBatch(records: readonly WaStoredThreadRecord[]): Promise<void> {
+        if (records.length === 0) return
+        await this.ensureIndexes()
+
+        const ops = records.map((record) => ({
+            updateOne: {
+                filter: { _id: this.makeId(record.jid) },
+                update: { $set: buildCoalesceSet(record) },
+                upsert: true
+            }
+        }))
+
+        await this.col<ThreadDoc>(COLLECTION).bulkWrite(ops, { ordered: false })
+    }
+
+    public async getByJid(jid: string): Promise<WaStoredThreadRecord | null> {
+        await this.ensureIndexes()
+        const doc = await this.col<ThreadDoc>(COLLECTION).findOne({ _id: this.makeId(jid) })
+        if (!doc) return null
+        return docToRecord(doc)
+    }
+
+    public async list(limit?: number): Promise<readonly WaStoredThreadRecord[]> {
+        await this.ensureIndexes()
+        const resolved = safeLimit(limit, 100)
+        const docs = await this.col<ThreadDoc>(COLLECTION)
+            .find({ '_id.session_id': this.sessionId })
+            .limit(resolved)
+            .toArray()
+        return docs.map(docToRecord)
+    }
+
+    public async deleteByJid(jid: string): Promise<number> {
+        await this.ensureIndexes()
+        const result = await this.col<ThreadDoc>(COLLECTION).deleteOne({ _id: this.makeId(jid) })
+        return result.deletedCount
+    }
+
+    public async clear(): Promise<void> {
+        await this.ensureIndexes()
+        await this.col<ThreadDoc>(COLLECTION).deleteMany({ '_id.session_id': this.sessionId })
+    }
+}

--- a/packages/store-mongo/src/types.ts
+++ b/packages/store-mongo/src/types.ts
@@ -1,0 +1,7 @@
+import type { Db } from 'mongodb'
+
+export interface WaMongoStorageOptions {
+    readonly db: Db
+    readonly sessionId: string
+    readonly collectionPrefix?: string
+}

--- a/packages/store-mongo/tsconfig.build.cjs.json
+++ b/packages/store-mongo/tsconfig.build.cjs.json
@@ -1,0 +1,27 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "baseUrl": "../..",
+        "paths": {
+            "zapo-js": ["dist/types/index.d.ts"],
+            "zapo-js/store": ["dist/types/store/index.d.ts"],
+            "zapo-js/signal": ["dist/types/signal/index.d.ts"],
+            "zapo-js/auth": ["dist/types/auth/index.d.ts"],
+            "zapo-js/appstate": ["dist/types/appstate/index.d.ts"],
+            "zapo-js/retry": ["dist/types/retry/index.d.ts"],
+            "zapo-js/proto": ["dist/types/proto.d.ts"],
+            "zapo-js/protocol": ["dist/types/protocol/index.d.ts"],
+            "zapo-js/crypto": ["dist/types/crypto/index.d.ts"],
+            "zapo-js/util": ["dist/types/util/index.d.ts"]
+        }
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/store-mongo/tsconfig.json
+++ b/packages/store-mongo/tsconfig.json
@@ -1,0 +1,42 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "types": ["node"],
+        "rootDir": "../..",
+        "baseUrl": "../..",
+        "paths": {
+            "zapo-js": ["src/index.ts"],
+            "zapo-js/store": ["src/store/index.ts"],
+            "zapo-js/signal": ["src/signal/index.ts"],
+            "zapo-js/auth": ["src/auth/index.ts"],
+            "zapo-js/appstate": ["src/appstate/index.ts"],
+            "zapo-js/retry": ["src/retry/index.ts"],
+            "zapo-js/proto": ["src/proto.ts"],
+            "zapo-js/protocol": ["src/protocol/index.ts"],
+            "zapo-js/crypto": ["src/crypto/index.ts"],
+            "zapo-js/util": ["src/util/index.ts"],
+            "@appstate": ["src/appstate/index.ts"],
+            "@appstate/*": ["src/appstate/*"],
+            "@auth": ["src/auth/index.ts"],
+            "@auth/*": ["src/auth/*"],
+            "@crypto": ["src/crypto/index.ts"],
+            "@crypto/*": ["src/crypto/*"],
+            "@infra/*": ["src/infra/*"],
+            "@protocol": ["src/protocol/index.ts"],
+            "@protocol/*": ["src/protocol/*"],
+            "@proto": ["src/proto.ts"],
+            "@retry": ["src/retry/index.ts"],
+            "@retry/*": ["src/retry/*"],
+            "@signal": ["src/signal/index.ts"],
+            "@signal/*": ["src/signal/*"],
+            "@store": ["src/store/index.ts"],
+            "@store/*": ["src/store/*"],
+            "@transport": ["src/transport/index.ts"],
+            "@transport/*": ["src/transport/*"],
+            "@util/*": ["src/util/*"]
+        },
+        "noEmit": true
+    },
+    "include": ["src"],
+    "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
- implement all 11 store contracts backed by MongoDB via mongodb driver
- use native Binary type for zero-copy binary field storage
- use compound _id for composite primary keys (no separate indexes needed)
- use MongoDB TTL indexes for automatic cache expiration (participants, deviceList, retry)
- use findOneAndUpdate with $inc for atomic incrementInboundCounter
- use findOneAndDelete for atomic consumePreKeyById
- use bulkWrite for all batch operations
- use withSession for snapshot-consistent multi-collection reads
- COALESCE-style upserts via $set with only defined fields
- lazy index creation on first use with error-reset
- add createMongoStore() helper for plug-and-play backend registration
- validate collectionPrefix in constructor
- no migrations needed (MongoDB is schemaless)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added MongoDB storage backend enabling persistent data storage for authentication, messages, conversations, contacts, app state, and device lists.
* Implemented configurable factory for creating MongoDB stores with built-in TTL support for automatic cache expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->