### PR TITLE
fix: harden store backends with TTL validation, bounds, and chunked deletes

### DIFF
--- a/packages/store-mongo/src/BaseMongoStore.ts
+++ b/packages/store-mongo/src/BaseMongoStore.ts
@@ -8,6 +8,7 @@ export abstract class BaseMongoStore {
     protected readonly sessionId: string
     protected readonly collectionPrefix: string
     private indexPromise: Promise<void> | null
+    private transactionSupportPromise: Promise<boolean> | null
 
     protected constructor(options: WaMongoStorageOptions) {
         this.db = options.db
@@ -15,6 +16,7 @@ export abstract class BaseMongoStore {
         this.collectionPrefix = options.collectionPrefix ?? ''
         assertSafeCollectionPrefix(this.collectionPrefix)
         this.indexPromise = null
+        this.transactionSupportPromise = null
     }
 
     protected col<T extends Document = Document>(name: string): Collection<T> {
@@ -39,17 +41,77 @@ export abstract class BaseMongoStore {
         await this.ensureIndexes()
         const session = this.db.client.startSession()
         try {
-            let result: T
-            await session.withTransaction(async () => {
-                result = await run(session)
-            })
-            return result!
+            const supportsTransactions = await this.canUseTransactions()
+            if (!supportsTransactions) {
+                return run(session)
+            }
+            try {
+                let result: T | undefined
+                let hasResult = false
+                await session.withTransaction(async () => {
+                    result = await run(session)
+                    hasResult = true
+                })
+                if (!hasResult) {
+                    throw new Error('mongo transaction callback did not execute')
+                }
+                return result as T
+            } catch (error) {
+                if (!this.isTransactionUnsupportedError(error)) {
+                    throw error
+                }
+                this.transactionSupportPromise = Promise.resolve(false)
+                return run(session)
+            }
         } finally {
             await session.endSession()
         }
     }
 
+    private async canUseTransactions(): Promise<boolean> {
+        if (!this.transactionSupportPromise) {
+            this.transactionSupportPromise = this.detectTransactionSupport()
+        }
+        return this.transactionSupportPromise
+    }
+
+    private async detectTransactionSupport(): Promise<boolean> {
+        try {
+            const hello = await this.db.admin().command({ hello: 1 })
+            if (!hello || typeof hello !== 'object') {
+                return false
+            }
+            const helloRecord = hello as {
+                readonly msg?: unknown
+                readonly setName?: unknown
+            }
+            if (helloRecord.msg === 'isdbgrid') {
+                return true
+            }
+            return typeof helloRecord.setName === 'string' && helloRecord.setName.length > 0
+        } catch {
+            return false
+        }
+    }
+
+    private isTransactionUnsupportedError(error: unknown): boolean {
+        if (!(error instanceof Error)) {
+            return false
+        }
+        const code = (error as { readonly code?: unknown }).code
+        if (code === 20 || code === 303) {
+            return true
+        }
+        const message = error.message.toLowerCase()
+        return (
+            message.includes(
+                'transaction numbers are only allowed on a replica set member or mongos'
+            ) || message.includes('transactions are not supported by this deployment')
+        )
+    }
+
     public async destroy(): Promise<void> {
         this.indexPromise = null
+        this.transactionSupportPromise = null
     }
 }

--- a/packages/store-mongo/src/device-list.store.ts
+++ b/packages/store-mongo/src/device-list.store.ts
@@ -17,8 +17,8 @@ export class WaDeviceListMongoStore extends BaseMongoStore implements WaDeviceLi
 
     public constructor(options: WaMongoStorageOptions, ttlMs = DEFAULT_DEVICE_LIST_TTL_MS) {
         super(options)
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('device-list ttlMs must be a non-negative finite number')
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('device-list ttlMs must be a positive finite number')
         }
         this.ttlMs = ttlMs
     }
@@ -50,7 +50,7 @@ export class WaDeviceListMongoStore extends BaseMongoStore implements WaDeviceLi
 
     public async getUserDevicesBatch(
         userJids: readonly string[],
-        _nowMs?: number
+        nowMs = Date.now()
     ): Promise<readonly (WaDeviceListSnapshot | null)[]> {
         if (userJids.length === 0) return []
         await this.ensureIndexes()
@@ -59,7 +59,8 @@ export class WaDeviceListMongoStore extends BaseMongoStore implements WaDeviceLi
         const docs = await col
             .find({
                 '_id.session_id': this.sessionId,
-                '_id.user_jid': { $in: uniqueUserJids }
+                '_id.user_jid': { $in: uniqueUserJids },
+                expires_at: { $gt: new Date(nowMs) }
             })
             .toArray()
 

--- a/packages/store-mongo/src/message-secret.store.ts
+++ b/packages/store-mongo/src/message-secret.store.ts
@@ -18,8 +18,8 @@ export class WaMessageSecretMongoStore extends BaseMongoStore implements WaMessa
 
     public constructor(options: WaMongoStorageOptions, ttlMs = DEFAULT_MESSAGE_SECRET_TTL_MS) {
         super(options)
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('message-secret ttlMs must be a non-negative finite number')
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('message-secret ttlMs must be a positive finite number')
         }
         this.ttlMs = ttlMs
     }

--- a/packages/store-mongo/src/participants.store.ts
+++ b/packages/store-mongo/src/participants.store.ts
@@ -17,8 +17,8 @@ export class WaParticipantsMongoStore extends BaseMongoStore implements WaPartic
 
     public constructor(options: WaMongoStorageOptions, ttlMs = DEFAULT_PARTICIPANTS_TTL_MS) {
         super(options)
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('participants ttlMs must be a non-negative finite number')
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('participants ttlMs must be a positive finite number')
         }
         this.ttlMs = ttlMs
     }
