### PR TITLE
feat(client): add dangerous escape-hatch options for security checks

### DIFF
--- a/src/appstate/WaAppStateCrypto.ts
+++ b/src/appstate/WaAppStateCrypto.ts
@@ -63,13 +63,22 @@ const DEFAULT_DERIVED_KEYS_CACHE_MAX_SIZE = 256
 export class WaAppStateCrypto {
     private readonly derivedKeysCache: Map<string, WaAppStateDerivedKeys>
     private readonly derivedKeysCacheMaxSize: number
+    private readonly skipMacVerification: boolean
 
-    public constructor(derivedKeysCacheMaxSize = DEFAULT_DERIVED_KEYS_CACHE_MAX_SIZE) {
+    public constructor(
+        derivedKeysCacheMaxSize = DEFAULT_DERIVED_KEYS_CACHE_MAX_SIZE,
+        skipMacVerification = false
+    ) {
         this.derivedKeysCache = new Map()
         this.derivedKeysCacheMaxSize = normalizeNonNegativeInteger(
             derivedKeysCacheMaxSize,
             DEFAULT_DERIVED_KEYS_CACHE_MAX_SIZE
         )
+        this.skipMacVerification = skipMacVerification
+    }
+
+    public get isMacVerificationSkipped(): boolean {
+        return this.skipMacVerification
     }
 
     public clearCache(): void {
@@ -204,14 +213,16 @@ export class WaAppStateCrypto {
             args.valueBlob.byteLength - APP_STATE_VALUE_MAC_LENGTH
         )
 
-        const associatedData = this.generateAssociatedData(args.operation, args.keyId)
-        const expectedMac = await this.generateValueMac(
-            derivedKeys.valueMacHmacKey,
-            associatedData,
-            cipherWithIv
-        )
-        if (!uint8TimingSafeEqual(mac, expectedMac)) {
-            throw new Error('mutation value MAC mismatch')
+        if (!this.skipMacVerification) {
+            const associatedData = this.generateAssociatedData(args.operation, args.keyId)
+            const expectedMac = await this.generateValueMac(
+                derivedKeys.valueMacHmacKey,
+                associatedData,
+                cipherWithIv
+            )
+            if (!uint8TimingSafeEqual(mac, expectedMac)) {
+                throw new Error('mutation value MAC mismatch')
+            }
         }
 
         const plaintext = await aesCbcDecrypt(derivedKeys.valueEncryptionAesKey, iv, cipherText)
@@ -223,12 +234,14 @@ export class WaAppStateCrypto {
             throw new Error('missing sync action version')
         }
 
-        const generatedIndexMac = await this.generateIndexMac(
-            derivedKeys.indexHmacKey,
-            syncActionData.index
-        )
-        if (!uint8TimingSafeEqual(generatedIndexMac, args.indexMac)) {
-            throw new Error('mutation index MAC mismatch')
+        if (!this.skipMacVerification) {
+            const generatedIndexMac = await this.generateIndexMac(
+                derivedKeys.indexHmacKey,
+                syncActionData.index
+            )
+            if (!uint8TimingSafeEqual(generatedIndexMac, args.indexMac)) {
+                throw new Error('mutation index MAC mismatch')
+            }
         }
 
         return {

--- a/src/appstate/WaAppStateSyncClient.ts
+++ b/src/appstate/WaAppStateSyncClient.ts
@@ -748,11 +748,13 @@ export class WaAppStateSyncClient {
         if (!snapshot.version?.version) {
             throw new Error(`snapshot for ${collection} is missing version`)
         }
-        if (!snapshot.mac) {
-            throw new Error(`snapshot for ${collection} is missing mac`)
-        }
-        if (!snapshot.keyId?.id) {
-            throw new Error(`snapshot for ${collection} is missing keyId`)
+        if (!this.crypto.isMacVerificationSkipped) {
+            if (!snapshot.mac) {
+                throw new Error(`snapshot for ${collection} is missing mac`)
+            }
+            if (!snapshot.keyId?.id) {
+                throw new Error(`snapshot for ${collection} is missing keyId`)
+            }
         }
         return snapshot
     }
@@ -778,14 +780,16 @@ export class WaAppStateSyncClient {
         if (!patch.version?.version) {
             throw new Error(`patch for ${collection} is missing version`)
         }
-        if (!patch.snapshotMac) {
-            throw new Error(`patch for ${collection} is missing snapshotMac`)
-        }
-        if (!patch.patchMac) {
-            throw new Error(`patch for ${collection} is missing patchMac`)
-        }
-        if (!patch.keyId?.id) {
-            throw new Error(`patch for ${collection} is missing keyId`)
+        if (!this.crypto.isMacVerificationSkipped) {
+            if (!patch.snapshotMac) {
+                throw new Error(`patch for ${collection} is missing snapshotMac`)
+            }
+            if (!patch.patchMac) {
+                throw new Error(`patch for ${collection} is missing patchMac`)
+            }
+            if (!patch.keyId?.id) {
+                throw new Error(`patch for ${collection} is missing keyId`)
+            }
         }
         if (patch.mutations && patch.mutations.length > 0 && patch.externalMutations) {
             throw new Error(`patch for ${collection} has inline and external mutations together`)
@@ -810,14 +814,17 @@ export class WaAppStateSyncClient {
             snapshot.version?.version,
             `snapshot.version.version (${collection})`
         )
-        const keyId = decodeProtoBytes(snapshot.keyId?.id, `snapshot.keyId.id (${collection})`)
-        const keyData = await this.getKeyData(keyId)
-        if (!keyData) {
-            throw new WaAppStateMissingKeyError(
-                `missing snapshot key ${bytesToHex(keyId)} for ${collection}`,
-                keyId,
-                collection
-            )
+        let keyData: Uint8Array | null = null
+        if (!this.crypto.isMacVerificationSkipped) {
+            const keyId = decodeProtoBytes(snapshot.keyId?.id, `snapshot.keyId.id (${collection})`)
+            keyData = await this.getKeyData(keyId)
+            if (!keyData) {
+                throw new WaAppStateMissingKeyError(
+                    `missing snapshot key ${bytesToHex(keyId)} for ${collection}`,
+                    keyId,
+                    collection
+                )
+            }
         }
 
         const indexValueMap = new Map<string, Uint8Array>()
@@ -850,7 +857,7 @@ export class WaAppStateSyncClient {
             ltHashInputIndex += 1
         }
         const ltHash = await this.crypto.ltHashAdd(APP_STATE_EMPTY_LT_HASH, ltHashInput)
-        if (!this.crypto.isMacVerificationSkipped) {
+        if (keyData !== null) {
             const expectedSnapshotMac = await this.crypto.generateSnapshotMac(
                 keyData,
                 ltHash,
@@ -880,14 +887,17 @@ export class WaAppStateSyncClient {
             )
         }
 
-        const patchKeyId = decodeProtoBytes(patch.keyId?.id, `patch.keyId.id (${collection})`)
-        const patchKeyData = await this.getKeyData(patchKeyId)
-        if (!patchKeyData) {
-            throw new WaAppStateMissingKeyError(
-                `missing patch key ${bytesToHex(patchKeyId)} for ${collection}`,
-                patchKeyId,
-                collection
-            )
+        let patchKeyData: Uint8Array | null = null
+        if (!this.crypto.isMacVerificationSkipped) {
+            const patchKeyId = decodeProtoBytes(patch.keyId?.id, `patch.keyId.id (${collection})`)
+            patchKeyData = await this.getKeyData(patchKeyId)
+            if (!patchKeyData) {
+                throw new WaAppStateMissingKeyError(
+                    `missing patch key ${bytesToHex(patchKeyId)} for ${collection}`,
+                    patchKeyId,
+                    collection
+                )
+            }
         }
 
         const decryptedMutations = await this.decryptPatchMutations(collection, patch)
@@ -908,14 +918,16 @@ export class WaAppStateSyncClient {
             macMutations,
             collection
         )
-        await this.assertPatchMacsMatch(
-            patch,
-            collection,
-            patchKeyData,
-            patchVersion,
-            nextState.hash,
-            valueMacs
-        )
+        if (patchKeyData !== null) {
+            await this.assertPatchMacsMatch(
+                patch,
+                collection,
+                patchKeyData,
+                patchVersion,
+                nextState.hash,
+                valueMacs
+            )
+        }
         this.setCollectionState(collection, patchVersion, nextState.hash, nextState.indexValueMap)
         return decryptedMutations
     }
@@ -1083,9 +1095,6 @@ export class WaAppStateSyncClient {
         nextHash: Uint8Array,
         valueMacs: readonly Uint8Array[]
     ): Promise<void> {
-        if (this.crypto.isMacVerificationSkipped) {
-            return
-        }
         const snapshotMac = decodeProtoBytes(patch.snapshotMac, `patch.snapshotMac (${collection})`)
         const expectedSnapshotMac = await this.crypto.generateSnapshotMac(
             patchKeyData,

--- a/src/appstate/WaAppStateSyncClient.ts
+++ b/src/appstate/WaAppStateSyncClient.ts
@@ -59,6 +59,7 @@ interface WaAppStateSyncClientOptions {
     readonly hostDomain?: string
     readonly defaultTimeoutMs?: number
     readonly onMissingKeys?: (event: WaAppStateMissingKeysEvent) => Promise<void>
+    readonly skipMacVerification?: boolean
 }
 
 export class WaAppStateMissingKeyError extends Error {
@@ -102,7 +103,7 @@ export class WaAppStateSyncClient {
         this.defaultTimeoutMs = options.defaultTimeoutMs ?? WA_DEFAULTS.APP_STATE_SYNC_TIMEOUT_MS
         this.onMissingKeys = options.onMissingKeys
 
-        this.crypto = new WaAppStateCrypto()
+        this.crypto = new WaAppStateCrypto(undefined, options.skipMacVerification === true)
         this.syncContext = null
         this.syncPromise = null
     }
@@ -849,14 +850,16 @@ export class WaAppStateSyncClient {
             ltHashInputIndex += 1
         }
         const ltHash = await this.crypto.ltHashAdd(APP_STATE_EMPTY_LT_HASH, ltHashInput)
-        const expectedSnapshotMac = await this.crypto.generateSnapshotMac(
-            keyData,
-            ltHash,
-            version,
-            collection
-        )
-        if (!uint8Equal(expectedSnapshotMac, snapshot.mac as Uint8Array)) {
-            throw new Error(`snapshot MAC mismatch for ${collection}`)
+        if (!this.crypto.isMacVerificationSkipped) {
+            const expectedSnapshotMac = await this.crypto.generateSnapshotMac(
+                keyData,
+                ltHash,
+                version,
+                collection
+            )
+            if (!uint8Equal(expectedSnapshotMac, snapshot.mac as Uint8Array)) {
+                throw new Error(`snapshot MAC mismatch for ${collection}`)
+            }
         }
         this.setCollectionState(collection, version, ltHash, indexValueMap)
         return mutations
@@ -1080,6 +1083,9 @@ export class WaAppStateSyncClient {
         nextHash: Uint8Array,
         valueMacs: readonly Uint8Array[]
     ): Promise<void> {
+        if (this.crypto.isMacVerificationSkipped) {
+            return
+        }
         const snapshotMac = decodeProtoBytes(patch.snapshotMac, `patch.snapshotMac (${collection})`)
         const expectedSnapshotMac = await this.crypto.generateSnapshotMac(
             patchKeyData,

--- a/src/appstate/__tests__/appstate.test.ts
+++ b/src/appstate/__tests__/appstate.test.ts
@@ -165,6 +165,82 @@ test('appstate crypto encrypts/decrypts mutation and computes hash transitions',
     assert.equal(updated.hash.length, APP_STATE_EMPTY_LT_HASH.length)
 })
 
+test('appstate crypto rejects tampered value and index MACs by default', async () => {
+    const crypto = new WaAppStateCrypto()
+    const keyId = new Uint8Array([0, 1, 2, 3, 4, 5])
+    const keyData = new Uint8Array(32).fill(9)
+
+    const encrypted = await crypto.encryptMutation({
+        operation: proto.SyncdMutation.SyncdOperation.SET,
+        keyId,
+        keyData,
+        index: 'chat:1',
+        value: { timestamp: 123 },
+        version: 1,
+        iv: new Uint8Array(16).fill(1)
+    })
+
+    const tamperedValueBlob = new Uint8Array(encrypted.valueBlob)
+    tamperedValueBlob[tamperedValueBlob.length - 1] ^= 0x01
+    await assert.rejects(
+        () =>
+            crypto.decryptMutation({
+                operation: proto.SyncdMutation.SyncdOperation.SET,
+                keyId,
+                keyData,
+                indexMac: encrypted.indexMac,
+                valueBlob: tamperedValueBlob
+            }),
+        /mutation value MAC mismatch/
+    )
+
+    const tamperedIndexMac = new Uint8Array(encrypted.indexMac)
+    tamperedIndexMac[0] ^= 0x01
+    await assert.rejects(
+        () =>
+            crypto.decryptMutation({
+                operation: proto.SyncdMutation.SyncdOperation.SET,
+                keyId,
+                keyData,
+                indexMac: tamperedIndexMac,
+                valueBlob: encrypted.valueBlob
+            }),
+        /mutation index MAC mismatch/
+    )
+})
+
+test('appstate crypto bypasses value and index MAC checks when skipMacVerification is set', async () => {
+    const crypto = new WaAppStateCrypto(undefined, true)
+    const keyId = new Uint8Array([0, 1, 2, 3, 4, 5])
+    const keyData = new Uint8Array(32).fill(9)
+
+    const encrypted = await crypto.encryptMutation({
+        operation: proto.SyncdMutation.SyncdOperation.SET,
+        keyId,
+        keyData,
+        index: 'chat:1',
+        value: { timestamp: 123 },
+        version: 1,
+        iv: new Uint8Array(16).fill(1)
+    })
+
+    const tamperedValueBlob = new Uint8Array(encrypted.valueBlob)
+    tamperedValueBlob[tamperedValueBlob.length - 1] ^= 0x01
+    const tamperedIndexMac = new Uint8Array(encrypted.indexMac)
+    tamperedIndexMac[0] ^= 0x01
+
+    const decrypted = await crypto.decryptMutation({
+        operation: proto.SyncdMutation.SyncdOperation.SET,
+        keyId,
+        keyData,
+        indexMac: tamperedIndexMac,
+        valueBlob: tamperedValueBlob
+    })
+    assert.equal(decrypted.index, 'chat:1')
+    assert.equal(decrypted.version, 1)
+    assert.equal(crypto.isMacVerificationSkipped, true)
+})
+
 test('appstate sync client builds outgoing patch without inline version field', async () => {
     const store = new WaAppStateMemoryStore()
     const key = {

--- a/src/auth/WaAuthClient.ts
+++ b/src/auth/WaAuthClient.ts
@@ -142,7 +142,8 @@ export class WaAuthClient {
             version: this.options.version,
             noiseTrustedRootCa: overrides.noiseTrustedRootCa,
             disableNoiseCertificateChainVerification:
-                overrides.disableNoiseCertificateChainVerification
+                overrides.disableNoiseCertificateChainVerification ??
+                this.options.dangerous?.disableNoiseCertificateChainVerification
         })
     }
 

--- a/src/auth/WaAuthClient.ts
+++ b/src/auth/WaAuthClient.ts
@@ -90,7 +90,8 @@ export class WaAuthClient {
                 emitPairingCode: (code) => this.callbacks.onPairingCode?.(code),
                 emitPairingRefresh: (forceManual) => this.callbacks.onPairingRefresh?.(forceManual),
                 emitPaired: (credentials) => this.callbacks.onPaired?.(credentials)
-            }
+            },
+            dangerous: options.dangerous
         })
     }
 
@@ -114,7 +115,9 @@ export class WaAuthClient {
                 logger: this.logger,
                 authStore: this.authStore,
                 signalStore: this.signalStore,
-                preKeyStore: this.preKeyStore
+                preKeyStore: this.preKeyStore,
+                skipSignedPreKeySignatureVerification:
+                    this.options.dangerous?.disableSignedPreKeySignatureVerification
             })
             this.logger.info('auth client credentials ready', {
                 registered:
@@ -126,7 +129,10 @@ export class WaAuthClient {
 
     public buildCommsConfig(
         socketOptions: WaAuthSocketOptions,
-        overrides: { readonly noiseTrustedRootCa?: WaNoiseTrustedRootCa } = {}
+        overrides: {
+            readonly noiseTrustedRootCa?: WaNoiseTrustedRootCa
+            readonly disableNoiseCertificateChainVerification?: boolean
+        } = {}
     ) {
         this.logger.trace('auth client building comms config')
         return buildCommsConfig(this.logger, this.requireCredentials(), socketOptions, {
@@ -134,7 +140,9 @@ export class WaAuthClient {
             deviceOsDisplayName: this.options.deviceOsDisplayName,
             requireFullSync: this.options.requireFullSync,
             version: this.options.version,
-            noiseTrustedRootCa: overrides.noiseTrustedRootCa
+            noiseTrustedRootCa: overrides.noiseTrustedRootCa,
+            disableNoiseCertificateChainVerification:
+                overrides.disableNoiseCertificateChainVerification
         })
     }
 

--- a/src/auth/credentials-flow.ts
+++ b/src/auth/credentials-flow.ts
@@ -17,6 +17,7 @@ interface WaAuthCredentialsFlowArgs {
     readonly authStore: WaAuthStore
     readonly signalStore: WaSignalStore
     readonly preKeyStore: WaPreKeyStore
+    readonly skipSignedPreKeySignatureVerification?: boolean
 }
 
 export async function loadOrCreateCredentials(
@@ -35,7 +36,12 @@ export async function loadOrCreateCredentials(
         hasServerStaticKey:
             existing.serverStaticKey !== null && existing.serverStaticKey !== undefined
     })
-    if (!existing.meJid && !(await hasValidSignedPreKey(args.logger, existing))) {
+    const skipSignedPreKeyCheck = args.skipSignedPreKeySignatureVerification === true
+    if (
+        !existing.meJid &&
+        !skipSignedPreKeyCheck &&
+        !(await hasValidSignedPreKey(args.logger, existing))
+    ) {
         args.logger.warn('signed pre-key is invalid, regenerating credentials')
         const fresh = await createFreshAndPersistCredentials(args)
         args.logger.info('regenerated credentials due to invalid signed pre-key')
@@ -66,6 +72,7 @@ export function buildCommsConfig(
         'deviceBrowser' | 'deviceOsDisplayName' | 'requireFullSync' | 'version'
     > & {
         readonly noiseTrustedRootCa?: WaNoiseTrustedRootCa
+        readonly disableNoiseCertificateChainVerification?: boolean
     }
 ): WaCommsConfig {
     const meJid = credentials.meJid
@@ -94,6 +101,9 @@ export function buildCommsConfig(
             serverStaticKey: credentials.serverStaticKey,
             routingInfo: credentials.routingInfo,
             trustedRootCa: clientOptions.noiseTrustedRootCa,
+            verifyCertificateChain: clientOptions.disableNoiseCertificateChainVerification
+                ? false
+                : undefined,
             loginPayloadConfig: loginIdentity
                 ? {
                       username: loginIdentity.username,

--- a/src/auth/pairing/WaPairingFlow.ts
+++ b/src/auth/pairing/WaPairingFlow.ts
@@ -3,7 +3,7 @@ import {
     createCompanionHello,
     normalizeCustomPairingCode
 } from '@auth/pairing/pairing-code-crypto'
-import type { WaAuthCredentials } from '@auth/types'
+import type { WaAuthCredentials, WaAuthDangerousOptions } from '@auth/types'
 import { randomBytesAsync } from '@crypto'
 import type { SignalKeyPair } from '@crypto/curves/types'
 import type { Logger } from '@infra/log/types'
@@ -69,6 +69,7 @@ interface WaPairingFlowOptions {
         readonly emitPairingRefresh: (forceManual: boolean) => void
         readonly emitPaired: (credentials: WaAuthCredentials) => void
     }
+    readonly dangerous?: WaAuthDangerousOptions
 }
 
 export class WaPairingFlow {
@@ -298,13 +299,15 @@ export class WaPairingFlow {
         )
         const accountType = wrappedIdentity.accountType ?? proto.ADVEncryptionType.E2EE
         const isHosted = accountType === proto.ADVEncryptionType.HOSTED
-        const hmacInput = isHosted
-            ? concatBytes([ADV_PREFIX_HOSTED_ACCOUNT_SIGNATURE, wrappedDetails])
-            : wrappedDetails
-        const expectedHmac = await computeAdvIdentityHmac(credentials.advSecretKey, hmacInput)
-        if (!uint8Equal(expectedHmac, wrappedHmac)) {
-            this.opts.logger.error('pair-success hmac mismatch')
-            throw new Error('pair-success HMAC validation failed')
+        if (this.opts.dangerous?.disablePairSuccessHmacVerification !== true) {
+            const hmacInput = isHosted
+                ? concatBytes([ADV_PREFIX_HOSTED_ACCOUNT_SIGNATURE, wrappedDetails])
+                : wrappedDetails
+            const expectedHmac = await computeAdvIdentityHmac(credentials.advSecretKey, hmacInput)
+            if (!uint8Equal(expectedHmac, wrappedHmac)) {
+                this.opts.logger.error('pair-success hmac mismatch')
+                throw new Error('pair-success HMAC validation failed')
+            }
         }
 
         const { signedIdentity, keyIndex, responseIdentityBytes } =
@@ -370,16 +373,18 @@ export class WaPairingFlow {
             'ADVSignedDeviceIdentity.accountSignatureKey'
         )
         const localIdentity = credentials.registrationInfo.identityKeyPair
-        const validAccountSignature = await verifyDeviceIdentityAccountSignature(
-            details,
-            accountSignature,
-            localIdentity.pubKey,
-            accountSignatureKey,
-            isHosted
-        )
-        if (!validAccountSignature) {
-            this.opts.logger.error('pair-success account signature invalid')
-            throw new Error('pair-success account signature validation failed')
+        if (this.opts.dangerous?.disableAdvSignatureVerification !== true) {
+            const validAccountSignature = await verifyDeviceIdentityAccountSignature(
+                details,
+                accountSignature,
+                localIdentity.pubKey,
+                accountSignatureKey,
+                isHosted
+            )
+            if (!validAccountSignature) {
+                this.opts.logger.error('pair-success account signature invalid')
+                throw new Error('pair-success account signature validation failed')
+            }
         }
 
         signedIdentity.deviceSignature = await generateDeviceSignature(

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -50,6 +50,12 @@ export interface WaAuthClientOptions {
 
 export interface WaAuthDangerousOptions {
     /**
+     * Skip the noise certificate-chain verification during the handshake.
+     * The server's static key will be accepted without proof that it was
+     * issued by a trusted root.
+     */
+    readonly disableNoiseCertificateChainVerification?: boolean
+    /**
      * Skip the XEdDSA account-signature check on the `pair-success` ADV
      * identity payload, which normally proves the primary device signed off
      * on this companion.

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -45,6 +45,26 @@ export interface WaAuthClientOptions {
     readonly deviceOsDisplayName?: string
     readonly requireFullSync?: boolean
     readonly version?: string
+    readonly dangerous?: WaAuthDangerousOptions
+}
+
+export interface WaAuthDangerousOptions {
+    /**
+     * Skip the XEdDSA account-signature check on the `pair-success` ADV
+     * identity payload, which normally proves the primary device signed off
+     * on this companion.
+     */
+    readonly disableAdvSignatureVerification?: boolean
+    /**
+     * Skip the HMAC check on the `pair-success` stanza that ties the ADV
+     * payload to the shared pairing secret.
+     */
+    readonly disablePairSuccessHmacVerification?: boolean
+    /**
+     * Skip the XEdDSA signature check on the locally stored signed pre-key
+     * during credential load. Corrupt or forged credentials will be accepted.
+     */
+    readonly disableSignedPreKeySignatureVerification?: boolean
 }
 
 export interface WaSuccessPersistAttributes {

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -394,7 +394,8 @@ export function buildWaClientDependencies(input: {
         logger,
         defaultTimeoutMs: options.mediaTimeoutMs,
         defaultUploadAgent: toProxyAgent(options.proxy?.mediaUpload),
-        defaultDownloadAgent: toProxyAgent(options.proxy?.mediaDownload)
+        defaultDownloadAgent: toProxyAgent(options.proxy?.mediaDownload),
+        skipMacVerification: options.dangerous?.disableMediaMacVerification
     })
     const mediaMessageBuildOptions: WaMediaMessageOptions = {
         logger,
@@ -424,7 +425,8 @@ export function buildWaClientDependencies(input: {
     })
     const senderKeyManager = new SenderKeyManager(sessionStore.senderKey, {
         getFutureMessagesMax: () =>
-            abPropsCoordinator.getConfigValue('web_signal_future_messages_max')
+            abPropsCoordinator.getConfigValue('web_signal_future_messages_max'),
+        skipSignatureVerification: options.dangerous?.disableSenderKeySignatureVerification
     })
     const signalProtocol = new SignalProtocol(
         {
@@ -479,7 +481,8 @@ export function buildWaClientDependencies(input: {
             deviceOsDisplayName: options.deviceOsDisplayName,
             devicePlatform: options.devicePlatform,
             requireFullSync: options.requireFullSync,
-            version: options.version
+            version: options.version,
+            dangerous: options.dangerous
         },
         {
             logger,
@@ -656,7 +659,8 @@ export function buildWaClientDependencies(input: {
         store: sessionStore.appState,
         onMissingKeys: async ({ keyIds }) => {
             await messageDispatch.requestAppStateSyncKeys(keyIds)
-        }
+        },
+        skipMacVerification: options.dangerous?.disableAppStateMacVerification
     })
 
     const appStateMutations = new WaAppStateMutationCoordinator({

--- a/src/client/connection/WaConnectionManager.ts
+++ b/src/client/connection/WaConnectionManager.ts
@@ -285,7 +285,9 @@ export class WaConnectionManager {
             registered: credentials.meJid !== null && credentials.meJid !== undefined
         })
         const commsConfig = this.authClient.buildCommsConfig(this.options, {
-            noiseTrustedRootCa: this.options.testHooks?.noiseRootCa
+            noiseTrustedRootCa: this.options.testHooks?.noiseRootCa,
+            disableNoiseCertificateChainVerification:
+                this.options.dangerous?.disableNoiseCertificateChainVerification
         })
         const comms = new WaComms(commsConfig, this.logger)
         this.pendingComms = comms

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -62,9 +62,12 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
     readonly logoutStoreClear?: WaLogoutStoreClearOptions
     readonly media?: WaMediaOptions
     /**
-     * Escape hatches intended exclusively for tests against a fake server.
-     * **Do not enable in production.** Each flag here disables a security check
-     * the production code path enforces.
+     * Test-only overrides intended for running against a fake server.
+     *
+     * These hooks **do not** bypass any security checks — they only swap in
+     * test fixtures (e.g. a different root CA) so the full verification code
+     * path still runs end-to-end. If you actually need to skip a check, use
+     * `dangerous` instead.
      */
     readonly testHooks?: WaClientTestHooks
     /**
@@ -75,12 +78,6 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
 }
 
 export interface WaClientDangerousOptions extends WaAuthDangerousOptions {
-    /**
-     * Skip the noise certificate-chain verification during the handshake.
-     * The server's static key will be accepted without proof that it was
-     * issued by a trusted root.
-     */
-    readonly disableNoiseCertificateChainVerification?: boolean
     /**
      * Skip the XEdDSA signature check on incoming group sender-key messages.
      * Ciphertexts will be decrypted even if the trailing signature does not

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,5 +1,10 @@
 import type { AppStateCollectionName } from '@appstate/types'
-import type { WaAuthClientOptions, WaAuthCredentials, WaAuthSocketOptions } from '@auth/types'
+import type {
+    WaAuthClientOptions,
+    WaAuthCredentials,
+    WaAuthDangerousOptions,
+    WaAuthSocketOptions
+} from '@auth/types'
 import type { WaMediaProcessor } from '@media/processor'
 import type { WaDecodedAddon } from '@message/addon-crypto'
 import type { WaMessagePublishOptions } from '@message/types'
@@ -62,6 +67,37 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
      * the production code path enforces.
      */
     readonly testHooks?: WaClientTestHooks
+    /**
+     * Dangerous escape hatches. **Do not enable in production.** Each flag here
+     * disables a security check the production code path enforces.
+     */
+    readonly dangerous?: WaClientDangerousOptions
+}
+
+export interface WaClientDangerousOptions extends WaAuthDangerousOptions {
+    /**
+     * Skip the noise certificate-chain verification during the handshake.
+     * The server's static key will be accepted without proof that it was
+     * issued by a trusted root.
+     */
+    readonly disableNoiseCertificateChainVerification?: boolean
+    /**
+     * Skip the XEdDSA signature check on incoming group sender-key messages.
+     * Ciphertexts will be decrypted even if the trailing signature does not
+     * verify against the stored sender signing public key.
+     */
+    readonly disableSenderKeySignatureVerification?: boolean
+    /**
+     * Skip HMAC verification across the app-state sync pipeline: per-mutation
+     * value and index MACs, snapshot MACs, and patch MACs. Tampered server
+     * payloads will be accepted as long as the ciphertext decrypts cleanly.
+     */
+    readonly disableAppStateMacVerification?: boolean
+    /**
+     * Skip the truncated HMAC-SHA256 check on encrypted media payloads
+     * during download. Tampered ciphertexts will still be decrypted.
+     */
+    readonly disableMediaMacVerification?: boolean
 }
 
 export interface WaClientTestHooks {

--- a/src/media/WaMediaCrypto.ts
+++ b/src/media/WaMediaCrypto.ts
@@ -239,7 +239,8 @@ export class WaMediaCrypto {
         mediaKey: Uint8Array,
         ciphertextHmac: Uint8Array,
         expectedFileSha256?: Uint8Array,
-        expectedFileEncSha256?: Uint8Array
+        expectedFileEncSha256?: Uint8Array,
+        skipMacVerification = false
     ): Promise<WaMediaDecryptionResult> {
         if (ciphertextHmac.byteLength < HMAC_TRUNCATED_SIZE) {
             throw new Error(`ciphertext too short: ${ciphertextHmac.byteLength}`)
@@ -264,10 +265,12 @@ export class WaMediaCrypto {
         const expectedMac = ciphertextHmac.subarray(ciphertextHmac.byteLength - HMAC_TRUNCATED_SIZE)
         const ivCiphertext = concatBytes([keys.iv, ciphertext])
 
-        const mac = await hmacSign(hmacKey, ivCiphertext)
-        const signature = mac.subarray(0, HMAC_TRUNCATED_SIZE)
-        if (!uint8TimingSafeEqual(signature, expectedMac)) {
-            throw new Error('media MAC mismatch')
+        if (!skipMacVerification) {
+            const mac = await hmacSign(hmacKey, ivCiphertext)
+            const signature = mac.subarray(0, HMAC_TRUNCATED_SIZE)
+            if (!uint8TimingSafeEqual(signature, expectedMac)) {
+                throw new Error('media MAC mismatch')
+            }
         }
 
         const plaintext = await aesCbcDecrypt(aesKey, keys.iv, ciphertext)
@@ -661,9 +664,11 @@ async function pumpDecryption(
             throw new Error(`ciphertext too short: ${trailing.byteLength}`)
         }
 
-        const signature = hmac.digest().subarray(0, HMAC_TRUNCATED_SIZE)
-        if (!uint8TimingSafeEqual(signature, trailing)) {
-            throw new Error('media MAC mismatch')
+        if (!options.skipMacVerification) {
+            const signature = hmac.digest().subarray(0, HMAC_TRUNCATED_SIZE)
+            if (!uint8TimingSafeEqual(signature, trailing)) {
+                throw new Error('media MAC mismatch')
+            }
         }
 
         if (pending.byteLength < AES_BLOCK_SIZE || pending.byteLength % AES_BLOCK_SIZE !== 0) {

--- a/src/media/WaMediaTransferClient.ts
+++ b/src/media/WaMediaTransferClient.ts
@@ -101,6 +101,7 @@ export class WaMediaTransferClient {
     private readonly defaultHeaders: Readonly<Record<string, string>>
     private readonly defaultUploadAgent: WaMediaTransferClientOptions['defaultUploadAgent']
     private readonly defaultDownloadAgent: WaMediaTransferClientOptions['defaultDownloadAgent']
+    private readonly skipMacVerification: boolean
 
     public constructor(options: WaMediaTransferClientOptions = {}) {
         this.logger = options.logger
@@ -110,6 +111,7 @@ export class WaMediaTransferClient {
         this.defaultHeaders = normalizeHeaderRecord(options.defaultHeaders)
         this.defaultUploadAgent = options.defaultUploadAgent
         this.defaultDownloadAgent = options.defaultDownloadAgent
+        this.skipMacVerification = options.skipMacVerification === true
     }
 
     public async downloadStream(request: StreamDownloadRequest): Promise<StreamTransferResponse> {
@@ -252,7 +254,8 @@ export class WaMediaTransferClient {
             mediaType: request.mediaType,
             mediaKey: request.mediaKey,
             expectedFileSha256: request.fileSha256,
-            expectedFileEncSha256: request.fileEncSha256
+            expectedFileEncSha256: request.fileEncSha256,
+            skipMacVerification: this.skipMacVerification
         })
         decrypted.metadata.catch(() => undefined)
         this.logger?.debug('media encrypted download stream ready', {

--- a/src/media/__tests__/media.test.ts
+++ b/src/media/__tests__/media.test.ts
@@ -181,6 +181,64 @@ test('media crypto encrypt/decrypt bytes round-trip and hash validation', async 
     )
 })
 
+test('media crypto decryptBytes rejects tampered MAC by default and bypasses it when skip is set', async () => {
+    const mediaKey = await WaMediaCrypto.generateMediaKey()
+    const plaintext = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+    const encrypted = await WaMediaCrypto.encryptBytes('image', mediaKey, plaintext)
+
+    const tampered = new Uint8Array(encrypted.ciphertextHmac)
+    tampered[tampered.length - 1] ^= 0x01
+
+    await assert.rejects(
+        () => WaMediaCrypto.decryptBytes('image', mediaKey, tampered),
+        /media MAC mismatch/
+    )
+
+    const bypassed = await WaMediaCrypto.decryptBytes(
+        'image',
+        mediaKey,
+        tampered,
+        undefined,
+        undefined,
+        true
+    )
+    assert.deepEqual(bypassed.plaintext, plaintext)
+})
+
+test('media crypto decryptReadable rejects tampered MAC by default and bypasses it when skip is set', async () => {
+    const mediaKey = await WaMediaCrypto.generateMediaKey()
+    const plaintext = createPatternBytes(4_096)
+    const encryptedReadable = await WaMediaCrypto.encryptReadable(
+        'audio',
+        mediaKey,
+        createChunkedReadable(plaintext, [1_024])
+    )
+    const [ciphertext] = await Promise.all([
+        readAllFromStream(encryptedReadable.encrypted),
+        encryptedReadable.metadata
+    ])
+
+    const tampered = new Uint8Array(ciphertext)
+    tampered[tampered.length - 1] ^= 0x01
+
+    const strictDecrypt = await WaMediaCrypto.decryptReadable(
+        createChunkedReadable(tampered, [1_024]),
+        { mediaType: 'audio', mediaKey }
+    )
+    await assert.rejects(() => readAllFromStream(strictDecrypt.plaintext), /media MAC mismatch/)
+    await assert.rejects(() => strictDecrypt.metadata, /media MAC mismatch/)
+
+    const bypassDecrypt = await WaMediaCrypto.decryptReadable(
+        createChunkedReadable(tampered, [1_024]),
+        { mediaType: 'audio', mediaKey, skipMacVerification: true }
+    )
+    const [bypassedBytes] = await Promise.all([
+        readAllFromStream(bypassDecrypt.plaintext),
+        bypassDecrypt.metadata
+    ])
+    assert.deepEqual(bypassedBytes, plaintext)
+})
+
 test('media crypto encryptReadable matches byte encryption for large payloads', async () => {
     const mediaKey = await WaMediaCrypto.generateMediaKey()
     const plaintext = createPatternBytes(200_000)

--- a/src/media/types.ts
+++ b/src/media/types.ts
@@ -25,6 +25,7 @@ export interface WaMediaTransferClientOptions {
     readonly defaultHeaders?: Readonly<Record<string, string>>
     readonly defaultUploadAgent?: WaProxyAgent
     readonly defaultDownloadAgent?: WaProxyAgent
+    readonly skipMacVerification?: boolean
 }
 
 export interface WaMediaDerivedKeys {
@@ -82,4 +83,5 @@ export interface WaMediaDecryptReadableOptions {
     readonly mediaKey: Uint8Array
     readonly expectedFileSha256?: Uint8Array
     readonly expectedFileEncSha256?: Uint8Array
+    readonly skipMacVerification?: boolean
 }

--- a/src/signal/group/SenderKeyManager.ts
+++ b/src/signal/group/SenderKeyManager.ts
@@ -61,13 +61,18 @@ export class SenderKeyManager {
     private readonly store: WaSenderKeyStore
     private readonly senderLock = new StoreLock()
     private readonly getFutureMessagesMax: (() => number) | undefined
+    private readonly skipSignatureVerification: boolean
 
     public constructor(
         store: WaSenderKeyStore,
-        options?: { readonly getFutureMessagesMax?: () => number }
+        options?: {
+            readonly getFutureMessagesMax?: () => number
+            readonly skipSignatureVerification?: boolean
+        }
     ) {
         this.store = store
         this.getFutureMessagesMax = options?.getFutureMessagesMax
+        this.skipSignatureVerification = options?.skipSignatureVerification === true
     }
 
     public async prepareGroupEncryption(
@@ -242,20 +247,22 @@ export class SenderKeyManager {
                 throw new Error('sender key iteration mismatch')
             }
 
-            const signedContent = parsed.versionContentMac.subarray(
-                0,
-                parsed.versionContentMac.length - SIGNAL_SIGNATURE_LENGTH
-            )
-            const signature = parsed.versionContentMac.subarray(
-                parsed.versionContentMac.length - SIGNAL_SIGNATURE_LENGTH
-            )
-            const validSignature = await xeddsaVerify(
-                toRawPubKey(senderKey.signingPublicKey),
-                signedContent,
-                signature
-            )
-            if (!validSignature) {
-                throw new Error('invalid sender key signature')
+            if (!this.skipSignatureVerification) {
+                const signedContent = parsed.versionContentMac.subarray(
+                    0,
+                    parsed.versionContentMac.length - SIGNAL_SIGNATURE_LENGTH
+                )
+                const signature = parsed.versionContentMac.subarray(
+                    parsed.versionContentMac.length - SIGNAL_SIGNATURE_LENGTH
+                )
+                const validSignature = await xeddsaVerify(
+                    toRawPubKey(senderKey.signingPublicKey),
+                    signedContent,
+                    signature
+                )
+                if (!validSignature) {
+                    throw new Error('invalid sender key signature')
+                }
             }
 
             const selected = await selectMessageKey(

--- a/src/signal/group/__tests__/sender-key.test.ts
+++ b/src/signal/group/__tests__/sender-key.test.ts
@@ -178,3 +178,43 @@ test('sender key manager handles distribution, encryption/decryption and validat
         /invalid sender key signature/
     )
 })
+
+test('sender key manager bypasses signature check when skipSignatureVerification is set', async () => {
+    const senderStore = new SenderKeyMemoryStore()
+    const receiverStore = new SenderKeyMemoryStore()
+    const senderManager = new SenderKeyManager(senderStore)
+    const receiverStrict = new SenderKeyManager(receiverStore)
+    const receiverSkipping = new SenderKeyManager(receiverStore, {
+        skipSignatureVerification: true
+    })
+    const groupId = '120363000000000000@g.us'
+    const sender = makeAddress('5511777777777', 0)
+    const plaintext = makeBytes(24, 7)
+
+    const prepared = await senderManager.prepareGroupEncryption(groupId, sender, plaintext)
+    await receiverStrict.processSenderKeyDistributionPayload(
+        groupId,
+        sender,
+        prepared.distributionMessage.axolotlSenderKeyDistributionMessage!
+    )
+
+    const tamperedCiphertext = new Uint8Array(prepared.ciphertext.ciphertext)
+    tamperedCiphertext[tamperedCiphertext.length - 1] ^= 0x01
+
+    await assert.rejects(
+        () =>
+            receiverStrict.decryptGroupMessage({
+                groupId,
+                sender,
+                ciphertext: tamperedCiphertext
+            }),
+        /invalid sender key signature/
+    )
+
+    const decrypted = await receiverSkipping.decryptGroupMessage({
+        groupId,
+        sender,
+        ciphertext: tamperedCiphertext
+    })
+    assert.deepEqual(decrypted, plaintext)
+})


### PR DESCRIPTION
Introduce `WaClientDangerousOptions` with flags to bypass individual security verifications during testing against fake servers. All flags default off and preserve production behavior.

- disableNoiseCertificateChainVerification: skip noise cert chain
- disableSenderKeySignatureVerification: skip group sender-key XEdDSA
- disableAppStateMacVerification: skip value/index/snapshot/patch MACs
- disableMediaMacVerification: skip truncated HMAC on media download
- disableAdvSignatureVerification: skip ADV account signature on pair
- disablePairSuccessHmacVerification: skip pair-success HMAC
- disableSignedPreKeySignatureVerification: skip local signed prekey

Auth-local flags live in `WaAuthDangerousOptions` (@auth/types) and `WaClientDangerousOptions` extends it with the non-auth flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional runtime "dangerous" flags to selectively disable MAC/signature/certificate verifications across app-state sync, media transfer, auth flows, and group messages (configurable via client options). Defaults remain secure (verifications enabled).

* **Tests**
  * Added tests verifying that tampered MAC/signature data is rejected by default and accepted when the corresponding verification flags are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->