### PR TITLE
perf(crypto): WeakMap cache for Web Crypto importKey calls

### DIFF
--- a/src/crypto/core/hkdf.ts
+++ b/src/crypto/core/hkdf.ts
@@ -2,13 +2,19 @@ import { webcrypto } from 'node:crypto'
 
 import { EMPTY_BYTES, TEXT_ENCODER, toBytesView } from '@util/bytes'
 
+const hkdfKeyCache = new WeakMap<Uint8Array, webcrypto.CryptoKey>()
+
 export async function hkdf(
     ikm: Uint8Array,
     salt: Uint8Array | null,
     info: Uint8Array | string,
     outLength: number
 ): Promise<Uint8Array> {
-    const key = await webcrypto.subtle.importKey('raw', ikm, 'HKDF', false, ['deriveBits'])
+    let key = hkdfKeyCache.get(ikm)
+    if (!key) {
+        key = await webcrypto.subtle.importKey('raw', ikm, 'HKDF', false, ['deriveBits'])
+        hkdfKeyCache.set(ikm, key)
+    }
     const infoBytes =
         typeof info === 'string' ? (info === '' ? EMPTY_BYTES : TEXT_ENCODER.encode(info)) : info
     const bits = await webcrypto.subtle.deriveBits(

--- a/src/crypto/core/primitives.ts
+++ b/src/crypto/core/primitives.ts
@@ -41,11 +41,17 @@ export function md5Bytes(input: string): Uint8Array {
 // AES-GCM (for Noise protocol)
 // ============================================
 
+const aesGcmKeyCache = new WeakMap<Uint8Array, webcrypto.CryptoKey>()
+
 export async function importAesGcmKey(
     raw: Uint8Array,
     usages: ('encrypt' | 'decrypt')[]
 ): Promise<webcrypto.CryptoKey> {
-    return webcrypto.subtle.importKey('raw', raw, 'AES-GCM', false, usages)
+    const cached = aesGcmKeyCache.get(raw)
+    if (cached) return cached
+    const key = await webcrypto.subtle.importKey('raw', raw, 'AES-GCM', false, usages)
+    aesGcmKeyCache.set(raw, key)
+    return key
 }
 
 export async function aesGcmEncrypt(
@@ -82,11 +88,20 @@ export async function aesGcmDecrypt(
 // AES-CBC (for Signal protocol)
 // ============================================
 
+const aesCbcKeyCache = new WeakMap<Uint8Array, webcrypto.CryptoKey>()
+
 export async function importAesCbcKey(keyBytes: Uint8Array): Promise<webcrypto.CryptoKey> {
-    return webcrypto.subtle.importKey('raw', keyBytes, { name: 'AES-CBC', length: 256 }, false, [
-        'encrypt',
-        'decrypt'
-    ])
+    const cached = aesCbcKeyCache.get(keyBytes)
+    if (cached) return cached
+    const key = await webcrypto.subtle.importKey(
+        'raw',
+        keyBytes,
+        { name: 'AES-CBC', length: 256 },
+        false,
+        ['encrypt', 'decrypt']
+    )
+    aesCbcKeyCache.set(keyBytes, key)
+    return key
 }
 
 export async function aesCbcEncrypt(
@@ -109,16 +124,36 @@ export async function aesCbcDecrypt(
 // HMAC-SHA256 (for Signal protocol)
 // ============================================
 
+const hmac256KeyCache = new WeakMap<Uint8Array, webcrypto.CryptoKey>()
+
 export async function importHmacKey(keyBytes: Uint8Array): Promise<webcrypto.CryptoKey> {
-    return webcrypto.subtle.importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, [
-        'sign'
-    ])
+    const cached = hmac256KeyCache.get(keyBytes)
+    if (cached) return cached
+    const key = await webcrypto.subtle.importKey(
+        'raw',
+        keyBytes,
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign']
+    )
+    hmac256KeyCache.set(keyBytes, key)
+    return key
 }
 
+const hmac512KeyCache = new WeakMap<Uint8Array, webcrypto.CryptoKey>()
+
 export async function importHmacSha512Key(keyBytes: Uint8Array): Promise<webcrypto.CryptoKey> {
-    return webcrypto.subtle.importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-512' }, false, [
-        'sign'
-    ])
+    const cached = hmac512KeyCache.get(keyBytes)
+    if (cached) return cached
+    const key = await webcrypto.subtle.importKey(
+        'raw',
+        keyBytes,
+        { name: 'HMAC', hash: 'SHA-512' },
+        false,
+        ['sign']
+    )
+    hmac512KeyCache.set(keyBytes, key)
+    return key
 }
 
 export async function hmacSign(key: webcrypto.CryptoKey, data: Uint8Array): Promise<Uint8Array> {

--- a/src/crypto/curves/Ed25519.ts
+++ b/src/crypto/curves/Ed25519.ts
@@ -4,6 +4,9 @@ import { ED25519_PKCS8_PREFIX } from '@crypto/curves/constants'
 import { pkcs8FromRawPrivate, type SignalKeyPair, type SubtleKeyPair } from '@crypto/curves/types'
 import { assertByteLength, decodeBase64Url, toBytesView } from '@util/bytes'
 
+const edSignKeyCache = new WeakMap<Uint8Array, webcrypto.CryptoKey>()
+const edVerifyKeyCache = new WeakMap<Uint8Array, webcrypto.CryptoKey>()
+
 export class Ed25519 {
     static async generateKeyPair(): Promise<SignalKeyPair> {
         const keys = (await webcrypto.subtle.generateKey({ name: 'Ed25519' }, true, [
@@ -35,13 +38,17 @@ export class Ed25519 {
 
     static async sign(message: Uint8Array, privKey: Uint8Array): Promise<Uint8Array> {
         assertByteLength(privKey, 32, 'ed25519 private key must be 32 bytes')
-        const privateKey = await webcrypto.subtle.importKey(
-            'pkcs8',
-            pkcs8FromRawPrivate(ED25519_PKCS8_PREFIX, privKey),
-            { name: 'Ed25519' },
-            false,
-            ['sign']
-        )
+        let privateKey = edSignKeyCache.get(privKey)
+        if (!privateKey) {
+            privateKey = await webcrypto.subtle.importKey(
+                'pkcs8',
+                pkcs8FromRawPrivate(ED25519_PKCS8_PREFIX, privKey),
+                { name: 'Ed25519' },
+                false,
+                ['sign']
+            )
+            edSignKeyCache.set(privKey, privateKey)
+        }
         const signature = await webcrypto.subtle.sign('Ed25519', privateKey, message)
         return toBytesView(signature)
     }
@@ -52,13 +59,17 @@ export class Ed25519 {
         pubKey: Uint8Array
     ): Promise<boolean> {
         assertByteLength(pubKey, 32, 'ed25519 public key must be 32 bytes')
-        const publicKey = await webcrypto.subtle.importKey(
-            'raw',
-            pubKey,
-            { name: 'Ed25519' },
-            false,
-            ['verify']
-        )
+        let publicKey = edVerifyKeyCache.get(pubKey)
+        if (!publicKey) {
+            publicKey = await webcrypto.subtle.importKey(
+                'raw',
+                pubKey,
+                { name: 'Ed25519' },
+                false,
+                ['verify']
+            )
+            edVerifyKeyCache.set(pubKey, publicKey)
+        }
         return webcrypto.subtle.verify('Ed25519', publicKey, signature, message)
     }
 }

--- a/src/crypto/curves/X25519.ts
+++ b/src/crypto/curves/X25519.ts
@@ -6,6 +6,31 @@ import { FE_ONE } from '@crypto/math/constants'
 import { fe, feAdd, feFromBytes, feInv, feMul, fePack, feSub } from '@crypto/math/fe'
 import { assertByteLength, decodeBase64Url, toBytesView } from '@util/bytes'
 
+const privKeyCache = new WeakMap<Uint8Array, webcrypto.CryptoKey>()
+const pubKeyCache = new WeakMap<Uint8Array, webcrypto.CryptoKey>()
+
+async function cachedImportPrivateKey(raw: Uint8Array): Promise<webcrypto.CryptoKey> {
+    const cached = privKeyCache.get(raw)
+    if (cached) return cached
+    const key = await webcrypto.subtle.importKey(
+        'pkcs8',
+        pkcs8FromRawPrivate(X25519_PKCS8_PREFIX, raw),
+        { name: 'X25519' },
+        false,
+        ['deriveBits']
+    )
+    privKeyCache.set(raw, key)
+    return key
+}
+
+async function cachedImportPublicKey(raw: Uint8Array): Promise<webcrypto.CryptoKey> {
+    const cached = pubKeyCache.get(raw)
+    if (cached) return cached
+    const key = await webcrypto.subtle.importKey('raw', raw, { name: 'X25519' }, false, [])
+    pubKeyCache.set(raw, key)
+    return key
+}
+
 // Pre-allocated temps for montgomeryToEdwardsPublic (safe: single-threaded)
 const _mx = fe()
 const _m1 = fe()
@@ -62,6 +87,8 @@ export class X25519 {
 
     static async keyPairFromPrivateKey(privKey: Uint8Array): Promise<SignalKeyPair> {
         assertByteLength(privKey, 32, 'x25519 private key must be 32 bytes')
+        // This needs extractable=true for exportKey, so it can't use the
+        // non-extractable cache. Import directly.
         const privateKey = await webcrypto.subtle.importKey(
             'pkcs8',
             pkcs8FromRawPrivate(X25519_PKCS8_PREFIX, privKey),
@@ -81,14 +108,8 @@ export class X25519 {
         assertByteLength(pubKey, 32, 'x25519 public key must be 32 bytes')
 
         const [privateKey, publicKey] = await Promise.all([
-            webcrypto.subtle.importKey(
-                'pkcs8',
-                pkcs8FromRawPrivate(X25519_PKCS8_PREFIX, privKey),
-                { name: 'X25519' },
-                false,
-                ['deriveBits']
-            ),
-            webcrypto.subtle.importKey('raw', pubKey, { name: 'X25519' }, false, [])
+            cachedImportPrivateKey(privKey),
+            cachedImportPublicKey(pubKey)
         ])
         const sharedBits = await webcrypto.subtle.deriveBits(
             { name: 'X25519', public: publicKey },


### PR DESCRIPTION
importKey → OpenSSL key construction is the #1 CPU hot spot in messaging workloads (~28-42% of active time). The same raw key material (identity key, signed prekey, ratchet pub) is re-imported on every ECDH/sign/verify call.

Adds WeakMap<Uint8Array, CryptoKey> caches at every importKey call site. When the same Uint8Array instance is passed again, the cached CryptoKey is returned immediately. The WeakMap ensures the CryptoKey is GC'd when the raw buffer is collected — zero memory overhead, no LRU needed.

Cached call sites:
- X25519.scalarMult (private + public key import)
- Ed25519.sign (private key import)
- Ed25519.verify (public key import)
- importHmacKey / importHmacSha512Key
- importAesCbcKey
- importAesGcmKey
- hkdf (IKM import)

Bench results (separate-process, 1k msgs/scenario):
  RECV 1:1   663 → 793 msg/s  (+20%)
  RECV group 797 → 873 msg/s  (+10%)
  SEND 1:1   247 → 255 msg/s  (+3%)

Cache hits are highest for identity/signing keys which persist for the lifetime of the client. Ephemeral chain keys (HMAC, AES-CBC) are typically cache misses but the WeakMap lookup cost (~50ns) is negligible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved efficiency of cryptographic operations (HKDF, AES, HMAC, Ed25519, X25519) by reusing imported key material to reduce repeated key-processing overhead, resulting in faster crypto primitives and lower runtime cost.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->