@@ -46,12 +46,13 @@ export class WaParticipantsMongoStore extends BaseMongoStore implements WaPartic
 
     public async getGroupParticipants(
         groupJid: string,
-        _nowMs?: number
+        nowMs = Date.now()
     ): Promise<WaParticipantsSnapshot | null> {
         await this.ensureIndexes()
         const col = this.col<ParticipantsDoc>('group_participants_cache')
         const doc = await col.findOne({
-            _id: { session_id: this.sessionId, group_jid: groupJid }
+            _id: { session_id: this.sessionId, group_jid: groupJid },
+            expires_at: { $gt: new Date(nowMs) }
         })
         if (!doc) return null
         return {

--- a/packages/store-mongo/src/retry.store.ts
+++ b/packages/store-mongo/src/retry.store.ts
@@ -43,8 +43,8 @@ export class WaRetryMongoStore extends BaseMongoStore implements WaRetryStore {
 
     public constructor(options: WaMongoStorageOptions, ttlMs = DEFAULT_RETRY_TTL_MS) {
         super(options)
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('retry ttlMs must be a non-negative finite number')
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('retry ttlMs must be a positive finite number')
         }
         this.ttlMs = ttlMs
     }
@@ -75,8 +75,10 @@ export class WaRetryMongoStore extends BaseMongoStore implements WaRetryStore {
     } | null> {
         await this.ensureIndexes()
         const col = this.col<OutboundDoc>('retry_outbound_messages')
+        const now = new Date(Date.now())
         const doc = await col.findOne({
-            _id: { session_id: this.sessionId, message_id: messageId }
+            _id: { session_id: this.sessionId, message_id: messageId },
+            expires_at: { $gt: now }
         })
         if (!doc) return null
         if (!doc.requesters_json) return null
@@ -146,8 +148,10 @@ export class WaRetryMongoStore extends BaseMongoStore implements WaRetryStore {
     ): Promise<WaRetryOutboundMessageRecord | null> {
         await this.ensureIndexes()
         const col = this.col<OutboundDoc>('retry_outbound_messages')
+        const now = new Date(Date.now())
         const doc = await col.findOne({
-            _id: { session_id: this.sessionId, message_id: messageId }
+            _id: { session_id: this.sessionId, message_id: messageId },
+            expires_at: { $gt: now }
         })
         if (!doc) return null
         const requesters = doc.requesters_json
@@ -200,8 +204,12 @@ export class WaRetryMongoStore extends BaseMongoStore implements WaRetryStore {
     ): Promise<void> {
         await this.withSession(async (session) => {
             const col = this.col<OutboundDoc>('retry_outbound_messages')
+            const now = new Date(Date.now())
             const doc = await col.findOne(
-                { _id: { session_id: this.sessionId, message_id: messageId } },
+                {
+                    _id: { session_id: this.sessionId, message_id: messageId },
+                    expires_at: { $gt: now }
+                },
                 { session }
             )
             if (!doc) return
@@ -225,7 +233,10 @@ export class WaRetryMongoStore extends BaseMongoStore implements WaRetryStore {
                 requesterDeviceJid
             ])
             await col.updateOne(
-                { _id: { session_id: this.sessionId, message_id: messageId } },
+                {
+                    _id: { session_id: this.sessionId, message_id: messageId },
+                    expires_at: { $gt: now }
+                },
                 {
                     $set: {
                         requesters_json: nextRequestersJson,

--- a/packages/store-mysql/src/connection.ts
+++ b/packages/store-mysql/src/connection.ts
@@ -1,7 +1,7 @@
 import mysql from 'mysql2/promise'
 import type { Pool, PoolOptions } from 'mysql2/promise'
 
-import { queryRows } from './helpers'
+import { assertSafeTablePrefix, queryRows } from './helpers'
 import type { WaMysqlMigrationDomain } from './types'
 
 interface Migration {
@@ -328,6 +328,7 @@ export async function ensureMysqlMigrations(
     domains: readonly WaMysqlMigrationDomain[],
     tablePrefix = ''
 ): Promise<void> {
+    assertSafeTablePrefix(tablePrefix)
     const t = (name: string) => `${tablePrefix}${name}`
     const domainSet = new Set(domains)
     const pending = MIGRATIONS.filter((m) => domainSet.has(m.domain))

--- a/packages/store-mysql/src/device-list.store.ts
+++ b/packages/store-mysql/src/device-list.store.ts
@@ -13,8 +13,8 @@ export class WaDeviceListMysqlStore extends BaseMysqlStore implements WaDeviceLi
 
     public constructor(options: WaMysqlStorageOptions, ttlMs = DEFAULT_DEVICE_LIST_TTL_MS) {
         super(options, ['deviceList'])
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('device-list ttlMs must be a non-negative finite number')
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('device-list ttlMs must be a positive finite number')
         }
         this.ttlMs = ttlMs
     }

--- a/packages/store-mysql/src/message-secret.store.ts
+++ b/packages/store-mysql/src/message-secret.store.ts
@@ -13,8 +13,8 @@ export class WaMessageSecretMysqlStore extends BaseMysqlStore implements WaMessa
 
     public constructor(options: WaMysqlStorageOptions, ttlMs = DEFAULT_MESSAGE_SECRET_TTL_MS) {
         super(options, ['messageSecret'])
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('message-secret ttlMs must be a non-negative finite number')
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('message-secret ttlMs must be a positive finite number')
         }
         this.ttlMs = ttlMs
     }

--- a/packages/store-mysql/src/participants.store.ts
+++ b/packages/store-mysql/src/participants.store.ts
@@ -11,8 +11,8 @@ export class WaParticipantsMysqlStore extends BaseMysqlStore implements WaPartic
 
     public constructor(options: WaMysqlStorageOptions, ttlMs = DEFAULT_PARTICIPANTS_TTL_MS) {
         super(options, ['participants'])
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('participants ttlMs must be a non-negative finite number')
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('participants ttlMs must be a positive finite number')
         }
         this.ttlMs = ttlMs
     }

--- a/packages/store-mysql/src/retry.store.ts
+++ b/packages/store-mysql/src/retry.store.ts
@@ -21,8 +21,8 @@ export class WaRetryMysqlStore extends BaseMysqlStore implements WaRetryStore {
 
     public constructor(options: WaMysqlStorageOptions, ttlMs = DEFAULT_RETRY_TTL_MS) {
         super(options, ['retry'])
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('retry ttlMs must be a non-negative finite number')
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('retry ttlMs must be a positive finite number')
         }
         this.ttlMs = ttlMs
     }

--- a/packages/store-postgres/src/device-list.store.ts
+++ b/packages/store-postgres/src/device-list.store.ts
@@ -12,8 +12,8 @@ export class WaDeviceListPgStore extends BasePgStore implements WaDeviceListStor
 
     public constructor(options: WaPgStorageOptions, ttlMs = DEFAULT_DEVICE_LIST_TTL_MS) {
         super(options, ['deviceList'])
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('device-list ttlMs must be a non-negative finite number')
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('device-list ttlMs must be a positive finite number')
         }
         this.ttlMs = ttlMs
     }

--- a/packages/store-postgres/src/message-secret.store.ts
+++ b/packages/store-postgres/src/message-secret.store.ts
@@ -12,8 +12,8 @@ export class WaMessageSecretPgStore extends BasePgStore implements WaMessageSecr
 
     public constructor(options: WaPgStorageOptions, ttlMs = DEFAULT_MESSAGE_SECRET_TTL_MS) {
         super(options, ['messageSecret'])
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('message-secret ttlMs must be a non-negative finite number')
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('message-secret ttlMs must be a positive finite number')
         }
         this.ttlMs = ttlMs
     }

--- a/packages/store-postgres/src/participants.store.ts
+++ b/packages/store-postgres/src/participants.store.ts
@@ -11,8 +11,8 @@ export class WaParticipantsPgStore extends BasePgStore implements WaParticipants
 
     public constructor(options: WaPgStorageOptions, ttlMs = DEFAULT_PARTICIPANTS_TTL_MS) {
         super(options, ['participants'])
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('participants ttlMs must be a non-negative finite number')
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('participants ttlMs must be a positive finite number')
         }
         this.ttlMs = ttlMs
     }

--- a/packages/store-postgres/src/retry.store.ts
+++ b/packages/store-postgres/src/retry.store.ts
@@ -21,8 +21,8 @@ export class WaRetryPgStore extends BasePgStore implements WaRetryStore {
 
     public constructor(options: WaPgStorageOptions, ttlMs = DEFAULT_RETRY_TTL_MS) {
         super(options, ['retry'])
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('retry ttlMs must be a non-negative finite number')
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('retry ttlMs must be a positive finite number')
         }
         this.ttlMs = ttlMs
     }

--- a/packages/store-redis/src/appstate.store.ts
+++ b/packages/store-redis/src/appstate.store.ts
@@ -18,6 +18,7 @@ import type {
 import { BaseRedisStore } from './BaseRedisStore'
 import {
     bytesToHex,
+    deleteKeysChunked,
     hexToBytes,
     scanKeys,
     toBytesOrNull,
@@ -428,7 +429,7 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
         const scannedKeys = await Promise.all(scanPatterns.map((p) => scanKeys(this.redis, p)))
         const allKeys = [...fixedKeys, ...scannedKeys.flat()]
         if (allKeys.length > 0) {
-            await this.redis.del(...allKeys)
+            await deleteKeysChunked(this.redis, allKeys)
         }
     }
 }

--- a/packages/store-redis/src/auth.store.ts
+++ b/packages/store-redis/src/auth.store.ts
@@ -3,7 +3,13 @@ import { proto } from 'zapo-js/proto'
 import type { WaAuthStore } from 'zapo-js/store'
 
 import { BaseRedisStore } from './BaseRedisStore'
-import { scanKeys, toBytesOrNull, toRedisBuffer, toStringOrNull } from './helpers'
+import {
+    deleteKeysChunked,
+    scanKeys,
+    toBytesOrNull,
+    toRedisBuffer,
+    toStringOrNull
+} from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
 const BINARY_FIELDS = [
@@ -202,7 +208,7 @@ export class WaAuthRedisStore extends BaseRedisStore implements WaAuthStore {
         const baseKey = this.k('auth', this.sessionId)
         const subKeys = await scanKeys(this.redis, `${baseKey}:*`)
         if (subKeys.length > 0) {
-            await this.redis.del(...subKeys)
+            await deleteKeysChunked(this.redis, subKeys)
         }
         await this.redis.del(baseKey)
     }

--- a/packages/store-redis/src/device-list.store.ts
+++ b/packages/store-redis/src/device-list.store.ts
@@ -1,7 +1,7 @@
 import type { WaDeviceListSnapshot, WaDeviceListStore } from 'zapo-js/store'
 
 import { BaseRedisStore } from './BaseRedisStore'
-import { scanKeys } from './helpers'
+import { deleteKeysChunked, scanKeys } from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
 const DEFAULT_DEVICE_LIST_TTL_MS = 5 * 60 * 1000
@@ -11,8 +11,8 @@ export class WaDeviceListRedisStore extends BaseRedisStore implements WaDeviceLi
 
     public constructor(options: WaRedisStorageOptions, ttlMs = DEFAULT_DEVICE_LIST_TTL_MS) {
         super(options)
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('device-list ttlMs must be a non-negative finite number')
+        if (!Number.isSafeInteger(ttlMs) || ttlMs <= 0) {
+            throw new Error('device-list ttlMs must be a positive integer')
         }
         this.ttlMs = ttlMs
     }
@@ -76,7 +76,7 @@ export class WaDeviceListRedisStore extends BaseRedisStore implements WaDeviceLi
         const pattern = this.k('devlist', this.sessionId, '*')
         const keys = await scanKeys(this.redis, pattern)
         if (keys.length > 0) {
-            await this.redis.del(...keys)
+            await deleteKeysChunked(this.redis, keys)
         }
     }
 }

--- a/packages/store-redis/src/helpers.ts
+++ b/packages/store-redis/src/helpers.ts
@@ -43,6 +43,27 @@ export async function scanKeys(redis: Redis, pattern: string): Promise<string[]>
     return keys
 }
 
+const DEFAULT_DELETE_CHUNK_SIZE = 500
+
+export async function deleteKeysChunked(
+    redis: Redis,
+    keys: readonly string[],
+    chunkSize = DEFAULT_DELETE_CHUNK_SIZE
+): Promise<number> {
+    if (keys.length === 0) {
+        return 0
+    }
+    if (!Number.isSafeInteger(chunkSize) || chunkSize <= 0) {
+        throw new Error('delete keys chunkSize must be a positive safe integer')
+    }
+    let deleted = 0
+    for (let start = 0; start < keys.length; start += chunkSize) {
+        const end = Math.min(start + chunkSize, keys.length)
+        deleted += await redis.del(...keys.slice(start, end))
+    }
+    return deleted
+}
+
 export function toRedisBuffer(bytes: Uint8Array): Buffer {
     return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)
 }

--- a/packages/store-redis/src/identity.store.ts
+++ b/packages/store-redis/src/identity.store.ts
@@ -3,7 +3,7 @@ import { toSignalAddressParts } from 'zapo-js/signal'
 import type { WaIdentityStore } from 'zapo-js/store'
 
 import { BaseRedisStore } from './BaseRedisStore'
-import { scanKeys, toRedisBuffer } from './helpers'
+import { deleteKeysChunked, scanKeys, toRedisBuffer } from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
 export class WaIdentityRedisStore extends BaseRedisStore implements WaIdentityStore {
@@ -93,7 +93,7 @@ export class WaIdentityRedisStore extends BaseRedisStore implements WaIdentitySt
         const scannedKeys = await Promise.all(scanPatterns.map((p) => scanKeys(this.redis, p)))
         const allKeys = scannedKeys.flat()
         if (allKeys.length > 0) {
-            await this.redis.del(...allKeys)
+            await deleteKeysChunked(this.redis, allKeys)
         }
     }
 }

--- a/packages/store-redis/src/message-secret.store.ts
+++ b/packages/store-redis/src/message-secret.store.ts
@@ -1,7 +1,7 @@
 import type { WaMessageSecretStore } from 'zapo-js/store'
 
 import { BaseRedisStore } from './BaseRedisStore'
-import { scanKeys, toBytesOrNull, toRedisBuffer } from './helpers'
+import { deleteKeysChunked, scanKeys, toBytesOrNull, toRedisBuffer } from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
 const DEFAULT_MESSAGE_SECRET_TTL_MS = 30 * 60 * 1000
@@ -11,8 +11,8 @@ export class WaMessageSecretRedisStore extends BaseRedisStore implements WaMessa
 
     public constructor(options: WaRedisStorageOptions, ttlMs = DEFAULT_MESSAGE_SECRET_TTL_MS) {
         super(options)
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('message-secret ttlMs must be a non-negative finite number')
+        if (!Number.isSafeInteger(ttlMs) || ttlMs <= 0) {
+            throw new Error('message-secret ttlMs must be a positive integer')
         }
         this.ttlMs = ttlMs
     }
@@ -68,7 +68,7 @@ export class WaMessageSecretRedisStore extends BaseRedisStore implements WaMessa
         const pattern = this.k('msgsecret', this.sessionId, '*')
         const keys = await scanKeys(this.redis, pattern)
         if (keys.length > 0) {
-            await this.redis.del(...keys)
+            await deleteKeysChunked(this.redis, keys)
         }
     }
 }

