### PR TITLE
feat: add media-utils package with ffmpeg/sharp processing and media message support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,36 @@ jobs:
             - name: run core tests
               run: npm test
 
+    test-media-utils:
+        runs-on: ubuntu-latest
+        needs: test-core
+
+        steps:
+            - name: checkout repository
+              uses: actions/checkout@v4
+
+            - name: setup node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: npm
+
+            - name: install ffmpeg and ffprobe
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y ffmpeg
+                  ffmpeg -version
+                  ffprobe -version
+
+            - name: install dependencies
+              run: npm ci
+
+            - name: build
+              run: npm run build && npx turbo run build --filter=@zapo-js/media-utils
+
+            - name: run media-utils tests
+              run: npm test -w packages/media-utils
+
     test-sqlite:
         runs-on: ubuntu-latest
         needs: test-core

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,7 +42,8 @@ module.exports = [
                     './packages/store-sqlite/tsconfig.json',
                     './packages/store-postgres/tsconfig.json',
                     './packages/store-redis/tsconfig.json',
-                    './packages/store-mongo/tsconfig.json'
+                    './packages/store-mongo/tsconfig.json',
+                    './packages/media-utils/tsconfig.json'
                 ]
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
     "name": "zapo-js",
-    "version": "0.1.2",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "dev": true,
     "packages": {
         "": {
             "name": "zapo-js",
-            "version": "0.1.2",
+            "version": "0.2.0",
             "hasInstallScript": true,
             "workspaces": [
                 "packages/*"
@@ -22,7 +22,6 @@
                 "c8": "^11.0.0",
                 "eslint": "^9.39.4",
                 "eslint-plugin-import": "^2.32.0",
-                "got": "14.6.4",
                 "pino": "^10.3.1",
                 "pino-pretty": "^13.1.3",
                 "prettier": "^3.8.1",
@@ -41,15 +40,11 @@
                 "url": "https://github.com/sponsors/vinikjkkj"
             },
             "peerDependencies": {
-                "got": "14.6.4",
                 "pino": "^9.0.0",
                 "pino-pretty": "^13.0.0",
                 "ws": "^8.18.3"
             },
             "peerDependenciesMeta": {
-                "got": {
-                    "optional": true
-                },
                 "pino": {
                     "optional": true
                 },
@@ -373,6 +368,17 @@
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -1075,6 +1081,386 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@img/sharp-darwin-arm64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+            "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-arm64": "1.0.4"
+            }
+        },
+        "node_modules/@img/sharp-darwin-x64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+            "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-x64": "1.0.4"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-arm64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+            "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-x64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+            "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+            "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+            "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-s390x": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+            "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-x64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+            "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+            "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+            "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+            "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm": "1.0.5"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+            "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm64": "1.0.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-s390x": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+            "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-s390x": "1.0.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-x64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+            "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-x64": "1.0.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-arm64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+            "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-x64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+            "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+            }
+        },
+        "node_modules/@img/sharp-wasm32": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+            "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/runtime": "^1.2.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-ia32": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+            "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-x64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+            "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
         "node_modules/@inquirer/external-editor": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
@@ -1141,13 +1527,6 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
-        },
-        "node_modules/@keyv/serialize": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
-            "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@manypkg/find-root": {
             "version": "1.1.0",
@@ -1339,26 +1718,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@sec-ant/readable-stream": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@sindresorhus/is": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
-            "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/is?sponsor=1"
-            }
-        },
         "node_modules/@turbo/darwin-64": {
             "version": "2.8.20",
             "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.8.20.tgz",
@@ -1447,13 +1806,6 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/http-cache-semantics": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-            "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -1771,6 +2123,10 @@
                 "eslint-plugin-import": "^2.31.0",
                 "typescript-eslint": "^8.12.2"
             }
+        },
+        "node_modules/@zapo-js/media-utils": {
+            "resolved": "packages/media-utils",
+            "link": true
         },
         "node_modules/@zapo-js/store-mongo": {
             "resolved": "packages/store-mongo",
@@ -2236,19 +2592,6 @@
                 "ieee754": "^1.1.13"
             }
         },
-        "node_modules/byte-counter": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
-            "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/c8": {
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/c8/-/c8-11.0.0.tgz",
@@ -2281,58 +2624,6 @@
                 "monocart-coverage-reports": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/cacheable-lookup": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-            "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            }
-        },
-        "node_modules/cacheable-request": {
-            "version": "13.0.18",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.18.tgz",
-            "integrity": "sha512-rFWadDRKJs3s2eYdXlGggnBZKG7MTblkFBB0YllFds+UYnfogDp2wcR6JN97FhRkHTvq59n2vhNoHNZn29dh/Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-cache-semantics": "^4.0.4",
-                "get-stream": "^9.0.1",
-                "http-cache-semantics": "^4.2.0",
-                "keyv": "^5.5.5",
-                "mimic-response": "^4.0.0",
-                "normalize-url": "^8.1.1",
-                "responselike": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/cacheable-request/node_modules/keyv": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-            "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@keyv/serialize": "^1.1.1"
-            }
-        },
-        "node_modules/cacheable-request/node_modules/mimic-response": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
-            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/call-bind": {
@@ -2489,6 +2780,20 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/color": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1",
+                "color-string": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=12.5.0"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2508,6 +2813,17 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/color-string": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
+            }
         },
         "node_modules/colorette": {
             "version": "2.0.20",
@@ -3598,16 +3914,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/form-data-encoder": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
-            "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 18"
-            }
-        },
         "node_modules/fs-constants": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -3755,23 +4061,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/get-stream": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sec-ant/readable-stream": "^0.4.1",
-                "is-stream": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/get-symbol-description": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -3905,72 +4194,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/got": {
-            "version": "14.6.4",
-            "resolved": "https://registry.npmjs.org/got/-/got-14.6.4.tgz",
-            "integrity": "sha512-DjsLab39NUMf5iYlK9asVCkHMhaA2hEhrlmf+qXRhjEivuuBHWYbjmty9DA3OORUwZgENTB+6vSmY2ZW8gFHVw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sindresorhus/is": "^7.0.1",
-                "byte-counter": "^0.1.0",
-                "cacheable-lookup": "^7.0.0",
-                "cacheable-request": "^13.0.12",
-                "decompress-response": "^10.0.0",
-                "form-data-encoder": "^4.0.2",
-                "http2-wrapper": "^2.2.1",
-                "keyv": "^5.5.3",
-                "lowercase-keys": "^3.0.0",
-                "p-cancelable": "^4.0.1",
-                "responselike": "^4.0.2",
-                "type-fest": "^4.26.1"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/got?sponsor=1"
-            }
-        },
-        "node_modules/got/node_modules/decompress-response": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
-            "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-response": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/got/node_modules/keyv": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-            "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@keyv/serialize": "^1.1.1"
-            }
-        },
-        "node_modules/got/node_modules/mimic-response": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
-            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4085,27 +4308,6 @@
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/http-cache-semantics": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-            "dev": true,
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/http2-wrapper": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-            "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "quick-lru": "^5.1.1",
-                "resolve-alpn": "^1.2.0"
-            },
-            "engines": {
-                "node": ">=10.19.0"
-            }
         },
         "node_modules/human-id": {
             "version": "4.1.3",
@@ -4263,6 +4465,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+            "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-async-function": {
             "version": "2.1.1",
@@ -4569,19 +4778,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-stream": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-string": {
@@ -4899,19 +5095,6 @@
             "dev": true,
             "license": "Apache-2.0"
         },
-        "node_modules/lowercase-keys": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-            "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/lru-cache": {
             "version": "11.2.7",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
@@ -5226,19 +5409,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/normalize-url": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
-            "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -5397,16 +5567,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/p-cancelable": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
-            "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
             }
         },
         "node_modules/p-filter": {
@@ -5971,19 +6131,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/quick-lru": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/rc": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -6199,13 +6346,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/resolve-alpn": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -6224,22 +6364,6 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-            }
-        },
-        "node_modules/responselike": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
-            "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lowercase-keys": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/reusify": {
@@ -6449,6 +6573,46 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/sharp": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+            "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "color": "^4.2.3",
+                "detect-libc": "^2.0.3",
+                "semver": "^7.6.3"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-darwin-arm64": "0.33.5",
+                "@img/sharp-darwin-x64": "0.33.5",
+                "@img/sharp-libvips-darwin-arm64": "1.0.4",
+                "@img/sharp-libvips-darwin-x64": "1.0.4",
+                "@img/sharp-libvips-linux-arm": "1.0.5",
+                "@img/sharp-libvips-linux-arm64": "1.0.4",
+                "@img/sharp-libvips-linux-s390x": "1.0.4",
+                "@img/sharp-libvips-linux-x64": "1.0.4",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+                "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+                "@img/sharp-linux-arm": "0.33.5",
+                "@img/sharp-linux-arm64": "0.33.5",
+                "@img/sharp-linux-s390x": "0.33.5",
+                "@img/sharp-linux-x64": "0.33.5",
+                "@img/sharp-linuxmusl-arm64": "0.33.5",
+                "@img/sharp-linuxmusl-x64": "0.33.5",
+                "@img/sharp-wasm32": "0.33.5",
+                "@img/sharp-win32-ia32": "0.33.5",
+                "@img/sharp-win32-x64": "0.33.5"
+            }
+        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6606,6 +6770,16 @@
                 "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
                 "simple-concat": "^1.0.0"
