### PR TITLE
feat: add addon auto-decrypt with message_addon event and poll option resolution

### DIFF
--- a/packages/store-mongo/src/__tests__/integration.test.ts
+++ b/packages/store-mongo/src/__tests__/integration.test.ts
@@ -491,25 +491,37 @@ describe('store-mongo integration', { timeout: 60_000 }, () => {
         const secretStore = store.caches.messageSecret(sessionId)
         const now = Date.now()
 
-        const secretA = new Uint8Array([1, 2, 3, 4])
-        const secretB = new Uint8Array([5, 6, 7, 8])
+        const entryA = { secret: new Uint8Array([1, 2, 3, 4]), senderJid: 'alice@s.whatsapp.net' }
+        const entryB = { secret: new Uint8Array([5, 6, 7, 8]), senderJid: 'bob@s.whatsapp.net' }
 
-        await secretStore.set('msg-1', secretA)
-        await secretStore.set('msg-2', secretB)
+        await secretStore.set('msg-1', entryA)
+        await secretStore.set('msg-2', entryB)
         const got1 = await secretStore.get('msg-1', now)
-        assert.ok(got1 && got1.length === secretA.length && got1.every((b, i) => b === secretA[i]))
+        assert.ok(
+            got1 &&
+                got1.secret.length === entryA.secret.length &&
+                got1.secret.every((b, i) => b === entryA.secret[i])
+        )
+        assert.equal(got1.senderJid, entryA.senderJid)
         assert.equal(await secretStore.get('missing', now), null)
 
         const batch = await secretStore.getBatch(['msg-2', 'missing', 'msg-1'], now)
         assert.equal(batch.length, 3)
-        assert.ok(batch[0] && batch[0].every((b, i) => b === secretB[i]))
+        assert.ok(batch[0] && batch[0].secret.every((b, i) => b === entryB.secret[i]))
+        assert.equal(batch[0].senderJid, entryB.senderJid)
         assert.equal(batch[1], null)
-        assert.ok(batch[2] && batch[2].every((b, i) => b === secretA[i]))
+        assert.ok(batch[2] && batch[2].secret.every((b, i) => b === entryA.secret[i]))
+        assert.equal(batch[2].senderJid, entryA.senderJid)
 
-        const secretC = new Uint8Array([9, 10])
-        await secretStore.setBatch([{ messageId: 'msg-3', secret: secretC }])
+        const entryC = { secret: new Uint8Array([9, 10]), senderJid: 'carol@s.whatsapp.net' }
+        await secretStore.setBatch([{ messageId: 'msg-3', entry: entryC }])
         const got3 = await secretStore.get('msg-3', now)
-        assert.ok(got3 && got3.length === secretC.length && got3.every((b, i) => b === secretC[i]))
+        assert.ok(
+            got3 &&
+                got3.secret.length === entryC.secret.length &&
+                got3.secret.every((b, i) => b === entryC.secret[i])
+        )
+        assert.equal(got3.senderJid, entryC.senderJid)
 
         assert.equal(await secretStore.cleanupExpired(now), 0)
         await secretStore.clear()

--- a/packages/store-mongo/src/message-secret.store.ts
+++ b/packages/store-mongo/src/message-secret.store.ts
@@ -1,5 +1,5 @@
 import type { Binary } from 'mongodb'
-import type { WaMessageSecretStore } from 'zapo-js/store'
+import type { WaMessageSecretEntry, WaMessageSecretStore } from 'zapo-js/store'
 
 import { BaseMongoStore } from './BaseMongoStore'
 import { fromBinary, toBinary } from './helpers'
@@ -8,6 +8,7 @@ import type { WaMongoStorageOptions } from './types'
 interface MessageSecretDoc {
     _id: { session_id: string; message_id: string }
     secret: Binary
+    sender_jid: string
     expires_at: Date
 }
 
@@ -29,7 +30,7 @@ export class WaMessageSecretMongoStore extends BaseMongoStore implements WaMessa
         await col.createIndex({ expires_at: 1 }, { expireAfterSeconds: 0 })
     }
 
-    public async get(messageId: string, nowMs = Date.now()): Promise<Uint8Array | null> {
+    public async get(messageId: string, nowMs = Date.now()): Promise<WaMessageSecretEntry | null> {
         await this.ensureIndexes()
         const col = this.col<MessageSecretDoc>('message_secrets_cache')
         const doc = await col.findOne({
@@ -37,13 +38,13 @@ export class WaMessageSecretMongoStore extends BaseMongoStore implements WaMessa
             expires_at: { $gt: new Date(nowMs) }
         })
         if (!doc) return null
-        return fromBinary(doc.secret)
+        return { secret: fromBinary(doc.secret), senderJid: doc.sender_jid }
     }
 
     public async getBatch(
         messageIds: readonly string[],
         nowMs = Date.now()
-    ): Promise<readonly (Uint8Array | null)[]> {
+    ): Promise<readonly (WaMessageSecretEntry | null)[]> {
         if (messageIds.length === 0) return []
         await this.ensureIndexes()
         const col = this.col<MessageSecretDoc>('message_secrets_cache')
@@ -56,21 +57,25 @@ export class WaMessageSecretMongoStore extends BaseMongoStore implements WaMessa
             })
             .toArray()
 
-        const byMessageId = new Map<string, Uint8Array>()
+        const byMessageId = new Map<string, WaMessageSecretEntry>()
         for (const doc of docs) {
-            byMessageId.set(doc._id.message_id, fromBinary(doc.secret))
+            byMessageId.set(doc._id.message_id, {
+                secret: fromBinary(doc.secret),
+                senderJid: doc.sender_jid
+            })
         }
         return messageIds.map((id) => byMessageId.get(id) ?? null)
     }
 