--- a/packages/store-redis/src/participants.store.ts
+++ b/packages/store-redis/src/participants.store.ts
@@ -1,7 +1,7 @@
 import type { WaParticipantsSnapshot, WaParticipantsStore } from 'zapo-js/store'
 
 import { BaseRedisStore } from './BaseRedisStore'
-import { scanKeys } from './helpers'
+import { deleteKeysChunked, scanKeys } from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
 const DEFAULT_PARTICIPANTS_TTL_MS = 5 * 60 * 1000
@@ -11,8 +11,8 @@ export class WaParticipantsRedisStore extends BaseRedisStore implements WaPartic
 
     public constructor(options: WaRedisStorageOptions, ttlMs = DEFAULT_PARTICIPANTS_TTL_MS) {
         super(options)
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('participants ttlMs must be a non-negative finite number')
+        if (!Number.isSafeInteger(ttlMs) || ttlMs <= 0) {
+            throw new Error('participants ttlMs must be a positive integer')
         }
         this.ttlMs = ttlMs
     }
@@ -61,7 +61,7 @@ export class WaParticipantsRedisStore extends BaseRedisStore implements WaPartic
         const pattern = this.k('participants', this.sessionId, '*')
         const keys = await scanKeys(this.redis, pattern)
         if (keys.length > 0) {
-            await this.redis.del(...keys)
+            await deleteKeysChunked(this.redis, keys)
         }
     }
 }