+            }
+        },
+        "node_modules/simple-swizzle": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+            "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-arrayish": "^0.3.1"
             }
         },
         "node_modules/slash": {
@@ -7011,6 +7185,14 @@
                 "strip-bom": "^3.0.0"
             }
         },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
         "node_modules/tsx": {
             "version": "4.21.0",
             "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -7073,19 +7255,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/type-fest": {
-            "version": "4.41.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/typed-array-buffer": {
@@ -7526,9 +7695,29 @@
             "resolved": "",
             "link": true
         },
+        "packages/media-utils": {
+            "name": "@zapo-js/media-utils",
+            "version": "0.1.0",
+            "devDependencies": {
+                "sharp": "^0.33.0",
+                "zapo-js": "file:../.."
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "peerDependencies": {
+                "sharp": ">=0.33.0",
+                "zapo-js": ">=0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "zapo-js": {
+                    "optional": true
+                }
+            }
+        },
         "packages/store-mongo": {
             "name": "@zapo-js/store-mongo",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "devDependencies": {
                 "mongodb": "^6.16.0",
                 "zapo-js": "file:../.."
@@ -7548,7 +7737,7 @@
         },
         "packages/store-mysql": {
             "name": "@zapo-js/store-mysql",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "devDependencies": {
                 "mysql2": "^3.14.0",
                 "zapo-js": "file:../.."
@@ -7568,7 +7757,7 @@
         },
         "packages/store-postgres": {
             "name": "@zapo-js/store-postgres",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "devDependencies": {
                 "@types/pg": "^8.11.0",
                 "pg": "^8.14.1",
@@ -7589,7 +7778,7 @@
         },
         "packages/store-redis": {
             "name": "@zapo-js/store-redis",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "devDependencies": {
                 "ioredis": "^5.6.1",
                 "zapo-js": "file:../.."
@@ -7609,7 +7798,7 @@
         },
         "packages/store-sqlite": {
             "name": "@zapo-js/store-sqlite",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "devDependencies": {
                 "better-sqlite3": "^12.6.2",
                 "zapo-js": "file:../.."

--- a/package.json
+++ b/package.json
@@ -147,15 +147,11 @@
         "format:check": "prettier . --check"
     },
     "peerDependencies": {
-        "got": "14.6.4",
         "pino": "^9.0.0",
         "pino-pretty": "^13.0.0",
         "ws": "^8.18.3"
     },
     "peerDependenciesMeta": {
-        "got": {
-            "optional": true
-        },
         "pino": {
             "optional": true
         },
@@ -176,7 +172,6 @@
         "c8": "^11.0.0",
         "eslint": "^9.39.4",
         "eslint-plugin-import": "^2.32.0",
-        "got": "14.6.4",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "prettier": "^3.8.1",

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -1,0 +1,36 @@
+{
+    "name": "@zapo-js/media-utils",
+    "version": "0.1.0",
+    "description": "Media processing utilities for zapo-js (thumbnails, waveforms, probing)",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "require": "./dist/index.js",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": [
+        "dist"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsc -p tsconfig.build.cjs.json",
+        "typecheck": "tsc --noEmit",
+        "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
+    },
+    "peerDependencies": {
+        "zapo-js": ">=0.1.0",
+        "sharp": ">=0.33.0"
+    },
+    "devDependencies": {
+        "sharp": "^0.33.0",
+        "zapo-js": "file:../.."
+    },
+    "engines": {
+        "node": ">=20.9.0"
+    }
+}

--- a/packages/media-utils/src/__tests__/factory.test.ts
+++ b/packages/media-utils/src/__tests__/factory.test.ts
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readdirSync } from 'node:fs'
+import { unlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Readable } from 'node:stream'
+import { describe, it } from 'node:test'
+
+import sharpLib from 'sharp'
+
+import { createMediaProcessor } from '../index'
+
+function hasFFmpeg(): boolean {
+    try {
+        execFileSync('ffmpeg', ['-version'], { stdio: 'ignore', timeout: 5_000 })
+        return true
+    } catch {
+        return false
+    }
+}
+
+function hasFFprobe(): boolean {
+    try {
+        execFileSync('ffprobe', ['-version'], { stdio: 'ignore', timeout: 5_000 })
+        return true
+    } catch {
+        return false
+    }
+}
+
+function generateTestVideo(): Uint8Array {
+    const buf = execFileSync(
+        'ffmpeg',
+        [
+            '-f',
+            'lavfi',
+            '-i',
+            'color=c=red:s=320x240:d=1',
+            '-frames:v',
+            '1',
+            '-f',
+            'mp4',
+            '-movflags',
+            'frag_keyframe+empty_moov',
+            'pipe:1'
+        ],
+        { timeout: 10_000, maxBuffer: 2 * 1024 * 1024 }
+    )
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+}
+
+function createTempPath(suffix: string): string {
+    return join(
+        tmpdir(),
+        `zapo-media-utils-${Date.now()}-${Math.random().toString(36).slice(2)}${suffix}`
+    )
+}
+
+async function writeTempVideoFile(): Promise<string> {
+    const filePath = createTempPath('.mp4')
+    await writeFile(filePath, generateTestVideo())
+    return filePath
+}
+
+function createTempAudioFile(): string {
+    const filePath = createTempPath('.wav')
+    execFileSync(
+        'ffmpeg',
+        ['-f', 'lavfi', '-i', 'sine=frequency=1000:duration=1', '-y', filePath],
+        { stdio: 'ignore', timeout: 10_000 }
+    )
+    return filePath
+}
+
+async function createTestImage(width: number, height: number): Promise<Uint8Array> {
+    const buf = await sharpLib({
+        create: { width, height, channels: 3, background: { r: 128, g: 64, b: 32 } }
+    })
+        .jpeg()
+        .toBuffer()
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+}
+
+describe('createMediaProcessor', () => {
+    it('returns an object with all processor methods', () => {
+        const processor = createMediaProcessor()
+        assert.equal(typeof processor.generateImageThumbnail, 'function')
+        assert.equal(typeof processor.generateVideoThumbnail, 'function')
+        assert.equal(typeof processor.probeMedia, 'function')
+        assert.equal(typeof processor.computeWaveform, 'function')
+    })
+
+    it('generateImageThumbnail respects options override', async () => {
+        const processor = createMediaProcessor({
+            imageThumbMaxEdge: 100,
+            imageThumbQuality: 50
+        })
+        const img = await createTestImage(800, 600)
+        const result = await processor.generateImageThumbnail!(img, 320)
+        assert.ok(result.width <= 100)
+        assert.ok(result.height <= 100)
+    })
+
+    it('generateStickerThumbnail returns a PNG thumbnail within max edge', async () => {
+        const processor = createMediaProcessor()
+        const img = await createTestImage(512, 256)
+        const result = await processor.generateStickerThumbnail!(img, 96)
+        assert.ok(result.pngThumbnail.byteLength > 0)
+        assert.ok(result.width <= 96)
+        assert.ok(result.height <= 96)
+        assert.equal(result.pngThumbnail[0], 0x89)
+        assert.equal(result.pngThumbnail[1], 0x50)
+    })
+
+    it('probeMedia returns empty object for unknown format without ffmpeg', async () => {
+        const processor = createMediaProcessor()
+        const result = await processor.probeMedia!(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]))
+        assert.deepEqual(result, {})
+    })
+
+    it('computeWaveform returns null when ffmpeg is not available or input is empty', async () => {
+        const processor = createMediaProcessor({ waveformPoints: 32 })
+        const result = await processor.computeWaveform!(new Uint8Array(0))
+        assert.equal(result, null)
+    })
+
+    it(
+        'probeMedia supports file path input and valid ffprobe after a prior missing-bin probe',
+        { skip: !hasFFprobe() },
+        async () => {
+            const videoPath = await writeTempVideoFile()
+            try {
+                const missingProcessor = createMediaProcessor({
+                    ffprobePath: `missing-ffprobe-${Date.now()}`
+                })
+                const missingResult = await missingProcessor.probeMedia!(videoPath)
+                assert.deepEqual(missingResult, {})
+
+                const processor = createMediaProcessor({ ffprobePath: 'ffprobe' })
+                const result = await processor.probeMedia!(videoPath)
+                assert.equal(result.width, 320)
+                assert.equal(result.height, 240)
+                assert.ok((result.durationSeconds ?? 0) > 0)
+            } finally {
+                await unlink(videoPath).catch(() => undefined)
+            }
+        }
+    )
+
+    it(
+        'computeWaveform supports file path input and clamps waveform points after a prior missing-bin probe',
+        { skip: !hasFFmpeg() },
+        async () => {
+            const audioPath = createTempAudioFile()
+            try {
+                const missingProcessor = createMediaProcessor({
+                    ffmpegPath: `missing-ffmpeg-${Date.now()}`,
+                    waveformPoints: 32
+                })
+                const missingResult = await missingProcessor.computeWaveform!(audioPath)
+                assert.equal(missingResult, null)
+
+                const processor = createMediaProcessor({
+                    ffmpegPath: 'ffmpeg',
+                    waveformPoints: 32
+                })
+                const result = await processor.computeWaveform!(audioPath)
+                assert.notEqual(result, null)
+                assert.equal(result!.waveform.length, 64)
+                assert.ok(result!.durationSeconds > 0.9)
+                assert.ok(result!.durationSeconds < 1.1)
+            } finally {
+                await unlink(audioPath).catch(() => undefined)
+            }
+        }
+    )
+
+    it('cleans temp files when probing a failing stream', { skip: !hasFFprobe() }, async () => {
+        const before = new Set(readdirSync(tmpdir()).filter((name) => name.startsWith('zapo-tmp-')))
+        const processor = createMediaProcessor({ ffprobePath: 'ffprobe' })
+
+        const failing = new Readable({
+            read() {
+                this.push(Buffer.from([1, 2, 3]))
+                this.destroy(new Error('forced stream failure'))
+            }
+        })
+
+        await assert.rejects(() => processor.probeMedia!(failing), /forced stream failure/)
+
+        const after = readdirSync(tmpdir()).filter((name) => name.startsWith('zapo-tmp-'))
+        const leaked = after.filter((name) => !before.has(name))
+
+        try {
+            assert.deepEqual(leaked, [])
+        } finally {
+            await Promise.all(
+                leaked.map((name) => unlink(join(tmpdir(), name)).catch(() => undefined))
+            )
+        }
+    })
+
+    it('generateVideoThumbnail extracts first frame as JPEG', { skip: !hasFFmpeg() }, async () => {
+        const processor = createMediaProcessor()
+        const video = generateTestVideo()
+        const result = await processor.generateVideoThumbnail!(video, 160)
+        assert.notEqual(result, null)
+        assert.ok(result!.jpegThumbnail.byteLength > 0)
+        assert.equal(result!.jpegThumbnail[0], 0xff)
+        assert.equal(result!.jpegThumbnail[1], 0xd8)
+        assert.ok(result!.width <= 160)
+        assert.ok(result!.height <= 160)
+        assert.ok(result!.width > 0)
+        assert.ok(result!.height > 0)
+    })
+
+    it(
+        'generateVideoThumbnail returns null for invalid input',
+        { skip: !hasFFmpeg() },
+        async () => {
+            const processor = createMediaProcessor()
+            const result = await processor.generateVideoThumbnail!(new Uint8Array([1, 2, 3]), 320)
+            assert.equal(result, null)
+        }
+    )
+})

--- a/packages/media-utils/src/__tests__/sharp.test.ts
+++ b/packages/media-utils/src/__tests__/sharp.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import { Readable } from 'node:stream'
+import { describe, it } from 'node:test'
+
+import sharpLib from 'sharp'
+
+import { generateImageThumbnail } from '../sharp'
+
+async function createTestImage(width: number, height: number): Promise<Uint8Array> {
+    const buf = await sharpLib({
+        create: { width, height, channels: 3, background: { r: 128, g: 64, b: 32 } }
+    })
+        .jpeg()
+        .toBuffer()
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+}
+
+describe('generateImageThumbnail', () => {
+    it('resizes image within max edge and returns JPEG', async () => {
+        const img = await createTestImage(1920, 1080)
+        const result = await generateImageThumbnail(img, 320)
+        assert.ok(result.jpegThumbnail.byteLength > 0)
+        assert.ok(result.width <= 320)
+        assert.ok(result.height <= 320)
+        assert.ok(result.width > 0)
+        assert.ok(result.height > 0)
+        // JPEG magic bytes
+        assert.equal(result.jpegThumbnail[0], 0xff)
+        assert.equal(result.jpegThumbnail[1], 0xd8)
+    })
+
+    it('does not enlarge small images', async () => {
+        const img = await createTestImage(100, 80)
+        const result = await generateImageThumbnail(img, 320)
+        assert.equal(result.width, 100)
+        assert.equal(result.height, 80)
+    })
+
+    it('works with Readable stream input', async () => {
+        const img = await createTestImage(640, 480)
+        const stream = Readable.from([img])
+        const result = await generateImageThumbnail(stream, 200)
+        assert.ok(result.jpegThumbnail.byteLength > 0)
+        assert.ok(result.width <= 200)
+        assert.ok(result.height <= 200)
+    })
+})

--- a/packages/media-utils/src/ffmpeg.ts
+++ b/packages/media-utils/src/ffmpeg.ts
@@ -1,0 +1,339 @@
+import { execFile, spawn } from 'node:child_process'
+import { createWriteStream } from 'node:fs'
+import { unlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+
+import type {
+    WaMediaProcessorImageResult,
+    WaMediaProcessorInput,
+    WaMediaProcessorProbeResult,
+    WaMediaProcessorWaveformResult
+} from 'zapo-js/media'
+
+import { generateImageThumbnail } from './sharp'
+
+export type FfmpegWarnFn = (message: string) => void
+
+const WAVEFORM_POINTS = 64
+const WAVEFORM_MIN_POINTS = 64
+const WAVEFORM_MAX_POINTS = 192
+
+function inputToReadable(input: WaMediaProcessorInput): Readable {
+    if (input instanceof Readable) return input
+    return Readable.from([input])
+}
+
+function which(bin: string): Promise<boolean> {
+    return new Promise((resolve) => {
+        execFile(bin, ['-version'], { timeout: 5_000 }, (err) => resolve(!err))
+    })
+}
+
+const binCache = new Map<string, boolean>()
+const warnedBins = new Set<string>()
+
+async function hasBin(path: string, label: string, warn?: FfmpegWarnFn): Promise<boolean> {
+    let available = binCache.get(path)
+    if (available === undefined) {
+        available = await which(path)
+        binCache.set(path, available)
+    }
+    if (!available && warn && !warnedBins.has(path)) {
+        warnedBins.add(path)
+        warn(`${label} not found at '${path}', related processing will be skipped`)
+    }
+    return available
+}
+
+export async function probeWithFfmpeg(
+    input: WaMediaProcessorInput,
+    ffprobePath?: string,
+    warn?: FfmpegWarnFn
+): Promise<WaMediaProcessorProbeResult | null> {
+    const bin = ffprobePath ?? 'ffprobe'
+    if (!(await hasBin(bin, 'ffprobe', warn))) return null
+
+    let filePath: string
+    let needsCleanup: boolean
+
+    if (typeof input === 'string') {
+        filePath = input
+        needsCleanup = false
+    } else {
+        filePath = await inputToTempFile(input)
+        needsCleanup = true
+    }
+
+    try {
+        const args = [
+            '-v',
+            'quiet',
+            '-print_format',
+            'json',
+            '-show_format',
+            '-show_streams',
+            filePath
+        ]
+
+        return await new Promise<WaMediaProcessorProbeResult | null>((resolve) => {
+            execFile(bin, args, { timeout: 10_000, maxBuffer: 1024 * 1024 }, (err, stdout) => {
+                if (err || !stdout) {
+                    resolve(null)
+                    return
+                }
+                try {
+                    const data = JSON.parse(stdout) as {
+                        format?: { duration?: string }
+                        streams?: readonly {
+                            width?: number
+                            height?: number
+                            codec_type?: string
+                        }[]
+                    }
+                    const videoStream = data.streams?.find((s) => s.codec_type === 'video')
+                    resolve({
+                        durationSeconds: data.format?.duration
+                            ? parseFloat(data.format.duration)
+                            : undefined,
+                        width: videoStream?.width,
+                        height: videoStream?.height
+                    })
+                } catch {
+                    resolve(null)
+                }
+            })
+        })
+    } finally {
+        if (needsCleanup) {
+            await unlink(filePath).catch(() => undefined)
+        }
+    }
+}
+
+async function inputToTempFile(input: Uint8Array | Readable): Promise<string> {
+    const path = join(tmpdir(), `zapo-tmp-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    let output: ReturnType<typeof createWriteStream> | undefined
+    try {
+        if (input instanceof Uint8Array) {
+            await writeFile(path, input)
+            return path
+        }
+
+        output = createWriteStream(path)
+        await pipeline(input, output)
+        return path
+    } catch (error) {
+        if (output && !output.closed) {
+            await new Promise<void>((resolve) => {
+                output!.once('close', resolve)
+                output!.destroy()
+            })
+        }
+        await unlink(path).catch(() => undefined)
+        throw error
+    }
+}
+
+export async function generateVideoThumbnailWithFfmpeg(
+    input: WaMediaProcessorInput,
+    maxEdge: number,
+    ffmpegPath?: string,
+    warn?: FfmpegWarnFn
+): Promise<WaMediaProcessorImageResult | null> {
+    const bin = ffmpegPath ?? 'ffmpeg'
+    if (!(await hasBin(bin, 'ffmpeg', warn))) return null
+
+    let filePath: string
+    let needsCleanup: boolean
+
+    if (typeof input === 'string') {
+        filePath = input
+        needsCleanup = false
+    } else {
+        filePath = await inputToTempFile(input)
+        needsCleanup = true
+    }
+
+    try {
+        const args = ['-i', filePath, '-frames:v', '1', '-f', 'image2', '-c:v', 'mjpeg', 'pipe:1']
+
+        return await new Promise((resolve, reject) => {
+            const proc = spawn(bin, args, {
+                stdio: ['ignore', 'pipe', 'ignore'],
+                timeout: 15_000
+            })
+
+            const thumbPromise = generateImageThumbnail(proc.stdout, maxEdge)
+
+            thumbPromise.then((result) => resolve(result)).catch(() => resolve(null))
+
+            proc.on('error', (err) => reject(err))
+        })
+    } finally {
+        if (needsCleanup) {
+            await unlink(filePath).catch(() => undefined)
+        }
+    }
+}
+
+const SAMPLES_PER_RAW_BUCKET = 125
+const BYTES_PER_SAMPLE = 4
+
+export async function computeWaveformWithFfmpeg(
+    input: WaMediaProcessorInput,
+    ffmpegPath?: string,
+    points?: number,
+    warn?: FfmpegWarnFn
+): Promise<WaMediaProcessorWaveformResult | null> {
+    const bin = ffmpegPath ?? 'ffmpeg'
+    if (!(await hasBin(bin, 'ffmpeg', warn))) return null
+
+    const useFile = typeof input === 'string'
+    const args = [
+        '-i',
+        useFile ? input : 'pipe:0',
+        '-f',
+        'f32le',
+        '-ac',
+        '1',
+        '-ar',
+        '8000',
+        'pipe:1'
+    ]
+    const targetPoints = Math.max(
+        WAVEFORM_MIN_POINTS,
+        Math.min(points ?? WAVEFORM_POINTS, WAVEFORM_MAX_POINTS)
+    )
+
+    return new Promise((resolve, reject) => {
+        const proc = spawn(bin, args, {
+            stdio: [useFile ? 'ignore' : 'pipe', 'pipe', 'ignore'],
+            timeout: 30_000
+        })
+
+        const rawBuckets: number[] = []
+        let bucketSum = 0
+        let bucketCount = 0
+        let totalSamples = 0
+        let leftover = new Uint8Array(0)
+
+        proc.stdout!.on('data', (chunk: Buffer) => {
+            let offset = 0
+
+            if (leftover.byteLength > 0) {
+                const need = BYTES_PER_SAMPLE - leftover.byteLength
+                if (chunk.byteLength < need) {
+                    const merged = new Uint8Array(leftover.byteLength + chunk.byteLength)
+                    merged.set(leftover, 0)
+                    merged.set(chunk, leftover.byteLength)
+                    leftover = merged
+                    return
+                }
+                const merged = new Uint8Array(BYTES_PER_SAMPLE)
+                merged.set(leftover, 0)
+                merged.set(chunk.subarray(0, need), leftover.byteLength)
+                const view = new DataView(merged.buffer, 0, BYTES_PER_SAMPLE)
+                bucketSum += Math.abs(view.getFloat32(0, true))
+                bucketCount++
+                totalSamples++
+                if (bucketCount >= SAMPLES_PER_RAW_BUCKET) {
+                    rawBuckets.push(bucketSum / bucketCount)
+                    bucketSum = 0
+                    bucketCount = 0
+                }
+                offset = need
+                leftover = new Uint8Array(0)
+            }
+
+            const remaining = chunk.byteLength - offset
+            const alignedLen = Math.floor(remaining / BYTES_PER_SAMPLE) * BYTES_PER_SAMPLE
+
+            for (let i = 0; i < alignedLen; i += BYTES_PER_SAMPLE) {
+                bucketSum += Math.abs(chunk.readFloatLE(offset + i))
+                bucketCount++
+                totalSamples++
+                if (bucketCount >= SAMPLES_PER_RAW_BUCKET) {
+                    rawBuckets.push(bucketSum / bucketCount)
+                    bucketSum = 0
+                    bucketCount = 0
+                }
+            }
+
+            const tail = remaining - alignedLen
+            if (tail > 0) {
+                leftover = new Uint8Array(
+                    chunk.subarray(offset + alignedLen, offset + alignedLen + tail)
+                )
+            }
+        })
+
+        proc.on('error', (err) => reject(err))
+
+        proc.on('close', (code) => {
+            if (bucketCount > 0) {
+                rawBuckets.push(bucketSum / bucketCount)
+            }
+            if (rawBuckets.length === 0 || code !== 0) {
+                resolve(null)
+                return
+            }
+            const SAMPLE_RATE = 8000
+            resolve({
+                waveform: scaleAndNormalize(rawBuckets, targetPoints),
+                durationSeconds: totalSamples / SAMPLE_RATE
+            })
+        })
+
+        if (!useFile) {
+            const stream = inputToReadable(input)
+            proc.stdin!.on('error', () => stream.destroy())
+            stream.pipe(proc.stdin!)
+            stream.on('error', (err) => {
+                proc.kill()
+                reject(err)
+            })
+        }
+    })
+}
+
+function scaleAndNormalize(raw: number[], points: number): Uint8Array {
+    const scaled = new Float32Array(points)
+    if (raw.length <= points) {
+        if (raw.length === 1) {
+            scaled.fill(raw[0])
+        } else {
+            for (let i = 0; i < points; i++) {
+                const pos = (i / (points - 1)) * (raw.length - 1)
+                const lo = Math.floor(pos)
+                const hi = Math.ceil(pos)
+                const frac = pos - lo
+                scaled[i] = raw[lo] + (raw[hi] - raw[lo]) * frac
+            }
+        }
+    } else {
+        const bucketSize = raw.length / points
+        for (let i = 0; i < points; i++) {
+            const start = Math.floor(i * bucketSize)
+            const end = Math.floor((i + 1) * bucketSize)
+            let sum = 0
+            for (let j = start; j < end; j++) sum += raw[j]
+            scaled[i] = sum / (end - start)
+        }
+    }
+
+    let max = 0
+    for (let i = 0; i < points; i++) {
+        if (scaled[i] > max) max = scaled[i]
+    }
+
+    const waveform = new Uint8Array(points)
+    if (max > 0) {
+        for (let i = 0; i < points; i++) {
+            waveform[i] = Math.round((scaled[i] / max) * 100)
+        }
+    }
+    return waveform
+}

--- a/packages/media-utils/src/index.ts
+++ b/packages/media-utils/src/index.ts
@@ -1,0 +1,47 @@
+import type { WaMediaProcessor, WaMediaProcessorInput } from 'zapo-js/media'
+
+import {
+    computeWaveformWithFfmpeg,
+    generateVideoThumbnailWithFfmpeg,
+    probeWithFfmpeg
+} from './ffmpeg'
+import { generateImageThumbnail, generateStickerThumbnail } from './sharp'
+import type { WaMediaProcessorOptions } from './types'
+
+export type { WaMediaProcessorOptions } from './types'
+
+export function createMediaProcessor(options?: WaMediaProcessorOptions): WaMediaProcessor {
+    const opts = options ?? {}
+    const warn = opts.onWarning
+
+    return {
+        async generateImageThumbnail(input: WaMediaProcessorInput, maxEdge: number) {
+            return generateImageThumbnail(
+                input,
+                opts.imageThumbMaxEdge ?? maxEdge,
+                opts.imageThumbQuality
+            )
+        },
+
+        async generateVideoThumbnail(input: WaMediaProcessorInput, maxEdge: number) {
+            return generateVideoThumbnailWithFfmpeg(
+                input,
+                opts.imageThumbMaxEdge ?? maxEdge,
+                opts.ffmpegPath,
+                warn
+            )
+        },
+
+        async probeMedia(input: WaMediaProcessorInput) {
+            return (await probeWithFfmpeg(input, opts.ffprobePath, warn)) ?? {}
+        },
+
+        async computeWaveform(input: WaMediaProcessorInput) {
+            return computeWaveformWithFfmpeg(input, opts.ffmpegPath, opts.waveformPoints, warn)
+        },
+
+        async generateStickerThumbnail(input: WaMediaProcessorInput, maxEdge: number) {
+            return generateStickerThumbnail(input, maxEdge)
+        }
+    }
+}

--- a/packages/media-utils/src/sharp.ts
+++ b/packages/media-utils/src/sharp.ts
@@ -1,0 +1,47 @@
+import sharp from 'sharp'
+import type {
+    WaMediaProcessorImageResult,
+    WaMediaProcessorInput,
+    WaMediaProcessorStickerThumbnailResult
+} from 'zapo-js/media'
+
+const DEFAULT_THUMB_QUALITY = 70
+
+function createPipeline(input: WaMediaProcessorInput): sharp.Sharp {
+    if (input instanceof Uint8Array || typeof input === 'string') return sharp(input)
+    const pipeline = sharp()
+    ;(input as NodeJS.ReadableStream).pipe(pipeline)
+    return pipeline
+}
+
+export async function generateImageThumbnail(
+    input: WaMediaProcessorInput,
+    maxEdge: number,
+    quality?: number
+): Promise<WaMediaProcessorImageResult> {
+    const { data, info } = await createPipeline(input)
+        .rotate()
+        .resize(maxEdge, maxEdge, { fit: 'inside', withoutEnlargement: true })
+        .jpeg({ quality: quality ?? DEFAULT_THUMB_QUALITY })
+        .toBuffer({ resolveWithObject: true })
+    return {
+        jpegThumbnail: new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
+        width: info.width,
+        height: info.height
+    }
+}
+
+export async function generateStickerThumbnail(
+    input: WaMediaProcessorInput,
+    maxEdge: number
+): Promise<WaMediaProcessorStickerThumbnailResult> {
+    const { data, info } = await createPipeline(input)
+        .resize(maxEdge, maxEdge, { fit: 'inside', withoutEnlargement: true })
+        .png()
+        .toBuffer({ resolveWithObject: true })
+    return {
+        pngThumbnail: new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
+        width: info.width,
+        height: info.height
+    }
+}

--- a/packages/media-utils/src/types.ts
+++ b/packages/media-utils/src/types.ts
@@ -1,0 +1,8 @@
+export interface WaMediaProcessorOptions {
+    readonly ffmpegPath?: string
+    readonly ffprobePath?: string
+    readonly imageThumbMaxEdge?: number
+    readonly imageThumbQuality?: number
+    readonly waveformPoints?: number
+    readonly onWarning?: (message: string) => void
+}

--- a/packages/media-utils/tsconfig.build.cjs.json
+++ b/packages/media-utils/tsconfig.build.cjs.json
@@ -1,0 +1,14 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.build.paths.json"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/media-utils/tsconfig.json
+++ b/packages/media-utils/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.paths.json"],
+    "compilerOptions": {
+        "types": ["node"],
+        "rootDir": "../..",
+        "noEmit": true
+    },
+    "include": ["src"],
+    "exclude": ["dist", "node_modules"]
+}

--- a/packages/tsconfig.build.paths.json
+++ b/packages/tsconfig.build.paths.json
@@ -11,6 +11,7 @@
             "zapo-js/proto": ["dist/types/proto.d.ts"],
             "zapo-js/protocol": ["dist/types/protocol/index.d.ts"],
             "zapo-js/crypto": ["dist/types/crypto/index.d.ts"],
+            "zapo-js/media": ["dist/types/media/index.d.ts"],
             "zapo-js/util": ["dist/types/util/index.d.ts"]
         }
     }

--- a/packages/tsconfig.paths.json
+++ b/packages/tsconfig.paths.json
@@ -11,6 +11,7 @@
             "zapo-js/proto": ["src/proto.ts"],
             "zapo-js/protocol": ["src/protocol/index.ts"],
             "zapo-js/crypto": ["src/crypto/index.ts"],
+            "zapo-js/media": ["src/media/index.ts"],
             "zapo-js/util": ["src/util/index.ts"],
             "@appstate": ["src/appstate/index.ts"],
             "@appstate/*": ["src/appstate/*"],

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -82,7 +82,7 @@ import { getFirstNodeChild } from '@transport/node/helpers'
 import { createUsyncSidGenerator } from '@transport/node/usync'
 import { WaNodeOrchestrator } from '@transport/node/WaNodeOrchestrator'
 import { WaNodeTransport } from '@transport/node/WaNodeTransport'
-import { isProxyTransport, toProxyAgent, toProxyDispatcher } from '@transport/proxy'
+import { isProxyTransport, toProxyAgent } from '@transport/proxy'
 import type { BinaryNode } from '@transport/types'
 import { toError } from '@util/primitives'
 import { getRuntimeOsDisplayName } from '@util/runtime'
@@ -393,8 +393,6 @@ export function buildWaClientDependencies(input: {
     const mediaTransfer = new WaMediaTransferClient({
         logger,
         defaultTimeoutMs: options.mediaTimeoutMs,
-        defaultUploadDispatcher: toProxyDispatcher(options.proxy?.mediaUpload),
-        defaultDownloadDispatcher: toProxyDispatcher(options.proxy?.mediaDownload),
         defaultUploadAgent: toProxyAgent(options.proxy?.mediaUpload),
         defaultDownloadAgent: toProxyAgent(options.proxy?.mediaDownload)
     })
@@ -412,7 +410,8 @@ export function buildWaClientDependencies(input: {
         setMediaConnCache: (mediaConn) => {
             mediaConnCacheFallback = mediaConn
             connectionManager?.setMediaConnCache(mediaConn)
-        }
+        },
+        media: options.media
     }
 
     const messageClient = new WaMessageClient({

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -1,0 +1,347 @@
+import { createReadStream, createWriteStream } from 'node:fs'
+import { open, unlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+
+import type { WaMediaOptions } from '@client/types'
+import type { Logger } from '@infra/log/types'
+import type { WaSendMediaMessage } from '@message/types'
+import { toBytesView } from '@util/bytes'
+import { toError } from '@util/primitives'
+
+export interface ProcessedMediaFields {
+    readonly jpegThumbnail?: Uint8Array
+    readonly pngThumbnail?: Uint8Array
+    readonly width?: number
+    readonly height?: number
+    readonly seconds?: number
+    readonly waveform?: Uint8Array
+    readonly isAnimated?: boolean
+    readonly firstFrameLength?: number
+}
+
+interface MutableProcessedMediaFields {
+    jpegThumbnail?: Uint8Array
+    pngThumbnail?: Uint8Array
+    width?: number
+    height?: number
+    seconds?: number
+    waveform?: Uint8Array
+    isAnimated?: boolean
+    firstFrameLength?: number
+}
+
+export async function readFileHead(filePath: string, bytes: number): Promise<Uint8Array> {
+    const fh = await open(filePath, 'r')
+    try {
+        const buf = new Uint8Array(bytes)
+        const { bytesRead } = await fh.read(buf, 0, bytes, 0)
+        return buf.subarray(0, bytesRead)
+    } finally {
+        await fh.close()
+    }
+}
+
+const RIFF_HEADER_SIZE = 12
+const CHUNK_HEADER_SIZE = 8
+const CHUNK_ID_SIZE = 4
+const ANMF_ID = [0x41, 0x4e, 0x4d, 0x46]
+
+interface WebpAnimInfo {
+    readonly isAnimated: true
+    readonly firstFrameLength: number
+}
+
+export function parseWebpAnimation(data: Uint8Array): WebpAnimInfo | null {
+    if (data.byteLength < RIFF_HEADER_SIZE + CHUNK_HEADER_SIZE) return null
+    let offset = RIFF_HEADER_SIZE
+    if (
+        data[offset] !== 0x56 ||
+        data[offset + 1] !== 0x50 ||
+        data[offset + 2] !== 0x38 ||
+        data[offset + 3] !== 0x58
+    ) {
+        return null
+    }
+    // Skip VP8X chunk: 8 byte header + 10 byte payload
+    offset += CHUNK_HEADER_SIZE + 10
+
+    while (offset + CHUNK_HEADER_SIZE <= data.byteLength) {
+        const isAnmf =
+            data[offset] === ANMF_ID[0] &&
+            data[offset + 1] === ANMF_ID[1] &&
+            data[offset + 2] === ANMF_ID[2] &&
+            data[offset + 3] === ANMF_ID[3]
+
+        const sizeOffset = offset + CHUNK_ID_SIZE
+        if (sizeOffset + 4 > data.byteLength) return null
+
+        let chunkSize =
+            (data[sizeOffset] |
+                (data[sizeOffset + 1] << 8) |
+                (data[sizeOffset + 2] << 16) |
+                (data[sizeOffset + 3] << 24)) >>>
+            0
+        if (chunkSize % 2 !== 0) chunkSize += 1
+
+        const nextOffset = offset + CHUNK_HEADER_SIZE + chunkSize
+        if (nextOffset <= offset || nextOffset > data.byteLength) return null
+
+        if (isAnmf) {
+            return { isAnimated: true, firstFrameLength: nextOffset }
+        }
+
+        offset = nextOffset
+    }
+    return null
+}
+
+const IMAGE_THUMB_MAX_EDGE = 320
+const VIDEO_THUMB_MAX_EDGE = 48
+const STICKER_THUMB_MAX_EDGE = 100
+const EMPTY_PROCESSED: ProcessedMediaFields = {}
+type MediaProcessorStep = 'thumbnail' | 'probe' | 'waveform' | 'stickerThumbnail'
+
+export function isReadableStream(value: unknown): value is Readable {
+    return (
+        !!value &&
+        typeof value === 'object' &&
+        'pipe' in value &&
+        typeof (value as Readable).pipe === 'function'
+    )
+}
+
+async function streamToTempFile(source: Readable): Promise<string> {
+    const filePath = join(
+        tmpdir(),
+        `zapo-media-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    )
+    try {
+        await pipeline(source, createWriteStream(filePath))
+    } catch (error) {
+        await unlink(filePath).catch(() => undefined)
+        throw error
+    }
+    return filePath
+}
+
+export async function cleanupTempFile(filePath: string): Promise<void> {
+    await unlink(filePath).catch(() => undefined)
+}
+
+export interface ResolvedMediaInputs {
+    readonly processorInput?: Uint8Array | string
+    readonly uploadMedia: Uint8Array | Readable
+    readonly tempFilePath?: string
+}
+
+export async function resolveMediaInputs(
+    shouldProcess: boolean,
+    raw: Uint8Array | ArrayBuffer | Readable | string
+): Promise<ResolvedMediaInputs> {
+    if (typeof raw === 'string') {
+        return {
+            processorInput: raw,
+            uploadMedia: createReadStream(raw)
+        }
+    }
+    if (isReadableStream(raw)) {
+        if (shouldProcess) {
+            const tempFilePath = await streamToTempFile(raw)
+            return {
+                processorInput: tempFilePath,
+                uploadMedia: createReadStream(tempFilePath),
+                tempFilePath
+            }
+        }
+        return { uploadMedia: raw }
+    }
+    const bytes = toBytesView(raw)
+    return { processorInput: bytes, uploadMedia: bytes }
+}
+
+function shouldGenerateThumbnail(
+    media: WaMediaOptions | undefined,
+    content: WaSendMediaMessage
+): boolean {
+    if (!media?.processor || media.generateThumbnail === false) {
+        return false
+    }
+
+    switch (content.type) {
+        case 'image':
+            return content.jpegThumbnail === undefined && !!media.processor.generateImageThumbnail
+        case 'video':
+        case 'ptv':
+            return content.jpegThumbnail === undefined && !!media.processor.generateVideoThumbnail
+        case 'document':
+            return !!media.processor.generateImageThumbnail
+        default:
+            return false
+    }
+}
+
+function shouldProbeMedia(media: WaMediaOptions | undefined, content: WaSendMediaMessage): boolean {
+    if (!media?.processor?.probeMedia || media.generateProbe === false) {
+        return false
+    }
+
+    switch (content.type) {
+        case 'video':
+        case 'ptv':
+            return (
+                content.seconds === undefined ||
+                content.width === undefined ||
+                content.height === undefined
+            )
+        case 'audio':
+            return content.seconds === undefined
+        default:
+            return false
+    }
+}
+
+function shouldGenerateWaveform(
+    media: WaMediaOptions | undefined,
+    content: WaSendMediaMessage
+): boolean {
+    return (
+        !!media?.processor?.computeWaveform &&
+        media.generateWaveform !== false &&
+        content.type === 'audio' &&
+        content.waveform === undefined
+    )
+}
+
+function shouldGenerateStickerThumbnail(
+    media: WaMediaOptions | undefined,
+    content: WaSendMediaMessage
+): boolean {
+    return (
+        !!media?.processor?.generateStickerThumbnail &&
+        media.generateStickerThumbnail !== false &&
+        content.type === 'sticker' &&
+        content.pngThumbnail === undefined
+    )
+}
+
+export function hasMediaProcessingTasks(
+    media: WaMediaOptions | undefined,
+    content: WaSendMediaMessage
+): boolean {
+    return (
+        shouldGenerateThumbnail(media, content) ||
+        shouldProbeMedia(media, content) ||
+        shouldGenerateWaveform(media, content) ||
+        shouldGenerateStickerThumbnail(media, content)
+    )
+}
+
+async function runProcessorStep<T>(
+    step: MediaProcessorStep,
+    content: WaSendMediaMessage,
+    logger: Logger,
+    fn: () => Promise<T>
+): Promise<T | null> {
+    try {
+        return await fn()
+    } catch (error) {
+        logger.error('media processor step failed, skipping step', {
+            type: content.type,
+            step,
+            message: toError(error).message
+        })
+        return null
+    }
+}
+
+export async function runMediaProcessor(
+    media: WaMediaOptions | undefined,
+    input: Uint8Array | string | undefined,
+    content: WaSendMediaMessage,
+    logger: Logger
+): Promise<ProcessedMediaFields> {
+    const processor = media?.processor
+    if (!processor || !hasMediaProcessingTasks(media, content) || !input) return EMPTY_PROCESSED
+
+    const result: MutableProcessedMediaFields = {}
+
+    const isVideo = content.type === 'video' || content.type === 'ptv'
+    const thumbFn = isVideo ? processor.generateVideoThumbnail : processor.generateImageThumbnail
+    const thumbMaxEdge = isVideo ? VIDEO_THUMB_MAX_EDGE : IMAGE_THUMB_MAX_EDGE
+
+    const thumbTask = shouldGenerateThumbnail(media, content)
+        ? runProcessorStep('thumbnail', content, logger, () => thumbFn!(input, thumbMaxEdge))
+        : null
+
+    const probeTask = shouldProbeMedia(media, content)
+        ? runProcessorStep('probe', content, logger, () => processor.probeMedia!(input))
+        : null
+
+    const [thumb, probe] = await Promise.all([thumbTask, probeTask])
+
+    if (thumb) {
+        result.jpegThumbnail = thumb.jpegThumbnail
+        if (!isVideo && !probe) {
+            result.width = thumb.width
+            result.height = thumb.height
+        }
+    }
+
+    if (probe) {
+        if (
+            probe.durationSeconds !== undefined &&
+            !('seconds' in content && content.seconds !== undefined)
+        ) {
+            result.seconds = Math.floor(probe.durationSeconds)
+        }
+        if (!('width' in content && content.width !== undefined) && probe.width !== undefined) {
+            result.width = probe.width
+        }
+        if (!('height' in content && content.height !== undefined) && probe.height !== undefined) {
+            result.height = probe.height
+        }
+    }
+
+    if (shouldGenerateWaveform(media, content)) {
+        const waveformResult = await runProcessorStep('waveform', content, logger, () =>
+            processor.computeWaveform!(input)
+        )
+        if (waveformResult) {
+            result.waveform = waveformResult.waveform
+            if (
+                result.seconds === undefined &&
+                !('seconds' in content && content.seconds !== undefined)
+            ) {
+                result.seconds = Math.floor(waveformResult.durationSeconds)
+            }
+        }
+    }
+
+    if (content.type === 'sticker') {
+        if (shouldGenerateStickerThumbnail(media, content)) {
+            const stickerThumb = await runProcessorStep('stickerThumbnail', content, logger, () =>
+                processor.generateStickerThumbnail!(input, STICKER_THUMB_MAX_EDGE)
+            )
+            if (stickerThumb) {
+                result.pngThumbnail = stickerThumb.pngThumbnail
+                result.width = stickerThumb.width
+                result.height = stickerThumb.height
+            }
+        }
+        if (content.isAnimated === undefined) {
+            const header = typeof input === 'string' ? await readFileHead(input, 100) : input
+            const anim = parseWebpAnimation(header)
+            if (anim) {
+                result.isAnimated = true
+                result.firstFrameLength = anim.firstFrameLength
+            } else {
+                result.isAnimated = false
+            }
+        }
+    }
+
+    return result
+}

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -1,6 +1,16 @@
 import { createReadStream } from 'node:fs'
 import type { Readable } from 'node:stream'
 
+import {
+    cleanupTempFile,
+    hasMediaProcessingTasks,
+    isReadableStream,
+    parseWebpAnimation,
+    readFileHead,
+    resolveMediaInputs,
+    runMediaProcessor
+} from '@client/media'
+import type { WaMediaOptions } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import { parseMediaConnResponse } from '@media/conn'
 import { MEDIA_CONN_CACHE_GRACE_MS, MEDIA_UPLOAD_PATHS } from '@media/constants'
@@ -13,7 +23,7 @@ import type { Proto } from '@proto'
 import { WA_DEFAULTS } from '@protocol/constants'
 import { buildMediaConnIq } from '@transport/node/builders/media'
 import type { BinaryNode } from '@transport/types'
-import { bytesToBase64UrlSafe, TEXT_DECODER, toBytesView } from '@util/bytes'
+import { bytesToBase64UrlSafe, TEXT_DECODER } from '@util/bytes'
 import { toError } from '@util/primitives'
 
 export interface WaMediaMessageOptions {
@@ -28,6 +38,7 @@ export interface WaMediaMessageOptions {
     ) => Promise<BinaryNode>
     readonly getMediaConnCache: () => WaMediaConn | null
     readonly setMediaConnCache: (mediaConn: WaMediaConn | null) => void
+    readonly media?: WaMediaOptions
 }
 
 export async function buildMediaMessageContent(
@@ -67,100 +78,174 @@ export async function getMediaConn(
     return mediaConn
 }
 
+function needsSidecar(content: WaSendMediaMessage): boolean {
+    return content.type === 'video' || content.type === 'ptv' || content.type === 'audio'
+}
+
 function resolveUploadType(content: WaSendMediaMessage): MediaCryptoType {
     if (content.type === 'video' && content.gifPlayback) return 'gif'
     if (content.type === 'audio' && content.ptt) return 'ptt'
     return content.type as MediaCryptoType
 }
 
-function isReadableStream(value: unknown): value is Readable {
-    return (
-        !!value &&
-        typeof value === 'object' &&
-        'pipe' in value &&
-        typeof (value as Readable).pipe === 'function'
-    )
+function resolveMimetype(content: WaSendMediaMessage): string {
+    if (content.mimetype) return content.mimetype
+    if (content.type === 'sticker') return 'image/webp'
+    throw new Error(`mimetype is required for ${content.type} messages`)
 }
 
 async function buildMediaMessage(
     options: WaMediaMessageOptions,
     content: WaSendMediaMessage
 ): Promise<Proto.IMessage> {
-    const uploaded = isReadableStream(content.media)
-        ? await uploadMediaStream(options, content, content.media)
-        : await uploadMediaBytes(options, content, toBytesView(content.media))
-    const mediaKeyTimestamp = Math.floor(Date.now() / 1000)
-    const common = {
-        url: uploaded.url,
-        mimetype: content.mimetype,
-        fileSha256: uploaded.fileSha256,
-        fileLength: uploaded.fileLength,
-        mediaKey: uploaded.mediaKey,
-        fileEncSha256: uploaded.fileEncSha256,
-        directPath: uploaded.directPath,
-        mediaKeyTimestamp
-    }
+    const needsTempFile =
+        hasMediaProcessingTasks(options.media, content) ||
+        (content.type === 'sticker' && content.firstFrameLength === undefined)
+    const resolved = await resolveMediaInputs(needsTempFile, content.media)
 
-    switch (content.type) {
-        case 'image':
-            return {
-                imageMessage: {
-                    ...common,
-                    caption: content.caption,
-                    width: content.width,
-                    height: content.height
+    try {
+        let detectedFirstFrameLength: number | undefined
+        if (
+            content.type === 'sticker' &&
+            content.firstFrameLength === undefined &&
+            resolved.processorInput
+        ) {
+            const input = resolved.processorInput
+            const header =
+                typeof input === 'string' ? await readFileHead(input, 100) : input.subarray(0, 100)
+            detectedFirstFrameLength = parseWebpAnimation(header)?.firstFrameLength
+        }
+        const firstFrameLength =
+            content.type === 'sticker'
+                ? (content.firstFrameLength ?? detectedFirstFrameLength)
+                : undefined
+
+        const uploadPromise = isReadableStream(resolved.uploadMedia)
+            ? uploadMediaStream(options, content, resolved.uploadMedia, firstFrameLength)
+            : uploadMediaBytes(options, content, resolved.uploadMedia, firstFrameLength)
+        const processPromise = runMediaProcessor(
+            options.media,
+            resolved.processorInput,
+            content,
+            options.logger
+        )
+        const [uploadResult, processResult] = await Promise.allSettled([
+            uploadPromise,
+            processPromise
+        ])
+        if (uploadResult.status === 'rejected') throw uploadResult.reason
+        if (processResult.status === 'rejected') throw processResult.reason
+        const uploaded = uploadResult.value
+        const processed = processResult.value
+        const mediaKeyTimestamp = Math.floor(Date.now() / 1000)
+        const uploadedFields = {
+            url: uploaded.url,
+            fileSha256: uploaded.fileSha256,
+            fileLength: uploaded.fileLength,
+            mediaKey: uploaded.mediaKey,
+            fileEncSha256: uploaded.fileEncSha256,
+            directPath: uploaded.directPath,
+            mediaKeyTimestamp,
+            mimetype: resolveMimetype(content)
+        }
+
+        function spread(c: WaSendMediaMessage): Record<string, unknown> {
+            const result: Record<string, unknown> = {}
+            for (const key in c) {
+                if (
+                    key !== 'type' &&
+                    key !== 'media' &&
+                    key !== 'fileLength' &&
+                    key !== 'mimetype'
+                ) {
+                    result[key] = (c as unknown as Record<string, unknown>)[key]
                 }
             }
-        case 'video':
-            return {
-                videoMessage: {
-                    ...common,
-                    caption: content.caption,
-                    gifPlayback: content.gifPlayback,
-                    seconds: content.seconds,
-                    width: content.width,
-                    height: content.height,
-                    metadataUrl: uploaded.metadataUrl
+            return result
+        }
+
+        switch (content.type) {
+            case 'image':
+                return {
+                    imageMessage: {
+                        ...spread(content),
+                        ...uploadedFields,
+                        width: content.width ?? processed.width,
+                        height: content.height ?? processed.height,
+                        jpegThumbnail: content.jpegThumbnail ?? processed.jpegThumbnail
+                    }
                 }
-            }
-        case 'ptv':
-            return {
-                ptvMessage: {
-                    ...common,
-                    seconds: content.seconds,
-                    width: content.width,
-                    height: content.height
+            case 'video':
+                return {
+                    videoMessage: {
+                        ...spread(content),
+                        ...uploadedFields,
+                        seconds: content.seconds ?? processed.seconds,
+                        width: content.width ?? processed.width,
+                        height: content.height ?? processed.height,
+                        jpegThumbnail: content.jpegThumbnail ?? processed.jpegThumbnail,
+                        streamingSidecar: uploaded.streamingSidecar,
+                        metadataUrl: uploaded.metadataUrl
+                    }
                 }
-            }
-        case 'audio':
-            return {
-                audioMessage: {
-                    ...common,
-                    seconds: content.seconds,
-                    ptt: content.ptt
+            case 'ptv':
+                return {
+                    ptvMessage: {
+                        ...spread(content),
+                        ...uploadedFields,
+                        seconds: content.seconds ?? processed.seconds,
+                        width: content.width ?? processed.width,
+                        height: content.height ?? processed.height,
+                        jpegThumbnail: content.jpegThumbnail ?? processed.jpegThumbnail,
+                        streamingSidecar: uploaded.streamingSidecar
+                    }
                 }
-            }
-        case 'document':
-            return {
-                documentMessage: {
-                    ...common,
-                    caption: content.caption,
-                    fileName: content.fileName ?? 'file',
-                    title: content.fileName ?? undefined
+            case 'audio':
+                return {
+                    audioMessage: {
+                        ...spread(content),
+                        ...uploadedFields,
+                        seconds: content.seconds ?? processed.seconds,
+                        streamingSidecar: uploaded.streamingSidecar,
+                        waveform: content.waveform ?? processed.waveform
+                    }
                 }
-            }
-        case 'sticker':
-            return {
-                stickerMessage: {
-                    ...common,
-                    width: content.width,
-                    height: content.height
+            case 'document':
+                return {
+                    documentMessage: {
+                        ...spread(content),
+                        ...uploadedFields,
+                        fileName: content.fileName ?? 'file',
+                        title: content.title ?? content.fileName ?? undefined,
+                        jpegThumbnail: content.jpegThumbnail ?? processed.jpegThumbnail
+                    }
                 }
-            }
-        default:
-            throw new Error(
-                `unsupported media message type: ${String((content as Record<string, unknown>).type)}`
-            )
+            case 'sticker':
+                return {
+                    stickerMessage: {
+                        ...spread(content),
+                        ...uploadedFields,
+                        width: content.width ?? processed.width,
+                        height: content.height ?? processed.height,
+                        pngThumbnail: content.pngThumbnail ?? processed.pngThumbnail,
+                        isAnimated:
+                            content.isAnimated ??
+                            processed.isAnimated ??
+                            firstFrameLength !== undefined,
+                        firstFrameLength: content.firstFrameLength ?? uploaded.firstFrameLength,
+                        firstFrameSidecar: content.firstFrameSidecar ?? uploaded.firstFrameSidecar,
+                        stickerSentTs: content.stickerSentTs ?? Date.now()
+                    }
+                }
+            default:
+                throw new Error(
+                    `unsupported media message type: ${String((content as Record<string, unknown>).type)}`
+                )
+        }
+    } finally {
+        if (resolved.tempFilePath) {
+            await cleanupTempFile(resolved.tempFilePath)
+        }
     }
 }
 
@@ -172,6 +257,9 @@ interface UploadResult {
     readonly fileEncSha256: Uint8Array
     readonly fileLength: number
     readonly metadataUrl?: string
+    readonly streamingSidecar?: Uint8Array
+    readonly firstFrameSidecar?: Uint8Array
+    readonly firstFrameLength?: number
 }
 
 function buildUploadUrl(
@@ -222,12 +310,16 @@ function parseUploadResponse(
 async function uploadMediaBytes(
     options: WaMediaMessageOptions,
     content: WaSendMediaMessage,
-    mediaBytes: Uint8Array
+    mediaBytes: Uint8Array,
+    firstFrameLength?: number
 ): Promise<UploadResult> {
     const uploadType = resolveUploadType(content)
     const mediaKey = await WaMediaCrypto.generateMediaKey()
     const [encrypted, mediaConn] = await Promise.all([
-        WaMediaCrypto.encryptBytes(uploadType, mediaKey, mediaBytes),
+        WaMediaCrypto.encryptBytes(uploadType, mediaKey, mediaBytes, {
+            sidecar: needsSidecar(content),
+            firstFrameLength
+        }),
         getMediaConn(options)
     ])
     const selectedHost =
@@ -249,7 +341,7 @@ async function uploadMediaBytes(
         method: 'POST',
         body: encrypted.ciphertextHmac,
         contentLength: encrypted.ciphertextHmac.byteLength,
-        contentType: content.mimetype
+        contentType: resolveMimetype(content)
     })
     const responseBody = await options.mediaTransfer.readResponseBytes(uploadResponse)
     const parsed = parseUploadResponse(responseBody, uploadResponse.status)
@@ -258,18 +350,25 @@ async function uploadMediaBytes(
         mediaKey,
         fileSha256: encrypted.fileSha256,
         fileEncSha256: encrypted.fileEncSha256,
-        fileLength: mediaBytes.byteLength
+        fileLength: mediaBytes.byteLength,
+        streamingSidecar: encrypted.streamingSidecar,
+        firstFrameSidecar: encrypted.firstFrameSidecar,
+        firstFrameLength
     }
 }
 
 async function uploadMediaStream(
     options: WaMediaMessageOptions,
     content: WaSendMediaMessage,
-    stream: Readable
+    stream: Readable,
+    firstFrameLength?: number
 ): Promise<UploadResult> {
     const uploadType = resolveUploadType(content)
     const mediaKey = await WaMediaCrypto.generateMediaKey()
-    const encResult = await WaMediaCrypto.encryptToFile(uploadType, mediaKey, stream)
+    const encResult = await WaMediaCrypto.encryptToFile(uploadType, mediaKey, stream, {
+        sidecar: needsSidecar(content),
+        firstFrameLength
+    })
     let readStream: ReturnType<typeof createReadStream> | undefined
     try {
         const mediaConn = await getMediaConn(options)
@@ -295,7 +394,7 @@ async function uploadMediaStream(
             method: 'POST',
             body: readStream,
             contentLength: encResult.fileSize,
-            contentType: content.mimetype
+            contentType: resolveMimetype(content)
         })
         const responseBody = await options.mediaTransfer.readResponseBytes(uploadResponse)
         const parsed = parseUploadResponse(responseBody, uploadResponse.status)
@@ -304,7 +403,10 @@ async function uploadMediaStream(
             mediaKey,
             fileSha256: encResult.fileSha256,
             fileEncSha256: encResult.fileEncSha256,
-            fileLength: encResult.plaintextLength
+            fileLength: encResult.plaintextLength,
+            streamingSidecar: encResult.streamingSidecar,
+            firstFrameSidecar: encResult.firstFrameSidecar,
+            firstFrameLength
         }
     } finally {
         if (readStream && !readStream.closed) {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,5 +1,6 @@
 import type { AppStateCollectionName } from '@appstate/types'
 import type { WaAuthClientOptions, WaAuthCredentials, WaAuthSocketOptions } from '@auth/types'
+import type { WaMediaProcessor } from '@media/processor'
 import type { WaDecodedAddon } from '@message/addon-crypto'
 import type { WaMessagePublishOptions } from '@message/types'
 import type { Proto } from '@proto'
@@ -54,6 +55,15 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
     readonly privacyToken?: WaPrivacyTokenOptions
     readonly addons?: WaAddonOptions
     readonly logoutStoreClear?: WaLogoutStoreClearOptions
+    readonly media?: WaMediaOptions
+}
+
+export interface WaMediaOptions {
+    readonly processor?: WaMediaProcessor
+    readonly generateThumbnail?: boolean
+    readonly generateProbe?: boolean
+    readonly generateWaveform?: boolean
+    readonly generateStickerThumbnail?: boolean
 }
 
 export interface WaAddonOptions {

--- a/src/media/WaMediaCrypto.ts
+++ b/src/media/WaMediaCrypto.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, createDecipheriv, createHash, createHmac } from 'node:crypto'
+import { createHash, createHmac } from 'node:crypto'
 import { once } from 'node:events'
 import { createWriteStream } from 'node:fs'
 import { stat, unlink } from 'node:fs/promises'
@@ -8,6 +8,7 @@ import { PassThrough } from 'node:stream'
 import type { Readable, Writable } from 'node:stream'
 
 import { hkdf } from '@crypto/core/hkdf'
+import type { CryptoKey } from '@crypto/core/primitives'
 import {
     aesCbcDecrypt,
     aesCbcEncrypt,
@@ -24,7 +25,9 @@ import {
     IV_SIZE,
     MAC_KEY_END,
     MAC_KEY_START,
-    MEDIA_HKDF_SIZE
+    MEDIA_HKDF_SIZE,
+    SIDECAR_CHUNK_SIZE,
+    SIDECAR_HMAC_SIZE
 } from '@media/constants'
 import type {
     MediaCryptoType,
@@ -47,6 +50,117 @@ import {
     uint8TimingSafeEqual
 } from '@util/bytes'
 import { toError } from '@util/primitives'
+
+const AES_BLOCK_SIZE = 16
+const PKCS7_FULL_BLOCK = new Uint8Array(AES_BLOCK_SIZE).fill(AES_BLOCK_SIZE)
+
+async function aesCbcEncryptChunk(
+    key: CryptoKey,
+    iv: Uint8Array,
+    chunk: Uint8Array,
+    isFinal: boolean
+): Promise<{ ciphertext: Uint8Array; nextIv: Uint8Array }> {
+    const encrypted = await aesCbcEncrypt(key, iv, chunk)
+    if (isFinal) {
+        return {
+            ciphertext: encrypted,
+            nextIv: encrypted.subarray(encrypted.byteLength - AES_BLOCK_SIZE)
+        }
+    }
+    const ciphertext = encrypted.subarray(0, encrypted.byteLength - AES_BLOCK_SIZE)
+    return {
+        ciphertext,
+        nextIv: ciphertext.subarray(ciphertext.byteLength - AES_BLOCK_SIZE)
+    }
+}
+
+async function aesCbcDecryptChunk(
+    key: CryptoKey,
+    iv: Uint8Array,
+    ciphertext: Uint8Array,
+    isFinal: boolean
+): Promise<{ plaintext: Uint8Array; nextIv: Uint8Array }> {
+    const nextIv = toBytesView(ciphertext.subarray(ciphertext.byteLength - AES_BLOCK_SIZE))
+    if (isFinal) {
+        return { plaintext: await aesCbcDecrypt(key, iv, ciphertext), nextIv }
+    }
+    const padBlock = (await aesCbcEncrypt(key, nextIv, PKCS7_FULL_BLOCK)).subarray(
+        0,
+        AES_BLOCK_SIZE
+    )
+    const withPad = concatBytes([ciphertext, padBlock])
+    return { plaintext: await aesCbcDecrypt(key, iv, withPad), nextIv }
+}
+
+async function computeFirstFrameSidecar(
+    macKey: Uint8Array,
+    ivCiphertext: Uint8Array,
+    firstFrameLength: number
+): Promise<Uint8Array> {
+    const aligned = Math.ceil(firstFrameLength / AES_BLOCK_SIZE) * AES_BLOCK_SIZE
+    const slice = ivCiphertext.subarray(0, IV_SIZE + aligned)
+    const key = await importHmacKey(macKey)
+    const digest = await hmacSign(key, slice)
+    return digest.subarray(0, SIDECAR_HMAC_SIZE)
+}
+
+class SidecarAccumulator {
+    private readonly macKey: Uint8Array
+    private result: Uint8Array
+    private resultOffset = 0
+    private totalPushed = 0
+    private readonly window: Uint8Array
+    private windowOffset = 0
+    private nextChunkStart = 0
+
+    constructor(macKey: Uint8Array, estimatedSize = 0) {
+        this.macKey = macKey
+        this.window = new Uint8Array(IV_SIZE + SIDECAR_CHUNK_SIZE)
+        const estimated = Math.max(Math.ceil(estimatedSize / SIDECAR_CHUNK_SIZE) + 1, 16)
+        this.result = new Uint8Array(estimated * SIDECAR_HMAC_SIZE)
+    }
+
+    push(data: Uint8Array): void {
+        let srcOffset = 0
+        while (srcOffset < data.byteLength) {
+            const windowEnd = this.nextChunkStart + IV_SIZE + SIDECAR_CHUNK_SIZE
+            const remaining = windowEnd - this.totalPushed
+            const toCopy = Math.min(remaining, data.byteLength - srcOffset)
+            this.window.set(data.subarray(srcOffset, srcOffset + toCopy), this.windowOffset)
+            this.windowOffset += toCopy
+            this.totalPushed += toCopy
+            srcOffset += toCopy
+            if (this.totalPushed === windowEnd) {
+                this.flushChunk()
+            }
+        }
+    }
+
+    finish(): Uint8Array {
+        if (this.windowOffset > 0) {
+            this.flushChunk()
+        }
+        return this.result.subarray(0, this.resultOffset)
+    }
+
+    private flushChunk(): void {
+        const digest = createHmac('sha256', this.macKey)
+            .update(this.window.subarray(0, this.windowOffset))
+            .digest()
+        if (this.resultOffset + SIDECAR_HMAC_SIZE > this.result.byteLength) {
+            const grown = new Uint8Array(this.result.byteLength * 2)
+            grown.set(this.result)
+            this.result = grown
+        }
+        this.result.set(digest.subarray(0, SIDECAR_HMAC_SIZE), this.resultOffset)
+        this.resultOffset += SIDECAR_HMAC_SIZE
+
+        this.nextChunkStart += SIDECAR_CHUNK_SIZE
+        const overlapSrc = this.window.subarray(this.windowOffset - IV_SIZE, this.windowOffset)
+        this.window.set(overlapSrc, 0)
+        this.windowOffset = IV_SIZE
+    }
+}
 
 export class WaMediaCrypto {
     static async generateMediaKey(): Promise<Uint8Array> {
@@ -75,7 +189,8 @@ export class WaMediaCrypto {
     static async encryptBytes(
         mediaType: MediaCryptoType,
         mediaKey: Uint8Array,
-        plaintext: Uint8Array
+        plaintext: Uint8Array,
+        options?: { readonly sidecar?: boolean; readonly firstFrameLength?: number }
     ): Promise<WaMediaEncryptionResult> {
         const keys = await WaMediaCrypto.deriveKeys(mediaType, mediaKey)
         const [aesKey, hmacKey] = await Promise.all([
@@ -89,11 +204,35 @@ export class WaMediaCrypto {
         const signature = mac.subarray(0, HMAC_TRUNCATED_SIZE)
         const ciphertextHmac = concatBytes([ciphertext, signature])
 
+        let streamingSidecar: Uint8Array | undefined
+        if (options?.sidecar !== false) {
+            const acc = new SidecarAccumulator(keys.macKey)
+            acc.push(keys.iv)
+            acc.push(ciphertext)
+            acc.push(signature)
+            streamingSidecar = acc.finish()
+        }
+
+        const firstFrameSidecar =
+            options?.firstFrameLength !== undefined
+                ? await computeFirstFrameSidecar(
+                      keys.macKey,
+                      ivCiphertext,
+                      options.firstFrameLength
+                  )
+                : undefined
+
         const [fileSha256, fileEncSha256] = await Promise.all([
             sha256(plaintext),
             sha256(ciphertextHmac)
         ])
-        return { ciphertextHmac, fileSha256, fileEncSha256 }
+        return {
+            ciphertextHmac,
+            fileSha256,
+            fileEncSha256,
+            streamingSidecar,
+            firstFrameSidecar
+        }
     }
 
     static async decryptBytes(
@@ -145,18 +284,26 @@ export class WaMediaCrypto {
     static async encryptReadable(
         mediaType: MediaCryptoType,
         mediaKey: Uint8Array,
-        plaintext: Readable
+        plaintext: Readable,
+        options?: { readonly sidecar?: boolean; readonly firstFrameLength?: number }
     ): Promise<WaMediaReadableEncryptionResult> {
         const keys = await WaMediaCrypto.deriveKeys(mediaType, mediaKey)
         const encrypted = new PassThrough()
-        const metadata = pumpEncryption(plaintext, encrypted, keys)
+        const metadata = pumpEncryption(
+            plaintext,
+            encrypted,
+            keys,
+            options?.sidecar !== false,
+            options?.firstFrameLength
+        )
         return { encrypted, metadata }
     }
 
     static async encryptToFile(
         mediaType: MediaCryptoType,
         mediaKey: Uint8Array,
-        plaintext: Readable
+        plaintext: Readable,
+        options?: { readonly sidecar?: boolean; readonly firstFrameLength?: number }
     ): Promise<WaMediaFileEncryptionResult> {
         const keys = await WaMediaCrypto.deriveKeys(mediaType, mediaKey)
         const filePath = join(
@@ -165,7 +312,13 @@ export class WaMediaCrypto {
         )
         const output = createWriteStream(filePath)
         try {
-            const metadata = await pumpEncryptionToWritable(plaintext, output, keys)
+            const metadata = await pumpEncryptionToWritable(
+                plaintext,
+                output,
+                keys,
+                options?.sidecar !== false,
+                options?.firstFrameLength
+            )
             const fileSize = (await stat(filePath)).size
             return { filePath, fileSize, ...metadata }
         } catch (error) {
@@ -200,51 +353,107 @@ export class WaMediaCrypto {
 async function pumpEncryption(
     plaintext: Readable,
     encrypted: PassThrough,
-    keys: WaMediaDerivedKeys
+    keys: WaMediaDerivedKeys,
+    computeSidecar: boolean,
+    firstFrameLength?: number
 ): Promise<{
     readonly fileSha256: Uint8Array
     readonly fileEncSha256: Uint8Array
     readonly plaintextLength: number
+    readonly streamingSidecar?: Uint8Array
+    readonly firstFrameSidecar?: Uint8Array
 }> {
+    const aesKey = await importAesCbcKey(keys.encKey)
     const plainHash = createHash('sha256')
     const encHash = createHash('sha256')
     const hmac = createHmac('sha256', keys.macKey)
-    const cipher = createCipheriv('aes-256-cbc', keys.encKey, keys.iv)
+    const sidecar = computeSidecar ? new SidecarAccumulator(keys.macKey) : null
+    const ffTarget =
+        firstFrameLength !== undefined
+            ? IV_SIZE + Math.ceil(firstFrameLength / AES_BLOCK_SIZE) * AES_BLOCK_SIZE
+            : 0
+    let ffCollected = 0
+    const ffChunks: Uint8Array[] = ffTarget > 0 ? [keys.iv] : []
+    if (ffTarget > 0) ffCollected = IV_SIZE
     let plaintextLength = 0
+    let currentIv = keys.iv
+    let pending: Uint8Array = EMPTY_BYTES
 
     hmac.update(keys.iv)
+    sidecar?.push(keys.iv)
     try {
         for await (const chunk of plaintext) {
             const plainChunk = toChunkBytes(chunk)
-            if (plainChunk.byteLength === 0) {
-                continue
-            }
+            if (plainChunk.byteLength === 0) continue
             plaintextLength += plainChunk.byteLength
             plainHash.update(plainChunk)
-            const encryptedChunk = cipher.update(plainChunk)
-            if (encryptedChunk.byteLength > 0) {
-                hmac.update(encryptedChunk)
-                encHash.update(encryptedChunk)
-                await writeChunk(encrypted, encryptedChunk)
+
+            const combined =
+                pending.byteLength > 0
+                    ? concatBytes([pending, plainChunk])
+                    : toBytesView(plainChunk)
+            const aligned = combined.byteLength - (combined.byteLength % AES_BLOCK_SIZE)
+            if (aligned === 0) {
+                pending = combined
+                continue
             }
+
+            const toEncrypt = toBytesView(combined.subarray(0, aligned))
+            pending = toBytesView(combined.subarray(aligned))
+
+            const { ciphertext, nextIv } = await aesCbcEncryptChunk(
+                aesKey,
+                currentIv,
+                toEncrypt,
+                false
+            )
+            currentIv = nextIv
+            hmac.update(ciphertext)
+            encHash.update(ciphertext)
+            sidecar?.push(ciphertext)
+            if (ffCollected < ffTarget) {
+                const need = ffTarget - ffCollected
+                ffChunks.push(ciphertext.subarray(0, Math.min(need, ciphertext.byteLength)))
+                ffCollected += ciphertext.byteLength
+            }
+            await writeChunk(encrypted, ciphertext)
         }
 
-        const encryptedFinal = cipher.final()
-        if (encryptedFinal.byteLength > 0) {
-            hmac.update(encryptedFinal)
-            encHash.update(encryptedFinal)
-            await writeChunk(encrypted, encryptedFinal)
+        const { ciphertext: finalCiphertext } = await aesCbcEncryptChunk(
+            aesKey,
+            currentIv,
+            pending,
+            true
+        )
+        hmac.update(finalCiphertext)
+        encHash.update(finalCiphertext)
+        sidecar?.push(finalCiphertext)
+        if (ffCollected < ffTarget) {
+            const need = ffTarget - ffCollected
+            ffChunks.push(finalCiphertext.subarray(0, Math.min(need, finalCiphertext.byteLength)))
         }
+        await writeChunk(encrypted, finalCiphertext)
 
-        const signature = hmac.digest().subarray(0, HMAC_TRUNCATED_SIZE)
+        const signature = toBytesView(hmac.digest().subarray(0, HMAC_TRUNCATED_SIZE))
         encHash.update(signature)
+        sidecar?.push(signature)
         await writeChunk(encrypted, signature)
         encrypted.end()
+
+        let firstFrameSidecar: Uint8Array | undefined
+        if (ffTarget > 0) {
+            const ivCiphertextSlice = concatBytes(ffChunks)
+            const ffKey = await importHmacKey(keys.macKey)
+            const ffDigest = await hmacSign(ffKey, ivCiphertextSlice)
+            firstFrameSidecar = ffDigest.subarray(0, SIDECAR_HMAC_SIZE)
+        }
 
         return {
             fileSha256: toBytesView(plainHash.digest()),
             fileEncSha256: toBytesView(encHash.digest()),
-            plaintextLength
+            plaintextLength,
+            streamingSidecar: sidecar?.finish(),
+            firstFrameSidecar
         }
     } catch (error) {
         const normalized = toError(error)
@@ -284,51 +493,107 @@ async function endWritable(stream: Writable): Promise<void> {
 async function pumpEncryptionToWritable(
     plaintext: Readable,
     output: Writable,
-    keys: WaMediaDerivedKeys
+    keys: WaMediaDerivedKeys,
+    computeSidecar: boolean,
+    firstFrameLength?: number
 ): Promise<{
     readonly fileSha256: Uint8Array
     readonly fileEncSha256: Uint8Array
     readonly plaintextLength: number
+    readonly streamingSidecar?: Uint8Array
+    readonly firstFrameSidecar?: Uint8Array
 }> {
+    const aesKey = await importAesCbcKey(keys.encKey)
     const plainHash = createHash('sha256')
     const encHash = createHash('sha256')
     const hmac = createHmac('sha256', keys.macKey)
-    const cipher = createCipheriv('aes-256-cbc', keys.encKey, keys.iv)
+    const sidecar = computeSidecar ? new SidecarAccumulator(keys.macKey) : null
+    const ffTarget =
+        firstFrameLength !== undefined
+            ? IV_SIZE + Math.ceil(firstFrameLength / AES_BLOCK_SIZE) * AES_BLOCK_SIZE
+            : 0
+    let ffCollected = 0
+    const ffChunks: Uint8Array[] = ffTarget > 0 ? [keys.iv] : []
+    if (ffTarget > 0) ffCollected = IV_SIZE
     let plaintextLength = 0
+    let currentIv = keys.iv
+    let pending: Uint8Array = EMPTY_BYTES
 
     hmac.update(keys.iv)
+    sidecar?.push(keys.iv)
     try {
         for await (const chunk of plaintext) {
             const plainChunk = toChunkBytes(chunk)
-            if (plainChunk.byteLength === 0) {
-                continue
-            }
+            if (plainChunk.byteLength === 0) continue
             plaintextLength += plainChunk.byteLength
             plainHash.update(plainChunk)
-            const encryptedChunk = cipher.update(plainChunk)
-            if (encryptedChunk.byteLength > 0) {
-                hmac.update(encryptedChunk)
-                encHash.update(encryptedChunk)
-                await writeChunkToWritable(output, encryptedChunk)
+
+            const combined =
+                pending.byteLength > 0
+                    ? concatBytes([pending, plainChunk])
+                    : toBytesView(plainChunk)
+            const aligned = combined.byteLength - (combined.byteLength % AES_BLOCK_SIZE)
+            if (aligned === 0) {
+                pending = combined
+                continue
             }
+
+            const toEncrypt = toBytesView(combined.subarray(0, aligned))
+            pending = toBytesView(combined.subarray(aligned))
+
+            const { ciphertext, nextIv } = await aesCbcEncryptChunk(
+                aesKey,
+                currentIv,
+                toEncrypt,
+                false
+            )
+            currentIv = nextIv
+            hmac.update(ciphertext)
+            encHash.update(ciphertext)
+            sidecar?.push(ciphertext)
+            if (ffCollected < ffTarget) {
+                const need = ffTarget - ffCollected
+                ffChunks.push(ciphertext.subarray(0, Math.min(need, ciphertext.byteLength)))
+                ffCollected += ciphertext.byteLength
+            }
+            await writeChunkToWritable(output, ciphertext)
         }
 
-        const encryptedFinal = cipher.final()
-        if (encryptedFinal.byteLength > 0) {
-            hmac.update(encryptedFinal)
-            encHash.update(encryptedFinal)
-            await writeChunkToWritable(output, encryptedFinal)
+        const { ciphertext: finalCiphertext } = await aesCbcEncryptChunk(
+            aesKey,
+            currentIv,
+            pending,
+            true
+        )
+        hmac.update(finalCiphertext)
+        encHash.update(finalCiphertext)
+        sidecar?.push(finalCiphertext)
+        if (ffCollected < ffTarget) {
+            const need = ffTarget - ffCollected
+            ffChunks.push(finalCiphertext.subarray(0, Math.min(need, finalCiphertext.byteLength)))
         }
+        await writeChunkToWritable(output, finalCiphertext)
 
-        const signature = hmac.digest().subarray(0, HMAC_TRUNCATED_SIZE)
+        const signature = toBytesView(hmac.digest().subarray(0, HMAC_TRUNCATED_SIZE))
         encHash.update(signature)
+        sidecar?.push(signature)
         await writeChunkToWritable(output, signature)
         await endWritable(output)
+
+        let firstFrameSidecar: Uint8Array | undefined
+        if (ffTarget > 0) {
+            const ivCiphertextSlice = concatBytes(ffChunks)
+            const ffKey = await importHmacKey(keys.macKey)
+            const ffDigest = await hmacSign(ffKey, ivCiphertextSlice)
+            firstFrameSidecar = ffDigest.subarray(0, SIDECAR_HMAC_SIZE)
+        }
 
         return {
             fileSha256: toBytesView(plainHash.digest()),
             fileEncSha256: toBytesView(encHash.digest()),
-            plaintextLength
+            plaintextLength,
+            streamingSidecar: sidecar?.finish(),
+            firstFrameSidecar
         }
     } catch (error) {
         const normalized = toError(error)
@@ -343,10 +608,12 @@ async function pumpDecryption(
     keys: WaMediaDerivedKeys,
     options: WaMediaDecryptReadableOptions
 ): Promise<{ readonly fileSha256: Uint8Array; readonly fileEncSha256: Uint8Array }> {
+    const aesKey = await importAesCbcKey(keys.encKey)
     const plainHash = createHash('sha256')
     const encHash = createHash('sha256')
     const hmac = createHmac('sha256', keys.macKey)
-    const decipher = createDecipheriv('aes-256-cbc', keys.encKey, keys.iv)
+    let currentIv = keys.iv
+    let pending: Uint8Array = EMPTY_BYTES
 
     hmac.update(keys.iv)
     try {
@@ -366,10 +633,28 @@ async function pumpDecryption(
             const ciphertextChunk = merged.subarray(0, merged.byteLength - HMAC_TRUNCATED_SIZE)
             trailing = merged.subarray(merged.byteLength - HMAC_TRUNCATED_SIZE)
             hmac.update(ciphertextChunk)
-            const plainChunk = decipher.update(ciphertextChunk)
-            if (plainChunk.byteLength > 0) {
-                plainHash.update(plainChunk)
-                await writeChunk(plaintext, plainChunk)
+
+            const combined =
+                pending.byteLength > 0
+                    ? concatBytes([pending, ciphertextChunk])
+                    : toBytesView(ciphertextChunk)
+            const aligned = combined.byteLength - (combined.byteLength % AES_BLOCK_SIZE)
+            if (aligned > AES_BLOCK_SIZE) {
+                const toDecrypt = combined.subarray(0, aligned - AES_BLOCK_SIZE)
+                const { plaintext: plainChunk, nextIv } = await aesCbcDecryptChunk(
+                    aesKey,
+                    currentIv,
+                    toDecrypt,
+                    false
+                )
+                currentIv = nextIv
+                if (plainChunk.byteLength > 0) {
+                    plainHash.update(plainChunk)
+                    await writeChunk(plaintext, plainChunk)
+                }
+                pending = toBytesView(combined.subarray(aligned - AES_BLOCK_SIZE))
+            } else {
+                pending = combined
             }
         }
 
@@ -382,7 +667,10 @@ async function pumpDecryption(
             throw new Error('media MAC mismatch')
         }
 
-        const plainFinal = decipher.final()
+        if (pending.byteLength < AES_BLOCK_SIZE || pending.byteLength % AES_BLOCK_SIZE !== 0) {
+            throw new Error(`invalid ciphertext length: ${pending.byteLength}`)
+        }
+        const { plaintext: plainFinal } = await aesCbcDecryptChunk(aesKey, currentIv, pending, true)
         if (plainFinal.byteLength > 0) {
             plainHash.update(plainFinal)
             await writeChunk(plaintext, plainFinal)

--- a/src/media/WaMediaTransferClient.ts
+++ b/src/media/WaMediaTransferClient.ts
@@ -1,4 +1,6 @@
-import { Readable } from 'node:stream'
+import http from 'node:http'
+import https from 'node:https'
+import type { Readable } from 'node:stream'
 
 import type { Logger } from '@infra/log/types'
 import { DEFAULT_MEDIA_HOSTS } from '@media/constants'
@@ -9,18 +11,15 @@ import type {
 } from '@media/types'
 import { WaMediaCrypto } from '@media/WaMediaCrypto'
 import { WA_DEFAULTS } from '@protocol/constants'
-import type { WaProxyAgent, WaProxyDispatcher } from '@transport/types'
+import type { WaProxyAgent } from '@transport/types'
 import { EMPTY_BYTES, readAllBytes } from '@util/bytes'
 import { toError } from '@util/primitives'
-
-const GOT_OPTIONAL_MODULE = 'got'
 
 interface StreamDownloadRequest {
     readonly url?: string
     readonly directPath?: string
     readonly hosts?: readonly string[]
     readonly headers?: Readonly<Record<string, string>>
-    readonly dispatcher?: WaMediaTransferClientOptions['defaultDownloadDispatcher']
     readonly agent?: WaMediaTransferClientOptions['defaultDownloadAgent']
     readonly timeoutMs?: number
     readonly signal?: AbortSignal
@@ -40,6 +39,13 @@ interface StreamTransferResponse {
     readonly ok: boolean
     readonly headers: Readonly<Record<string, string>>
     readonly body: Readable | null
+}
+
+interface TransferRequestInit {
+    readonly method?: string
+    readonly headers?: Readonly<Record<string, string>>
+    readonly body?: Uint8Array | Readable
+    readonly signal?: AbortSignal
 }
 
 interface InternalTransferResponse {
@@ -74,10 +80,6 @@ interface EncryptedDownloadRequest extends StreamDownloadRequest {
     readonly fileEncSha256?: Uint8Array
 }
 
-interface OptionalGotModule {
-    readonly stream: (url: string, options?: Readonly<Record<string, unknown>>) => Readable
-}
-
 function normalizeHeaderRecord(
     headers: Readonly<Record<string, string>> | undefined
 ): Readonly<Record<string, string>> {
@@ -91,71 +93,14 @@ function normalizeHeaderRecord(
     return normalized
 }
 
-function asOptionalGotModule(loaded: unknown): OptionalGotModule | null {
-    if (loaded && typeof loaded === 'object') {
-        const direct = (loaded as { readonly stream?: unknown }).stream
-        if (typeof direct === 'function') {
-            return loaded as OptionalGotModule
-        }
-        const fallback = (loaded as { readonly default?: unknown }).default
-        if (
-            fallback &&
-            typeof fallback === 'object' &&
-            'stream' in fallback &&
-            typeof (fallback as { readonly stream?: unknown }).stream === 'function'
-        ) {
-            return fallback as OptionalGotModule
-        }
-        if (typeof fallback === 'function' && 'stream' in fallback) {
-            const maybeStream = (fallback as { readonly stream?: unknown }).stream
-            if (typeof maybeStream === 'function') {
-                return fallback as unknown as OptionalGotModule
-            }
-        }
-    }
-    if (typeof loaded === 'function' && 'stream' in loaded) {
-        const maybeStream = (loaded as { readonly stream?: unknown }).stream
-        if (typeof maybeStream === 'function') {
-            return loaded as unknown as OptionalGotModule
-        }
-    }
-    return null
-}
-
-async function loadOptionalGotModule(): Promise<OptionalGotModule> {
-    try {
-        const loaded = await import(GOT_OPTIONAL_MODULE)
-        const module = asOptionalGotModule(loaded)
-        if (module) {
-            return module
-        }
-        throw new Error('invalid got module export')
-    } catch (error) {
-        const normalized = toError(error)
-        const code = (normalized as NodeJS.ErrnoException).code
-        const message = normalized.message ?? ''
-        const isModuleNotFound =
-            (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') &&
-            (message.includes(`'${GOT_OPTIONAL_MODULE}'`) ||
-                message.includes(`"${GOT_OPTIONAL_MODULE}"`))
-        if (isModuleNotFound) {
-            throw new Error('optional dependency "got" is not installed. Install with: npm i got')
-        }
-        throw normalized
-    }
-}
-
 export class WaMediaTransferClient {
     private readonly logger?: Logger
     private readonly defaultHosts: readonly string[]
     private readonly defaultTimeoutMs: number
     private readonly defaultMaxReadBytes: number | undefined
     private readonly defaultHeaders: Readonly<Record<string, string>>
-    private readonly defaultUploadDispatcher: WaMediaTransferClientOptions['defaultUploadDispatcher']
-    private readonly defaultDownloadDispatcher: WaMediaTransferClientOptions['defaultDownloadDispatcher']
     private readonly defaultUploadAgent: WaMediaTransferClientOptions['defaultUploadAgent']
     private readonly defaultDownloadAgent: WaMediaTransferClientOptions['defaultDownloadAgent']
-    private gotModulePromise: Promise<OptionalGotModule> | null
 
     public constructor(options: WaMediaTransferClientOptions = {}) {
         this.logger = options.logger
@@ -163,16 +108,12 @@ export class WaMediaTransferClient {
         this.defaultTimeoutMs = options.defaultTimeoutMs ?? WA_DEFAULTS.MEDIA_TIMEOUT_MS
         this.defaultMaxReadBytes = options.defaultMaxReadBytes
         this.defaultHeaders = normalizeHeaderRecord(options.defaultHeaders)
-        this.defaultUploadDispatcher = options.defaultUploadDispatcher
-        this.defaultDownloadDispatcher = options.defaultDownloadDispatcher
         this.defaultUploadAgent = options.defaultUploadAgent
         this.defaultDownloadAgent = options.defaultDownloadAgent
-        this.gotModulePromise = null
     }
 
     public async downloadStream(request: StreamDownloadRequest): Promise<StreamTransferResponse> {
         const { urls, headers, timeoutMs } = this.resolveTransferRequest(request)
-        const dispatcher = request.dispatcher ?? this.defaultDownloadDispatcher
         const agent = request.agent ?? this.defaultDownloadAgent
         this.logger?.debug('media download stream start', {
             urls: urls.length,
@@ -182,17 +123,7 @@ export class WaMediaTransferClient {
             urls,
             timeoutMs,
             request.signal,
-            (url, signal) =>
-                this.transferRequest(
-                    url,
-                    {
-                        method: 'GET',
-                        headers,
-                        signal
-                    },
-                    dispatcher,
-                    agent
-                )
+            (url, signal) => this.httpRequest(url, { method: 'GET', headers, signal }, agent)
         )
         this.logger?.trace('media download stream response', {
             url: result.url,
@@ -221,7 +152,6 @@ export class WaMediaTransferClient {
                     ? String(request.contentLength)
                     : undefined
         })
-        const dispatcher = request.dispatcher ?? this.defaultUploadDispatcher
         const agent = request.agent ?? this.defaultUploadAgent
         const uploadUrls = bodyIsBytes ? urls : urls.slice(0, 1)
         if (!bodyIsBytes && urls.length > 1) {
@@ -240,34 +170,8 @@ export class WaMediaTransferClient {
             uploadUrls,
             timeoutMs,
             request.signal,
-            async (url, signal) => {
-                if (bodyIsBytes) {
-                    return this.transferRequest(
-                        url,
-                        {
-                            method,
-                            headers,
-                            signal,
-                            body: request.body
-                        },
-                        dispatcher,
-                        agent
-                    )
-                }
-
-                return this.transferRequest(
-                    url,
-                    {
-                        method,
-                        headers,
-                        signal,
-                        body: request.body as unknown as never,
-                        duplex: 'half'
-                    } as RequestInit,
-                    dispatcher,
-                    agent
-                )
-            }
+            (url, signal) =>
+                this.httpRequest(url, { method, headers, signal, body: request.body }, agent)
         )
         this.logger?.trace('media upload stream response', {
             url: result.url,
@@ -290,7 +194,6 @@ export class WaMediaTransferClient {
                 directPath: request.directPath,
                 hosts: request.hosts,
                 headers: request.headers,
-                dispatcher: request.dispatcher,
                 agent: request.agent,
                 timeoutMs: request.timeoutMs,
                 signal: request.signal,
@@ -371,141 +274,55 @@ export class WaMediaTransferClient {
         return readAllBytes(response.body, { maxBytes: maxBytes ?? this.defaultMaxReadBytes })
     }
 
-    private async transferRequest(
+    private async httpRequest(
         url: string,
-        init: RequestInit,
-        dispatcher: WaProxyDispatcher | undefined,
+        init: TransferRequestInit,
         agent: WaProxyAgent | undefined
     ): Promise<InternalTransferResponse> {
-        if (agent) {
-            return this.gotWithAgent(url, init, agent)
-        }
-        return this.fetchWithDispatcher(url, init, dispatcher)
-    }
-
-    private async fetchWithDispatcher(
-        url: string,
-        init: RequestInit,
-        dispatcher: WaProxyDispatcher | undefined
-    ): Promise<InternalTransferResponse> {
-        const response = !dispatcher
-            ? await fetch(url, init)
-            : await fetch(url, {
-                  ...init,
-                  dispatcher
-              } as RequestInit)
-        return this.toFetchTransferResponse(response)
-    }
-
-    private toFetchTransferResponse(response: Response): InternalTransferResponse {
-        return {
-            status: response.status,
-            ok: response.ok,
-            headers: Object.fromEntries(response.headers.entries()),
-            body: response.body
-                ? Readable.fromWeb(response.body as globalThis.ReadableStream<Uint8Array>)
-                : null,
-            cancel: async () => {
-                if (!response.body) {
-                    return
-                }
-                try {
-                    await response.body.cancel()
-                } catch {
-                    // ignore cancel errors from remote resets
-                }
-            }
-        }
-    }
-
-    private async gotWithAgent(
-        url: string,
-        init: RequestInit,
-        agent: WaProxyAgent
-    ): Promise<InternalTransferResponse> {
-        const got = await this.loadGotModule()
-        const urlObj = new URL(url)
-        const gotAgent =
-            urlObj.protocol === 'http:'
-                ? { http: agent }
-                : urlObj.protocol === 'https:'
-                  ? { https: agent }
-                  : { http: agent, https: agent }
+        const parsed = new URL(url)
+        const transport = parsed.protocol === 'https:' ? https : http
         return new Promise<InternalTransferResponse>((resolve, reject) => {
-            const request = got.stream(url, {
-                method: init.method,
-                headers: (init.headers ?? {}) as Readonly<Record<string, string>>,
-                body: init.body as unknown,
-                signal: init.signal,
-                throwHttpErrors: false,
-                retry: { limit: 0 },
-                agent: gotAgent
-            })
-            const onError = (error: unknown): void => {
-                request.off('response', onResponse)
-                reject(toError(error))
+            const req = transport.request(
+                url,
+                {
+                    method: init.method ?? 'GET',
+                    headers: init.headers as Record<string, string>,
+                    signal: init.signal ?? undefined,
+                    agent: agent ?? undefined
+                },
+                (res) => {
+                    const status = res.statusCode ?? 500
+                    const headers: Record<string, string> = {}
+                    for (const key in res.headers) {
+                        const value = res.headers[key]
+                        if (typeof value === 'string') {
+                            headers[key] = value
+                        } else if (Array.isArray(value)) {
+                            headers[key] = value.join(', ')
+                        }
+                    }
+                    resolve({
+                        status,
+                        ok: status >= 200 && status < 300,
+                        headers,
+                        body: res,
+                        cancel: async () => {
+                            res.destroy()
+                        }
+                    })
+                }
+            )
+            req.on('error', (error) => reject(toError(error)))
+            const body = init.body
+            if (body instanceof Uint8Array) {
+                req.end(body)
+            } else if (body) {
+                body.on('error', (err) => req.destroy(toError(err)))
+                body.pipe(req)
+            } else {
+                req.end()
             }
-            const onResponse = (incoming: unknown): void => {
-                request.off('error', onError)
-                resolve(this.toGotTransferResponse(incoming))
-            }
-            request.once('error', onError)
-            request.once('response', onResponse)
         })
-    }
-
-    private async loadGotModule(): Promise<OptionalGotModule> {
-        if (!this.gotModulePromise) {
-            this.gotModulePromise = loadOptionalGotModule().catch((error) => {
-                this.gotModulePromise = null
-                throw error
-            })
-        }
-        return this.gotModulePromise
-    }
-
-    private toGotTransferResponse(incoming: unknown): InternalTransferResponse {
-        if (!incoming || typeof incoming !== 'object') {
-            throw new Error('invalid got response object')
-        }
-        const stream = incoming as Readable & {
-            readonly statusCode?: unknown
-            readonly headers?: unknown
-        }
-        const status =
-            typeof stream.statusCode === 'number' &&
-            Number.isFinite(stream.statusCode) &&
-            stream.statusCode >= 100 &&
-            stream.statusCode <= 599
-                ? stream.statusCode
-                : 500
-        const headers: Record<string, string> = {}
-        if (stream.headers && typeof stream.headers === 'object') {
-            const input = stream.headers as Readonly<Record<string, unknown>>
-            for (const key in input) {
-                const value = input[key]
-                if (typeof value === 'string') {
-                    headers[key] = value
-                    continue
-                }
-                if (Array.isArray(value)) {
-                    headers[key] = value.join(', ')
-                    continue
-                }
-                if (value !== undefined && value !== null) {
-                    headers[key] = String(value)
-                }
-            }
-        }
-        return {
-            status,
-            ok: status >= 200 && status < 300,
-            headers,
-            body: stream,
-            cancel: async () => {
-                stream.destroy()
-            }
-        }
     }
 
     private resolveTransferRequest(

--- a/src/media/__tests__/media.test.ts
+++ b/src/media/__tests__/media.test.ts
@@ -1,15 +1,18 @@
 import assert from 'node:assert/strict'
-import { stat } from 'node:fs/promises'
+import { stat, unlink, writeFile } from 'node:fs/promises'
 import http from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { Readable } from 'node:stream'
 import test from 'node:test'
 
+import { parseWebpAnimation, runMediaProcessor } from '@client/media'
 import { buildMediaMessageContent, getMediaConn } from '@client/messages'
 import type { Logger } from '@infra/log/types'
 import { parseMediaConnResponse } from '@media/conn'
 import { WaMediaCrypto } from '@media/WaMediaCrypto'
 import { WaMediaTransferClient } from '@media/WaMediaTransferClient'
-import type { BinaryNode, WaProxyDispatcher } from '@transport/types'
+import type { BinaryNode } from '@transport/types'
 
 function createLogger(): Logger {
     return {
@@ -34,6 +37,87 @@ function buildMediaConnNode(auth = 'token', ttl = '120'): BinaryNode {
             }
         ]
     }
+}
+
+function createWebpWithChunks(
+    chunks: ReadonlyArray<{ readonly tag: string; readonly payloadLength: number }>
+): {
+    readonly bytes: Uint8Array
+    readonly offsets: readonly number[]
+} {
+    const vp8xLength = 10
+    let totalLength = 12 + 8 + vp8xLength
+    for (const chunk of chunks) {
+        totalLength += 8 + chunk.payloadLength + (chunk.payloadLength % 2)
+    }
+
+    const bytes = new Uint8Array(totalLength)
+    bytes[0] = 0x52
+    bytes[1] = 0x49
+    bytes[2] = 0x46
+    bytes[3] = 0x46
+    bytes[8] = 0x57
+    bytes[9] = 0x45
+    bytes[10] = 0x42
+    bytes[11] = 0x50
+    bytes[12] = 0x56
+    bytes[13] = 0x50
+    bytes[14] = 0x38
+    bytes[15] = 0x58
+    bytes[16] = vp8xLength
+
+    const offsets: number[] = []
+    let offset = 12 + 8 + vp8xLength
+    for (const chunk of chunks) {
+        offsets.push(offset)
+        bytes[offset] = chunk.tag.charCodeAt(0)
+        bytes[offset + 1] = chunk.tag.charCodeAt(1)
+        bytes[offset + 2] = chunk.tag.charCodeAt(2)
+        bytes[offset + 3] = chunk.tag.charCodeAt(3)
+        bytes[offset + 4] = chunk.payloadLength & 0xff
+        bytes[offset + 5] = (chunk.payloadLength >>> 8) & 0xff
+        bytes[offset + 6] = (chunk.payloadLength >>> 16) & 0xff
+        bytes[offset + 7] = (chunk.payloadLength >>> 24) & 0xff
+        offset += 8 + chunk.payloadLength + (chunk.payloadLength % 2)
+    }
+
+    return { bytes, offsets }
+}
+
+function createPatternBytes(length: number): Uint8Array {
+    const bytes = new Uint8Array(length)
+    for (let i = 0; i < length; i++) {
+        bytes[i] = i % 251
+    }
+    return bytes
+}
+
+function createChunkedReadable(bytes: Uint8Array, sizes: readonly number[]): Readable {
+    let offset = 0
+    return Readable.from(
+        (async function* () {
+            let index = 0
+            while (offset < bytes.byteLength) {
+                const size = sizes[index % sizes.length]
+                const end = Math.min(offset + size, bytes.byteLength)
+                yield bytes.subarray(offset, end)
+                offset = end
+                index++
+            }
+        })()
+    )
+}
+
+async function readAllFromStream(stream: Readable): Promise<Uint8Array> {
+    const chunks: Uint8Array[] = []
+    for await (const chunk of stream) {
+        const bufferChunk = Buffer.from(chunk as Uint8Array)
+        chunks.push(
+            new Uint8Array(bufferChunk.buffer, bufferChunk.byteOffset, bufferChunk.byteLength)
+        )
+    }
+    const merged = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)))
+    return new Uint8Array(merged.buffer, merged.byteOffset, merged.byteLength)
 }
 
 test('media conn parser validates hosts/auth and ttl semantics', () => {
@@ -74,6 +158,7 @@ test('media crypto encrypt/decrypt bytes round-trip and hash validation', async 
 
     const encrypted = await WaMediaCrypto.encryptBytes('image', mediaKey, plaintext)
     assert.ok(encrypted.ciphertextHmac.length > plaintext.length)
+    assert.ok(encrypted.streamingSidecar!.byteLength > 0)
 
     const decrypted = await WaMediaCrypto.decryptBytes(
         'image',
@@ -94,6 +179,191 @@ test('media crypto encrypt/decrypt bytes round-trip and hash validation', async 
             ),
         /plaintext file hash mismatch/
     )
+})
+
+test('media crypto encryptReadable matches byte encryption for large payloads', async () => {
+    const mediaKey = await WaMediaCrypto.generateMediaKey()
+    const plaintext = createPatternBytes(200_000)
+
+    const encryptedBytes = await WaMediaCrypto.encryptBytes('video', mediaKey, plaintext)
+    const encryptedReadable = await WaMediaCrypto.encryptReadable(
+        'video',
+        mediaKey,
+        createChunkedReadable(plaintext, [1, 7, 31, 4_096, 3, 16_384])
+    )
+
+    const [ciphertextReadable, metadata] = await Promise.all([
+        readAllFromStream(encryptedReadable.encrypted),
+        encryptedReadable.metadata
+    ])
+
+    assert.deepEqual(ciphertextReadable, encryptedBytes.ciphertextHmac)
+    assert.deepEqual(metadata.fileSha256, encryptedBytes.fileSha256)
+    assert.deepEqual(metadata.fileEncSha256, encryptedBytes.fileEncSha256)
+    assert.deepEqual(metadata.streamingSidecar, encryptedBytes.streamingSidecar)
+    assert.equal(metadata.plaintextLength, plaintext.byteLength)
+})
+
+test('media crypto decryptReadable round-trips fragmented payloads across block boundaries', async () => {
+    for (const size of [0, 1, 15, 16, 17, 31, 32, 33, 100, 1_000, 150_000]) {
+        const mediaKey = await WaMediaCrypto.generateMediaKey()
+        const plaintext = createPatternBytes(size)
+        const encryptedReadable = await WaMediaCrypto.encryptReadable(
+            'audio',
+            mediaKey,
+            createChunkedReadable(plaintext, [5, 7, 11, 4_096])
+        )
+
+        const [ciphertext, encryptedMetadata] = await Promise.all([
+            readAllFromStream(encryptedReadable.encrypted),
+            encryptedReadable.metadata
+        ])
+
+        const decryptedReadable = await WaMediaCrypto.decryptReadable(
+            createChunkedReadable(ciphertext, [2, 3, 5, 7, 8_191]),
+            {
+                mediaType: 'audio',
+                mediaKey,
+                expectedFileSha256: encryptedMetadata.fileSha256,
+                expectedFileEncSha256: encryptedMetadata.fileEncSha256
+            }
+        )
+
+        const [decryptedBytes, decryptedMetadata] = await Promise.all([
+            readAllFromStream(decryptedReadable.plaintext),
+            decryptedReadable.metadata
+        ])
+
+        assert.deepEqual(decryptedBytes, plaintext)
+        assert.deepEqual(decryptedMetadata.fileSha256, encryptedMetadata.fileSha256)
+        assert.deepEqual(decryptedMetadata.fileEncSha256, encryptedMetadata.fileEncSha256)
+    }
+})
+
+test('parseWebpAnimation skips intermediate chunks and respects padded chunk sizes', () => {
+    const webp = createWebpWithChunks([
+        { tag: 'ICCP', payloadLength: 3 },
+        { tag: 'ANMF', payloadLength: 4 }
+    ])
+    const anmfOffset = webp.offsets[1]
+
+    assert.deepEqual(parseWebpAnimation(webp.bytes), {
+        isAnimated: true,
+        firstFrameLength: anmfOffset + 8 + 4
+    })
+})
+
+test('parseWebpAnimation returns null for malformed chunk sizes that exceed the buffer', () => {
+    const webp = createWebpWithChunks([{ tag: 'JUNK', payloadLength: 0 }])
+    const sizeOffset = webp.offsets[0] + 4
+    webp.bytes[sizeOffset] = 0x00
+    webp.bytes[sizeOffset + 1] = 0x00
+    webp.bytes[sizeOffset + 2] = 0x00
+    webp.bytes[sizeOffset + 3] = 0x80
+
+    assert.equal(parseWebpAnimation(webp.bytes), null)
+})
+
+test('runMediaProcessor fills image dimensions from thumbnail output when probe is skipped', async () => {
+    const result = await runMediaProcessor(
+        {
+            processor: {
+                generateImageThumbnail: async () => ({
+                    jpegThumbnail: new Uint8Array([0xff, 0xd8]),
+                    width: 123,
+                    height: 45
+                })
+            }
+        },
+        new Uint8Array([1, 2, 3]),
+        {
+            type: 'image',
+            media: new Uint8Array([1, 2, 3]),
+            mimetype: 'image/jpeg'
+        },
+        createLogger()
+    )
+
+    assert.equal(result.width, 123)
+    assert.equal(result.height, 45)
+    assert.deepEqual(result.jpegThumbnail, new Uint8Array([0xff, 0xd8]))
+})
+
+test('runMediaProcessor derives audio seconds from waveform output when probe is absent', async () => {
+    const result = await runMediaProcessor(
+        {
+            processor: {
+                computeWaveform: async () => ({
+                    waveform: new Uint8Array([4, 5, 6]),
+                    durationSeconds: 7.9
+                })
+            }
+        },
+        new Uint8Array([1, 2, 3]),
+        {
+            type: 'audio',
+            media: new Uint8Array([1, 2, 3]),
+            mimetype: 'audio/ogg'
+        },
+        createLogger()
+    )
+
+    assert.equal(result.seconds, 7)
+    assert.deepEqual(result.waveform, new Uint8Array([4, 5, 6]))
+})
+
+test('runMediaProcessor handles sticker thumbnails and animated WebP detection', async () => {
+    const webp = createWebpWithChunks([{ tag: 'ANMF', payloadLength: 6 }])
+    const result = await runMediaProcessor(
+        {
+            processor: {
+                generateStickerThumbnail: async () => ({
+                    pngThumbnail: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+                    width: 96,
+                    height: 96
+                })
+            }
+        },
+        webp.bytes,
+        {
+            type: 'sticker',
+            media: webp.bytes
+        },
+        createLogger()
+    )
+
+    assert.equal(result.isAnimated, true)
+    assert.equal(result.firstFrameLength, webp.offsets[0] + 8 + 6)
+    assert.equal(result.width, 96)
+    assert.equal(result.height, 96)
+    assert.deepEqual(result.pngThumbnail, new Uint8Array([0x89, 0x50, 0x4e, 0x47]))
+})
+
+test('runMediaProcessor skips processing work when the input is unavailable', async () => {
+    let called = false
+    const result = await runMediaProcessor(
+        {
+            processor: {
+                computeWaveform: async () => {
+                    called = true
+                    return {
+                        waveform: new Uint8Array([1]),
+                        durationSeconds: 1
+                    }
+                }
+            }
+        },
+        undefined,
+        {
+            type: 'audio',
+            media: new Uint8Array([1, 2, 3]),
+            mimetype: 'audio/ogg'
+        },
+        createLogger()
+    )
+
+    assert.deepEqual(result, {})
+    assert.equal(called, false)
 })
 
 test('media message builder supports text passthrough and conn caching', async () => {
@@ -213,11 +483,230 @@ test('media message builder uploads ptv bytes and maps upload response fields', 
     assert.ok(message.ptvMessage)
     assert.equal(message.ptvMessage?.fileLength, 4)
     assert.equal(message.ptvMessage?.seconds, 7)
+    assert.ok((message.ptvMessage?.streamingSidecar?.byteLength ?? 0) > 0)
     assert.equal(uploadedRequests.length, 1)
     assert.match(uploadedRequests[0].url, /\/mms\/video\//)
     assert.match(uploadedRequests[0].url, /auth=auth-token/)
     assert.match(uploadedRequests[0].url, /token=/)
     assert.ok((uploadedRequests[0].contentLength ?? 0) > 0)
+})
+
+test('media message builder continues probe extraction when thumbnail generation fails', async () => {
+    const errors: unknown[] = []
+    const logger: Logger = {
+        ...createLogger(),
+        error: (message, context) => {
+            errors.push({ message, context })
+        }
+    }
+    const encoder = new TextEncoder()
+
+    const message = await buildMediaMessageContent(
+        {
+            logger,
+            mediaTransfer: {
+                uploadStream: async () => ({ status: 200 }) as Response,
+                readResponseBytes: async () =>
+                    encoder.encode(
+                        JSON.stringify({
+                            url: 'https://mmg.whatsapp.net/mms/video/thumb-fail',
+                            direct_path: '/mms/video/thumb-fail'
+                        })
+                    )
+            } as never,
+            queryWithContext: async () => buildMediaConnNode('auth-token', '120'),
+            getMediaConnCache: () => null,
+            setMediaConnCache: () => undefined,
+            media: {
+                processor: {
+                    generateVideoThumbnail: async () => {
+                        throw new Error('thumbnail failed')
+                    },
+                    probeMedia: async () => ({
+                        durationSeconds: 9,
+                        width: 640,
+                        height: 480
+                    })
+                }
+            }
+        },
+        {
+            type: 'video',
+            media: new Uint8Array([1, 2, 3, 4]),
+            mimetype: 'video/mp4'
+        }
+    )
+
+    assert.equal(message.videoMessage?.seconds, 9)
+    assert.equal(message.videoMessage?.width, 640)
+    assert.equal(message.videoMessage?.height, 480)
+    assert.equal(message.videoMessage?.jpegThumbnail, undefined)
+    assert.equal(errors.length, 1)
+})
+
+test('media message builder fills only missing probe fields', async () => {
+    const logger = createLogger()
+    const encoder = new TextEncoder()
+
+    const message = await buildMediaMessageContent(
+        {
+            logger,
+            mediaTransfer: {
+                uploadStream: async () => ({ status: 200 }) as Response,
+                readResponseBytes: async () =>
+                    encoder.encode(
+                        JSON.stringify({
+                            url: 'https://mmg.whatsapp.net/mms/video/partial-probe',
+                            direct_path: '/mms/video/partial-probe'
+                        })
+                    )
+            } as never,
+            queryWithContext: async () => buildMediaConnNode('auth-token', '120'),
+            getMediaConnCache: () => null,
+            setMediaConnCache: () => undefined,
+            media: {
+                processor: {
+                    probeMedia: async () => ({
+                        durationSeconds: 15,
+                        width: 320,
+                        height: 240
+                    })
+                }
+            }
+        },
+        {
+            type: 'video',
+            media: new Uint8Array([1, 2, 3, 4]),
+            mimetype: 'video/mp4',
+            width: 999
+        }
+    )
+
+    assert.equal(message.videoMessage?.seconds, 15)
+    assert.equal(message.videoMessage?.width, 999)
+    assert.equal(message.videoMessage?.height, 240)
+})
+
+test('media message builder reuses streamed media across processor steps', async () => {
+    const logger = createLogger()
+    const encoder = new TextEncoder()
+    const calls: Array<{ readonly step: string; readonly isStream: boolean }> = []
+
+    const message = await buildMediaMessageContent(
+        {
+            logger,
+            mediaTransfer: {
+                uploadStream: async () => ({ status: 200 }) as Response,
+                readResponseBytes: async () =>
+                    encoder.encode(
+                        JSON.stringify({
+                            url: 'https://mmg.whatsapp.net/mms/audio/streamed',
+                            direct_path: '/mms/audio/streamed'
+                        })
+                    )
+            } as never,
+            queryWithContext: async () => buildMediaConnNode('auth-token', '120'),
+            getMediaConnCache: () => null,
+            setMediaConnCache: () => undefined,
+            media: {
+                processor: {
+                    probeMedia: async (input) => {
+                        calls.push({
+                            step: 'probe',
+                            isStream: !(input instanceof Uint8Array)
+                        })
+                        return { durationSeconds: 11 }
+                    },
+                    computeWaveform: async (input) => {
+                        calls.push({
+                            step: 'waveform',
+                            isStream: !(input instanceof Uint8Array)
+                        })
+                        return { waveform: new Uint8Array([4, 5, 6]), durationSeconds: 7 }
+                    }
+                }
+            }
+        },
+        {
+            type: 'audio',
+            media: Readable.from([new Uint8Array([1, 2, 3, 4])]),
+            mimetype: 'audio/ogg'
+        }
+    )
+
+    assert.equal(message.audioMessage?.seconds, 11)
+    assert.deepEqual(message.audioMessage?.waveform, new Uint8Array([4, 5, 6]))
+    assert.ok((message.audioMessage?.streamingSidecar?.byteLength ?? 0) > 0)
+    assert.deepEqual(calls, [
+        { step: 'probe', isStream: true },
+        { step: 'waveform', isStream: true }
+    ])
+})
+
+test('media message builder supports file path input for upload and processing', async () => {
+    const logger = createLogger()
+    const encoder = new TextEncoder()
+    const filePath = join(
+        tmpdir(),
+        `zapo-media-path-${Date.now()}-${Math.random().toString(36).slice(2)}.bin`
+    )
+    const processorInputs: string[] = []
+
+    await writeFile(filePath, new Uint8Array([1, 2, 3, 4]))
+
+    try {
+        const message = await buildMediaMessageContent(
+            {
+                logger,
+                mediaTransfer: {
+                    uploadStream: async () => ({ status: 200 }) as Response,
+                    readResponseBytes: async () =>
+                        encoder.encode(
+                            JSON.stringify({
+                                url: 'https://mmg.whatsapp.net/mms/video/from-path',
+                                direct_path: '/mms/video/from-path'
+                            })
+                        )
+                } as never,
+                queryWithContext: async () => buildMediaConnNode('auth-token', '120'),
+                getMediaConnCache: () => null,
+                setMediaConnCache: () => undefined,
+                media: {
+                    processor: {
+                        generateVideoThumbnail: async (input) => {
+                            processorInputs.push(input as string)
+                            return {
+                                jpegThumbnail: new Uint8Array([0xff, 0xd8]),
+                                width: 48,
+                                height: 48
+                            }
+                        },
+                        probeMedia: async (input) => {
+                            processorInputs.push(input as string)
+                            return {
+                                durationSeconds: 12,
+                                width: 640,
+                                height: 480
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                type: 'video',
+                media: filePath,
+                mimetype: 'video/mp4'
+            }
+        )
+
+        assert.equal(message.videoMessage?.seconds, 12)
+        assert.equal(message.videoMessage?.width, 640)
+        assert.equal(message.videoMessage?.height, 480)
+        assert.deepEqual(message.videoMessage?.jpegThumbnail, new Uint8Array([0xff, 0xd8]))
+        assert.deepEqual(processorInputs, [filePath, filePath])
+    } finally {
+        await unlink(filePath).catch(() => undefined)
+    }
 })
 
 test('media message builder propagates upload response errors for byte uploads', async () => {
@@ -333,41 +822,82 @@ test('media message builder cleans encrypted temp file when stream upload fails'
     }
 })
 
-test('media transfer client applies separate upload/download dispatchers', async () => {
-    const downloadDispatcher: WaProxyDispatcher = {
-        dispatch: () => undefined
+test('media transfer client applies separate upload/download agents', async () => {
+    const server = http.createServer((req, res) => {
+        if (req.method === 'GET') {
+            res.writeHead(200, { 'content-type': 'text/plain' })
+            res.end('download-ok')
+            return
+        }
+        if (req.method === 'POST' && req.url?.includes('/ul-stream')) {
+            req.resume()
+            req.on('end', () => {
+                res.writeHead(202, { 'content-type': 'text/plain' })
+                res.end('upload-stream-ok')
+            })
+            return
+        }
+        req.resume()
+        req.on('end', () => {
+            res.writeHead(201, { 'content-type': 'text/plain' })
+            res.end('upload-ok')
+        })
+    })
+    await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', () => {
+            server.off('error', reject)
+            resolve()
+        })
+    })
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+        throw new Error('failed to resolve test server address')
     }
-    const uploadDispatcher: WaProxyDispatcher = {
-        dispatch: () => undefined
-    }
-    const seenDispatchers: unknown[] = []
-    const originalFetch = globalThis.fetch
-
-    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
-        const withDispatcher = init as RequestInit & { readonly dispatcher?: unknown }
-        seenDispatchers.push(withDispatcher.dispatcher)
-        return new Response('ok', { status: 200 })
-    }) as typeof fetch
+    const base = `http://127.0.0.1:${address.port}`
+    const downloadAgent = new http.Agent({ keepAlive: true })
+    const uploadAgent = new http.Agent({ keepAlive: true })
 
     try {
         const mediaTransfer = new WaMediaTransferClient({
-            defaultUploadDispatcher: uploadDispatcher,
-            defaultDownloadDispatcher: downloadDispatcher
+            defaultDownloadAgent: downloadAgent,
+            defaultUploadAgent: uploadAgent
         })
-        await mediaTransfer.downloadStream({
-            url: 'https://example.com/download'
+
+        const downloadResponse = await mediaTransfer.downloadStream({
+            url: `${base}/dl`
         })
-        await mediaTransfer.uploadStream({
-            url: 'https://example.com/upload',
+        const uploadResponse = await mediaTransfer.uploadStream({
+            url: `${base}/ul`,
+            method: 'POST',
             body: new Uint8Array([1, 2, 3])
         })
-    } finally {
-        globalThis.fetch = originalFetch
-    }
+        const streamUploadResponse = await mediaTransfer.uploadStream({
+            url: `${base}/ul-stream`,
+            method: 'POST',
+            contentType: 'text/plain',
+            body: Readable.from(['hello-', 'dispatcher'])
+        })
 
-    assert.equal(seenDispatchers.length, 2)
-    assert.equal(seenDispatchers[0], downloadDispatcher)
-    assert.equal(seenDispatchers[1], uploadDispatcher)
+        const [downloadBytes, uploadBytes, streamUploadBytes] = await Promise.all([
+            mediaTransfer.readResponseBytes(downloadResponse),
+            mediaTransfer.readResponseBytes(uploadResponse),
+            mediaTransfer.readResponseBytes(streamUploadResponse)
+        ])
+
+        assert.equal(downloadResponse.status, 200)
+        assert.equal(uploadResponse.status, 201)
+        assert.equal(streamUploadResponse.status, 202)
+        assert.equal(new TextDecoder().decode(downloadBytes), 'download-ok')
+        assert.equal(new TextDecoder().decode(uploadBytes), 'upload-ok')
+        assert.equal(new TextDecoder().decode(streamUploadBytes), 'upload-stream-ok')
+    } finally {
+        downloadAgent.destroy()
+        uploadAgent.destroy()
+        await new Promise<void>((resolve) => {
+            server.close(() => resolve())
+        })
+    }
 })
 
 test('media transfer client routes through optional got when proxy agent is set', async () => {

--- a/src/media/constants.ts
+++ b/src/media/constants.ts
@@ -11,6 +11,8 @@ export const ENC_KEY_END = 48
 export const MAC_KEY_START = 48
 export const MAC_KEY_END = 80
 export const HMAC_TRUNCATED_SIZE = 10
+export const SIDECAR_CHUNK_SIZE = 65_536
+export const SIDECAR_HMAC_SIZE = 10
 
 export const MEDIA_UPLOAD_PATHS: Readonly<
     Record<'image' | 'video' | 'audio' | 'document' | 'sticker' | 'gif' | 'ptt' | 'ptv', string>

--- a/src/media/index.ts
+++ b/src/media/index.ts
@@ -2,3 +2,11 @@ export { WaMediaTransferClient } from '@media/WaMediaTransferClient'
 export { parseMediaConnResponse } from '@media/conn'
 export type { WaMediaConn } from '@media/types'
 export { WaMediaCrypto } from '@media/WaMediaCrypto'
+export type {
+    WaMediaProcessor,
+    WaMediaProcessorImageResult,
+    WaMediaProcessorInput,
+    WaMediaProcessorProbeResult,
+    WaMediaProcessorStickerThumbnailResult,
+    WaMediaProcessorWaveformResult
+} from '@media/processor'

--- a/src/media/processor.ts
+++ b/src/media/processor.ts
@@ -1,0 +1,49 @@
+import type { Readable } from 'node:stream'
+
+export interface WaMediaProcessorImageResult {
+    readonly jpegThumbnail: Uint8Array
+    readonly width: number
+    readonly height: number
+}
+
+export interface WaMediaProcessorStickerThumbnailResult {
+    readonly pngThumbnail: Uint8Array
+    readonly width: number
+    readonly height: number
+}
+
+export interface WaMediaProcessorProbeResult {
+    readonly durationSeconds?: number
+    readonly width?: number
+    readonly height?: number
+}
+
+export interface WaMediaProcessorWaveformResult {
+    readonly waveform: Uint8Array
+    readonly durationSeconds: number
+}
+
+export type WaMediaProcessorInput = Uint8Array | Readable | string
+
+export interface WaMediaProcessor {
+    readonly generateImageThumbnail?: (
+        input: WaMediaProcessorInput,
+        maxEdge: number
+    ) => Promise<WaMediaProcessorImageResult>
+
+    readonly generateVideoThumbnail?: (
+        input: WaMediaProcessorInput,
+        maxEdge: number
+    ) => Promise<WaMediaProcessorImageResult | null>
+
+    readonly probeMedia?: (input: WaMediaProcessorInput) => Promise<WaMediaProcessorProbeResult>
+
+    readonly computeWaveform?: (
+        input: WaMediaProcessorInput
+    ) => Promise<WaMediaProcessorWaveformResult | null>
+
+    readonly generateStickerThumbnail?: (
+        input: WaMediaProcessorInput,
+        maxEdge: number
+    ) => Promise<WaMediaProcessorStickerThumbnailResult>
+}

--- a/src/media/types.ts
+++ b/src/media/types.ts
@@ -1,7 +1,7 @@
 import type { Readable } from 'node:stream'
 
 import type { Logger } from '@infra/log/types'
-import type { WaProxyAgent, WaProxyDispatcher } from '@transport/types'
+import type { WaProxyAgent } from '@transport/types'
 
 export type MediaKind = 'image' | 'video' | 'audio' | 'document' | 'sticker' | 'ptv'
 export type MediaCryptoType = MediaKind | 'ptt' | 'gif' | 'history' | 'md-app-state'
@@ -23,8 +23,6 @@ export interface WaMediaTransferClientOptions {
     readonly defaultTimeoutMs?: number
     readonly defaultMaxReadBytes?: number
     readonly defaultHeaders?: Readonly<Record<string, string>>
-    readonly defaultUploadDispatcher?: WaProxyDispatcher
-    readonly defaultDownloadDispatcher?: WaProxyDispatcher
     readonly defaultUploadAgent?: WaProxyAgent
     readonly defaultDownloadAgent?: WaProxyAgent
 }
@@ -40,6 +38,8 @@ export interface WaMediaEncryptionResult {
     readonly ciphertextHmac: Uint8Array
     readonly fileSha256: Uint8Array
     readonly fileEncSha256: Uint8Array
+    readonly streamingSidecar?: Uint8Array
+    readonly firstFrameSidecar?: Uint8Array
 }
 
 export interface WaMediaDecryptionResult {
@@ -54,6 +54,8 @@ export interface WaMediaReadableEncryptionResult {
         readonly fileSha256: Uint8Array
         readonly fileEncSha256: Uint8Array
         readonly plaintextLength: number
+        readonly streamingSidecar?: Uint8Array
+        readonly firstFrameSidecar?: Uint8Array
     }>
 }
 
@@ -71,6 +73,8 @@ export interface WaMediaFileEncryptionResult {
     readonly fileSha256: Uint8Array
     readonly fileEncSha256: Uint8Array
     readonly plaintextLength: number
+    readonly streamingSidecar?: Uint8Array
+    readonly firstFrameSidecar?: Uint8Array
 }
 
 export interface WaMediaDecryptReadableOptions {

--- a/src/message/content.ts
+++ b/src/message/content.ts
@@ -10,13 +10,7 @@ import {
 } from '@protocol/constants'
 
 export function isSendMediaMessage(content: unknown): content is WaSendMediaMessage {
-    return (
-        !!content &&
-        typeof content === 'object' &&
-        'type' in content &&
-        'media' in content &&
-        'mimetype' in content
-    )
+    return !!content && typeof content === 'object' && 'type' in content && 'media' in content
 }
 
 export function unwrapMessage(message: Proto.IMessage): Proto.IMessage {

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -26,7 +26,23 @@ export interface WaMessagePublishResult {
     readonly ack: WaMessageAckMetadata
 }
 
-type MediaInput = Uint8Array | ArrayBuffer | Readable
+type MediaInput = Uint8Array | ArrayBuffer | Readable | string
+
+type MediaFieldsFilledByBuilder =
+    | 'url'
+    | 'mimetype'
+    | 'fileSha256'
+    | 'fileLength'
+    | 'mediaKey'
+    | 'fileEncSha256'
+    | 'directPath'
+    | 'mediaKeyTimestamp'
+    | 'streamingSidecar'
+    | 'metadataUrl'
+
+type UserMediaFields<T> = {
+    readonly [K in keyof Omit<T, MediaFieldsFilledByBuilder>]?: T[K]
+}
 
 interface WaSendMediaBase {
     readonly media: MediaInput
@@ -34,45 +50,36 @@ interface WaSendMediaBase {
     readonly fileLength?: number
 }
 
-interface WaSendImageMessage extends WaSendMediaBase {
+interface WaSendMediaBaseOptionalMime {
+    readonly media: MediaInput
+    readonly mimetype?: string
+    readonly fileLength?: number
+}
+
+interface WaSendImageMessage extends WaSendMediaBase, UserMediaFields<Proto.Message.IImageMessage> {
     readonly type: 'image'
-    readonly caption?: string
-    readonly width?: number
-    readonly height?: number
 }
 
-interface WaSendVideoMessage extends WaSendMediaBase {
+interface WaSendVideoMessage extends WaSendMediaBase, UserMediaFields<Proto.Message.IVideoMessage> {
     readonly type: 'video'
-    readonly caption?: string
-    readonly gifPlayback?: boolean
-    readonly seconds?: number
-    readonly width?: number
-    readonly height?: number
 }
 
-interface WaSendPtvMessage extends WaSendMediaBase {
+interface WaSendPtvMessage extends WaSendMediaBase, UserMediaFields<Proto.Message.IVideoMessage> {
     readonly type: 'ptv'
-    readonly seconds?: number
-    readonly width?: number
-    readonly height?: number
 }
 
-interface WaSendAudioMessage extends WaSendMediaBase {
+interface WaSendAudioMessage extends WaSendMediaBase, UserMediaFields<Proto.Message.IAudioMessage> {
     readonly type: 'audio'
-    readonly ptt?: boolean
-    readonly seconds?: number
 }
 
-interface WaSendDocumentMessage extends WaSendMediaBase {
+interface WaSendDocumentMessage
+    extends WaSendMediaBase, UserMediaFields<Proto.Message.IDocumentMessage> {
     readonly type: 'document'
-    readonly caption?: string
-    readonly fileName?: string
 }
 
-interface WaSendStickerMessage extends WaSendMediaBase {
+interface WaSendStickerMessage
+    extends WaSendMediaBaseOptionalMime, UserMediaFields<Proto.Message.IStickerMessage> {
     readonly type: 'sticker'
-    readonly width?: number
-    readonly height?: number
 }
 
 export type WaSendMediaMessage =


### PR DESCRIPTION
Introduce @zapo-js/media-utils package for media processing (ffmpeg, sharp), add media upload/download client helpers, media processor, and extend message types to support image, video, audio, sticker, and document media messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in media processing: image/video thumbnail generation, media probing, audio waveform computation, and sticker first-frame detection; optional FFmpeg support.

* **Packaging**
  * New media-utils package with build/test scripts and TypeScript exports.

* **Client**
  * Client-side preprocessing for uploads with configurable media options and MIME/sidecar support.

* **Reliability & Uploads**
  * Improved temp-file cleanup, streaming upload flow, and optional streaming/first-frame sidecar inclusion.

* **Tests**
  * Expanded tests for media processing, FFmpeg paths, crypto streaming, and integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->