-    public async set(messageId: string, secret: Uint8Array): Promise<void> {
+    public async set(messageId: string, entry: WaMessageSecretEntry): Promise<void> {
         await this.ensureIndexes()
         const col = this.col<MessageSecretDoc>('message_secrets_cache')
         await col.updateOne(
             { _id: { session_id: this.sessionId, message_id: messageId } },
             {
                 $set: {
-                    secret: toBinary(secret),
+                    secret: toBinary(entry.secret),
+                    sender_jid: entry.senderJid,
                     expires_at: new Date(Date.now() + this.ttlMs)
                 }
             },
@@ -79,18 +84,19 @@ export class WaMessageSecretMongoStore extends BaseMongoStore implements WaMessa
     }
 
     public async setBatch(
-        entries: readonly { readonly messageId: string; readonly secret: Uint8Array }[]
+        entries: readonly { readonly messageId: string; readonly entry: WaMessageSecretEntry }[]
     ): Promise<void> {
         if (entries.length === 0) return
         await this.ensureIndexes()
         const col = this.col<MessageSecretDoc>('message_secrets_cache')
         const now = Date.now()
-        const ops = entries.map((entry) => ({
+        const ops = entries.map((e) => ({
             updateOne: {
-                filter: { _id: { session_id: this.sessionId, message_id: entry.messageId } },
+                filter: { _id: { session_id: this.sessionId, message_id: e.messageId } },
                 update: {
                     $set: {
-                        secret: toBinary(entry.secret),
+                        secret: toBinary(e.entry.secret),
+                        sender_jid: e.entry.senderJid,
                         expires_at: new Date(now + this.ttlMs)
                     }
                 },

--- a/packages/store-mysql/src/__tests__/integration.test.ts
+++ b/packages/store-mysql/src/__tests__/integration.test.ts
@@ -523,25 +523,37 @@ describe('store-mysql integration', { timeout: 60_000 }, () => {
         const secretStore = store.caches.messageSecret(sessionId)
         const now = Date.now()
 
-        const secretA = new Uint8Array([1, 2, 3, 4])
-        const secretB = new Uint8Array([5, 6, 7, 8])
+        const entryA = { secret: new Uint8Array([1, 2, 3, 4]), senderJid: 'alice@s.whatsapp.net' }
+        const entryB = { secret: new Uint8Array([5, 6, 7, 8]), senderJid: 'bob@s.whatsapp.net' }
 
-        await secretStore.set('msg-1', secretA)
-        await secretStore.set('msg-2', secretB)
+        await secretStore.set('msg-1', entryA)
+        await secretStore.set('msg-2', entryB)
         const got1 = await secretStore.get('msg-1', now)
-        assert.ok(got1 && got1.length === secretA.length && got1.every((b, i) => b === secretA[i]))
+        assert.ok(
+            got1 &&
+                got1.secret.length === entryA.secret.length &&
+                got1.secret.every((b, i) => b === entryA.secret[i])
+        )
+        assert.equal(got1.senderJid, entryA.senderJid)
         assert.equal(await secretStore.get('missing', now), null)
 
         const batch = await secretStore.getBatch(['msg-2', 'missing', 'msg-1'], now)
         assert.equal(batch.length, 3)
-        assert.ok(batch[0] && batch[0].every((b, i) => b === secretB[i]))
+        assert.ok(batch[0] && batch[0].secret.every((b, i) => b === entryB.secret[i]))
+        assert.equal(batch[0].senderJid, entryB.senderJid)
         assert.equal(batch[1], null)
-        assert.ok(batch[2] && batch[2].every((b, i) => b === secretA[i]))
+        assert.ok(batch[2] && batch[2].secret.every((b, i) => b === entryA.secret[i]))
+        assert.equal(batch[2].senderJid, entryA.senderJid)
 
-        const secretC = new Uint8Array([9, 10])
-        await secretStore.setBatch([{ messageId: 'msg-3', secret: secretC }])
+        const entryC = { secret: new Uint8Array([9, 10]), senderJid: 'carol@s.whatsapp.net' }
+        await secretStore.setBatch([{ messageId: 'msg-3', entry: entryC }])
         const got3 = await secretStore.get('msg-3', now)
-        assert.ok(got3 && got3.length === secretC.length && got3.every((b, i) => b === secretC[i]))
+        assert.ok(
+            got3 &&
+                got3.secret.length === entryC.secret.length &&
+                got3.secret.every((b, i) => b === entryC.secret[i])
+        )
+        assert.equal(got3.senderJid, entryC.senderJid)
 
         assert.equal(await secretStore.cleanupExpired(now), 0)
         await secretStore.clear()

--- a/packages/store-mysql/src/connection.ts
+++ b/packages/store-mysql/src/connection.ts
@@ -293,6 +293,7 @@ const MIGRATIONS: readonly Migration[] = [
                 session_id VARCHAR(255) NOT NULL,
                 message_id VARCHAR(255) NOT NULL,
                 secret BLOB NOT NULL,
+                sender_jid VARCHAR(255) NOT NULL DEFAULT '',
                 expires_at_ms BIGINT NOT NULL,
                 PRIMARY KEY (session_id, message_id),
                 INDEX idx_message_secrets_expires (session_id, expires_at_ms)

--- a/packages/store-mysql/src/message-secret.store.ts
+++ b/packages/store-mysql/src/message-secret.store.ts
@@ -1,4 +1,4 @@
-import type { WaMessageSecretStore } from 'zapo-js/store'
+import type { WaMessageSecretEntry, WaMessageSecretStore } from 'zapo-js/store'
 
 import { BaseMysqlStore } from './BaseMysqlStore'
 import { affectedRows, queryRows, toBytes } from './helpers'
@@ -19,11 +19,11 @@ export class WaMessageSecretMysqlStore extends BaseMysqlStore implements WaMessa
         this.ttlMs = ttlMs
     }
 
-    public async get(messageId: string, nowMs = Date.now()): Promise<Uint8Array | null> {
+    public async get(messageId: string, nowMs = Date.now()): Promise<WaMessageSecretEntry | null> {
         await this.ensureReady()
         const rows = queryRows(
             await this.pool.execute(
-                `SELECT secret, expires_at_ms
+                `SELECT secret, sender_jid, expires_at_ms
                  FROM ${this.t('message_secrets_cache')}
                  WHERE session_id = ? AND message_id = ?`,
                 [this.sessionId, messageId]
@@ -41,18 +41,18 @@ export class WaMessageSecretMysqlStore extends BaseMysqlStore implements WaMessa
             return null
         }
 
-        return toBytes(row.secret)
+        return { secret: toBytes(row.secret), senderJid: String(row.sender_jid) }
     }
 
     public async getBatch(
         messageIds: readonly string[],
         nowMs = Date.now()
-    ): Promise<readonly (Uint8Array | null)[]> {
+    ): Promise<readonly (WaMessageSecretEntry | null)[]> {
         if (messageIds.length === 0) return []
         await this.ensureReady()
 
         const uniqueIds = [...new Set(messageIds)]
-        const activeById = new Map<string, Uint8Array>()
+        const activeById = new Map<string, WaMessageSecretEntry>()
         const expiredIds: string[] = []
 
         for (let start = 0; start < uniqueIds.length; start += BATCH_SIZE) {
@@ -60,7 +60,7 @@ export class WaMessageSecretMysqlStore extends BaseMysqlStore implements WaMessa
             while (batch.length < BATCH_SIZE) batch.push('')
             const rows = queryRows(
                 await this.pool.execute(
-                    `SELECT message_id, secret, expires_at_ms
+                    `SELECT message_id, secret, sender_jid, expires_at_ms
                      FROM ${this.t('message_secrets_cache')}
                      WHERE session_id = ? AND message_id IN (${FIXED_IN_PLACEHOLDERS})`,
                     [this.sessionId, ...batch]
@@ -73,7 +73,10 @@ export class WaMessageSecretMysqlStore extends BaseMysqlStore implements WaMessa
                     expiredIds.push(id)
                     continue
                 }
-                activeById.set(id, toBytes(row.secret))
+                activeById.set(id, {
+                    secret: toBytes(row.secret),
+                    senderJid: String(row.sender_jid)
+                })
             }
         }
 
@@ -92,35 +95,43 @@ export class WaMessageSecretMysqlStore extends BaseMysqlStore implements WaMessa
         return messageIds.map((id) => activeById.get(id) ?? null)
     }
 
-    public async set(messageId: string, secret: Uint8Array): Promise<void> {
+    public async set(messageId: string, entry: WaMessageSecretEntry): Promise<void> {
         await this.ensureReady()
         const nowMs = Date.now()
         await this.pool.execute(
             `INSERT INTO ${this.t('message_secrets_cache')} (
-                session_id, message_id, secret, expires_at_ms
-            ) VALUES (?, ?, ?, ?)
+                session_id, message_id, secret, sender_jid, expires_at_ms
+            ) VALUES (?, ?, ?, ?, ?)
             ON DUPLICATE KEY UPDATE
                 secret = VALUES(secret),
+                sender_jid = VALUES(sender_jid),
                 expires_at_ms = VALUES(expires_at_ms)`,
-            [this.sessionId, messageId, secret, nowMs + this.ttlMs]
+            [this.sessionId, messageId, entry.secret, entry.senderJid, nowMs + this.ttlMs]
         )
     }
 
     public async setBatch(
-        entries: readonly { readonly messageId: string; readonly secret: Uint8Array }[]
+        entries: readonly { readonly messageId: string; readonly entry: WaMessageSecretEntry }[]
     ): Promise<void> {
         if (entries.length === 0) return
         const nowMs = Date.now()
         await this.withTransaction(async (conn) => {
-            for (const entry of entries) {
+            for (const e of entries) {
                 await conn.execute(
                     `INSERT INTO ${this.t('message_secrets_cache')} (
-                        session_id, message_id, secret, expires_at_ms
-                    ) VALUES (?, ?, ?, ?)
+                        session_id, message_id, secret, sender_jid, expires_at_ms
+                    ) VALUES (?, ?, ?, ?, ?)
                     ON DUPLICATE KEY UPDATE
                         secret = VALUES(secret),
+                        sender_jid = VALUES(sender_jid),
                         expires_at_ms = VALUES(expires_at_ms)`,
-                    [this.sessionId, entry.messageId, entry.secret, nowMs + this.ttlMs]
+                    [
+                        this.sessionId,
+                        e.messageId,
+                        e.entry.secret,
+                        e.entry.senderJid,
+                        nowMs + this.ttlMs
+                    ]
                 )
             }
         })

--- a/packages/store-postgres/src/__tests__/integration.test.ts
+++ b/packages/store-postgres/src/__tests__/integration.test.ts
@@ -509,25 +509,37 @@ describe('store-postgres integration', { timeout: 60_000 }, () => {
         const secretStore = store.caches.messageSecret(sessionId)
         const now = Date.now()
 
-        const secretA = new Uint8Array([1, 2, 3, 4])
-        const secretB = new Uint8Array([5, 6, 7, 8])
+        const entryA = { secret: new Uint8Array([1, 2, 3, 4]), senderJid: 'alice@s.whatsapp.net' }
+        const entryB = { secret: new Uint8Array([5, 6, 7, 8]), senderJid: 'bob@s.whatsapp.net' }
 
-        await secretStore.set('msg-1', secretA)
-        await secretStore.set('msg-2', secretB)
+        await secretStore.set('msg-1', entryA)
+        await secretStore.set('msg-2', entryB)
         const got1 = await secretStore.get('msg-1', now)
-        assert.ok(got1 && got1.length === secretA.length && got1.every((b, i) => b === secretA[i]))
+        assert.ok(
+            got1 &&
+                got1.secret.length === entryA.secret.length &&
+                got1.secret.every((b, i) => b === entryA.secret[i])
+        )
+        assert.equal(got1.senderJid, entryA.senderJid)
         assert.equal(await secretStore.get('missing', now), null)
 
         const batch = await secretStore.getBatch(['msg-2', 'missing', 'msg-1'], now)
         assert.equal(batch.length, 3)
-        assert.ok(batch[0] && batch[0].every((b, i) => b === secretB[i]))
+        assert.ok(batch[0] && batch[0].secret.every((b, i) => b === entryB.secret[i]))
+        assert.equal(batch[0].senderJid, entryB.senderJid)
         assert.equal(batch[1], null)
-        assert.ok(batch[2] && batch[2].every((b, i) => b === secretA[i]))
+        assert.ok(batch[2] && batch[2].secret.every((b, i) => b === entryA.secret[i]))
+        assert.equal(batch[2].senderJid, entryA.senderJid)
 
-        const secretC = new Uint8Array([9, 10])
-        await secretStore.setBatch([{ messageId: 'msg-3', secret: secretC }])
+        const entryC = { secret: new Uint8Array([9, 10]), senderJid: 'carol@s.whatsapp.net' }
+        await secretStore.setBatch([{ messageId: 'msg-3', entry: entryC }])
         const got3 = await secretStore.get('msg-3', now)
-        assert.ok(got3 && got3.length === secretC.length && got3.every((b, i) => b === secretC[i]))
+        assert.ok(
+            got3 &&
+                got3.secret.length === entryC.secret.length &&
+                got3.secret.every((b, i) => b === entryC.secret[i])
+        )
+        assert.equal(got3.senderJid, entryC.senderJid)
 
         assert.equal(await secretStore.cleanupExpired(now), 0)
         await secretStore.clear()

--- a/packages/store-postgres/src/connection.ts
+++ b/packages/store-postgres/src/connection.ts
@@ -307,6 +307,7 @@ const MIGRATIONS: readonly Migration[] = [
                 session_id TEXT NOT NULL,
                 message_id TEXT NOT NULL,
                 secret BYTEA NOT NULL,
+                sender_jid TEXT NOT NULL DEFAULT '',
                 expires_at_ms BIGINT NOT NULL,
                 PRIMARY KEY (session_id, message_id)
             );

--- a/packages/store-postgres/src/message-secret.store.ts
+++ b/packages/store-postgres/src/message-secret.store.ts
@@ -1,4 +1,4 @@
-import type { WaMessageSecretStore } from 'zapo-js/store'
+import type { WaMessageSecretEntry, WaMessageSecretStore } from 'zapo-js/store'
 
 import { BasePgStore } from './BasePgStore'
 import { affectedRows, queryFirst, queryRows, toBytes } from './helpers'
@@ -18,12 +18,12 @@ export class WaMessageSecretPgStore extends BasePgStore implements WaMessageSecr
         this.ttlMs = ttlMs
     }
 
-    public async get(messageId: string, nowMs = Date.now()): Promise<Uint8Array | null> {
+    public async get(messageId: string, nowMs = Date.now()): Promise<WaMessageSecretEntry | null> {
         await this.ensureReady()
         const row = queryFirst(
             await this.pool.query({
                 name: this.stmtName('msgsecret_get'),
-                text: `SELECT secret, expires_at_ms
+                text: `SELECT secret, sender_jid, expires_at_ms
                  FROM ${this.t('message_secrets_cache')}
                  WHERE session_id = $1 AND message_id = $2`,
                 values: [this.sessionId, messageId]
@@ -41,18 +41,18 @@ export class WaMessageSecretPgStore extends BasePgStore implements WaMessageSecr
             return null
         }
 
-        return toBytes(row.secret)
+        return { secret: toBytes(row.secret), senderJid: String(row.sender_jid) }
     }
 
     public async getBatch(
         messageIds: readonly string[],
         nowMs = Date.now()
-    ): Promise<readonly (Uint8Array | null)[]> {
+    ): Promise<readonly (WaMessageSecretEntry | null)[]> {
         if (messageIds.length === 0) return []
         await this.ensureReady()
 
         const uniqueIds = [...new Set(messageIds)]
-        const activeById = new Map<string, Uint8Array>()
+        const activeById = new Map<string, WaMessageSecretEntry>()
         const expiredIds: string[] = []
 
         for (let start = 0; start < uniqueIds.length; start += BATCH_SIZE) {
@@ -62,7 +62,7 @@ export class WaMessageSecretPgStore extends BasePgStore implements WaMessageSecr
             const params: PgParam[] = [this.sessionId, ...batch]
             const rows = queryRows(
                 await this.pool.query(
-                    `SELECT message_id, secret, expires_at_ms
+                    `SELECT message_id, secret, sender_jid, expires_at_ms
                      FROM ${this.t('message_secrets_cache')}
                      WHERE session_id = $1 AND message_id IN (${placeholders})`,
                     params
@@ -75,7 +75,10 @@ export class WaMessageSecretPgStore extends BasePgStore implements WaMessageSecr
                     expiredIds.push(id)
                     continue
                 }
-                activeById.set(id, toBytes(row.secret))
+                activeById.set(id, {
+                    secret: toBytes(row.secret),
+                    senderJid: String(row.sender_jid)
+                })
             }
         }
 
@@ -96,36 +99,44 @@ export class WaMessageSecretPgStore extends BasePgStore implements WaMessageSecr
         return messageIds.map((id) => activeById.get(id) ?? null)
     }
 
-    public async set(messageId: string, secret: Uint8Array): Promise<void> {
+    public async set(messageId: string, entry: WaMessageSecretEntry): Promise<void> {
         await this.ensureReady()
         const nowMs = Date.now()
         await this.pool.query({
             name: this.stmtName('msgsecret_set'),
             text: `INSERT INTO ${this.t('message_secrets_cache')} (
-                session_id, message_id, secret, expires_at_ms
-            ) VALUES ($1, $2, $3, $4)
+                session_id, message_id, secret, sender_jid, expires_at_ms
+            ) VALUES ($1, $2, $3, $4, $5)
             ON CONFLICT (session_id, message_id) DO UPDATE SET
                 secret = EXCLUDED.secret,
+                sender_jid = EXCLUDED.sender_jid,
                 expires_at_ms = EXCLUDED.expires_at_ms`,
-            values: [this.sessionId, messageId, secret, nowMs + this.ttlMs]
+            values: [this.sessionId, messageId, entry.secret, entry.senderJid, nowMs + this.ttlMs]
         })
     }
 
     public async setBatch(
-        entries: readonly { readonly messageId: string; readonly secret: Uint8Array }[]
+        entries: readonly { readonly messageId: string; readonly entry: WaMessageSecretEntry }[]
     ): Promise<void> {
         if (entries.length === 0) return
         await this.withTransaction(async (client) => {
             const nowMs = Date.now()
-            for (const entry of entries) {
+            for (const e of entries) {
                 await client.query(
                     `INSERT INTO ${this.t('message_secrets_cache')} (
-                        session_id, message_id, secret, expires_at_ms
-                    ) VALUES ($1, $2, $3, $4)
+                        session_id, message_id, secret, sender_jid, expires_at_ms
+                    ) VALUES ($1, $2, $3, $4, $5)
                     ON CONFLICT (session_id, message_id) DO UPDATE SET
                         secret = EXCLUDED.secret,
+                        sender_jid = EXCLUDED.sender_jid,
                         expires_at_ms = EXCLUDED.expires_at_ms`,
-                    [this.sessionId, entry.messageId, entry.secret, nowMs + this.ttlMs]
+                    [
+                        this.sessionId,
+                        e.messageId,
+                        e.entry.secret,
+                        e.entry.senderJid,
+                        nowMs + this.ttlMs
+                    ]
                 )
             }
         })

--- a/packages/store-redis/src/__tests__/integration.test.ts
+++ b/packages/store-redis/src/__tests__/integration.test.ts
@@ -489,25 +489,37 @@ describe('store-redis integration', { timeout: 60_000 }, () => {
         const secretStore = store.caches.messageSecret(sessionId)
         const now = Date.now()
 
-        const secretA = new Uint8Array([1, 2, 3, 4])
-        const secretB = new Uint8Array([5, 6, 7, 8])
+        const entryA = { secret: new Uint8Array([1, 2, 3, 4]), senderJid: 'alice@s.whatsapp.net' }
+        const entryB = { secret: new Uint8Array([5, 6, 7, 8]), senderJid: 'bob@s.whatsapp.net' }
 
-        await secretStore.set('msg-1', secretA)
-        await secretStore.set('msg-2', secretB)
+        await secretStore.set('msg-1', entryA)
+        await secretStore.set('msg-2', entryB)
         const got1 = await secretStore.get('msg-1', now)
-        assert.ok(got1 && got1.length === secretA.length && got1.every((b, i) => b === secretA[i]))
+        assert.ok(
+            got1 &&
+                got1.secret.length === entryA.secret.length &&
+                got1.secret.every((b, i) => b === entryA.secret[i])
+        )
+        assert.equal(got1.senderJid, entryA.senderJid)
         assert.equal(await secretStore.get('missing', now), null)
 
         const batch = await secretStore.getBatch(['msg-2', 'missing', 'msg-1'], now)
         assert.equal(batch.length, 3)
-        assert.ok(batch[0] && batch[0].every((b, i) => b === secretB[i]))
+        assert.ok(batch[0] && batch[0].secret.every((b, i) => b === entryB.secret[i]))
+        assert.equal(batch[0].senderJid, entryB.senderJid)
         assert.equal(batch[1], null)
-        assert.ok(batch[2] && batch[2].every((b, i) => b === secretA[i]))
+        assert.ok(batch[2] && batch[2].secret.every((b, i) => b === entryA.secret[i]))
+        assert.equal(batch[2].senderJid, entryA.senderJid)
 
-        const secretC = new Uint8Array([9, 10])
-        await secretStore.setBatch([{ messageId: 'msg-3', secret: secretC }])
+        const entryC = { secret: new Uint8Array([9, 10]), senderJid: 'carol@s.whatsapp.net' }
+        await secretStore.setBatch([{ messageId: 'msg-3', entry: entryC }])
         const got3 = await secretStore.get('msg-3', now)
-        assert.ok(got3 && got3.length === secretC.length && got3.every((b, i) => b === secretC[i]))
+        assert.ok(
+            got3 &&
+                got3.secret.length === entryC.secret.length &&
+                got3.secret.every((b, i) => b === entryC.secret[i])
+        )
+        assert.equal(got3.senderJid, entryC.senderJid)
 
         assert.equal(await secretStore.cleanupExpired(now), 0)
         await secretStore.clear()

--- a/packages/store-redis/src/message-secret.store.ts
+++ b/packages/store-redis/src/message-secret.store.ts
@@ -1,4 +1,4 @@
-import type { WaMessageSecretStore } from 'zapo-js/store'
+import type { WaMessageSecretEntry, WaMessageSecretStore } from 'zapo-js/store'
 
 import { BaseRedisStore } from './BaseRedisStore'
 import { deleteKeysChunked, scanKeys, toBytesOrNull, toRedisBuffer } from './helpers'
@@ -17,47 +17,82 @@ export class WaMessageSecretRedisStore extends BaseRedisStore implements WaMessa
         this.ttlMs = ttlMs
     }
 
-    public async get(messageId: string, _nowMs?: number): Promise<Uint8Array | null> {
+    public async get(messageId: string, _nowMs?: number): Promise<WaMessageSecretEntry | null> {
         const key = this.k('msgsecret', this.sessionId, messageId)
-        const value = await this.redis.getBuffer(key)
-        return toBytesOrNull(value)
+        const pipeline = this.redis.pipeline()
+        pipeline.hgetBuffer(key, 'secret')
+        pipeline.hget(key, 'sender_jid')
+        const results = await pipeline.exec()
+        if (!results) return null
+        const [errSecret, rawSecret] = results[0]
+        const [errJid, rawJid] = results[1]
+        if (errSecret || errJid) return null
+        const secret = toBytesOrNull(rawSecret)
+        if (!secret) return null
+        return { secret, senderJid: typeof rawJid === 'string' ? rawJid : '' }
     }
 
     public async getBatch(
         messageIds: readonly string[],
         _nowMs?: number
-    ): Promise<readonly (Uint8Array | null)[]> {
+    ): Promise<readonly (WaMessageSecretEntry | null)[]> {
         if (messageIds.length === 0) return []
 
         const pipeline = this.redis.pipeline()
         for (const messageId of messageIds) {
-            pipeline.getBuffer(this.k('msgsecret', this.sessionId, messageId))
+            const key = this.k('msgsecret', this.sessionId, messageId)
+            pipeline.hgetBuffer(key, 'secret')
+            pipeline.hget(key, 'sender_jid')
         }
         const results = await pipeline.exec()
         if (!results) return messageIds.map(() => null)
 
         return messageIds.map((_messageId, index) => {
-            const [err, data] = results[index]
-            if (err || data === null || data === undefined) return null
-            return toBytesOrNull(data)
+            const base = index * 2
+            const [errSecret, rawSecret] = results[base]
+            const [errJid, rawJid] = results[base + 1]
+            if (errSecret || errJid) return null
+            const secret = toBytesOrNull(rawSecret)
+            if (!secret) return null
+            return { secret, senderJid: typeof rawJid === 'string' ? rawJid : '' }
         })
     }
 
-    public async set(messageId: string, secret: Uint8Array): Promise<void> {
+    public async set(messageId: string, entry: WaMessageSecretEntry): Promise<void> {
         const key = this.k('msgsecret', this.sessionId, messageId)
-        await this.redis.set(key, toRedisBuffer(secret), 'PX', this.ttlMs)
+        const multi = this.redis.multi()
+        multi.hset(key, 'secret', toRedisBuffer(entry.secret), 'sender_jid', entry.senderJid)
+        multi.pexpire(key, this.ttlMs)
+        const results = await multi.exec()
+        if (results) {
+            for (const [err] of results) {
+                if (err) throw err
+            }
+        }
     }
 
     public async setBatch(
-        entries: readonly { readonly messageId: string; readonly secret: Uint8Array }[]
+        entries: readonly { readonly messageId: string; readonly entry: WaMessageSecretEntry }[]
     ): Promise<void> {
         if (entries.length === 0) return
-        const pipeline = this.redis.pipeline()
-        for (const entry of entries) {
-            const key = this.k('msgsecret', this.sessionId, entry.messageId)
-            pipeline.set(key, toRedisBuffer(entry.secret), 'PX', this.ttlMs)
+        const multi = this.redis.multi()
+        for (const e of entries) {
+            const key = this.k('msgsecret', this.sessionId, e.messageId)
+            multi.hset(
+                key,
+                'secret',
+                toRedisBuffer(e.entry.secret),
+                'sender_jid',
+                e.entry.senderJid
+            )
+            multi.pexpire(key, this.ttlMs)
         }
-        await pipeline.exec()
+        const results = await multi.exec()
+        if (results) {
+            for (const [err] of results) {
+                if (err) throw err
+            }
+        }
     }
 
     public async cleanupExpired(_nowMs: number): Promise<number> {

--- a/packages/store-sqlite/src/__tests__/sqlite-runtime.test.ts
+++ b/packages/store-sqlite/src/__tests__/sqlite-runtime.test.ts
@@ -671,35 +671,35 @@ test('sqlite message-secret store covers set/get, batch, TTL expiry and cleanup'
     const store = new WaMessageSecretSqliteStore(makeSqliteOptions(sqlitePath, 'session-a'), 100)
 
     try {
-        const secretA = new Uint8Array([1, 2, 3])
-        const secretB = new Uint8Array([4, 5, 6])
+        const entryA = { secret: new Uint8Array([1, 2, 3]), senderJid: 'alice@s.whatsapp.net' }
+        const entryB = { secret: new Uint8Array([4, 5, 6]), senderJid: 'bob@s.whatsapp.net' }
 
-        await store.set('msg-1', secretA)
-        await store.set('msg-2', secretB)
+        await store.set('msg-1', entryA)
+        await store.set('msg-2', entryB)
 
-        assert.deepEqual(await store.get('msg-1', Date.now()), secretA)
-        assert.deepEqual(await store.get('msg-2', Date.now()), secretB)
+        assert.deepEqual(await store.get('msg-1', Date.now()), entryA)
+        assert.deepEqual(await store.get('msg-2', Date.now()), entryB)
         assert.equal(await store.get('missing', Date.now()), null)
 
         // getBatch preserves order and handles missing
         const batch = await store.getBatch(['msg-2', 'missing', 'msg-1'], Date.now())
         assert.equal(batch.length, 3)
-        assert.deepEqual(batch[0], secretB)
+        assert.deepEqual(batch[0], entryB)
         assert.equal(batch[1], null)
-        assert.deepEqual(batch[2], secretA)
+        assert.deepEqual(batch[2], entryA)
 
         // empty getBatch
         assert.deepEqual(await store.getBatch([], Date.now()), [])
 
         // setBatch
-        const secretC = new Uint8Array([7, 8, 9])
-        const secretD = new Uint8Array([10, 11, 12])
+        const entryC = { secret: new Uint8Array([7, 8, 9]), senderJid: 'carol@s.whatsapp.net' }
+        const entryD = { secret: new Uint8Array([10, 11, 12]), senderJid: 'dave@s.whatsapp.net' }
         await store.setBatch([
-            { messageId: 'msg-3', secret: secretC },
-            { messageId: 'msg-4', secret: secretD }
+            { messageId: 'msg-3', entry: entryC },
+            { messageId: 'msg-4', entry: entryD }
         ])
-        assert.deepEqual(await store.get('msg-3', Date.now()), secretC)
-        assert.deepEqual(await store.get('msg-4', Date.now()), secretD)
+        assert.deepEqual(await store.get('msg-3', Date.now()), entryC)
+        assert.deepEqual(await store.get('msg-4', Date.now()), entryD)
 
         // TTL expiry — reading after TTL returns null
         const expired = await store.get('msg-1', Date.now() + 200)
@@ -709,7 +709,7 @@ test('sqlite message-secret store covers set/get, batch, TTL expiry and cleanup'
         assert.ok((await store.cleanupExpired(Date.now() + 200)) >= 1)
 
         // clear
-        await store.set('msg-5', secretA)
+        await store.set('msg-5', entryA)
         await store.clear()
         assert.equal(await store.get('msg-5', Date.now()), null)
     } finally {

--- a/packages/store-sqlite/src/message-secret.store.ts
+++ b/packages/store-sqlite/src/message-secret.store.ts
@@ -1,4 +1,4 @@
-import type { WaMessageSecretStore } from 'zapo-js/store'
+import type { WaMessageSecretEntry, WaMessageSecretStore } from 'zapo-js/store'
 import { asBytes, asNumber, asString } from 'zapo-js/util'
 
 import { BaseSqliteStore } from './BaseSqliteStore'
@@ -9,6 +9,7 @@ import type { WaSqliteStorageOptions } from './types'
 interface MessageSecretRow extends Record<string, unknown> {
     readonly message_id: unknown
     readonly secret: unknown
+    readonly sender_jid: unknown
     readonly expires_at_ms: unknown
 }
 
@@ -37,10 +38,10 @@ export class WaMessageSecretSqliteStore extends BaseSqliteStore implements WaMes
         this.batchSize = batchSize
     }
 
-    public async get(messageId: string, nowMs = Date.now()): Promise<Uint8Array | null> {
+    public async get(messageId: string, nowMs = Date.now()): Promise<WaMessageSecretEntry | null> {
         const db = await this.getConnection()
         const row = db.get<MessageSecretRow>(
-            `SELECT message_id, secret, expires_at_ms
+            `SELECT message_id, secret, sender_jid, expires_at_ms
              FROM message_secrets_cache
              WHERE session_id = ? AND message_id = ?`,
             [this.options.sessionId, messageId]
@@ -57,19 +58,22 @@ export class WaMessageSecretSqliteStore extends BaseSqliteStore implements WaMes
             )
             return null
         }
-        return asBytes(row.secret, 'message_secrets_cache.secret')
+        return {
+            secret: asBytes(row.secret, 'message_secrets_cache.secret'),
+            senderJid: asString(row.sender_jid, 'message_secrets_cache.sender_jid')
+        }
     }
 
     public async getBatch(
         messageIds: readonly string[],
         nowMs = Date.now()
-    ): Promise<readonly (Uint8Array | null)[]> {
+    ): Promise<readonly (WaMessageSecretEntry | null)[]> {
         if (messageIds.length === 0) {
             return []
         }
         const uniqueMessageIds = [...new Set(messageIds)]
         return this.withTransaction((db) => {
-            const activeByMessageId = new Map<string, Uint8Array>()
+            const activeByMessageId = new Map<string, WaMessageSecretEntry>()
             const expiredMessageIds: string[] = []
             for (let start = 0; start < uniqueMessageIds.length; start += this.batchSize) {
                 const end = Math.min(start + this.batchSize, uniqueMessageIds.length)
@@ -80,7 +84,7 @@ export class WaMessageSecretSqliteStore extends BaseSqliteStore implements WaMes
                     params.push(uniqueMessageIds[index])
                 }
                 const rows = db.all<MessageSecretRow>(
-                    `SELECT message_id, secret, expires_at_ms
+                    `SELECT message_id, secret, sender_jid, expires_at_ms
                      FROM message_secrets_cache
                      WHERE session_id = ? AND message_id IN (${placeholders})`,
                     params
@@ -95,16 +99,16 @@ export class WaMessageSecretSqliteStore extends BaseSqliteStore implements WaMes
                         expiredMessageIds.push(messageId)
                         continue
                     }
-                    activeByMessageId.set(
-                        messageId,
-                        asBytes(row.secret, 'message_secrets_cache.secret')
-                    )
+                    activeByMessageId.set(messageId, {
+                        secret: asBytes(row.secret, 'message_secrets_cache.secret'),
+                        senderJid: asString(row.sender_jid, 'message_secrets_cache.sender_jid')
+                    })
                 }
             }
             if (expiredMessageIds.length > 0) {
                 this.deleteMessageSecretsByIds(db, expiredMessageIds)
             }
-            const results = new Array<Uint8Array | null>(messageIds.length)
+            const results = new Array<WaMessageSecretEntry | null>(messageIds.length)
             for (let index = 0; index < messageIds.length; index += 1) {
                 results[index] = activeByMessageId.get(messageIds[index]) ?? null
             }
@@ -112,20 +116,20 @@ export class WaMessageSecretSqliteStore extends BaseSqliteStore implements WaMes
         })
     }
 
-    public async set(messageId: string, secret: Uint8Array): Promise<void> {
+    public async set(messageId: string, entry: WaMessageSecretEntry): Promise<void> {
         const db = await this.getConnection()
-        this.upsertRow(db, messageId, secret)
+        this.upsertRow(db, messageId, entry)
     }
 
     public async setBatch(
-        entries: readonly { readonly messageId: string; readonly secret: Uint8Array }[]
+        entries: readonly { readonly messageId: string; readonly entry: WaMessageSecretEntry }[]
     ): Promise<void> {
         if (entries.length === 0) {
             return
         }
         await this.withTransaction((db) => {
-            for (const entry of entries) {
-                this.upsertRow(db, entry.messageId, entry.secret)
+            for (const e of entries) {
+                this.upsertRow(db, e.messageId, e.entry)
             }
         })
     }
@@ -146,19 +150,25 @@ export class WaMessageSecretSqliteStore extends BaseSqliteStore implements WaMes
         db.run('DELETE FROM message_secrets_cache WHERE session_id = ?', [this.options.sessionId])
     }
 
-    private upsertRow(db: WaSqliteConnection, messageId: string, secret: Uint8Array): void {
+    private upsertRow(
+        db: WaSqliteConnection,
+        messageId: string,
+        entry: WaMessageSecretEntry
+    ): void {
         const nowMs = Date.now()
         db.run(
             `INSERT INTO message_secrets_cache (
                 session_id,
                 message_id,
                 secret,
+                sender_jid,
                 expires_at_ms
-            ) VALUES (?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(session_id, message_id) DO UPDATE SET
                 secret=excluded.secret,
+                sender_jid=excluded.sender_jid,
                 expires_at_ms=excluded.expires_at_ms`,
-            [this.options.sessionId, messageId, secret, nowMs + this.ttlMs]
+            [this.options.sessionId, messageId, entry.secret, entry.senderJid, nowMs + this.ttlMs]
         )
     }
 

--- a/packages/store-sqlite/src/migrations.ts
+++ b/packages/store-sqlite/src/migrations.ts
@@ -338,6 +338,7 @@ const SQLITE_MIGRATIONS: readonly WaSqliteMigration[] = [
                     session_id TEXT NOT NULL,
                     message_id TEXT NOT NULL,
                     secret BLOB NOT NULL,
+                    sender_jid TEXT NOT NULL DEFAULT '',
                     expires_at_ms INTEGER NOT NULL,
                     PRIMARY KEY (session_id, message_id)
                 );

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -26,6 +26,7 @@ import type {
     WaClientOptions,
     WaSendMessageOptions,
     WaClientEventMap,
+    WaIncomingAddonEvent,
     WaIncomingProtocolMessageEvent,
     WaIncomingNodeHandlerRegistration,
     WaIncomingMessageEvent
@@ -34,6 +35,15 @@ import { buildWaClientDependencies, resolveWaClientBase } from '@client/WaClient
 import { ConsoleLogger } from '@infra/log/ConsoleLogger'
 import type { Logger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
+import {
+    decryptAddonPayload,
+    shouldUseAddonAdditionalData,
+    buildAddonAdditionalData,
+    identifyEncryptedAddon,
+    decodeAddonPlaintext,
+    resolveParentMessageSecret,
+    resolvePollOptionNames
+} from '@message/addon-crypto'
 import type {
     WaMessagePublishResult,
     WaSendMessageContent,
@@ -58,6 +68,7 @@ import type { WaSenderKeyStore } from '@store/contracts/sender-key.store'
 import type { WaSessionStore } from '@store/contracts/session.store'
 import type { WaSignalStore } from '@store/contracts/signal.store'
 import type { WaThreadStore } from '@store/contracts/thread.store'
+import { NOOP_MESSAGE_SECRET_STORE } from '@store/noop.store'
 import type { WaKeepAlive } from '@transport/keepalive/WaKeepAlive'
 import { queryWithContext as queryNodeWithContext } from '@transport/node/query'
 import type { WaNodeOrchestrator } from '@transport/node/WaNodeOrchestrator'
@@ -149,6 +160,16 @@ export class WaClient extends EventEmitter {
             this.logger,
             this.options.writeBehind
         )
+
+        if (
+            this.options.addons?.autoDecrypt &&
+            this.messageSecretStore === NOOP_MESSAGE_SECRET_STORE
+        ) {
+            this.logger.warn(
+                'addons.autoDecrypt is enabled but messageSecret cache is noop — ' +
+                    'addon decryption will only work if secrets are in the message store'
+            )
+        }
 
         const dependencies = buildWaClientDependencies({
             base,
@@ -282,6 +303,14 @@ export class WaClient extends EventEmitter {
                 messageSecretStore: this.messageSecretStore,
                 event
             })
+            if (this.options.addons?.autoDecrypt && event.message) {
+                void this.tryDecryptAddon(event).catch((err) => {
+                    this.logger.warn('addon auto-decrypt failed', {
+                        id: event.stanzaId,
+                        message: toError(err).message
+                    })
+                })
+            }
             const protocolMessage = event.message?.protocolMessage
             if (!protocolMessage) {
                 return
@@ -895,6 +924,70 @@ export class WaClient extends EventEmitter {
         if (shouldClear('senderKey')) await this.senderKeyStore.clear()
         if (shouldClear('threads')) await this.threadStore.clear()
         if (shouldClear('privacyToken')) await this.privacyTokenStore.clear()
+    }
+
+    private async tryDecryptAddon(event: WaIncomingMessageEvent): Promise<void> {
+        const message = event.message
+        if (!message) return
+
+        const addon = identifyEncryptedAddon(message)
+        if (!addon) return
+
+        const targetMessageId = addon.targetMessageKey.id
+        if (!targetMessageId) return
+
+        const parentEntry = await resolveParentMessageSecret(
+            targetMessageId,
+            this.messageSecretStore,
+            this.messageStore
+        )
+        if (!parentEntry) {
+            this.logger.debug('addon parent message secret not found', {
+                id: event.stanzaId,
+                targetId: targetMessageId
+            })
+            return
+        }
+
+        const parentMsgOriginalSender = parentEntry.senderJid
+        const modificationSender = event.senderJid ?? ''
+
+        const plaintext = await decryptAddonPayload({
+            messageSecret: parentEntry.secret,
+            stanzaId: targetMessageId,
+            parentMsgOriginalSender,
+            modificationSender,
+            modificationType: addon.modificationType,
+            ciphertext: addon.encPayload,
+            iv: addon.encIv,
+            additionalData: shouldUseAddonAdditionalData(addon.modificationType)
+                ? buildAddonAdditionalData(targetMessageId, modificationSender)
+                : undefined
+        })
+
+        let decrypted = decodeAddonPlaintext(addon.kind, plaintext)
+        if (decrypted.kind === 'poll_vote' && decrypted.pollVote.selectedOptions) {
+            const names = await resolvePollOptionNames(
+                decrypted.pollVote.selectedOptions,
+                targetMessageId,
+                this.messageStore
+            )
+            if (names) {
+                decrypted = { ...decrypted, selectedOptionNames: names }
+            }
+        }
+        const addonEvent: WaIncomingAddonEvent = {
+            rawNode: event.rawNode,
+            stanzaId: event.stanzaId,
+            chatJid: event.chatJid,
+            stanzaType: event.stanzaType,
+            kind: addon.kind,
+            targetMessageId,
+            senderJid: modificationSender,
+            decrypted,
+            raw: message
+        }
+        this.emit('message_addon', addonEvent)
     }
 
     private tryEnterIncomingHandler(): boolean {

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -280,8 +280,9 @@ export class WaMessageDispatchCoordinator {
             sendOptions.id &&
             needsSecretPersistence(messageWithSecret)
         ) {
+            const meJid = this.getCurrentMeJid() ?? ''
             void this.messageSecretStore
-                .set(sendOptions.id, toBytesView(rawSecret))
+                .set(sendOptions.id, { secret: toBytesView(rawSecret), senderJid: meJid })
                 .catch((error) => {
                     this.logger.warn('failed to persist outgoing message secret', {
                         id: sendOptions.id,

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -121,7 +121,9 @@ function createMessageDispatchCoordinator(
         sessionStore: {} as never,
         identityStore: {} as never,
         deviceListStore: {} as never,
-        messageSecretStore: { set: async () => {} } as never,
+        messageSecretStore: {
+            set: async (_id: string, _entry: { secret: Uint8Array; senderJid: string }) => {}
+        } as never,
         getCurrentMeJid: () => null,
         getCurrentMeLid: () => null,
         getCurrentSignedIdentity: () => null,

--- a/src/client/mailbox.ts
+++ b/src/client/mailbox.ts
@@ -64,12 +64,15 @@ export function persistIncomingMailboxEntities(options: WaPersistIncomingMailbox
             event.message &&
             needsSecretPersistence(event.message)
         ) {
-            void messageSecretStore.set(stanzaId, toBytesView(rawSecret)).catch((error) => {
-                logger.warn('failed to persist message secret', {
-                    id: stanzaId,
-                    message: toError(error).message
+            const senderJid = event.senderJid ?? event.rawNode.attrs.participant ?? ''
+            void messageSecretStore
+                .set(stanzaId, { secret: toBytesView(rawSecret), senderJid })
+                .catch((error) => {
+                    logger.warn('failed to persist message secret', {
+                        id: stanzaId,
+                        message: toError(error).message
+                    })
                 })
-            })
         }
     } catch (error) {
         logger.warn('failed to persist incoming mailbox entities', {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,5 +1,6 @@
 import type { AppStateCollectionName } from '@appstate/types'
 import type { WaAuthClientOptions, WaAuthCredentials, WaAuthSocketOptions } from '@auth/types'
+import type { WaDecodedAddon } from '@message/addon-crypto'
 import type { WaMessagePublishOptions } from '@message/types'
 import type { Proto } from '@proto'
 import type { WaConnectionCode, WaConnectionOpenReason, WaDisconnectReason } from '@protocol/stream'
@@ -51,7 +52,12 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
         readonly emitSnapshotMutations?: boolean
     }
     readonly privacyToken?: WaPrivacyTokenOptions
+    readonly addons?: WaAddonOptions
     readonly logoutStoreClear?: WaLogoutStoreClearOptions
+}
+
+export interface WaAddonOptions {
+    readonly autoDecrypt?: boolean
 }
 
 export interface WaPrivacyTokenOptions {
@@ -159,6 +165,16 @@ export interface WaIncomingNotificationEvent extends WaIncomingBaseEvent {
     readonly notificationType?: string
     readonly classification?: 'core' | 'out_of_scope' | 'unknown' | 'info_bulletin'
     readonly details?: Readonly<Record<string, unknown>>
+}
+
+export type WaAddonKind = 'reaction' | 'poll_vote' | 'event_response' | 'comment'
+
+export interface WaIncomingAddonEvent extends WaIncomingBaseEvent {
+    readonly kind: WaAddonKind
+    readonly targetMessageId: string
+    readonly senderJid: string
+    readonly decrypted: WaDecodedAddon
+    readonly raw: Proto.IMessage
 }
 
 export interface WaIncomingFailureEvent extends WaIncomingBaseEvent {
@@ -354,6 +370,7 @@ export interface WaClientEventMap {
         readonly frame: Uint8Array
     }) => void
     readonly message: (event: WaIncomingMessageEvent) => void
+    readonly message_addon: (event: WaIncomingAddonEvent) => void
     readonly message_protocol: (event: WaIncomingProtocolMessageEvent) => void
     readonly message_receipt: (event: WaIncomingReceiptEvent) => void
     readonly presence: (event: WaIncomingPresenceEvent) => void

--- a/src/message/addon-crypto.ts
+++ b/src/message/addon-crypto.ts
@@ -1,18 +1,29 @@
-import { aesGcmDecrypt, aesGcmEncrypt, importAesGcmKey } from '@crypto'
+import type { WaAddonKind } from '@client/types'
+import { aesGcmDecrypt, aesGcmEncrypt, importAesGcmKey, sha256 } from '@crypto'
+import { unwrapMessage } from '@message/content'
 import {
     assertMessageSecret,
     createUseCaseSecret,
+    WA_MESSAGE_SECRET_BYTES,
     WA_USE_CASE_SECRET_MODIFICATION_TYPES
 } from '@message/use-case-secret'
-import { EMPTY_BYTES, TEXT_ENCODER, toBytesView } from '@util/bytes'
+import { proto } from '@proto'
+import type { Proto } from '@proto'
+import type {
+    WaMessageSecretEntry,
+    WaMessageSecretStore
+} from '@store/contracts/message-secret.store'
+import type { WaMessageStore } from '@store/contracts/message.store'
+import { bytesToHex, EMPTY_BYTES, TEXT_ENCODER, toBytesView } from '@util/bytes'
 
 const WA_ADDON_ENCRYPTION_NONCE_BYTES = 12
 
 type WaAddonBytes = Uint8Array | ArrayBuffer | ArrayBufferView
 
-export function shouldUseAddonAdditionalData(
-    modificationType: (typeof WA_USE_CASE_SECRET_MODIFICATION_TYPES)[keyof typeof WA_USE_CASE_SECRET_MODIFICATION_TYPES]
-): boolean {
+type ModificationType =
+    (typeof WA_USE_CASE_SECRET_MODIFICATION_TYPES)[keyof typeof WA_USE_CASE_SECRET_MODIFICATION_TYPES]
+
+export function shouldUseAddonAdditionalData(modificationType: ModificationType): boolean {
     return (
         modificationType === WA_USE_CASE_SECRET_MODIFICATION_TYPES.POLL_VOTE ||
         modificationType === WA_USE_CASE_SECRET_MODIFICATION_TYPES.EVENT_RESPONSE
@@ -34,7 +45,7 @@ export async function encryptAddonPayload(input: {
     readonly stanzaId: string
     readonly parentMsgOriginalSender: string
     readonly modificationSender: string
-    readonly modificationType: (typeof WA_USE_CASE_SECRET_MODIFICATION_TYPES)[keyof typeof WA_USE_CASE_SECRET_MODIFICATION_TYPES]
+    readonly modificationType: ModificationType
     readonly payload: WaAddonBytes
     readonly iv: WaAddonBytes
     readonly additionalData?: WaAddonBytes
@@ -57,7 +68,7 @@ export async function decryptAddonPayload(input: {
     readonly stanzaId: string
     readonly parentMsgOriginalSender: string
     readonly modificationSender: string
-    readonly modificationType: (typeof WA_USE_CASE_SECRET_MODIFICATION_TYPES)[keyof typeof WA_USE_CASE_SECRET_MODIFICATION_TYPES]
+    readonly modificationType: ModificationType
     readonly ciphertext: WaAddonBytes
     readonly iv: WaAddonBytes
     readonly additionalData?: WaAddonBytes
@@ -75,6 +86,167 @@ export async function decryptAddonPayload(input: {
     return aesGcmDecrypt(key, iv, toBytesView(input.ciphertext), additionalData)
 }
 
+export interface WaIdentifiedEncAddon {
+    readonly kind: WaAddonKind
+    readonly targetMessageKey: Proto.IMessageKey
+    readonly encPayload: Uint8Array
+    readonly encIv: Uint8Array
+    readonly modificationType: ModificationType
+    readonly raw: Proto.IMessage
+}
+
+export function identifyEncryptedAddon(message: Proto.IMessage): WaIdentifiedEncAddon | null {
+    const msg = unwrapMessage(message)
+
+    if (msg.encReactionMessage) {
+        const { targetMessageKey, encPayload, encIv } = msg.encReactionMessage
+        if (targetMessageKey && encPayload && encIv) {
+            return {
+                kind: 'reaction',
+                targetMessageKey,
+                encPayload: toBytesView(encPayload),
+                encIv: toBytesView(encIv),
+                modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.ENC_REACTION,
+                raw: message
+            }
+        }
+    }
+
+    if (msg.pollUpdateMessage) {
+        const { pollCreationMessageKey, vote } = msg.pollUpdateMessage
+        if (pollCreationMessageKey && vote?.encPayload && vote.encIv) {
+            return {
+                kind: 'poll_vote',
+                targetMessageKey: pollCreationMessageKey,
+                encPayload: toBytesView(vote.encPayload),
+                encIv: toBytesView(vote.encIv),
+                modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.POLL_VOTE,
+                raw: message
+            }
+        }
+    }
+
+    if (msg.encEventResponseMessage) {
+        const { eventCreationMessageKey, encPayload, encIv } = msg.encEventResponseMessage
+        if (eventCreationMessageKey && encPayload && encIv) {
+            return {
+                kind: 'event_response',
+                targetMessageKey: eventCreationMessageKey,
+                encPayload: toBytesView(encPayload),
+                encIv: toBytesView(encIv),
+                modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.EVENT_RESPONSE,
+                raw: message
+            }
+        }
+    }
+
+    if (msg.encCommentMessage) {
+        const { targetMessageKey, encPayload, encIv } = msg.encCommentMessage
+        if (targetMessageKey && encPayload && encIv) {
+            return {
+                kind: 'comment',
+                targetMessageKey,
+                encPayload: toBytesView(encPayload),
+                encIv: toBytesView(encIv),
+                modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.ENC_COMMENT,
+                raw: message
+            }
+        }
+    }
+
+    return null
+}
+
+export type WaDecodedAddon =
+    | { readonly kind: 'reaction'; readonly reaction: Proto.Message.IReactionMessage }
+    | {
+          readonly kind: 'poll_vote'
+          readonly pollVote: Proto.Message.IPollVoteMessage
+          readonly selectedOptionNames: readonly string[] | null
+      }
+    | {
+          readonly kind: 'event_response'
+          readonly eventResponse: Proto.Message.IEventResponseMessage
+      }
+    | { readonly kind: 'comment'; readonly comment: Proto.Message.ICommentMessage }
+
+export function decodeAddonPlaintext(kind: WaAddonKind, plaintext: Uint8Array): WaDecodedAddon {
+    switch (kind) {
+        case 'reaction':
+            return { kind, reaction: proto.Message.ReactionMessage.decode(plaintext) }
+        case 'poll_vote':
+            return {
+                kind,
+                pollVote: proto.Message.PollVoteMessage.decode(plaintext),
+                selectedOptionNames: null
+            }
+        case 'event_response':
+            return { kind, eventResponse: proto.Message.EventResponseMessage.decode(plaintext) }
+        case 'comment':
+            return { kind, comment: proto.Message.CommentMessage.decode(plaintext) }
+    }
+}
+
+export async function resolveParentMessageSecret(
+    targetMessageId: string,
+    messageSecretStore: WaMessageSecretStore,
+    messageStore: WaMessageStore
+): Promise<WaMessageSecretEntry | null> {
+    const cached = await messageSecretStore.get(targetMessageId)
+    if (cached) return cached
+
+    const record = await messageStore.getById(targetMessageId)
+    if (!record?.messageBytes) return null
+
+    try {
+        const decoded = proto.Message.decode(record.messageBytes)
+        const secret = decoded.messageContextInfo?.messageSecret
+        if (!secret || toBytesView(secret).byteLength !== WA_MESSAGE_SECRET_BYTES) return null
+        return { secret: toBytesView(secret), senderJid: record.senderJid ?? '' }
+    } catch {
+        return null
+    }
+}
+
+export async function resolvePollOptionNames(
+    selectedOptions: readonly Uint8Array[],
+    pollCreationMessageId: string,
+    messageStore: WaMessageStore
+): Promise<readonly string[] | null> {
+    const record = await messageStore.getById(pollCreationMessageId)
+    if (!record?.messageBytes) return null
+
+    let decoded: ReturnType<typeof proto.Message.decode>
+    try {
+        decoded = proto.Message.decode(record.messageBytes)
+    } catch {
+        return null
+    }
+    const pollMsg = unwrapMessage(decoded)
+    const options =
+        pollMsg.pollCreationMessage?.options ??
+        pollMsg.pollCreationMessageV2?.options ??
+        pollMsg.pollCreationMessageV3?.options ??
+        pollMsg.pollCreationMessageV5?.options
+    if (!options || options.length === 0) return null
+
+    const hashToName = new Map<string, string>()
+    for (const option of options) {
+        if (!option.optionName) continue
+        const hash = await sha256(TEXT_ENCODER.encode(option.optionName))
+        hashToName.set(bytesToHex(hash), option.optionName)
+    }
+
+    const names: string[] = []
+    for (const selected of selectedOptions) {
+        const hex = bytesToHex(selected)
+        const name = hashToName.get(hex)
+        if (!name) return null
+        names.push(name)
+    }
+    return names
+}
+
 function assertAddonIv(iv: WaAddonBytes): Uint8Array {
     const normalized = toBytesView(iv)
     if (normalized.byteLength !== WA_ADDON_ENCRYPTION_NONCE_BYTES) {
@@ -88,7 +260,7 @@ function assertAddonIv(iv: WaAddonBytes): Uint8Array {
 function resolveAddonAdditionalData(input: {
     readonly stanzaId: string
     readonly modificationSender: string
-    readonly modificationType: (typeof WA_USE_CASE_SECRET_MODIFICATION_TYPES)[keyof typeof WA_USE_CASE_SECRET_MODIFICATION_TYPES]
+    readonly modificationType: ModificationType
     readonly additionalData?: WaAddonBytes
 }): Uint8Array {
     if (input.additionalData) {

--- a/src/message/content.ts
+++ b/src/message/content.ts
@@ -19,7 +19,7 @@ export function isSendMediaMessage(content: unknown): content is WaSendMediaMess
     )
 }
 
-function unwrapMessage(message: Proto.IMessage): Proto.IMessage {
+export function unwrapMessage(message: Proto.IMessage): Proto.IMessage {
     let msg = message
     for (;;) {
         const inner =

--- a/src/store/contracts/message-secret.store.ts
+++ b/src/store/contracts/message-secret.store.ts
@@ -1,9 +1,17 @@
+export interface WaMessageSecretEntry {
+    readonly secret: Uint8Array
+    readonly senderJid: string
+}
+
 export interface WaMessageSecretStore {
-    get(messageId: string, nowMs?: number): Promise<Uint8Array | null>
-    getBatch(messageIds: readonly string[], nowMs?: number): Promise<readonly (Uint8Array | null)[]>
-    set(messageId: string, secret: Uint8Array): Promise<void>
+    get(messageId: string, nowMs?: number): Promise<WaMessageSecretEntry | null>
+    getBatch(
+        messageIds: readonly string[],
+        nowMs?: number
+    ): Promise<readonly (WaMessageSecretEntry | null)[]>
+    set(messageId: string, entry: WaMessageSecretEntry): Promise<void>
     setBatch(
-        entries: readonly { readonly messageId: string; readonly secret: Uint8Array }[]
+        entries: readonly { readonly messageId: string; readonly entry: WaMessageSecretEntry }[]
     ): Promise<void>
     cleanupExpired(nowMs: number): Promise<number>
     clear(): Promise<void>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,7 +11,10 @@ export { createStore } from '@store/createStore'
 export type { WaAuthStore } from '@store/contracts/auth.store'
 export type { WaContactStore, WaStoredContactRecord } from '@store/contracts/contact.store'
 export type { WaDeviceListSnapshot, WaDeviceListStore } from '@store/contracts/device-list.store'
-export type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
+export type {
+    WaMessageSecretEntry,
+    WaMessageSecretStore
+} from '@store/contracts/message-secret.store'
 export type { WaMessageStore, WaStoredMessageRecord } from '@store/contracts/message.store'
 export type {
     WaParticipantsSnapshot,

--- a/src/store/locks/message-secret.lock.ts
+++ b/src/store/locks/message-secret.lock.ts
@@ -10,7 +10,7 @@ export function withMessageSecretLock(
     return {
         get: (messageId, nowMs) => gate.runShared(() => store.get(messageId, nowMs)),
         getBatch: (messageIds, nowMs) => gate.runShared(() => store.getBatch(messageIds, nowMs)),
-        set: (messageId, secret) => gate.runShared(() => store.set(messageId, secret)),
+        set: (messageId, entry) => gate.runShared(() => store.set(messageId, entry)),
         setBatch: (entries) => gate.runShared(() => store.setBatch(entries)),
         cleanupExpired: (nowMs) => gate.runExclusive(() => store.cleanupExpired(nowMs)),
         clear: () => gate.runExclusive(() => store.clear()),

--- a/src/store/noop.store.ts
+++ b/src/store/noop.store.ts
@@ -1,7 +1,10 @@
 import type { WaRetryOutboundMessageRecord } from '@retry/types'
 import type { WaContactStore, WaStoredContactRecord } from '@store/contracts/contact.store'
 import type { WaDeviceListSnapshot, WaDeviceListStore } from '@store/contracts/device-list.store'
-import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
+import type {
+    WaMessageSecretEntry,
+    WaMessageSecretStore
+} from '@store/contracts/message-secret.store'
 import type { WaMessageStore, WaStoredMessageRecord } from '@store/contracts/message.store'
 import type {
     WaParticipantsSnapshot,
@@ -13,12 +16,17 @@ import type { WaStoredThreadRecord, WaThreadStore } from '@store/contracts/threa
 const EMPTY_STORE_LIST = Object.freeze([]) as readonly unknown[]
 
 export const NOOP_MESSAGE_SECRET_STORE: WaMessageSecretStore = Object.freeze({
-    get: async (_messageId: string): Promise<Uint8Array | null> => null,
-    getBatch: async (messageIds: readonly string[]): Promise<readonly (Uint8Array | null)[]> =>
-        new Array<Uint8Array | null>(messageIds.length).fill(null),
-    set: async (_messageId: string, _secret: Uint8Array): Promise<void> => {},
+    get: async (_messageId: string): Promise<WaMessageSecretEntry | null> => null,
+    getBatch: async (
+        messageIds: readonly string[]
+    ): Promise<readonly (WaMessageSecretEntry | null)[]> =>
+        new Array<WaMessageSecretEntry | null>(messageIds.length).fill(null),
+    set: async (_messageId: string, _entry: WaMessageSecretEntry): Promise<void> => {},
     setBatch: async (
-        _entries: readonly { readonly messageId: string; readonly secret: Uint8Array }[]
+        _entries: readonly {
+            readonly messageId: string
+            readonly entry: WaMessageSecretEntry
+        }[]
     ): Promise<void> => {},
     cleanupExpired: async (_nowMs: number): Promise<number> => 0,
     clear: async (): Promise<void> => {}

--- a/src/store/providers/memory/__tests__/memory-providers.test.ts
+++ b/src/store/providers/memory/__tests__/memory-providers.test.ts
@@ -217,24 +217,24 @@ test('memory signal/sender-key/appstate stores cover key workflows', async () =>
 test('memory message secret store covers set/get, batch, TTL expiry, bounds and cleanup', async () => {
     const store = new WaMessageSecretMemoryStore(100, { maxSecrets: 2 })
 
-    const secretA = new Uint8Array([1, 2, 3])
-    const secretB = new Uint8Array([4, 5, 6])
-    const secretC = new Uint8Array([7, 8, 9])
+    const entryA = { secret: new Uint8Array([1, 2, 3]), senderJid: 'alice@s.whatsapp.net' }
+    const entryB = { secret: new Uint8Array([4, 5, 6]), senderJid: 'bob@s.whatsapp.net' }
+    const entryC = { secret: new Uint8Array([7, 8, 9]), senderJid: 'carol@s.whatsapp.net' }
 
-    await store.set('msg-1', secretA)
-    await store.set('msg-2', secretB)
-    assert.deepEqual(await store.get('msg-1'), secretA)
-    assert.deepEqual(await store.get('msg-2'), secretB)
+    await store.set('msg-1', entryA)
+    await store.set('msg-2', entryB)
+    assert.deepEqual(await store.get('msg-1'), entryA)
+    assert.deepEqual(await store.get('msg-2'), entryB)
     assert.equal(await store.get('missing'), null)
 
     // bounds eviction — maxSecrets=2, so msg-1 gets evicted
-    await store.set('msg-3', secretC)
+    await store.set('msg-3', entryC)
     assert.equal(await store.get('msg-1'), null)
-    assert.deepEqual(await store.get('msg-3'), secretC)
+    assert.deepEqual(await store.get('msg-3'), entryC)
 
     // getBatch preserves order and handles missing
     const batch = await store.getBatch(['msg-3', 'missing', 'msg-2'])
-    assert.deepEqual(batch, [secretC, null, secretB])
+    assert.deepEqual(batch, [entryC, null, entryB])
 
     // empty getBatch
     assert.deepEqual(await store.getBatch([]), [])
@@ -242,11 +242,11 @@ test('memory message secret store covers set/get, batch, TTL expiry, bounds and 
     // setBatch
     await store.clear()
     await store.setBatch([
-        { messageId: 'b-1', secret: secretA },
-        { messageId: 'b-2', secret: secretB }
+        { messageId: 'b-1', entry: entryA },
+        { messageId: 'b-2', entry: entryB }
     ])
-    assert.deepEqual(await store.get('b-1'), secretA)
-    assert.deepEqual(await store.get('b-2'), secretB)
+    assert.deepEqual(await store.get('b-1'), entryA)
+    assert.deepEqual(await store.get('b-2'), entryB)
 
     // TTL expiry on get
     const expired = await store.get('b-1', Date.now() + 200)
@@ -258,14 +258,14 @@ test('memory message secret store covers set/get, batch, TTL expiry, bounds and 
 
     // cleanupExpired
     await store.clear()
-    await store.set('c-1', secretA)
-    await store.set('c-2', secretB)
+    await store.set('c-1', entryA)
+    await store.set('c-2', entryB)
     const removed = await store.cleanupExpired(Date.now() + 200)
     assert.equal(removed, 2)
     assert.equal(await store.get('c-1'), null)
 
     // clear
-    await store.set('d-1', secretA)
+    await store.set('d-1', entryA)
     await store.clear()
     assert.equal(await store.get('d-1'), null)
 

--- a/src/store/providers/memory/message-secret.store.ts
+++ b/src/store/providers/memory/message-secret.store.ts
@@ -1,9 +1,13 @@
-import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
+import type {
+    WaMessageSecretEntry,
+    WaMessageSecretStore
+} from '@store/contracts/message-secret.store'
 import { resolvePositive } from '@util/coercion'
 import { resolveCleanupIntervalMs, setBoundedMapEntry } from '@util/collections'
 
-interface WaMessageSecretEntry {
+interface CachedEntry {
     readonly secret: Uint8Array
+    readonly senderJid: string
     readonly expiresAtMs: number
 }
 
@@ -17,7 +21,7 @@ export interface WaMessageSecretMemoryStoreOptions {
 }
 
 export class WaMessageSecretMemoryStore implements WaMessageSecretStore {
-    private readonly secrets: Map<string, WaMessageSecretEntry>
+    private readonly secrets: Map<string, CachedEntry>
     private readonly ttlMs: number
     private readonly maxSecrets: number
     private readonly cleanupTimer: NodeJS.Timeout
@@ -39,55 +43,63 @@ export class WaMessageSecretMemoryStore implements WaMessageSecretStore {
         this.cleanupTimer.unref()
     }
 
-    public async get(messageId: string, nowMs = Date.now()): Promise<Uint8Array | null> {
-        const entry = this.secrets.get(messageId)
-        if (!entry) return null
-        if (entry.expiresAtMs <= nowMs) {
+    public async get(messageId: string, nowMs = Date.now()): Promise<WaMessageSecretEntry | null> {
+        const cached = this.secrets.get(messageId)
+        if (!cached) return null
+        if (cached.expiresAtMs <= nowMs) {
             this.secrets.delete(messageId)
             return null
         }
-        return entry.secret
+        return { secret: cached.secret, senderJid: cached.senderJid }
     }
 
     public async getBatch(
         messageIds: readonly string[],
         nowMs = Date.now()
-    ): Promise<readonly (Uint8Array | null)[]> {
-        const result = new Array<Uint8Array | null>(messageIds.length)
+    ): Promise<readonly (WaMessageSecretEntry | null)[]> {
+        const result = new Array<WaMessageSecretEntry | null>(messageIds.length)
         for (let i = 0; i < messageIds.length; i += 1) {
-            const entry = this.secrets.get(messageIds[i])
-            if (!entry) {
+            const cached = this.secrets.get(messageIds[i])
+            if (!cached) {
                 result[i] = null
                 continue
             }
-            if (entry.expiresAtMs <= nowMs) {
+            if (cached.expiresAtMs <= nowMs) {
                 this.secrets.delete(messageIds[i])
                 result[i] = null
                 continue
             }
-            result[i] = entry.secret
+            result[i] = { secret: cached.secret, senderJid: cached.senderJid }
         }
         return result
     }
 
-    public async set(messageId: string, secret: Uint8Array): Promise<void> {
+    public async set(messageId: string, entry: WaMessageSecretEntry): Promise<void> {
         setBoundedMapEntry(
             this.secrets,
             messageId,
-            { secret, expiresAtMs: Date.now() + this.ttlMs },
+            {
+                secret: entry.secret,
+                senderJid: entry.senderJid,
+                expiresAtMs: Date.now() + this.ttlMs
+            },
             this.maxSecrets
         )
     }
 
     public async setBatch(
-        entries: readonly { readonly messageId: string; readonly secret: Uint8Array }[]
+        entries: readonly { readonly messageId: string; readonly entry: WaMessageSecretEntry }[]
     ): Promise<void> {
         const nowMs = Date.now()
         for (let i = 0; i < entries.length; i += 1) {
             setBoundedMapEntry(
                 this.secrets,
                 entries[i].messageId,
-                { secret: entries[i].secret, expiresAtMs: nowMs + this.ttlMs },
+                {
+                    secret: entries[i].entry.secret,
+                    senderJid: entries[i].entry.senderJid,
+                    expiresAtMs: nowMs + this.ttlMs
+                },
                 this.maxSecrets
             )
         }


### PR DESCRIPTION
- add addons.autoDecrypt option to WaClientOptions (default false)
- add message_addon event with WaDecodedAddon discriminated union
- identify and decrypt encReactionMessage, pollUpdateMessage, encEventResponseMessage, and encCommentMessage automatically
- resolve poll vote selectedOptions to option names via SHA-256 matching against the poll creation message
- extend WaMessageSecretEntry with senderJid for correct addon key derivation (parentMsgOriginalSender)
- consolidate addon-decrypt.ts and addon-secret.ts into addon-crypto.ts
- export unwrapMessage from content.ts
- update all store backends and tests for new WaMessageSecretEntry shape

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional auto-decryption for addon messages (reactions, poll votes, responses, comments)
  * New message_addon event emits decrypted addon content and metadata

* **Refactor**
  * Message secret cache now stores sender info alongside secrets
  * Persistence schemas updated across storage backends to keep sender metadata with secrets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->