### PR TITLE
fix: remove unnecessary toBytesView calls, fix store provider defaults, and backend lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,14 @@ const store = createStore({
     providers: {
         auth: 'sqlite',
         signal: 'sqlite',
+        preKey: 'sqlite',
+        session: 'sqlite',
+        identity: 'sqlite',
         senderKey: 'sqlite',
         appState: 'sqlite',
         messages: 'sqlite',
         threads: 'sqlite',
-        contacts: 'sqlite',
-        privacyToken: 'sqlite'
+        contacts: 'sqlite'
     }
 })
 

--- a/packages/store-redis/src/createRedisStore.ts
+++ b/packages/store-redis/src/createRedisStore.ts
@@ -97,7 +97,7 @@ export function createRedisStore(config: WaRedisStoreConfig): WaRedisStoreResult
         },
         async destroy(): Promise<void> {
             if (ownsRedis) {
-                redis.disconnect()
+                await redis.quit()
             }
         }
     }

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -62,7 +62,7 @@ import {
     buildMetaNode
 } from '@transport/node/builders/message'
 import type { BinaryNode } from '@transport/types'
-import { bytesToHex, concatBytes, TEXT_ENCODER, toBytesView } from '@util/bytes'
+import { bytesToHex, concatBytes, TEXT_ENCODER } from '@util/bytes'
 import { toError } from '@util/primitives'
 
 interface WaMessageDispatchCoordinatorOptions {
@@ -282,7 +282,7 @@ export class WaMessageDispatchCoordinator {
         ) {
             const meJid = this.getCurrentMeJid() ?? ''
             void this.messageSecretStore
-                .set(sendOptions.id, { secret: toBytesView(rawSecret), senderJid: meJid })
+                .set(sendOptions.id, { secret: rawSecret, senderJid: meJid })
                 .catch((error) => {
                     this.logger.warn('failed to persist outgoing message secret', {
                         id: sendOptions.id,

--- a/src/client/events/privacy-token.ts
+++ b/src/client/events/privacy-token.ts
@@ -1,7 +1,6 @@
 import { WA_PRIVACY_TOKEN_TAGS } from '@protocol/privacy-token'
 import { findNodeChild, getNodeChildren } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
-import { toBytesView } from '@util/bytes'
 import { asNumber } from '@util/coercion'
 
 export interface ParsedPrivacyToken {
@@ -38,7 +37,7 @@ export function parsePrivacyTokenNotification(node: BinaryNode): readonly Parsed
         }
         result[result.length] = {
             type,
-            tokenBytes: toBytesView(content),
+            tokenBytes: content,
             timestampS: asNumber(Number(rawTimestamp), 'privacy_token.t')
         }
     }

--- a/src/client/mailbox.ts
+++ b/src/client/mailbox.ts
@@ -4,7 +4,6 @@ import type { Logger } from '@infra/log/types'
 import { needsSecretPersistence } from '@message/content'
 import { proto } from '@proto'
 import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
-import { toBytesView } from '@util/bytes'
 import { toError } from '@util/primitives'
 
 interface WaPersistIncomingMailboxOptions {
@@ -66,7 +65,7 @@ export function persistIncomingMailboxEntities(options: WaPersistIncomingMailbox
         ) {
             const senderJid = event.senderJid ?? event.rawNode.attrs.participant ?? ''
             void messageSecretStore
-                .set(stanzaId, { secret: toBytesView(rawSecret), senderJid })
+                .set(stanzaId, { secret: rawSecret, senderJid })
                 .catch((error) => {
                     logger.warn('failed to persist message secret', {
                         id: stanzaId,

--- a/src/crypto/core/random.ts
+++ b/src/crypto/core/random.ts
@@ -1,15 +1,6 @@
 import { randomBytes, randomFill, randomInt } from 'node:crypto'
 import { promisify } from 'node:util'
 
-import { toBytesView } from '@util/bytes'
-
-const randomBytesAsyncImpl = promisify(randomBytes) as (size: number) => Promise<Uint8Array>
-const randomIntAsyncImpl = promisify(randomInt) as (min: number, max: number) => Promise<number>
-
-export async function randomBytesAsync(size: number): Promise<Uint8Array> {
-    return toBytesView(await randomBytesAsyncImpl(size))
-}
-
 export async function randomFillAsync(
     target: Uint8Array,
     offset?: number,
@@ -36,4 +27,5 @@ export async function randomFillAsync(
     return target
 }
 
-export const randomIntAsync = randomIntAsyncImpl
+export const randomIntAsync = promisify(randomInt) as (min: number, max: number) => Promise<number>
+export const randomBytesAsync = promisify(randomBytes) as (size: number) => Promise<Uint8Array>

--- a/src/message/addon-crypto.ts
+++ b/src/message/addon-crypto.ts
@@ -104,8 +104,8 @@ export function identifyEncryptedAddon(message: Proto.IMessage): WaIdentifiedEnc
             return {
                 kind: 'reaction',
                 targetMessageKey,
-                encPayload: toBytesView(encPayload),
-                encIv: toBytesView(encIv),
+                encPayload: encPayload,
+                encIv: encIv,
                 modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.ENC_REACTION,
                 raw: message
             }
@@ -118,8 +118,8 @@ export function identifyEncryptedAddon(message: Proto.IMessage): WaIdentifiedEnc
             return {
                 kind: 'poll_vote',
                 targetMessageKey: pollCreationMessageKey,
-                encPayload: toBytesView(vote.encPayload),
-                encIv: toBytesView(vote.encIv),
+                encPayload: vote.encPayload,
+                encIv: vote.encIv,
                 modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.POLL_VOTE,
                 raw: message
             }
@@ -132,8 +132,8 @@ export function identifyEncryptedAddon(message: Proto.IMessage): WaIdentifiedEnc
             return {
                 kind: 'event_response',
                 targetMessageKey: eventCreationMessageKey,
-                encPayload: toBytesView(encPayload),
-                encIv: toBytesView(encIv),
+                encPayload: encPayload,
+                encIv: encIv,
                 modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.EVENT_RESPONSE,
                 raw: message
             }
@@ -146,8 +146,8 @@ export function identifyEncryptedAddon(message: Proto.IMessage): WaIdentifiedEnc
             return {
                 kind: 'comment',
                 targetMessageKey,
-                encPayload: toBytesView(encPayload),
-                encIv: toBytesView(encIv),
+                encPayload: encPayload,
+                encIv: encIv,
                 modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.ENC_COMMENT,
                 raw: message
             }
@@ -201,8 +201,8 @@ export async function resolveParentMessageSecret(
     try {
         const decoded = proto.Message.decode(record.messageBytes)
         const secret = decoded.messageContextInfo?.messageSecret
-        if (!secret || toBytesView(secret).byteLength !== WA_MESSAGE_SECRET_BYTES) return null
-        return { secret: toBytesView(secret), senderJid: record.senderJid ?? '' }
+        if (!secret || secret.byteLength !== WA_MESSAGE_SECRET_BYTES) return null
+        return { secret, senderJid: record.senderJid ?? '' }
     } catch {
         return null
     }

--- a/src/message/reporting-token.ts
+++ b/src/message/reporting-token.ts
@@ -1,13 +1,7 @@
 import { hkdf, hmacSign, importHmacKey } from '@crypto'
 import { proto, type Proto } from '@proto'
 import type { BinaryNode } from '@transport/types'
-import {
-    base64ToBytesChecked,
-    concatBytes,
-    EMPTY_BYTES,
-    TEXT_ENCODER,
-    toBytesView
-} from '@util/bytes'
+import { base64ToBytesChecked, concatBytes, EMPTY_BYTES, TEXT_ENCODER } from '@util/bytes'
 
 const WA_REPORTING_TOKEN_BYTES = 16
 const WA_REPORTING_TOKEN_KEY_BYTES = 32
@@ -95,7 +89,7 @@ export async function buildReportingTokenArtifacts(
     }
 
     const messageSecret = input.message.messageContextInfo?.messageSecret
-    if (!messageSecret || toBytesView(messageSecret).byteLength === 0) {
+    if (!messageSecret || messageSecret.byteLength === 0) {
         return null
     }
 
@@ -111,7 +105,7 @@ export async function buildReportingTokenArtifacts(
         stanzaId + input.senderUserJid + input.remoteJid + WA_REPORTING_TOKEN_USE_CASE
     )
     const reportingTokenKey = await hkdf(
-        toBytesView(messageSecret),
+        messageSecret,
         null,
         secretInfo,
         WA_REPORTING_TOKEN_KEY_BYTES

--- a/src/message/use-case-secret.ts
+++ b/src/message/use-case-secret.ts
@@ -29,7 +29,7 @@ export function assertMessageSecret(
 
 export async function ensureMessageSecret(message: Proto.IMessage): Promise<Proto.IMessage> {
     const messageSecret = message.messageContextInfo?.messageSecret
-    if (messageSecret && toBytesView(messageSecret).byteLength > 0) {
+    if (messageSecret && messageSecret.byteLength > 0) {
         return message
     }
 

--- a/src/signal/__tests__/encoding.test.ts
+++ b/src/signal/__tests__/encoding.test.ts
@@ -18,7 +18,6 @@ import {
     toSignalAddressParts
 } from '@signal/encoding'
 import type { SignalAddress, SignalSessionRecord } from '@signal/types'
-import { toBytesView } from '@util/bytes'
 
 function makeBytes(length: number, seed = 0): Uint8Array {
     const out = new Uint8Array(length)
@@ -193,7 +192,7 @@ test('sqlite signal helpers encode/decode sender key records and distribution ro
     assert.equal(decoded.keyId, 55)
     assert.equal(decoded.iteration, 12)
     assert.equal(decoded.unusedMessageKeys?.length, 2)
-    assert.equal(toBytesView(decoded.signingPublicKey)[0], toBytesView(record.signingPublicKey)[0])
+    assert.equal(decoded.signingPublicKey[0], record.signingPublicKey[0])
 
     const distribution = decodeSenderKeyDistributionRow({
         group_id: record.groupId,

--- a/src/signal/group/SenderKeyCodec.ts
+++ b/src/signal/group/SenderKeyCodec.ts
@@ -2,7 +2,7 @@ import { readVersionedContent, toSerializedPubKey } from '@crypto'
 import { proto } from '@proto'
 import { SIGNAL_SIGNATURE_LENGTH } from '@signal/api/constants'
 import { SIGNAL_GROUP_VERSION } from '@signal/constants'
-import { assertByteLength, toBytesView } from '@util/bytes'
+import { assertByteLength } from '@util/bytes'
 
 export function parseDistributionPayload(payload: Uint8Array): {
     readonly keyId: number
@@ -25,14 +25,13 @@ export function parseDistributionPayload(payload: Uint8Array): {
         throw new Error('invalid sender key distribution message')
     }
 
-    const chainKey = toBytesView(decoded.chainKey)
-    assertByteLength(chainKey, 32, 'sender key distribution chainKey must be 32 bytes')
+    assertByteLength(decoded.chainKey, 32, 'sender key distribution chainKey must be 32 bytes')
 
     return {
         keyId: decoded.id,
         iteration: decoded.iteration,
-        chainKey,
-        signingPublicKey: toSerializedPubKey(toBytesView(decoded.signingKey))
+        chainKey: decoded.chainKey,
+        signingPublicKey: toSerializedPubKey(decoded.signingKey)
     }
 }
 
@@ -62,7 +61,7 @@ export function parseSenderKeyMessage(versionContentMac: Uint8Array): {
     return {
         keyId: decoded.id,
         iteration: decoded.iteration,
-        ciphertext: toBytesView(decoded.ciphertext),
+        ciphertext: decoded.ciphertext,
         versionContentMac
     }
 }

--- a/src/signal/session/SignalSerializer.ts
+++ b/src/signal/session/SignalSerializer.ts
@@ -9,7 +9,6 @@ import type {
 } from '@signal/types'
 import type { WaPreKeyStore } from '@store/contracts/pre-key.store'
 import type { WaSignalStore } from '@store/contracts/signal.store'
-import { toBytesView } from '@util/bytes'
 
 export function deserializeMsg(versionContentMac: Uint8Array): ParsedSignalMessage {
     const content = readVersionedContent(versionContentMac, SIGNAL_VERSION, SIGNAL_MAC_SIZE)
@@ -25,9 +24,9 @@ export function deserializeMsg(versionContentMac: Uint8Array): ParsedSignalMessa
         throw new Error('invalid signal message')
     }
     return {
-        ratchetPubKey: toSerializedPubKey(toBytesView(parsed.ratchetKey)),
+        ratchetPubKey: toSerializedPubKey(parsed.ratchetKey),
         counter: parsed.counter,
-        ciphertext: toBytesView(parsed.ciphertext),
+        ciphertext: parsed.ciphertext,
         versionContentMac
     }
 }
@@ -50,14 +49,14 @@ export function deserializePkMsg(versionContent: Uint8Array): ParsedPreKeySignal
         throw new Error('invalid prekey signal message')
     }
 
-    const signal = deserializeMsg(toBytesView(parsed.message))
+    const signal = deserializeMsg(parsed.message)
     return {
         ...signal,
         remote: {
             regId: parsed.registrationId,
-            pubKey: toSerializedPubKey(toBytesView(parsed.identityKey))
+            pubKey: toSerializedPubKey(parsed.identityKey)
         },
-        sessionBaseKey: toSerializedPubKey(toBytesView(parsed.baseKey)),
+        sessionBaseKey: toSerializedPubKey(parsed.baseKey),
         localSignedPreKeyId: parsed.signedPreKeyId,
         localOneTimeKeyId: parsed.preKeyId ?? null
     }

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -406,6 +406,8 @@ export function createStore<B extends string>(options: WaCreateStoreOptions<B>):
             const list = Array.from(sessions.values())
             sessions.clear()
             await Promise.all(list.map((s) => s.destroy()))
+            const uniqueBackends = new Set(Object.values(backends))
+            await Promise.all(Array.from(uniqueBackends, (backend) => destroyIfSupported(backend)))
         }
     }
 }

--- a/src/transport/node/builders/prekeys.ts
+++ b/src/transport/node/builders/prekeys.ts
@@ -3,7 +3,7 @@ import { SIGNAL_KEY_BUNDLE_TYPE_BYTES } from '@signal/api/constants'
 import type { SignalMissingPreKeysTarget } from '@signal/api/SignalMissingPreKeysSyncApi'
 import type { PreKeyRecord, RegistrationInfo, SignedPreKeyRecord } from '@signal/types'
 import { buildIqNode } from '@transport/node/query'
-import { intToBytes, toBytesView } from '@util/bytes'
+import { intToBytes } from '@util/bytes'
 
 function buildSignedPreKeyNode(signedPreKey: SignedPreKeyRecord) {
     return {
@@ -18,12 +18,12 @@ function buildSignedPreKeyNode(signedPreKey: SignedPreKeyRecord) {
             {
                 tag: WA_NODE_TAGS.VALUE,
                 attrs: {},
-                content: toBytesView(signedPreKey.keyPair.pubKey)
+                content: signedPreKey.keyPair.pubKey
             },
             {
                 tag: WA_NODE_TAGS.SIGNATURE,
                 attrs: {},
-                content: toBytesView(signedPreKey.signature)
+                content: signedPreKey.signature
             }
         ]
     }
@@ -48,7 +48,7 @@ export function buildPreKeyUploadIq(
         {
             tag: WA_NODE_TAGS.IDENTITY,
             attrs: {},
-            content: toBytesView(registrationInfo.identityKeyPair.pubKey)
+            content: registrationInfo.identityKeyPair.pubKey
         },
         {
             tag: WA_NODE_TAGS.LIST,
@@ -65,7 +65,7 @@ export function buildPreKeyUploadIq(
                     {
                         tag: WA_NODE_TAGS.VALUE,
                         attrs: {},
-                        content: toBytesView(record.keyPair.pubKey)
+                        content: record.keyPair.pubKey
                     }
                 ]
             }))

--- a/src/transport/noise/WaClientPayload.ts
+++ b/src/transport/noise/WaClientPayload.ts
@@ -8,7 +8,7 @@ import type {
     WaPayloadCommonConfig,
     WaRegistrationPayloadConfig
 } from '@transport/noise/types'
-import { intToBytes, toBytesView } from '@util/bytes'
+import { intToBytes } from '@util/bytes'
 
 function parseVersion(versionBase: string): {
     primary: number
@@ -191,16 +191,14 @@ export function buildRegistrationPayload(config: WaRegistrationPayloadConfig): U
     const version = parseVersion(versionBase)
     const common = buildCommonPayload(config, version)
     const devicePairingData = {
-        buildHash: config.buildHash ? toBytesView(config.buildHash) : md5Bytes(versionBase),
-        deviceProps: config.deviceProps
-            ? toBytesView(config.deviceProps)
-            : defaultDeviceProps(versionBase, config, version),
+        buildHash: config.buildHash ?? md5Bytes(versionBase),
+        deviceProps: config.deviceProps ?? defaultDeviceProps(versionBase, config, version),
         eRegid: intToBytes(4, registrationId),
         eKeytype: intToBytes(1, 5),
-        eIdent: toBytesView(config.registrationInfo.identityKeyPair.pubKey),
+        eIdent: config.registrationInfo.identityKeyPair.pubKey,
         eSkeyId: intToBytes(3, signedPreKeyId),
-        eSkeyVal: toBytesView(config.signedPreKey.keyPair.pubKey),
-        eSkeySig: toBytesView(config.signedPreKey.signature)
+        eSkeyVal: config.signedPreKey.keyPair.pubKey,
+        eSkeySig: config.signedPreKey.signature
     }
     return proto.ClientPayload.encode({
         ...common,

--- a/src/transport/noise/WaFrameCodec.ts
+++ b/src/transport/noise/WaFrameCodec.ts
@@ -1,4 +1,4 @@
-import { EMPTY_BYTES, toBytesView } from '@util/bytes'
+import { EMPTY_BYTES } from '@util/bytes'
 
 const WA_MAX_FRAME_LENGTH = (1 << 24) - 1
 
@@ -19,7 +19,7 @@ export class WaFrameCodec {
         if (maxFrameLength >= 1 << 24) {
             throw new Error('maxFrameLength must be lower than protocol limit (16777216)')
         }
-        this.introFrame = introFrame && introFrame.length > 0 ? toBytesView(introFrame) : null
+        this.introFrame = introFrame && introFrame.length > 0 ? introFrame : null
         this.maxFrameLength = maxFrameLength
         this.introSent = false
         this.buffered = EMPTY_BYTES

--- a/src/transport/noise/WaNoiseSession.ts
+++ b/src/transport/noise/WaNoiseSession.ts
@@ -16,7 +16,7 @@ import { verifyNoiseCertificateChain } from '@transport/noise/WaNoiseCert'
 import { WaNoiseHandshake } from '@transport/noise/WaNoiseHandshake'
 import type { WaNoiseSocket } from '@transport/noise/WaNoiseSocket'
 import type { WaNoiseConfig } from '@transport/types'
-import { concatBytes, toBytesView } from '@util/bytes'
+import { concatBytes } from '@util/bytes'
 import { toError } from '@util/primitives'
 
 function resolvePayload(
@@ -25,7 +25,7 @@ function resolvePayload(
     if (payload instanceof Uint8Array) {
         return Promise.resolve(payload)
     }
-    return Promise.resolve(payload()).then((value) => toBytesView(value))
+    return Promise.resolve(payload())
 }
 
 async function resolveHandshakePayload(config: WaNoiseConfig): Promise<Uint8Array> {
@@ -91,9 +91,7 @@ export class WaNoiseSession {
             isRegistered: config.isRegistered,
             hasServerStaticKey: !!config.serverStaticKey
         })
-        const protocolHeader = config.protocolHeader
-            ? toBytesView(config.protocolHeader)
-            : WA_PROTO_HEADER
+        const protocolHeader = config.protocolHeader ?? WA_PROTO_HEADER
         const introFrame =
             config.routingInfo && config.routingInfo.length > 0
                 ? concatBytes([buildRoutingInfoPrefix(config.routingInfo), protocolHeader])
@@ -354,7 +352,7 @@ export class WaNoiseSession {
         if (!serverHello.payload) {
             throw new Error('noise resume handshake missing certificate payload')
         }
-        const serverEphemeral = toBytesView(serverHello.ephemeral)
+        const serverEphemeral = serverHello.ephemeral
         await handshake.authenticate(serverEphemeral)
 
         const [dh1, dh2] = await Promise.all([
@@ -365,7 +363,7 @@ export class WaNoiseSession {
         await handshake.mixIntoKey(dh1)
         await handshake.mixIntoKey(dh2)
 
-        await handshake.decrypt(toBytesView(serverHello.payload))
+        await handshake.decrypt(serverHello.payload)
         this.serverStaticKey = serverStaticKey
         this.logger.info('noise resume handshake successful without fallback')
         return { socket: await handshake.finish(), serverHelloFrame: null }
@@ -407,16 +405,16 @@ export class WaNoiseSession {
             throw new Error('noise full handshake missing server hello fields')
         }
 
-        const serverEphemeral = toBytesView(serverHello.ephemeral)
+        const serverEphemeral = serverHello.ephemeral
         await handshake.authenticate(serverEphemeral)
         await handshake.mixIntoKey(
             await X25519.scalarMult(ephemeralKeyPair.privKey, serverEphemeral)
         )
 
-        const serverStatic = await handshake.decrypt(toBytesView(serverHello.static))
+        const serverStatic = await handshake.decrypt(serverHello.static)
         await handshake.mixIntoKey(await X25519.scalarMult(ephemeralKeyPair.privKey, serverStatic))
 
-        const certificate = await handshake.decrypt(toBytesView(serverHello.payload))
+        const certificate = await handshake.decrypt(serverHello.payload)
         if (verifyCertificates) {
             await verifyNoiseCertificateChain(certificate, serverStatic)
             this.logger.trace('noise certificate chain verified')


### PR DESCRIPTION
- Remove toBytesView where input is already Uint8Array (proto fields, signal types, config fields)
- Add missing preKey/session/identity providers to README and example
- Destroy backends on store.destroy() via destroyIfSupported
- Use redis.quit() instead of disconnect() for graceful shutdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README example to add SQLite-backed providers for preKey, session, and identity; removed the privacyToken provider.

* **Chores / Bug Fixes**
  * Ensure Redis and store backends shut down cleanly during destroy.

* **Refactor**
  * Simplified handling of byte-array values across crypto, messaging, transport, and signal code to use raw Uint8Array inputs.
  * Reworked async random-byte/int exports to a streamlined promisified form.

* **Tests**
  * Adjusted encoding test to match updated byte-array handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->