--- a/packages/store-redis/src/pre-key.store.ts
+++ b/packages/store-redis/src/pre-key.store.ts
@@ -2,7 +2,7 @@ import type { PreKeyRecord } from 'zapo-js/signal'
 import type { WaPreKeyStore } from 'zapo-js/store'
 
 import { BaseRedisStore } from './BaseRedisStore'
-import { safeLimit, scanKeys, toBytesOrNull, toRedisBuffer } from './helpers'
+import { deleteKeysChunked, safeLimit, scanKeys, toBytesOrNull, toRedisBuffer } from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
 const LUA_CONSUME_PREKEY = `
@@ -357,7 +357,7 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
         const scannedKeys = await Promise.all(scanPatterns.map((p) => scanKeys(this.redis, p)))
         const allKeys = [...patterns, ...scannedKeys.flat()]
         if (allKeys.length > 0) {
-            await this.redis.del(...allKeys)
+            await deleteKeysChunked(this.redis, allKeys)
         }
         const metaKey = this.k('signal:meta', this.sessionId)
         await this.redis.hmset(metaKey, {

--- a/packages/store-redis/src/retry.store.ts
+++ b/packages/store-redis/src/retry.store.ts
@@ -2,7 +2,13 @@ import type { WaRetryOutboundMessageRecord, WaRetryOutboundState } from 'zapo-js
 import type { WaRetryStore } from 'zapo-js/store'
 
 import { BaseRedisStore } from './BaseRedisStore'
-import { scanKeys, toBytesOrNull, toRedisBuffer, toStringOrNull } from './helpers'
+import {
+    deleteKeysChunked,
+    scanKeys,
+    toBytesOrNull,
+    toRedisBuffer,
+    toStringOrNull
+} from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
 interface RetryRequesterStatusPayload {
@@ -69,8 +75,8 @@ export class WaRetryRedisStore extends BaseRedisStore implements WaRetryStore {
 
     public constructor(options: WaRedisStorageOptions, ttlMs = DEFAULT_RETRY_TTL_MS) {
         super(options)
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('retry ttlMs must be a non-negative finite number')
+        if (!Number.isSafeInteger(ttlMs) || ttlMs <= 0) {
+            throw new Error('retry ttlMs must be a positive integer')
         }
         this.ttlMs = ttlMs
     }
@@ -285,7 +291,7 @@ export class WaRetryRedisStore extends BaseRedisStore implements WaRetryStore {
         ])
         const allKeys = [...outKeys, ...inKeys]
         if (allKeys.length > 0) {
-            await this.redis.del(...allKeys)
+            await deleteKeysChunked(this.redis, allKeys)
         }
     }
 

--- a/packages/store-redis/src/sender-key.store.ts
+++ b/packages/store-redis/src/sender-key.store.ts
@@ -3,7 +3,7 @@ import { encodeSenderKeyRecord, decodeSenderKeyRecord, toSignalAddressParts } fr
 import type { WaSenderKeyStore } from 'zapo-js/store'
 
 import { BaseRedisStore } from './BaseRedisStore'
-import { scanKeys, toRedisBuffer } from './helpers'
+import { deleteKeysChunked, scanKeys, toRedisBuffer } from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
 export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKeyStore {
@@ -316,7 +316,7 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
         const scannedKeys = await Promise.all(patterns.map((p) => scanKeys(this.redis, p)))
         const allKeys = scannedKeys.flat()
         if (allKeys.length > 0) {
-            await this.redis.del(...allKeys)
+            await deleteKeysChunked(this.redis, allKeys)
         }
     }
 }

--- a/packages/store-redis/src/session.store.ts
+++ b/packages/store-redis/src/session.store.ts
@@ -7,7 +7,7 @@ import {
 import type { WaSessionStore } from 'zapo-js/store'
 
 import { BaseRedisStore } from './BaseRedisStore'
-import { scanKeys, toRedisBuffer } from './helpers'
+import { deleteKeysChunked, scanKeys, toRedisBuffer } from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
 export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStore {
@@ -143,7 +143,7 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
         const scannedKeys = await Promise.all(scanPatterns.map((p) => scanKeys(this.redis, p)))
         const allKeys = scannedKeys.flat()
         if (allKeys.length > 0) {
-            await this.redis.del(...allKeys)
+            await deleteKeysChunked(this.redis, allKeys)
         }
     }
 }

--- a/packages/store-redis/src/signal.store.ts
+++ b/packages/store-redis/src/signal.store.ts
@@ -2,7 +2,7 @@ import type { RegistrationInfo, SignedPreKeyRecord } from 'zapo-js/signal'
 import type { WaSignalStore } from 'zapo-js/store'
 
 import { BaseRedisStore } from './BaseRedisStore'
-import { scanKeys, toBytesOrNull, toRedisBuffer } from './helpers'
+import { deleteKeysChunked, scanKeys, toBytesOrNull, toRedisBuffer } from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
 export class WaSignalRedisStore extends BaseRedisStore implements WaSignalStore {
@@ -110,7 +110,7 @@ export class WaSignalRedisStore extends BaseRedisStore implements WaSignalStore 
         const scannedKeys = await Promise.all(scanPatterns.map((p) => scanKeys(this.redis, p)))
         const allKeys = [...patterns, ...scannedKeys.flat()]
         if (allKeys.length > 0) {
-            await this.redis.del(...allKeys)
+            await deleteKeysChunked(this.redis, allKeys)
         }
     }
 

--- a/packages/store-sqlite/src/device-list.store.ts
+++ b/packages/store-sqlite/src/device-list.store.ts
@@ -28,6 +28,9 @@ export class WaDeviceListSqliteStore extends BaseSqliteStore implements WaDevice
         batchSize?: number
     ) {
         super(options, ['deviceList'])
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('device-list ttlMs must be a positive finite number')
+        }
         this.ttlMs = ttlMs
         this.batchSize = resolvePositive(
             batchSize,

--- a/packages/store-sqlite/src/message-secret.store.ts
+++ b/packages/store-sqlite/src/message-secret.store.ts
@@ -27,8 +27,8 @@ export class WaMessageSecretSqliteStore extends BaseSqliteStore implements WaMes
         batchSize = DEFAULTS.batchSize
     ) {
         super(options, ['messageSecret'])
-        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
-            throw new Error('message-secret ttlMs must be a non-negative finite number')
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('message-secret ttlMs must be a positive finite number')
         }
         if (!Number.isFinite(batchSize) || batchSize < 1) {
             throw new Error('message-secret batchSize must be a positive finite number')

--- a/packages/store-sqlite/src/participants.store.ts
+++ b/packages/store-sqlite/src/participants.store.ts
@@ -18,6 +18,9 @@ export class WaParticipantsSqliteStore extends BaseSqliteStore implements WaPart
 
     public constructor(options: WaSqliteStorageOptions, ttlMs = DEFAULT_PARTICIPANTS_TTL_MS) {
         super(options, ['participants'])
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('participants ttlMs must be a positive finite number')
+        }
         this.ttlMs = ttlMs
     }
 

--- a/packages/store-sqlite/src/retry.store.ts
+++ b/packages/store-sqlite/src/retry.store.ts
@@ -36,6 +36,9 @@ export class WaRetrySqliteStore extends BaseSqliteStore implements WaRetryStore 
 
     public constructor(options: WaSqliteStorageOptions, ttlMs = DEFAULT_RETRY_TTL_MS) {
         super(options, ['retry'])
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('retry ttlMs must be a positive finite number')
+        }
         this.ttlMs = ttlMs
     }
 

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -34,6 +34,7 @@ import {
     NOOP_MESSAGE_SECRET_STORE,
     NOOP_MESSAGE_STORE,
     NOOP_PARTICIPANTS_STORE,
+    NOOP_RETRY_STORE,
     NOOP_THREAD_STORE
 } from '@store/noop.store'
 import { WaAppStateMemoryStore } from '@store/providers/memory/appstate.store'
@@ -267,7 +268,13 @@ export function createStore<B extends string>(options: WaCreateStoreOptions<B>):
                 cacheProviders.retry ?? 'memory',
                 'retry',
                 'caches',
-                () => new WaRetryMemoryStore(cacheTtlsMs.retry)
+                () =>
+                    cacheProviders.retry === 'memory' || !cacheProviders.retry
+                        ? new WaRetryMemoryStore(cacheTtlsMs.retry, {
+                              maxOutboundMessages: ml.retryOutboundMessages,
+                              maxInboundCounters: ml.retryInboundCounters
+                          })
+                        : NOOP_RETRY_STORE
             )
             const rawParticipants = resolveStore<WaParticipantsStore>(
                 id,

--- a/src/store/noop.store.ts
+++ b/src/store/noop.store.ts
@@ -1,3 +1,4 @@
+import type { WaRetryOutboundMessageRecord } from '@retry/types'
 import type { WaContactStore, WaStoredContactRecord } from '@store/contracts/contact.store'
 import type { WaDeviceListSnapshot, WaDeviceListStore } from '@store/contracts/device-list.store'
 import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
@@ -6,6 +7,7 @@ import type {
     WaParticipantsSnapshot,
     WaParticipantsStore
 } from '@store/contracts/participants.store'
+import type { WaRetryStore } from '@store/contracts/retry.store'
 import type { WaStoredThreadRecord, WaThreadStore } from '@store/contracts/thread.store'
 
 const EMPTY_STORE_LIST = Object.freeze([]) as readonly unknown[]
@@ -52,6 +54,19 @@ export const NOOP_CONTACT_STORE: WaContactStore = Object.freeze({
     getByJid: async (_jid: string): Promise<WaStoredContactRecord | null> => null,
     deleteByJid: async (_jid: string): Promise<number> => 0,
     clear: async (): Promise<void> => {}
+})
+
+export const NOOP_RETRY_STORE: WaRetryStore = Object.freeze({
+    getOutboundRequesterStatus: async (): Promise<null> => null,
+    upsertOutboundMessage: async (_record: WaRetryOutboundMessageRecord): Promise<void> => {},
+    deleteOutboundMessage: async (_messageId: string): Promise<number> => 0,
+    getOutboundMessage: async (_messageId: string): Promise<null> => null,
+    updateOutboundMessageState: async (): Promise<void> => {},
+    markOutboundRequesterDelivered: async (): Promise<void> => {},
+    incrementInboundCounter: async (): Promise<number> => 0,
+    cleanupExpired: async (_nowMs: number): Promise<number> => 0,
+    clear: async (): Promise<void> => {},
+    destroy: async (): Promise<void> => {}
 })
 
 export const NOOP_PARTICIPANTS_STORE: WaParticipantsStore = Object.freeze({

--- a/src/store/providers/memory/device-list.store.ts
+++ b/src/store/providers/memory/device-list.store.ts
@@ -22,6 +22,9 @@ export class WaDeviceListMemoryStore implements WaDeviceListStore {
     private readonly cleanupTimer: NodeJS.Timeout
 
     public constructor(ttlMs = DEFAULTS.ttlMs, options: WaDeviceListMemoryStoreOptions = {}) {
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('device-list ttlMs must be a positive finite number')
+        }
         this.records = new Map()
         this.ttlMs = ttlMs
         this.maxUsers = resolvePositive(

--- a/src/store/providers/memory/message-secret.store.ts
+++ b/src/store/providers/memory/message-secret.store.ts
@@ -23,6 +23,9 @@ export class WaMessageSecretMemoryStore implements WaMessageSecretStore {
     private readonly cleanupTimer: NodeJS.Timeout
 
     public constructor(ttlMs = DEFAULTS.ttlMs, options: WaMessageSecretMemoryStoreOptions = {}) {
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('message-secret ttlMs must be a positive finite number')
+        }
         this.secrets = new Map()
         this.ttlMs = ttlMs
         this.maxSecrets = resolvePositive(

--- a/src/store/providers/memory/participants.store.ts
+++ b/src/store/providers/memory/participants.store.ts
@@ -25,6 +25,9 @@ export class WaParticipantsMemoryStore implements WaParticipantsStore {
     private readonly cleanupTimer: NodeJS.Timeout
 
     public constructor(ttlMs = DEFAULTS.ttlMs, options: WaParticipantsMemoryStoreOptions = {}) {
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('participants ttlMs must be a positive finite number')
+        }
         this.records = new Map()
         this.ttlMs = ttlMs
         this.maxGroups = resolvePositive(

--- a/src/store/providers/memory/retry.store.ts
+++ b/src/store/providers/memory/retry.store.ts
@@ -1,29 +1,54 @@
 import type { WaRetryOutboundMessageRecord, WaRetryOutboundState } from '@retry/types'
 import type { WaRetryStore } from '@store/contracts/retry.store'
-import { resolveCleanupIntervalMs } from '@util/collections'
+import { resolvePositive } from '@util/coercion'
+import { resolveCleanupIntervalMs, setBoundedMapEntry } from '@util/collections'
 
 interface RetryInboundCounterRecord {
-    count: number
-    expiresAtMs: number
+    readonly count: number
+    readonly expiresAtMs: number
 }
 
-const DEFAULT_RETRY_TTL_MS = 60 * 1000
+const DEFAULTS = Object.freeze({
+    ttlMs: 60 * 1000,
+    maxOutboundMessages: 10_000,
+    maxInboundCounters: 20_000
+} as const)
+
+export interface WaRetryMemoryStoreOptions {
+    readonly maxOutboundMessages?: number
+    readonly maxInboundCounters?: number
+}
 
 export class WaRetryMemoryStore implements WaRetryStore {
     private readonly outboundMessages: Map<string, WaRetryOutboundMessageRecord>
     private readonly eligibleSets: Map<string, Set<string>>
     private readonly inboundCounters: Map<string, RetryInboundCounterRecord>
     private readonly ttlMs: number
+    private readonly maxOutboundMessages: number
+    private readonly maxInboundCounters: number
     private readonly cleanupTimer: NodeJS.Timeout
 
-    public constructor(ttlMs = DEFAULT_RETRY_TTL_MS) {
+    public constructor(ttlMs = DEFAULTS.ttlMs, options: WaRetryMemoryStoreOptions = {}) {
+        if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+            throw new Error('retry ttlMs must be a positive finite number')
+        }
         this.outboundMessages = new Map()
         this.eligibleSets = new Map()
         this.inboundCounters = new Map()
         this.ttlMs = ttlMs
+        this.maxOutboundMessages = resolvePositive(
+            options.maxOutboundMessages,
+            DEFAULTS.maxOutboundMessages,
+            'WaRetryMemoryStoreOptions.maxOutboundMessages'
+        )
+        this.maxInboundCounters = resolvePositive(
+            options.maxInboundCounters,
+            DEFAULTS.maxInboundCounters,
+            'WaRetryMemoryStoreOptions.maxInboundCounters'
+        )
         this.cleanupTimer = setInterval(() => {
             void this.cleanupExpired(Date.now())
-        }, resolveCleanupIntervalMs(ttlMs))
+        }, resolveCleanupIntervalMs(this.ttlMs))
         this.cleanupTimer.unref()
     }
 
@@ -78,7 +103,7 @@ export class WaRetryMemoryStore implements WaRetryStore {
     }
 
     public async upsertOutboundMessage(record: WaRetryOutboundMessageRecord): Promise<void> {
-        this.outboundMessages.set(record.messageId, {
+        const storedRecord: WaRetryOutboundMessageRecord = {
             ...record,
             eligibleRequesterDeviceJids: record.eligibleRequesterDeviceJids
                 ? [...record.eligibleRequesterDeviceJids]
@@ -86,7 +111,16 @@ export class WaRetryMemoryStore implements WaRetryStore {
             deliveredRequesterDeviceJids: record.deliveredRequesterDeviceJids
                 ? [...record.deliveredRequesterDeviceJids]
                 : undefined
-        })
+        }
+        setBoundedMapEntry(
+            this.outboundMessages,
+            record.messageId,
+            storedRecord,
+            this.maxOutboundMessages,
+            (messageId) => {
+                this.eligibleSets.delete(messageId)
+            }
+        )
         if (record.eligibleRequesterDeviceJids && record.eligibleRequesterDeviceJids.length > 0) {
             this.eligibleSets.set(record.messageId, new Set(record.eligibleRequesterDeviceJids))
         } else {
@@ -116,12 +150,20 @@ export class WaRetryMemoryStore implements WaRetryStore {
         if (!current) {
             return
         }
-        this.outboundMessages.set(messageId, {
-            ...current,
-            state,
-            updatedAtMs,
-            expiresAtMs
-        })
+        setBoundedMapEntry(
+            this.outboundMessages,
+            messageId,
+            {
+                ...current,
+                state,
+                updatedAtMs,
+                expiresAtMs
+            },
+            this.maxOutboundMessages,
+            (evictedMessageId) => {
+                this.eligibleSets.delete(evictedMessageId)
+            }
+        )
     }
 
     public async markOutboundRequesterDelivered(
@@ -136,12 +178,20 @@ export class WaRetryMemoryStore implements WaRetryStore {
         }
         const delivered = new Set(current.deliveredRequesterDeviceJids ?? [])
         delivered.add(requesterDeviceJid)
-        this.outboundMessages.set(messageId, {
-            ...current,
-            deliveredRequesterDeviceJids: Array.from(delivered),
-            updatedAtMs,
-            expiresAtMs
-        })
+        setBoundedMapEntry(
+            this.outboundMessages,
+            messageId,
+            {
+                ...current,
+                deliveredRequesterDeviceJids: Array.from(delivered),
+                updatedAtMs,
+                expiresAtMs
+            },
+            this.maxOutboundMessages,
+            (evictedMessageId) => {
+                this.eligibleSets.delete(evictedMessageId)
+            }
+        )
     }
 
     public async incrementInboundCounter(
@@ -153,10 +203,12 @@ export class WaRetryMemoryStore implements WaRetryStore {
         const key = this.counterKey(messageId, requesterJid)
         const current = this.inboundCounters.get(key)
         const count = current ? current.count + 1 : 1
-        this.inboundCounters.set(key, {
-            count,
-            expiresAtMs
-        })
+        setBoundedMapEntry(
+            this.inboundCounters,
+            key,
+            { count, expiresAtMs },
+            this.maxInboundCounters
+        )
         return count
     }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -83,7 +83,7 @@ export interface WaCreateStoreOptions<B extends string = string> {
         readonly privacyToken?: B | 'memory'
     }
     readonly cacheProviders?: {
-        readonly retry?: B | 'memory'
+        readonly retry?: B | 'memory' | 'none'
         readonly participants?: B | 'memory' | 'none'
         readonly deviceList?: B | 'memory' | 'none'
         readonly messageSecret?: B | 'memory' | 'none'
@@ -111,6 +111,8 @@ export interface WaStoreMemoryLimitSelection {
     readonly deviceListUsers?: number
     readonly messages?: number
     readonly messageSecrets?: number
+    readonly retryOutboundMessages?: number
+    readonly retryInboundCounters?: number
     readonly threads?: number
     readonly contacts?: number
     readonly privacyTokens?: number


### PR DESCRIPTION
- reject ttlMs=0 across all cache stores (redis, mongo, sqlite, postgres, mysql) — prevents runtime errors in Redis SET PX and MongoDB TTL indexes
- add expires_at filter on mongo reads for device-list, participants, and retry stores to avoid stale reads between TTL sweeps
- add deleteKeysChunked helper in redis to avoid argmax overflow on large key sets during clear operations
- add assertSafeTablePrefix to mysql migration runner
- add ttlMs constructor validation to sqlite/memory stores that lacked it
- bound retry memory store with maxOutboundMessages and maxInboundCounters via setBoundedMapEntry with eligible-set eviction callback
- add mongo transaction fallback for standalone deployments
- make retry cache optional (accept 'none' like participants/deviceList)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory limits for retry cache; explicit option to disable retry cache.

* **Bug Fixes**
  * Expired records no longer returned from device-list/participant/retry lookups.
  * TTL validation tightened across stores to require positive values.

* **Improvements**
  * Chunked Redis key deletion for safer large-scale removals.
  * MongoDB transaction detection with automatic fallback and retry handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->