### PR TITLE
feat: add offline resume coordinator, presence support, and incoming node improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage
 *.cpuprofile
 /test/
 .claude
+*.log

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -70,6 +70,7 @@ import type { WaSignalStore } from '@store/contracts/signal.store'
 import type { WaThreadStore } from '@store/contracts/thread.store'
 import { NOOP_MESSAGE_SECRET_STORE } from '@store/noop.store'
 import type { WaKeepAlive } from '@transport/keepalive/WaKeepAlive'
+import { buildPresenceNode } from '@transport/node/builders/presence'
 import { queryWithContext as queryNodeWithContext } from '@transport/node/query'
 import type { WaNodeOrchestrator } from '@transport/node/WaNodeOrchestrator'
 import type { WaNodeTransport } from '@transport/node/WaNodeTransport'
@@ -255,6 +256,14 @@ export class WaClient extends EventEmitter {
             }
             throw normalized
         }
+    }
+
+    public async sendPresence(type?: 'available' | 'unavailable'): Promise<void> {
+        const credentials = this.authClient.getCurrentCredentials()
+        await this.nodeOrchestrator.sendNode(
+            buildPresenceNode({ type, name: credentials?.meDisplayName ?? undefined }),
+            false
+        )
     }
 
     public async query(

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -16,6 +16,7 @@ import {
 } from '@client/coordinators/WaGroupCoordinator'
 import { WaIncomingNodeCoordinator } from '@client/coordinators/WaIncomingNodeCoordinator'
 import { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
+import { WaOfflineResumeCoordinator } from '@client/coordinators/WaOfflineResumeCoordinator'
 import { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTasksCoordinator'
 import {
     createPrivacyCoordinator,
@@ -77,6 +78,7 @@ import { createSignalSessionResolver } from '@signal/session/resolver'
 import { SignalProtocol } from '@signal/session/SignalProtocol'
 import { WaKeepAlive } from '@transport/keepalive/WaKeepAlive'
 import { buildAckNode } from '@transport/node/builders/global'
+import { buildPresenceNode } from '@transport/node/builders/presence'
 import { getFirstNodeChild } from '@transport/node/helpers'
 import { createUsyncSidGenerator } from '@transport/node/usync'
 import { WaNodeOrchestrator } from '@transport/node/WaNodeOrchestrator'
@@ -347,7 +349,14 @@ function createPassiveTasksRuntime(input: {
         takeDanglingReceipts: () => receiptQueue.take(),
         requeueDanglingReceipt: (node) => receiptQueue.enqueue(node),
         shouldQueueDanglingReceipt: (node, error) => receiptQueue.shouldQueue(node, error),
-        syncAbProps: () => abPropsCoordinator.sync()
+        syncAbProps: () => abPropsCoordinator.sync(),
+        sendPresenceAvailable: async () => {
+            const credentials = getCurrentCredentials()
+            await nodeOrchestrator.sendNode(
+                buildPresenceNode({ name: credentials?.meDisplayName ?? undefined }),
+                false
+            )
+        }
     }
 }
 
@@ -378,6 +387,8 @@ export function buildWaClientDependencies(input: {
         nodeOrchestrator,
         getComms: () => connectionManager?.getComms() ?? null,
         intervalMs: options.keepAliveIntervalMs,
+        getIntervalMs: () =>
+            abPropsCoordinator.getConfigValue<number>('heartbeat_interval_s') * 1_000,
         timeoutMs: options.deadSocketTimeoutMs,
         hostDomain: WA_DEFAULTS.HOST_DOMAIN
     })
@@ -415,7 +426,10 @@ export function buildWaClientDependencies(input: {
         defaultMaxAttempts: options.messageMaxAttempts,
         defaultRetryDelayMs: options.messageRetryDelayMs
     })
-    const senderKeyManager = new SenderKeyManager(sessionStore.senderKey)
+    const senderKeyManager = new SenderKeyManager(sessionStore.senderKey, {
+        getFutureMessagesMax: () =>
+            abPropsCoordinator.getConfigValue('web_signal_future_messages_max')
+    })
     const signalProtocol = new SignalProtocol(
         {
             signal: sessionStore.signal,
@@ -559,7 +573,15 @@ export function buildWaClientDependencies(input: {
         numBuckets: options.privacyToken?.tcTokenNumBuckets,
         senderDurationS: options.privacyToken?.tcTokenSenderDurationS,
         senderNumBuckets: options.privacyToken?.tcTokenSenderNumBuckets,
-        maxDurationS: options.privacyToken?.tcTokenMaxDurationS
+        maxDurationS: options.privacyToken?.tcTokenMaxDurationS,
+        getConfigOverrides: () => ({
+            durationS: abPropsCoordinator.getConfigValue<number>('tctoken_duration'),
+            numBuckets: abPropsCoordinator.getConfigValue<number>('tctoken_num_buckets'),
+            senderDurationS: abPropsCoordinator.getConfigValue<number>('tctoken_duration_sender'),
+            senderNumBuckets: abPropsCoordinator.getConfigValue<number>(
+                'tctoken_num_buckets_sender'
+            )
+        })
     })
 
     const abPropsCoordinator = new WaAbPropsCoordinator({
@@ -609,7 +631,8 @@ export function buildWaClientDependencies(input: {
                     message: toError(err).message
                 })
             )
-        }
+        },
+        getIcdcHashLength: () => abPropsCoordinator.getConfigValue('md_icdc_hash_length')
     })
 
     const retryCoordinator = new WaRetryCoordinator({
@@ -669,6 +692,7 @@ export function buildWaClientDependencies(input: {
     ): Promise<void> => {
         keyShareCoordinator.notifyDisconnected()
         abPropsCoordinator.reset()
+        offlineResume.reset()
         await connectionManager?.disconnect()
         runtime.emitEvent('connection', {
             status: 'close',
@@ -737,8 +761,17 @@ export function buildWaClientDependencies(input: {
             dirtyBits
         )
 
+    const offlineResume = new WaOfflineResumeCoordinator({
+        logger,
+        runtime: {
+            sendNode: (node) => nodeOrchestrator.sendNode(node, false),
+            emitOfflineResume: (event) => runtime.emitEvent('offline_resume', event)
+        }
+    })
+
     const incomingNode = new WaIncomingNodeCoordinator({
         logger,
+        offlineResume,
         runtime: createIncomingNodeRuntime({
             logger,
             emitEvent: runtime.emitEvent,

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -9,6 +9,8 @@ import { WaClient } from '@client/WaClient'
 import { buildWaClientDependencies, resolveWaClientBase } from '@client/WaClientFactory'
 import type { Logger } from '@infra/log/types'
 import { proto } from '@proto'
+import type { AbPropName } from '@protocol/abprops'
+import { WaPrivacyTokenMemoryStore } from '@store/providers/memory/privacy-token.store'
 import type { BinaryNode } from '@transport/types'
 
 function createLogger(): Logger {
@@ -361,12 +363,97 @@ test('buildWaClientDependencies wires privacy coordinator', () => {
     assert.equal(typeof dependencies.privacyCoordinator.getPrivacySettings, 'function')
 })
 
+test('buildWaClientDependencies wires trusted contact token AB prop overrides', () => {
+    const sessionStore = {
+        auth: {} as never,
+        signal: {} as never,
+        senderKey: {} as never,
+        appState: {} as never,
+        messages: {} as never,
+        threads: {} as never,
+        contacts: {} as never,
+        retry: {} as never,
+        participants: {} as never,
+        deviceList: {} as never,
+        privacyToken: new WaPrivacyTokenMemoryStore()
+    }
+    const options = {
+        store: {
+            session: () => sessionStore
+        },
+        sessionId: 'session'
+    } as unknown as WaClientOptions
+
+    const base = resolveWaClientBase(options, createLogger())
+    const runtime = {
+        sendNode: async (_node: BinaryNode) => undefined,
+        query: async (_node: BinaryNode) =>
+            ({ tag: 'iq', attrs: { type: 'result' } }) as BinaryNode,
+        queryWithContext: async (_context: string, _node: BinaryNode) =>
+            ({ tag: 'iq', attrs: { type: 'result' } }) as BinaryNode,
+        syncAppState: async () => undefined,
+        syncAppStateWithOptions: async () => ({ collections: [] }) as never,
+        emitEvent: (() => undefined) as never,
+        handleIncomingMessageEvent: async () => undefined,
+        handleError: (_error: Error) => undefined,
+        handleIncomingFrame: async (_frame: Uint8Array) => undefined,
+        clearStoredState: async () => undefined,
+        resumeIncomingEvents: () => undefined
+    }
+
+    const dependencies = buildWaClientDependencies({ base, runtime })
+    const originalGetConfigValue = dependencies.abPropsCoordinator.getConfigValue.bind(
+        dependencies.abPropsCoordinator
+    )
+    dependencies.abPropsCoordinator.getConfigValue = ((name: AbPropName) => {
+        switch (name) {
+            case 'tctoken_duration':
+                return 60 as never
+            case 'tctoken_num_buckets':
+                return 2 as never
+            case 'tctoken_duration_sender':
+                return 120 as never
+            case 'tctoken_num_buckets_sender':
+                return 4 as never
+            default:
+                return originalGetConfigValue(name as never)
+        }
+    }) as never
+
+    const config = (
+        dependencies.trustedContactToken as unknown as {
+            resolveConfig(): {
+                readonly durationS: number
+                readonly numBuckets: number
+                readonly senderDurationS: number
+                readonly senderNumBuckets: number
+            }
+        }
+    ).resolveConfig()
+
+    assert.equal(config.durationS, 60)
+    assert.equal(config.numBuckets, 2)
+    assert.equal(config.senderDurationS, 120)
+    assert.equal(config.senderNumBuckets, 4)
+})
+
 function getClearStoredStateMethod() {
     return (
         WaClient.prototype as unknown as {
             readonly clearStoredState: (this: unknown) => Promise<void>
         }
     ).clearStoredState
+}
+
+function getSendPresenceMethod() {
+    return (
+        WaClient.prototype as unknown as {
+            readonly sendPresence: (
+                this: unknown,
+                type?: 'available' | 'unavailable'
+            ) => Promise<void>
+        }
+    ).sendPresence
 }
 
 function getCoordinatorGetterMethod(name: 'chat' | 'group' | 'privacy') {
@@ -502,6 +589,39 @@ test('clearStoredState clears every store domain by default', async () => {
         'senderKey',
         'threads',
         'privacyToken'
+    ])
+})
+
+test('WaClient.sendPresence sends a presence node without auto-generated id', async () => {
+    const calls: Array<{ readonly node: BinaryNode; readonly autoId: boolean | undefined }> = []
+
+    await getSendPresenceMethod().call(
+        {
+            authClient: {
+                getCurrentCredentials: () => ({
+                    meDisplayName: 'Vinicius'
+                })
+            },
+            nodeOrchestrator: {
+                sendNode: async (node: BinaryNode, autoId?: boolean) => {
+                    calls.push({ node, autoId })
+                }
+            }
+        },
+        'available'
+    )
+
+    assert.deepEqual(calls, [
+        {
+            node: {
+                tag: 'presence',
+                attrs: {
+                    type: 'available',
+                    name: 'Vinicius'
+                }
+            },
+            autoId: false
+        }
     ])
 })
 

--- a/src/client/coordinators/WaIncomingNodeCoordinator.ts
+++ b/src/client/coordinators/WaIncomingNodeCoordinator.ts
@@ -1,4 +1,5 @@
 import type { WaSuccessPersistAttributes } from '@auth/types'
+import type { WaOfflineResumeCoordinator } from '@client/coordinators/WaOfflineResumeCoordinator'
 import type { WaDirtyBit } from '@client/dirty'
 import {
     createIncomingBaseEvent,
@@ -34,6 +35,7 @@ import type { WaConnectionCode, WaDisconnectReason } from '@protocol/stream'
 import {
     decodeNodeContentBase64OrBytes,
     findNodeChild,
+    getNodeChildren,
     getNodeChildrenByTag
 } from '@transport/node/helpers'
 import {
@@ -85,9 +87,10 @@ interface WaIncomingNodeRuntime {
 interface WaIncomingNodeCoordinatorOptions {
     readonly logger: Logger
     readonly runtime: WaIncomingNodeRuntime
+    readonly offlineResume: WaOfflineResumeCoordinator
 }
 
-const INFO_BULLETIN_NOTIFICATION_TYPES = new Set<string>([
+const INFO_BULLETIN_CHILD_TAGS = new Set<string>([
     'offline',
     'offline_preview',
     'priority_offline_complete',
@@ -99,6 +102,7 @@ const INFO_BULLETIN_NOTIFICATION_TYPES = new Set<string>([
 export class WaIncomingNodeCoordinator {
     private readonly logger: Logger
     private readonly runtime: WaIncomingNodeRuntime
+    private readonly offlineResume: WaOfflineResumeCoordinator
     private readonly nodeHandlerRegistry: Map<
         string,
         { readonly subtype?: string; readonly handler: WaIncomingNodeHandler }[]
@@ -108,6 +112,7 @@ export class WaIncomingNodeCoordinator {
     public constructor(options: WaIncomingNodeCoordinatorOptions) {
         this.logger = options.logger
         this.runtime = options.runtime
+        this.offlineResume = options.offlineResume
         this.nodeHandlerRegistry = new Map()
         this.registerDefaultIncomingHandlers()
         this.mediaConnWarmupPromise = null
@@ -119,6 +124,9 @@ export class WaIncomingNodeCoordinator {
             id: node.attrs.id,
             type: node.attrs.type
         })
+        if (node.attrs.offline !== undefined) {
+            this.offlineResume.trackOfflineStanza()
+        }
         const streamControlResult = parseStreamControlNode(node)
         if (streamControlResult) {
             await this.runtime.handleStreamControlResult(streamControlResult)
@@ -372,15 +380,28 @@ export class WaIncomingNodeCoordinator {
         }
         let handled = false
 
-        const ibType = node.attrs.type
-        if (ibType && INFO_BULLETIN_NOTIFICATION_TYPES.has(ibType)) {
-            this.runtime.emitIncomingNotification(
-                createInfoBulletinNotificationEvent(node, ibType, {
-                    count: parseOptionalInt(node.attrs.count),
-                    t: parseOptionalInt(node.attrs.t)
-                })
-            )
-            handled = true
+        const children = getNodeChildren(node)
+        for (const child of children) {
+            if (INFO_BULLETIN_CHILD_TAGS.has(child.tag)) {
+                this.runtime.emitIncomingNotification(
+                    createInfoBulletinNotificationEvent(node, child.tag, {
+                        count: parseOptionalInt(child.attrs.count),
+                        message: parseOptionalInt(child.attrs.message),
+                        receipt: parseOptionalInt(child.attrs.receipt),
+                        notification: parseOptionalInt(child.attrs.notification),
+                        t: parseOptionalInt(child.attrs.t)
+                    })
+                )
+                if (child.tag === 'offline_preview') {
+                    this.offlineResume.handleOfflinePreview(
+                        parseOptionalInt(child.attrs.message) ?? 0
+                    )
+                }
+                if (child.tag === 'offline') {
+                    this.offlineResume.handleOfflineComplete()
+                }
+                handled = true
+            }
         }
 
         const edgeRoutingNode = findNodeChild(node, WA_NODE_TAGS.EDGE_ROUTING)

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -86,6 +86,7 @@ interface WaMessageDispatchCoordinatorOptions {
     readonly getCurrentSignedIdentity: () => Proto.IADVSignedDeviceIdentity | null | undefined
     readonly resolvePrivacyTokenNode: (recipientJid: string) => Promise<BinaryNode | null>
     readonly onDirectMessageSent: (recipientJid: string) => void
+    readonly getIcdcHashLength?: () => number
 }
 
 type GroupAddressingMode = 'pn' | 'lid'
@@ -120,6 +121,7 @@ export class WaMessageDispatchCoordinator {
         | undefined
     private readonly resolvePrivacyTokenNode: (recipientJid: string) => Promise<BinaryNode | null>
     private readonly onDirectMessageSent: (recipientJid: string) => void
+    private readonly getIcdcHashLength: (() => number) | undefined
     private readonly icdcDedup = new PromiseDedup()
     private readonly privacyTokenDedup = new PromiseDedup()
     private readonly distributionDedup = new PromiseDedup()
@@ -145,6 +147,7 @@ export class WaMessageDispatchCoordinator {
         this.getCurrentSignedIdentity = options.getCurrentSignedIdentity
         this.resolvePrivacyTokenNode = options.resolvePrivacyTokenNode
         this.onDirectMessageSent = options.onDirectMessageSent
+        this.getIcdcHashLength = options.getIcdcHashLength
     }
 
     public async publishMessageNode(
@@ -1216,7 +1219,8 @@ export class WaMessageDispatchCoordinator {
                     snapshot.deviceJids,
                     this.identityStore,
                     snapshot.updatedAtMs,
-                    localIdentity
+                    localIdentity,
+                    this.getIcdcHashLength?.()
                 )
             } catch (error) {
                 this.logger.trace('icdc resolution failed', {

--- a/src/client/coordinators/WaOfflineResumeCoordinator.ts
+++ b/src/client/coordinators/WaOfflineResumeCoordinator.ts
@@ -1,0 +1,176 @@
+import type { WaOfflineResumeEvent } from '@client/types'
+import type { Logger } from '@infra/log/types'
+import { buildOfflineBatchNode } from '@transport/node/builders/offline'
+import type { BinaryNode } from '@transport/types'
+import { toError } from '@util/primitives'
+
+const WA_OFFLINE_RESUME = Object.freeze({
+    BATCH_SIZE: 200,
+    BATCH_DEBOUNCE_MS: 100,
+    STANZA_TIMEOUT_MS: 60_000
+} as const)
+
+const WA_OFFLINE_RESUME_STATE = Object.freeze({
+    INIT: 'init',
+    RESUMING: 'resuming',
+    COMPLETE: 'complete'
+} as const)
+
+type WaOfflineResumeState = (typeof WA_OFFLINE_RESUME_STATE)[keyof typeof WA_OFFLINE_RESUME_STATE]
+
+interface WaOfflineResumeRuntime {
+    readonly sendNode: (node: BinaryNode) => Promise<void>
+    readonly emitOfflineResume: (event: WaOfflineResumeEvent) => void
+}
+
+interface WaOfflineResumeCoordinatorOptions {
+    readonly logger: Logger
+    readonly runtime: WaOfflineResumeRuntime
+}
+
+export class WaOfflineResumeCoordinator {
+    private readonly logger: Logger
+    private readonly runtime: WaOfflineResumeRuntime
+    private state: WaOfflineResumeState
+    private totalMessages: number
+    private pendingMessages: number
+    private batchInFlight: boolean
+    private batchDebounce: ReturnType<typeof setTimeout> | null
+    private stanzaTimeout: ReturnType<typeof setTimeout> | null
+
+    public constructor(options: WaOfflineResumeCoordinatorOptions) {
+        this.logger = options.logger
+        this.runtime = options.runtime
+        this.state = WA_OFFLINE_RESUME_STATE.INIT
+        this.totalMessages = 0
+        this.pendingMessages = 0
+        this.batchInFlight = false
+        this.batchDebounce = null
+        this.stanzaTimeout = null
+    }
+
+    public get isComplete(): boolean {
+        return this.state === WA_OFFLINE_RESUME_STATE.COMPLETE
+    }
+
+    public get isResuming(): boolean {
+        return this.state === WA_OFFLINE_RESUME_STATE.RESUMING
+    }
+
+    public handleOfflinePreview(messageCount: number): void {
+        this.clearTimers()
+        this.state = WA_OFFLINE_RESUME_STATE.RESUMING
+        this.totalMessages = messageCount
+        this.pendingMessages = messageCount
+        this.batchInFlight = false
+        this.logger.info('offline resume started', {
+            totalMessages: messageCount
+        })
+        this.runtime.emitOfflineResume({
+            status: 'resuming',
+            totalMessages: messageCount,
+            remainingMessages: messageCount,
+            forced: false
+        })
+        this.resetBatchDebounce()
+        this.resetStanzaTimeout()
+    }
+
+    public handleOfflineComplete(): void {
+        if (this.state !== WA_OFFLINE_RESUME_STATE.RESUMING) {
+            return
+        }
+        this.completeResume(false)
+    }
+
+    public trackOfflineStanza(): void {
+        if (this.state !== WA_OFFLINE_RESUME_STATE.RESUMING) {
+            return
+        }
+        this.pendingMessages = Math.max(0, this.pendingMessages - 1)
+        this.resetBatchDebounce()
+        this.resetStanzaTimeout()
+    }
+
+    public reset(): void {
+        this.clearTimers()
+        this.state = WA_OFFLINE_RESUME_STATE.INIT
+        this.totalMessages = 0
+        this.pendingMessages = 0
+        this.batchInFlight = false
+    }
+
+    private completeResume(forced: boolean): void {
+        this.clearTimers()
+        this.state = WA_OFFLINE_RESUME_STATE.COMPLETE
+        this.logger.info('offline resume complete', {
+            totalMessages: this.totalMessages,
+            remainingMessages: this.pendingMessages,
+            forced
+        })
+        this.runtime.emitOfflineResume({
+            status: 'complete',
+            totalMessages: this.totalMessages,
+            remainingMessages: this.pendingMessages,
+            forced
+        })
+    }
+
+    private resetBatchDebounce(): void {
+        if (this.batchDebounce !== null) {
+            clearTimeout(this.batchDebounce)
+        }
+        this.batchDebounce = setTimeout(() => {
+            this.batchDebounce = null
+            if (this.state === WA_OFFLINE_RESUME_STATE.RESUMING && !this.batchInFlight) {
+                void this.sendOfflineBatch()
+            }
+        }, WA_OFFLINE_RESUME.BATCH_DEBOUNCE_MS)
+    }
+
+    private async sendOfflineBatch(): Promise<void> {
+        if (this.state !== WA_OFFLINE_RESUME_STATE.RESUMING || this.batchInFlight) {
+            return
+        }
+        this.batchInFlight = true
+        try {
+            await this.runtime.sendNode(buildOfflineBatchNode(WA_OFFLINE_RESUME.BATCH_SIZE))
+            this.logger.debug('sent offline batch request', {
+                pending: this.pendingMessages
+            })
+        } catch (err: unknown) {
+            this.logger.warn('offline batch request failed', {
+                message: toError(err).message
+            })
+        } finally {
+            this.batchInFlight = false
+        }
+    }
+
+    private resetStanzaTimeout(): void {
+        if (this.stanzaTimeout !== null) {
+            clearTimeout(this.stanzaTimeout)
+        }
+        this.stanzaTimeout = setTimeout(() => {
+            this.stanzaTimeout = null
+            if (this.state === WA_OFFLINE_RESUME_STATE.RESUMING) {
+                this.logger.warn('offline resume forced complete due to stanza timeout', {
+                    totalMessages: this.totalMessages,
+                    remainingMessages: this.pendingMessages
+                })
+                this.completeResume(true)
+            }
+        }, WA_OFFLINE_RESUME.STANZA_TIMEOUT_MS)
+    }
+
+    private clearTimers(): void {
+        if (this.batchDebounce !== null) {
+            clearTimeout(this.batchDebounce)
+            this.batchDebounce = null
+        }
+        if (this.stanzaTimeout !== null) {
+            clearTimeout(this.stanzaTimeout)
+            this.stanzaTimeout = null
+        }
+    }
+}

--- a/src/client/coordinators/WaPassiveTasksCoordinator.ts
+++ b/src/client/coordinators/WaPassiveTasksCoordinator.ts
@@ -32,6 +32,7 @@ type WaPassiveTasksRuntime = {
     readonly requeueDanglingReceipt: (node: BinaryNode) => void
     readonly shouldQueueDanglingReceipt: (node: BinaryNode, error: Error) => boolean
     readonly syncAbProps: () => void
+    readonly sendPresenceAvailable: () => Promise<void>
 }
 
 export class WaPassiveTasksCoordinator {
@@ -112,6 +113,12 @@ export class WaPassiveTasksCoordinator {
         }
 
         this.runtime.syncAbProps()
+
+        await this.runtime.sendPresenceAvailable().catch((error) => {
+            this.logger.warn('presence available send failed', {
+                message: toError(error).message
+            })
+        })
 
         const [registrationInfo, signedPreKey, serverHasPreKeys, signedPreKeyRotationTs] =
             await Promise.all([

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -62,7 +62,7 @@ interface RetryDecryptFailurePreparation {
     readonly registrationId: number
     readonly retryCount: number
     readonly retryKeys?: WaRetryKeyBundle
-    readonly retryReason: number
+    readonly retryReason: number | undefined
     readonly timestamp: string
 }
 

--- a/src/client/coordinators/WaTrustedContactTokenCoordinator.ts
+++ b/src/client/coordinators/WaTrustedContactTokenCoordinator.ts
@@ -42,7 +42,8 @@ export class WaTrustedContactTokenCoordinator {
     private readonly logger: Logger
     private readonly store: WaPrivacyTokenStore
     private readonly runtime: WaTrustedContactTokenRuntime
-    private readonly config: WaTrustedContactTokenConfig
+    private readonly baseConfig: WaTrustedContactTokenConfig
+    private readonly getConfigOverrides: (() => Partial<WaTrustedContactTokenConfig>) | undefined
     private readonly csTokenGenerator: CsTokenGenerator
     private readonly senderTokenDedup: PromiseDedup
     private cachedNctSalt: Uint8Array | null
@@ -57,12 +58,13 @@ export class WaTrustedContactTokenCoordinator {
         readonly senderDurationS?: number
         readonly senderNumBuckets?: number
         readonly maxDurationS?: number
+        readonly getConfigOverrides?: () => Partial<WaTrustedContactTokenConfig>
     }) {
         this.logger = options.logger
         this.store = options.store
         this.runtime = options.runtime
         const maxDurationS = options.maxDurationS ?? WA_TC_TOKEN_DEFAULTS.MAX_DURATION_S
-        this.config = {
+        this.baseConfig = {
             durationS: clampDuration(
                 options.durationS ?? WA_TC_TOKEN_DEFAULTS.DURATION_S,
                 maxDurationS
@@ -75,24 +77,44 @@ export class WaTrustedContactTokenCoordinator {
             senderNumBuckets: options.senderNumBuckets ?? WA_TC_TOKEN_DEFAULTS.SENDER_NUM_BUCKETS,
             maxDurationS
         }
+        this.getConfigOverrides = options.getConfigOverrides
         this.csTokenGenerator = new CsTokenGenerator()
         this.senderTokenDedup = new PromiseDedup()
         this.cachedNctSalt = null
         this.nctSaltHydrated = false
     }
 
+    private resolveConfig(): WaTrustedContactTokenConfig {
+        const overrides = this.getConfigOverrides?.()
+        if (!overrides) {
+            return this.baseConfig
+        }
+        const maxDurationS = overrides.maxDurationS ?? this.baseConfig.maxDurationS
+        return {
+            durationS: clampDuration(overrides.durationS ?? this.baseConfig.durationS, maxDurationS),
+            numBuckets: overrides.numBuckets ?? this.baseConfig.numBuckets,
+            senderDurationS: clampDuration(
+                overrides.senderDurationS ?? this.baseConfig.senderDurationS,
+                maxDurationS
+            ),
+            senderNumBuckets: overrides.senderNumBuckets ?? this.baseConfig.senderNumBuckets,
+            maxDurationS
+        }
+    }
+
     public async resolveTokenForMessage(recipientJid: string): Promise<BinaryNode | null> {
         const record = await this.store.getByJid(recipientJid)
         const nowS = Math.floor(Date.now() / 1000)
 
+        const config = this.resolveConfig()
         if (
             record?.tcToken &&
             record.tcTokenTimestamp !== undefined &&
             !isTokenExpired(
                 record.tcTokenTimestamp,
                 nowS,
-                this.config.durationS,
-                this.config.numBuckets
+                config.durationS,
+                config.numBuckets
             )
         ) {
             return buildTcTokenMessageNode(record.tcToken)
@@ -144,8 +166,15 @@ export class WaTrustedContactTokenCoordinator {
             const record = await this.store.getByJid(recipientJid)
             const senderTimestampS = record?.tcTokenSenderTimestamp
 
+            const config = this.resolveConfig()
             if (senderTimestampS !== undefined && senderTimestampS > 0) {
-                if (!shouldSendNewToken(senderTimestampS, nowS, this.config.senderDurationS)) {
+                if (
+                    !shouldSendNewToken(
+                        senderTimestampS,
+                        nowS,
+                        config.senderDurationS
+                    )
+                ) {
                     return
                 }
             }
@@ -166,12 +195,13 @@ export class WaTrustedContactTokenCoordinator {
         }
 
         const nowS = Math.floor(Date.now() / 1000)
+        const config = this.resolveConfig()
         if (
             isTokenExpired(
                 record.tcTokenSenderTimestamp,
                 nowS,
-                this.config.senderDurationS,
-                this.config.senderNumBuckets
+                config.senderDurationS,
+                config.senderNumBuckets
             )
         ) {
             return

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -149,7 +149,15 @@ test('incoming node coordinator supports dynamic handler registration and unregi
     const { runtime, unhandled } = createIncomingRuntime()
     const coordinator = new WaIncomingNodeCoordinator({
         logger: createLogger(),
-        runtime
+        runtime,
+        offlineResume: {
+            trackOfflineStanza() {},
+            handleOfflinePreview() {},
+            handleOfflineComplete() {},
+            reset() {},
+            isComplete: false,
+            isResuming: false
+        } as never
     })
 
     let handledCount = 0
@@ -170,6 +178,165 @@ test('incoming node coordinator supports dynamic handler registration and unregi
     await coordinator.handleIncomingNode({ tag: 'custom', attrs: {} })
     assert.equal(handledCount, 1)
     assert.equal(unhandled.length, 1)
+})
+
+test('incoming node coordinator tracks offline stanzas before dispatching handlers', async () => {
+    const { runtime, unhandled } = createIncomingRuntime()
+    let trackedStanzas = 0
+    const coordinator = new WaIncomingNodeCoordinator({
+        logger: createLogger(),
+        runtime,
+        offlineResume: {
+            trackOfflineStanza() {
+                trackedStanzas += 1
+            },
+            handleOfflinePreview() {},
+            handleOfflineComplete() {},
+            reset() {},
+            isComplete: false,
+            isResuming: false
+        } as never
+    })
+
+    await coordinator.handleIncomingNode({
+        tag: 'custom',
+        attrs: { offline: '1' }
+    })
+
+    assert.equal(trackedStanzas, 1)
+    assert.equal(unhandled.length, 1)
+})
+
+test('incoming node coordinator emits info bulletin notifications and forwards offline resume hooks', async () => {
+    const notifications: unknown[] = []
+    const { runtime: baseRuntime } = createIncomingRuntime()
+    const runtime = {
+        ...baseRuntime,
+        emitIncomingNotification: (event: unknown) => {
+            notifications.push(event)
+        }
+    }
+
+    const previewCounts: number[] = []
+    let offlineCompleteCalls = 0
+    const coordinator = new WaIncomingNodeCoordinator({
+        logger: createLogger(),
+        runtime,
+        offlineResume: {
+            trackOfflineStanza() {},
+            handleOfflinePreview(messageCount: number) {
+                previewCounts.push(messageCount)
+            },
+            handleOfflineComplete() {
+                offlineCompleteCalls += 1
+            },
+            reset() {},
+            isComplete: false,
+            isResuming: false
+        } as never
+    })
+
+    await coordinator.handleIncomingNode({
+        tag: 'ib',
+        attrs: {
+            id: 'ib-1',
+            from: 's.whatsapp.net'
+        },
+        content: [
+            {
+                tag: 'offline_preview',
+                attrs: {
+                    count: '1',
+                    message: '3',
+                    t: '123'
+                }
+            },
+            {
+                tag: 'offline',
+                attrs: {
+                    count: '3'
+                }
+            }
+        ]
+    })
+
+    assert.deepEqual(previewCounts, [3])
+    assert.equal(offlineCompleteCalls, 1)
+    assert.equal(notifications.length, 2)
+    assert.deepEqual(notifications[0], {
+        rawNode: {
+            tag: 'ib',
+            attrs: {
+                id: 'ib-1',
+                from: 's.whatsapp.net'
+            },
+            content: [
+                {
+                    tag: 'offline_preview',
+                    attrs: {
+                        count: '1',
+                        message: '3',
+                        t: '123'
+                    }
+                },
+                {
+                    tag: 'offline',
+                    attrs: {
+                        count: '3'
+                    }
+                }
+            ]
+        },
+        stanzaId: 'ib-1',
+        chatJid: 's.whatsapp.net',
+        stanzaType: undefined,
+        notificationType: 'ib.offline_preview',
+        classification: 'info_bulletin',
+        details: {
+            count: 1,
+            message: 3,
+            receipt: undefined,
+            notification: undefined,
+            t: 123
+        }
+    })
+    assert.deepEqual(notifications[1], {
+        rawNode: {
+            tag: 'ib',
+            attrs: {
+                id: 'ib-1',
+                from: 's.whatsapp.net'
+            },
+            content: [
+                {
+                    tag: 'offline_preview',
+                    attrs: {
+                        count: '1',
+                        message: '3',
+                        t: '123'
+                    }
+                },
+                {
+                    tag: 'offline',
+                    attrs: {
+                        count: '3'
+                    }
+                }
+            ]
+        },
+        stanzaId: 'ib-1',
+        chatJid: 's.whatsapp.net',
+        stanzaType: undefined,
+        notificationType: 'ib.offline',
+        classification: 'info_bulletin',
+        details: {
+            count: 3,
+            message: undefined,
+            receipt: undefined,
+            notification: undefined,
+            t: undefined
+        }
+    })
 })
 
 test('stream control handler runs force-login and resume flows', async () => {
@@ -926,7 +1093,8 @@ function createPassiveTasksCoordinator(overrides: {
             requeueDanglingReceipt:
                 overrides.requeueDanglingReceipt ?? ((node) => requeued.push(node)),
             shouldQueueDanglingReceipt: overrides.shouldQueueDanglingReceipt ?? (() => true),
-            syncAbProps: () => undefined
+            syncAbProps: () => undefined,
+            sendPresenceAvailable: async () => undefined
         }
     })
 }

--- a/src/client/coordinators/__tests__/offline-resume-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/offline-resume-coordinator.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { WaOfflineResumeCoordinator } from '@client/coordinators/WaOfflineResumeCoordinator'
+import type { WaOfflineResumeEvent } from '@client/types'
+import type { Logger } from '@infra/log/types'
+import { buildOfflineBatchNode } from '@transport/node/builders/offline'
+import type { BinaryNode } from '@transport/types'
+
+function createLogger(): Logger {
+    return {
+        level: 'trace',
+        trace: () => undefined,
+        debug: () => undefined,
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined
+    }
+}
+
+async function flushMicrotasks(): Promise<void> {
+    await Promise.resolve()
+    await Promise.resolve()
+}
+
+test('offline resume coordinator emits preview event and requests offline batches', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    const sentNodes: BinaryNode[] = []
+    const emittedEvents: WaOfflineResumeEvent[] = []
+    const coordinator = new WaOfflineResumeCoordinator({
+        logger: createLogger(),
+        runtime: {
+            sendNode: async (node) => {
+                sentNodes.push(node)
+            },
+            emitOfflineResume: (event) => {
+                emittedEvents.push(event)
+            }
+        }
+    })
+
+    coordinator.handleOfflinePreview(3)
+
+    assert.equal(coordinator.isResuming, true)
+    assert.deepEqual(emittedEvents, [
+        {
+            status: 'resuming',
+            totalMessages: 3,
+            remainingMessages: 3,
+            forced: false
+        }
+    ])
+
+    t.mock.timers.tick(100)
+    await flushMicrotasks()
+
+    assert.deepEqual(sentNodes, [buildOfflineBatchNode(200)])
+})
+
+test('offline resume coordinator decrements pending messages and force completes on timeout', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    const emittedEvents: WaOfflineResumeEvent[] = []
+    const coordinator = new WaOfflineResumeCoordinator({
+        logger: createLogger(),
+        runtime: {
+            sendNode: async () => undefined,
+            emitOfflineResume: (event) => {
+                emittedEvents.push(event)
+            }
+        }
+    })
+
+    coordinator.handleOfflinePreview(2)
+    coordinator.trackOfflineStanza()
+    t.mock.timers.tick(60_000)
+    await flushMicrotasks()
+
+    assert.equal(coordinator.isComplete, true)
+    assert.deepEqual(emittedEvents[1], {
+        status: 'complete',
+        totalMessages: 2,
+        remainingMessages: 1,
+        forced: true
+    })
+})
+
+test('offline resume coordinator completes when offline completion bulletin arrives', () => {
+    const emittedEvents: WaOfflineResumeEvent[] = []
+    const coordinator = new WaOfflineResumeCoordinator({
+        logger: createLogger(),
+        runtime: {
+            sendNode: async () => undefined,
+            emitOfflineResume: (event) => {
+                emittedEvents.push(event)
+            }
+        }
+    })
+
+    coordinator.handleOfflinePreview(1)
+    coordinator.trackOfflineStanza()
+    coordinator.handleOfflineComplete()
+
+    assert.equal(coordinator.isComplete, true)
+    assert.deepEqual(emittedEvents[1], {
+        status: 'complete',
+        totalMessages: 1,
+        remainingMessages: 0,
+        forced: false
+    })
+})

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -384,6 +384,14 @@ export interface WaClientEventMap {
     readonly chat_event: (event: WaChatEvent) => void
     readonly history_sync_chunk: (event: WaHistorySyncChunkEvent) => void
     readonly privacy_token_update: (event: WaPrivacyTokenUpdateEvent) => void
+    readonly offline_resume: (event: WaOfflineResumeEvent) => void
+}
+
+export interface WaOfflineResumeEvent {
+    readonly status: 'resuming' | 'complete'
+    readonly totalMessages: number
+    readonly remainingMessages: number
+    readonly forced: boolean
 }
 
 export interface WaPrivacyTokenUpdateEvent {

--- a/src/message/__tests__/incoming.test.ts
+++ b/src/message/__tests__/incoming.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { Logger } from '@infra/log/types'
+import { handleIncomingMessageAck } from '@message/incoming'
+import type { BinaryNode } from '@transport/types'
+
+function createLogger(): Logger {
+    return {
+        level: 'trace',
+        trace: () => undefined,
+        debug: () => undefined,
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined
+    }
+}
+
+function createEncryptedMessageNode(): BinaryNode {
+    return {
+        tag: 'message',
+        attrs: {
+            id: 'msg-1',
+            from: '551100000000@s.whatsapp.net',
+            t: '123'
+        },
+        content: [
+            {
+                tag: 'enc',
+                attrs: {
+                    type: 'msg'
+                },
+                content: new Uint8Array([1, 2, 3])
+            }
+        ]
+    }
+}
+
+test('incoming message ack suppresses standard receipt when decrypt failure is delegated', async () => {
+    const sentNodes: BinaryNode[] = []
+    const decryptFailures: Array<{
+        readonly context: {
+            readonly messageNode: BinaryNode
+            readonly stanzaId: string
+            readonly from: string
+            readonly participant?: string
+            readonly recipient?: string
+            readonly t?: string
+        }
+        readonly error: unknown
+    }> = []
+
+    const handled = await handleIncomingMessageAck(createEncryptedMessageNode(), {
+        logger: createLogger(),
+        sendNode: async (node) => {
+            sentNodes.push(node)
+        },
+        signalProtocol: {
+            decryptMessage: async () => {
+                throw new Error('decrypt failed')
+            }
+        } as never,
+        onDecryptFailure: async (context, error) => {
+            decryptFailures.push({ context, error })
+            return true
+        }
+    })
+
+    assert.equal(handled, true)
+    assert.equal(decryptFailures.length, 1)
+    assert.deepEqual(decryptFailures[0].context.messageNode, createEncryptedMessageNode())
+    assert.equal(decryptFailures[0].context.stanzaId, 'msg-1')
+    assert.equal(decryptFailures[0].context.from, '551100000000@s.whatsapp.net')
+    assert.equal(decryptFailures[0].context.t, '123')
+    assert.match((decryptFailures[0].error as Error).message, /decrypt failed/)
+    assert.equal(sentNodes.length, 0)
+})
+
+test('incoming message ack falls back to retry receipt when decrypt fails', async () => {
+    const sentNodes: BinaryNode[] = []
+
+    const handled = await handleIncomingMessageAck(createEncryptedMessageNode(), {
+        logger: createLogger(),
+        sendNode: async (node) => {
+            sentNodes.push(node)
+        },
+        signalProtocol: {
+            decryptMessage: async () => {
+                throw new Error('decrypt failed')
+            }
+        } as never
+    })
+
+    assert.equal(handled, true)
+    assert.equal(sentNodes.length, 1)
+    assert.equal(sentNodes[0].tag, 'receipt')
+    assert.equal(sentNodes[0].attrs.id, 'msg-1')
+    assert.equal(sentNodes[0].attrs.to, '551100000000@s.whatsapp.net')
+    assert.equal(sentNodes[0].attrs.type, 'retry')
+})

--- a/src/message/icdc.ts
+++ b/src/message/icdc.ts
@@ -5,10 +5,9 @@ import type { SignalAddress } from '@signal/types'
 import type { WaIdentityStore } from '@store/contracts/identity.store'
 import { concatBytes } from '@util/bytes'
 
-const ICDC_HASH_LENGTH = 8
+const ICDC_DEFAULT_HASH_LENGTH = 8
 const ICDC_FRESHNESS_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1_000
 const DEVICE_LIST_METADATA_VERSION = 2
-const EMPTY_KEY_HASH = new Uint8Array(ICDC_HASH_LENGTH)
 
 export interface IcdcMeta {
     readonly keyHash: Uint8Array
@@ -16,10 +15,12 @@ export interface IcdcMeta {
 }
 
 export async function computeDeviceKeyHash(
-    identityKeys: readonly Uint8Array[]
+    identityKeys: readonly Uint8Array[],
+    hashLength?: number
 ): Promise<Uint8Array> {
+    const length = hashLength ?? ICDC_DEFAULT_HASH_LENGTH
     if (identityKeys.length === 0) {
-        return EMPTY_KEY_HASH
+        return new Uint8Array(length)
     }
     const rawKeys: Uint8Array[] = new Array(identityKeys.length)
     for (let i = 0; i < identityKeys.length; i += 1) {
@@ -28,14 +29,15 @@ export async function computeDeviceKeyHash(
     }
     const combined = concatBytes(rawKeys)
     const hash = await sha256(combined)
-    return hash.subarray(0, ICDC_HASH_LENGTH)
+    return hash.subarray(0, length)
 }
 
 export async function resolveIcdcMeta(
     deviceJids: readonly string[],
     identityStore: WaIdentityStore,
     updatedAtMs: number | undefined,
-    localIdentity?: { readonly address: SignalAddress; readonly pubKey: Uint8Array }
+    localIdentity?: { readonly address: SignalAddress; readonly pubKey: Uint8Array },
+    hashLength?: number
 ): Promise<IcdcMeta | null> {
     if (deviceJids.length === 0) {
         return null
@@ -61,7 +63,7 @@ export async function resolveIcdcMeta(
     if (keys.length === 0) {
         return null
     }
-    const keyHash = await computeDeviceKeyHash(keys)
+    const keyHash = await computeDeviceKeyHash(keys, hashLength)
     const timestamp =
         updatedAtMs !== undefined && Date.now() - updatedAtMs < ICDC_FRESHNESS_THRESHOLD_MS
             ? Math.floor(updatedAtMs / 1_000)

--- a/src/message/incoming.ts
+++ b/src/message/incoming.ts
@@ -371,12 +371,13 @@ export async function handleIncomingMessageAck(
             })
         }
         if (encCount > 0 && !hasSuccessfulDecrypt && firstDecryptFailure) {
-            shouldSendStandardReceipt = !(await sendRetryReceiptForDecryptFailure(
+            await sendRetryReceiptForDecryptFailure(
                 node,
                 options,
                 firstDecryptFailure.error,
                 firstDecryptFailure.encType
-            ))
+            )
+            shouldSendStandardReceipt = false
         }
     }
 

--- a/src/protocol/__tests__/protocol.test.ts
+++ b/src/protocol/__tests__/protocol.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
+import { AB_PROP_CONFIGS, resolveAbPropNameByCode } from '@protocol/abprops'
 import {
     WA_APP_STATE_CHAT_MUTATION_SPECS,
     getWaCompanionPlatformId,
@@ -149,4 +150,31 @@ test('privacy protocol constants keep mapping invariants', () => {
         (category) => WA_PRIVACY_CATEGORY_TO_SETTING[category]
     )
     assert.deepEqual(disallowedSettings.sort(), ['about', 'groupAdd', 'lastSeen', 'profilePicture'])
+})
+
+test('ab props keep protocol-specific group and trusted-contact mappings', () => {
+    assert.deepEqual(AB_PROP_CONFIGS.group_size_limit, {
+        configCode: 1304,
+        type: 'int',
+        defaultValue: 257
+    })
+    assert.deepEqual(AB_PROP_CONFIGS.community_announcement_group_size_limit, {
+        configCode: 2774,
+        type: 'int',
+        defaultValue: 5000
+    })
+    assert.deepEqual(AB_PROP_CONFIGS.tctoken_duration, {
+        configCode: 865,
+        type: 'int',
+        defaultValue: 604800
+    })
+    assert.deepEqual(AB_PROP_CONFIGS.tctoken_duration_sender, {
+        configCode: 996,
+        type: 'int',
+        defaultValue: 604800
+    })
+    assert.equal(resolveAbPropNameByCode(1304), 'group_size_limit')
+    assert.equal(resolveAbPropNameByCode(2774), 'community_announcement_group_size_limit')
+    assert.equal(resolveAbPropNameByCode(865), 'tctoken_duration')
+    assert.equal(resolveAbPropNameByCode(996), 'tctoken_duration_sender')
 })

--- a/src/protocol/abprops.ts
+++ b/src/protocol/abprops.ts
@@ -67,9 +67,10 @@ export const AB_PROP_CONFIGS = Object.freeze({
     wa_nct_token_history_sync_enabled: prop(25189, 'bool', false),
 
     // --- group ---
-    group_size_limit: prop(3596, 'int', 1_024),
+    community_announcement_group_size_limit: prop(2774, 'int', 5_000),
+    group_size_limit: prop(1304, 'int', 257),
     group_max_subject: prop(3597, 'int', 100),
-    group_description_length: prop(3598, 'int', 2_048),
+    group_description_length: prop(14778, 'int', 2_048),
     anyone_can_link_to_groups: prop(3978, 'bool', false),
     group_call_max_participants: prop(4190, 'int', 32),
     group_history_receive: prop(15311, 'bool', false),
@@ -93,8 +94,8 @@ export const AB_PROP_CONFIGS = Object.freeze({
 
     // --- history sync ---
     web_abprop_drop_full_history_sync: prop(13034, 'bool', false),
-    wa_web_history_sync_dynamic_throttling: prop(14178, 'bool', false),
-    web_e2e_backfill_expire_time: prop(11244, 'int', 0),
+    wa_web_history_sync_dynamic_throttling: prop(19110, 'bool', true),
+    web_e2e_backfill_expire_time: prop(3234, 'int', 5),
     history_sync_on_demand: prop(3337, 'bool', false),
     history_sync_on_demand_message_count: prop(3811, 'int', 50),
     history_sync_on_demand_failure_limit: prop(4364, 'int', 10),
@@ -106,12 +107,12 @@ export const AB_PROP_CONFIGS = Object.freeze({
     web_history_sync_allow_duplicate_in_bulk_error: prop(10842, 'bool', false),
 
     // --- media ---
-    default_media_limit_mb: prop(1290, 'int', 100),
+    default_media_limit_mb: prop(3660, 'int', 16),
     web_image_max_edge: prop(10371, 'int', 1_600),
     web_image_max_hd_edge: prop(3204, 'int', 2_560),
     web_channel_video_server_transcode_upload: prop(19920, 'bool', false),
     web_deprecate_mms4_hash_based_download: prop(3152, 'bool', false),
-    kaleidoscope_thumbnail_validation: prop(18114, 'bool', true),
+    kaleidoscope_thumbnail_validation: prop(18114, 'bool', false),
     web_use_kaleidoscope_media_check_enabled: prop(20375, 'bool', false),
     low_cache_hit_rate_media_types: prop(4836, 'string', 'ptt,audio,document,ppic'),
     web_anr_async_media_decryption_enabled: prop(23200, 'bool', false),
@@ -119,7 +120,7 @@ export const AB_PROP_CONFIGS = Object.freeze({
     web_media_compute_in_worker_enabled: prop(25641, 'bool', false),
 
     // --- device management / auth ---
-    adv_accept_hosted_devices: prop(6939, 'bool', true),
+    adv_accept_hosted_devices: prop(6939, 'bool', false),
     num_days_key_index_list_expiration: prop(730, 'int', 35),
     num_days_before_device_expiry_check: prop(731, 'int', 7),
     web_adv_logout_on_self_device_list_expired: prop(11011, 'bool', false),
@@ -127,12 +128,13 @@ export const AB_PROP_CONFIGS = Object.freeze({
     noise_pq_mode: prop(20161, 'int', 0),
 
     // --- trusted contacts / privacy tokens ---
+    tctoken_duration: prop(865, 'int', 604_800),
     tctoken_num_buckets: prop(909, 'int', 4),
     tctoken_num_buckets_sender: prop(997, 'int', 4),
     tctoken_duration_sender: prop(996, 'int', 604_800),
 
     // --- connection / offline ---
-    heartbeat_interval_s: prop(1430, 'int', 5),
+    heartbeat_interval_s: prop(1430, 'int', 10),
     web_offline_message_processor_timeout_seconds: prop(12834, 'int', 15),
     web_offline_resume_wait_for_ping_response_enabled: prop(14567, 'bool', false),
     web_offline_resume_wait_for_ping_timeout_seconds: prop(14568, 'int', 5),
@@ -144,7 +146,6 @@ export const AB_PROP_CONFIGS = Object.freeze({
     lid_status_non_soaked_client_support_enabled: prop(19696, 'bool', true),
 
     // --- signal protocol ---
-    s567418_local_keys_strict_validation: prop(23899, 'bool', true),
     s567418_mitigation_enabled: prop(22029, 'bool', true),
     web_signal_future_messages_max: prop(12509, 'int', 20_000),
 
@@ -167,7 +168,7 @@ export const AB_PROP_CONFIGS = Object.freeze({
     username_min_length: prop(20494, 'int', 3),
 
     // --- message capping ---
-    wa_individual_new_chat_msg_capping_enabled: prop(20865, 'bool', true),
+    wa_individual_new_chat_msg_capping_enabled: prop(20865, 'bool', false),
     wa_individual_new_chat_msg_capping_limit: prop(17845, 'int', 0),
     wa_individual_new_chat_msg_capping_fetch_ttl_seconds: prop(20649, 'int', 3_600),
 

--- a/src/retry/__tests__/retry.test.ts
+++ b/src/retry/__tests__/retry.test.ts
@@ -105,10 +105,7 @@ test('retry state ranking and reason mapping favor higher-priority states', () =
         mapRetryReasonFromError(new Error('invalid signature data')),
         RETRY_REASON.SignalErrorInvalidSignature
     )
-    assert.equal(
-        mapRetryReasonFromError(new Error('totally unknown error')),
-        RETRY_REASON.UnknownError
-    )
+    assert.equal(mapRetryReasonFromError(new Error('totally unknown error')), undefined)
 })
 
 test('retry receipt parser validates and decodes built retry nodes', () => {

--- a/src/retry/reason.ts
+++ b/src/retry/reason.ts
@@ -39,7 +39,7 @@ const RETRY_REASON_MATCHERS = [
     }
 ] as const
 
-export function mapRetryReasonFromError(error: unknown): WaRetryReasonCode {
+export function mapRetryReasonFromError(error: unknown): WaRetryReasonCode | undefined {
     const message = toError(error).message.toLowerCase()
 
     for (const matcher of RETRY_REASON_MATCHERS) {
@@ -53,5 +53,5 @@ export function mapRetryReasonFromError(error: unknown): WaRetryReasonCode {
             return matcher.code
         }
     }
-    return RETRY_REASON.UnknownError
+    return undefined
 }

--- a/src/signal/group/SenderKeyChain.ts
+++ b/src/signal/group/SenderKeyChain.ts
@@ -27,10 +27,11 @@ export interface SenderKeyMessageKeySelection {
 
 export async function selectMessageKey(
     senderKey: SenderKeyRecord,
-    targetIteration: number
+    targetIteration: number,
+    futureMessagesMax?: number
 ): Promise<SenderKeyMessageKeySelection> {
     const delta = targetIteration - senderKey.iteration
-    if (delta > SENDER_KEY_FUTURE_MESSAGES_MAX) {
+    if (delta > (futureMessagesMax ?? SENDER_KEY_FUTURE_MESSAGES_MAX)) {
         throw new Error('sender key message is too far in future')
     }
 

--- a/src/signal/group/SenderKeyManager.ts
+++ b/src/signal/group/SenderKeyManager.ts
@@ -59,9 +59,14 @@ async function aesCbcDecryptFromSeed(
 export class SenderKeyManager {
     private readonly store: WaSenderKeyStore
     private readonly senderLock = new StoreLock()
+    private readonly getFutureMessagesMax: (() => number) | undefined
 
-    public constructor(store: WaSenderKeyStore) {
+    public constructor(
+        store: WaSenderKeyStore,
+        options?: { readonly getFutureMessagesMax?: () => number }
+    ) {
         this.store = store
+        this.getFutureMessagesMax = options?.getFutureMessagesMax
     }
 
     public async prepareGroupEncryption(
@@ -252,7 +257,11 @@ export class SenderKeyManager {
                 throw new Error('invalid sender key signature')
             }
 
-            const selected = await selectMessageKey(senderKey, parsed.iteration)
+            const selected = await selectMessageKey(
+                senderKey,
+                parsed.iteration,
+                this.getFutureMessagesMax?.()
+            )
             // Keep decrypt + persist ordered: failed decrypt must not advance sender-key state.
             const plaintext = await aesCbcDecryptFromSeed(
                 selected.messageKey.seed,

--- a/src/transport/keepalive/WaKeepAlive.ts
+++ b/src/transport/keepalive/WaKeepAlive.ts
@@ -16,6 +16,7 @@ interface WaKeepAliveOptions {
     }
     readonly getComms: () => WaComms | null
     readonly intervalMs?: number
+    readonly getIntervalMs?: () => number
     readonly timeoutMs?: number
     readonly hostDomain?: string
     readonly jitterRatio?: number
@@ -26,7 +27,8 @@ export class WaKeepAlive {
     private readonly logger: Logger
     private readonly nodeOrchestrator: WaKeepAliveOptions['nodeOrchestrator']
     private readonly getCommsFn: () => WaComms | null
-    private readonly intervalMs: number
+    private readonly baseIntervalMs: number
+    private readonly getIntervalMs: (() => number) | undefined
     private readonly timeoutMs: number
     private readonly hostDomain: string
     private readonly jitterRatio: number
@@ -39,7 +41,8 @@ export class WaKeepAlive {
         this.logger = options.logger
         this.nodeOrchestrator = options.nodeOrchestrator
         this.getCommsFn = options.getComms
-        this.intervalMs = options.intervalMs ?? WA_DEFAULTS.HEALTH_CHECK_INTERVAL_MS
+        this.baseIntervalMs = options.intervalMs ?? WA_DEFAULTS.HEALTH_CHECK_INTERVAL_MS
+        this.getIntervalMs = options.getIntervalMs
         this.timeoutMs = options.timeoutMs ?? WA_DEFAULTS.DEAD_SOCKET_TIMEOUT_MS
         this.hostDomain = options.hostDomain ?? WA_DEFAULTS.HOST_DOMAIN
         this.jitterRatio = this.normalizeJitterRatio(options.jitterRatio)
@@ -54,7 +57,7 @@ export class WaKeepAlive {
 
     public start(): void {
         this.logger.info('keepalive start', {
-            intervalMs: this.intervalMs,
+            intervalMs: this.resolveIntervalMs(),
             timeoutMs: this.timeoutMs,
             jitterRatio: this.jitterRatio,
             minJitterMs: this.minJitterMs
@@ -85,7 +88,7 @@ export class WaKeepAlive {
         this.logger.trace('keepalive scheduled', {
             generation,
             inMs: nextDelayMs,
-            baseIntervalMs: this.intervalMs
+            baseIntervalMs: this.resolveIntervalMs()
         })
     }
 
@@ -151,20 +154,29 @@ export class WaKeepAlive {
         return Math.min(Math.max(normalized, 0), KEEPALIVE_MAX_JITTER_RATIO)
     }
 
+    private resolveIntervalMs(): number {
+        const candidate = this.getIntervalMs?.() ?? this.baseIntervalMs
+        if (!Number.isFinite(candidate) || candidate <= 0) {
+            return this.baseIntervalMs
+        }
+        return candidate
+    }
+
     private computeNextDelayMs(): number {
-        if (this.intervalMs <= 0) {
+        const intervalMs = this.resolveIntervalMs()
+        if (intervalMs <= 0) {
             return 0
         }
         if (this.jitterRatio <= 0 && this.minJitterMs <= 0) {
-            return this.intervalMs
+            return intervalMs
         }
-        const ratioJitterMs = Math.floor(this.intervalMs * this.jitterRatio)
+        const ratioJitterMs = Math.floor(intervalMs * this.jitterRatio)
         const jitterWindowMs = Math.max(this.minJitterMs, ratioJitterMs)
         if (jitterWindowMs <= 0) {
-            return this.intervalMs
+            return intervalMs
         }
         const offsetMs = Math.floor(Math.random() * (jitterWindowMs * 2 + 1) - jitterWindowMs)
-        return Math.max(1, this.intervalMs + offsetMs)
+        return Math.max(1, intervalMs + offsetMs)
     }
 
     private clearTimer(): void {

--- a/src/transport/node/WaNodeOrchestrator.ts
+++ b/src/transport/node/WaNodeOrchestrator.ts
@@ -103,8 +103,8 @@ export class WaNodeOrchestrator {
         return true
     }
 
-    public async sendNode(node: BinaryNode): Promise<void> {
-        const outbound = await this.withAutoId(node)
+    public async sendNode(node: BinaryNode, autoId = true): Promise<void> {
+        const outbound = autoId ? await this.withAutoId(node) : node
         await this.sendNodeFn(outbound)
     }
 

--- a/src/transport/node/__tests__/node.test.ts
+++ b/src/transport/node/__tests__/node.test.ts
@@ -184,6 +184,35 @@ test('WaNodeOrchestrator resolves pending queries and handles ping iq', async ()
     assert.equal(sentNodes[sentNodes.length - 1].attrs.type, WA_IQ_TYPES.RESULT)
 })
 
+test('WaNodeOrchestrator can send nodes without auto-generated ids', async () => {
+    const sentNodes: BinaryNode[] = []
+    const orchestrator = new WaNodeOrchestrator({
+        logger: createLogger(),
+        sendNode: async (node) => {
+            sentNodes.push(node)
+        }
+    })
+
+    await orchestrator.sendNode(
+        {
+            tag: 'presence',
+            attrs: {
+                name: 'Vinicius'
+            }
+        },
+        false
+    )
+
+    assert.deepEqual(sentNodes, [
+        {
+            tag: 'presence',
+            attrs: {
+                name: 'Vinicius'
+            }
+        }
+    ])
+})
+
 test('WaNodeOrchestrator query timeout rejects pending request', async () => {
     const orchestrator = new WaNodeOrchestrator({
         logger: createLogger(),

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -29,6 +29,8 @@ import {
     buildIqResultNode,
     buildLeaveGroupIq,
     buildNewsletterMetadataSyncIq,
+    buildOfflineBatchNode,
+    buildPresenceNode,
     buildReceiptNode,
     buildSignedPreKeyRotateIq,
     buildUsyncIq,
@@ -59,9 +61,37 @@ test('builders barrel exports stable constructors', () => {
     assert.equal(typeof buildAccountDevicesSyncIq, 'function')
     assert.equal(typeof buildCompanionHelloRequestNode, 'function')
     assert.equal(typeof buildGroupSenderKeyMessageNode, 'function')
+    assert.equal(typeof buildOfflineBatchNode, 'function')
+    assert.equal(typeof buildPresenceNode, 'function')
     assert.equal(typeof buildSignedPreKeyRotateIq, 'function')
     assert.equal(typeof buildUsyncIq, 'function')
     assert.equal(typeof buildUsyncUserNode, 'function')
+})
+
+test('presence and offline builders generate expected lightweight nodes', () => {
+    const presence = buildPresenceNode({
+        type: 'unavailable',
+        name: 'Vinicius'
+    })
+    assert.deepEqual(presence, {
+        tag: 'presence',
+        attrs: {
+            type: 'unavailable',
+            name: 'Vinicius'
+        }
+    })
+
+    const offlineBatch = buildOfflineBatchNode(200)
+    assert.equal(offlineBatch.tag, WA_NODE_TAGS.INFO_BULLETIN)
+    assert.ok(Array.isArray(offlineBatch.content))
+    if (!Array.isArray(offlineBatch.content)) {
+        throw new Error('expected offline batch content array')
+    }
+    assert.deepEqual(offlineBatch.content[0], {
+        tag: 'offline_batch',
+        attrs: { count: '200' },
+        content: undefined
+    })
 })
 
 test('usync builder composes query/list nodes with defaults and overrides', () => {

--- a/src/transport/node/builders/index.ts
+++ b/src/transport/node/builders/index.ts
@@ -21,6 +21,8 @@ export {
     buildGroupSenderKeyMessageNode,
     buildMetaNode
 } from '@transport/node/builders/message'
+export { buildOfflineBatchNode } from '@transport/node/builders/offline'
+export { buildPresenceNode, type BuildPresenceNodeInput } from '@transport/node/builders/presence'
 export { buildRetryReceiptNode } from '@transport/node/builders/retry'
 export {
     buildMissingPreKeysFetchIq,

--- a/src/transport/node/builders/offline.ts
+++ b/src/transport/node/builders/offline.ts
@@ -1,0 +1,16 @@
+import { WA_NODE_TAGS } from '@protocol/constants'
+import type { BinaryNode } from '@transport/types'
+
+export function buildOfflineBatchNode(count: number): BinaryNode {
+    return {
+        tag: WA_NODE_TAGS.INFO_BULLETIN,
+        attrs: {},
+        content: [
+            {
+                tag: 'offline_batch',
+                attrs: { count: String(count) },
+                content: undefined
+            }
+        ]
+    }
+}

--- a/src/transport/node/builders/presence.ts
+++ b/src/transport/node/builders/presence.ts
@@ -1,0 +1,20 @@
+import type { BinaryNode } from '@transport/types'
+
+export interface BuildPresenceNodeInput {
+    readonly type?: 'available' | 'unavailable'
+    readonly name?: string
+}
+
+export function buildPresenceNode(input?: BuildPresenceNodeInput): BinaryNode {
+    const attrs: Record<string, string> = {}
+    if (input?.type) {
+        attrs.type = input.type
+    }
+    if (input?.name) {
+        attrs.name = input.name
+    }
+    return {
+        tag: 'presence',
+        attrs
+    }
+}

--- a/src/transport/node/builders/retry.ts
+++ b/src/transport/node/builders/retry.ts
@@ -91,7 +91,7 @@ export function buildRetryReceiptNode(input: {
         id: input.originalMsgId,
         t: input.t
     }
-    if (input.error !== undefined) {
+    if (input.error !== undefined && input.error !== 0) {
         retryAttrs.error = String(input.error)
     }
 


### PR DESCRIPTION
- Add WaOfflineResumeCoordinator for handling offline message sync on reconnect
- Add presence node builder and sendPresence method on WaClient
- Add offline node builder for critical_unblock_low notifications
- Improve incoming node routing with receipt, notification, and call handling
- Update trusted contact token coordinator with retry and caching logic
- Fix sender key distribution to skip own JID and improve group signal handling
- Refactor keepalive to use dynamic interval from server props
- Update AB props to use prefixed keys and fix protocol sync
- Add comprehensive tests for new and updated coordinators

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline resume flow to request and sync missed messages after reconnect
  * User presence support (available/unavailable) and automatic presence send after connect

* **Bug Fixes**
  * More reliable handling of message decryption failures and retry receipts to avoid duplicate delivery receipts
  * Improved keepalive/heartbeat handling for more stable connections

* **Tests**
  * New tests covering offline resume, presence, decryption failure paths, node builders, and related behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->