### PR TITLE
perf(protocol): optimize JID/phash parsing and canonicalization in hot paths

### DIFF
--- a/packages/fake-server/bench/messaging.bench.ts
+++ b/packages/fake-server/bench/messaging.bench.ts
@@ -917,14 +917,17 @@ async function mainSeparateProcess(
     await rpc.spawn()
     await rpc.start()
 
+    const skipServerProf = argSet.has('--no-server-prof')
     const serverProfilingOpts = {
-        cpu: profiler.options.cpu,
-        heap: profiler.options.heap,
+        cpu: skipServerProf ? false : profiler.options.cpu,
+        heap: skipServerProf ? false : profiler.options.heap,
         outDir: profiler.options.outDir
     }
     if (serverProfilingOpts.cpu || serverProfilingOpts.heap) {
         await rpc.startProfiling(serverProfilingOpts)
         console.log('[server] profiling started')
+    } else if (skipServerProf) {
+        console.log('[server] profiling skipped (--no-server-prof)')
     }
 
     const authStore = new InMemoryAuthStore()

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -34,12 +34,12 @@ import { proto, type Proto } from '@proto'
 import { WA_DEFAULTS } from '@protocol/constants'
 import {
     isGroupJid,
+    isLidJid,
     normalizeDeviceJid,
     normalizeRecipientJid,
     parseJidFull,
     parseSignalAddressFromJid,
     signalAddressKey,
-    splitJid,
     toUserJid
 } from '@protocol/jid'
 import type { OutboundRetryTracker } from '@retry/tracker'
@@ -712,16 +712,8 @@ export class WaMessageDispatchCoordinator {
         groupJid: string
     ): GroupAddressingMode {
         for (let index = 0; index < participantUserJids.length; index += 1) {
-            const participantJid = participantUserJids[index]
-            try {
-                if (splitJid(participantJid).server === 'lid') {
-                    return 'lid'
-                }
-            } catch (error) {
-                this.logger.trace(
-                    'ignoring malformed participant jid in addressing mode resolution',
-                    { participantJid, message: toError(error).message }
-                )
+            if (isLidJid(participantUserJids[index])) {
+                return 'lid'
             }
         }
 

--- a/src/message/phash.ts
+++ b/src/message/phash.ts
@@ -1,5 +1,4 @@
 import { sha256 } from '@crypto/core'
-import { splitJid } from '@protocol/jid'
 import { bytesToBase64, TEXT_ENCODER } from '@util/bytes'
 
 export async function computePhashV2(participants: readonly string[]): Promise<string> {
@@ -16,17 +15,40 @@ export async function computePhashV2(participants: readonly string[]): Promise<s
 }
 
 function toPhashCanonicalWid(jid: string): string {
-    const { user, server } = splitJid(jid)
-    const normalizedServer = server === 'c.us' ? 's.whatsapp.net' : server
+    const atIndex = jid.indexOf('@')
+    if (atIndex < 1) return jid
+    const colonIndex = jid.indexOf(':', 0)
+    const userEnd = colonIndex >= 0 && colonIndex < atIndex ? colonIndex : atIndex
+    const hasZeroAgent =
+        userEnd >= 2 && jid.charCodeAt(userEnd - 2) === 46 && jid.charCodeAt(userEnd - 1) === 48
+    const baseUserEnd = hasZeroAgent ? userEnd - 2 : userEnd
+    const baseUser = jid.slice(0, baseUserEnd)
 
-    const colonIndex = user.indexOf(':')
-    const userWithOptionalAgent = colonIndex >= 0 ? user.slice(0, colonIndex) : user
-    const baseUser = userWithOptionalAgent.endsWith('.0')
-        ? userWithOptionalAgent.slice(0, userWithOptionalAgent.length - 2)
-        : userWithOptionalAgent
-    const deviceRaw = colonIndex >= 0 ? user.slice(colonIndex + 1) : '0'
-    const device = Number.parseInt(deviceRaw, 10)
-    const normalizedDevice = Number.isSafeInteger(device) && device >= 0 ? device : 0
+    let device = 0
+    if (colonIndex >= 0 && colonIndex < atIndex) {
+        for (let i = colonIndex + 1; i < atIndex; i += 1) {
+            const digit = jid.charCodeAt(i) - 48
+            if (digit < 0 || digit > 9) {
+                device = 0
+                break
+            }
+            device = device * 10 + digit
+            if (device > Number.MAX_SAFE_INTEGER) {
+                device = 0
+                break
+            }
+        }
+    }
 
-    return `${baseUser}.0:${normalizedDevice}@${normalizedServer}`
+    const serverStart = atIndex + 1
+    const serverLen = jid.length - serverStart
+    const isCUs =
+        serverLen === 4 &&
+        jid.charCodeAt(serverStart) === 99 &&
+        jid.charCodeAt(serverStart + 1) === 46 &&
+        jid.charCodeAt(serverStart + 2) === 117 &&
+        jid.charCodeAt(serverStart + 3) === 115
+    const normalizedServer = isCUs ? 's.whatsapp.net' : jid.slice(serverStart)
+
+    return `${baseUser}.0:${device}@${normalizedServer}`
 }

--- a/src/message/phash.ts
+++ b/src/message/phash.ts
@@ -16,7 +16,7 @@ export async function computePhashV2(participants: readonly string[]): Promise<s
 
 function toPhashCanonicalWid(jid: string): string {
     const atIndex = jid.indexOf('@')
-    if (atIndex < 1) return jid
+    if (atIndex < 1 || atIndex >= jid.length - 1) return jid
     const colonIndex = jid.indexOf(':', 0)
     const userEnd = colonIndex >= 0 && colonIndex < atIndex ? colonIndex : atIndex
     const hasZeroAgent =

--- a/src/protocol/jid.ts
+++ b/src/protocol/jid.ts
@@ -60,7 +60,12 @@ export function normalizeRecipientJid(to: string): string {
 
 function isJidType(jid: string, type: string): boolean {
     const atIndex = jid.length - type.length - 1
-    return atIndex >= 1 && jid.charCodeAt(atIndex) === 64 && jid.endsWith(type)
+    return (
+        atIndex >= 1 &&
+        jid.charCodeAt(atIndex) === 64 &&
+        jid.indexOf('@') === atIndex &&
+        jid.endsWith(type)
+    )
 }
 
 export function isLidJid(jid: string): boolean {
@@ -140,7 +145,7 @@ export function toUserJid(
     const canonicalize = options.canonicalizeSignalServer === true
     if (!canonicalize) {
         const atIndex = jid.indexOf('@')
-        if (atIndex >= 1) {
+        if (atIndex >= 1 && atIndex < jid.length - 1) {
             const colonIndex = jid.indexOf(':', 0)
             if (colonIndex === -1 || colonIndex > atIndex) {
                 return jid
@@ -179,7 +184,7 @@ export function isHostedDeviceJid(jid: string): boolean {
         return true
     }
     const atIndex = jid.indexOf('@')
-    if (atIndex < 1) return false
+    if (atIndex < 1 || atIndex >= jid.length - 1) return false
     const colonIndex = jid.indexOf(':')
     if (colonIndex < 0 || colonIndex >= atIndex - 1) return false
     let deviceId = 0

--- a/src/protocol/jid.ts
+++ b/src/protocol/jid.ts
@@ -63,6 +63,10 @@ function isJidType(jid: string, type: string): boolean {
     return atIndex >= 1 && jid.charCodeAt(atIndex) === 64 && jid.endsWith(type)
 }
 
+export function isLidJid(jid: string): boolean {
+    return isJidType(jid, WA_DEFAULTS.LID_SERVER)
+}
+
 export function isGroupJid(jid: string): boolean {
     return isJidType(jid, WA_DEFAULTS.GROUP_SERVER)
 }
@@ -88,8 +92,14 @@ export function parseSignalAddressFromJid(jid: string): SignalAddress {
     if (colonIndex === -1 || colonIndex > atIndex) {
         return { user: jid.slice(0, atIndex), server, device: 0 }
     }
-    const device = Number.parseInt(jid.slice(colonIndex + 1, atIndex), 10)
-    if (!Number.isFinite(device) || device < 0) throw new Error(`invalid jid device: ${jid}`)
+    if (colonIndex >= atIndex - 1) throw new Error(`invalid jid device: ${jid}`)
+    let device = 0
+    for (let i = colonIndex + 1; i < atIndex; i += 1) {
+        const digit = jid.charCodeAt(i) - 48
+        if (digit < 0 || digit > 9) throw new Error(`invalid jid device: ${jid}`)
+        device = device * 10 + digit
+        if (device > Number.MAX_SAFE_INTEGER) throw new Error(`invalid jid device: ${jid}`)
+    }
     return { user: jid.slice(0, colonIndex), server, device }
 }
 
@@ -127,14 +137,23 @@ export function toUserJid(
         readonly hostDomain?: string
     } = {}
 ): string {
+    const canonicalize = options.canonicalizeSignalServer === true
+    if (!canonicalize) {
+        const atIndex = jid.indexOf('@')
+        if (atIndex >= 1) {
+            const colonIndex = jid.indexOf(':', 0)
+            if (colonIndex === -1 || colonIndex > atIndex) {
+                return jid
+            }
+        }
+    }
     const address = parseSignalAddressFromJid(jid)
-    const server =
-        options.canonicalizeSignalServer === true
-            ? canonicalizeSignalServer(
-                  address.server ?? WA_DEFAULTS.HOST_DOMAIN,
-                  options.hostDomain ?? WA_DEFAULTS.HOST_DOMAIN
-              )
-            : address.server
+    const server = canonicalize
+        ? canonicalizeSignalServer(
+              address.server ?? WA_DEFAULTS.HOST_DOMAIN,
+              options.hostDomain ?? WA_DEFAULTS.HOST_DOMAIN
+          )
+        : address.server
     return `${address.user}@${server}`
 }
 
@@ -153,16 +172,24 @@ export function isHostedServer(server: string): boolean {
 }
 
 export function isHostedDeviceJid(jid: string): boolean {
-    const { user, server } = splitJid(jid)
-    if (isHostedServer(server)) {
+    if (
+        isJidType(jid, WA_DEFAULTS.HOSTED_SERVER) ||
+        isJidType(jid, WA_DEFAULTS.HOSTED_LID_SERVER)
+    ) {
         return true
     }
-    const colonIndex = user.indexOf(':')
-    if (colonIndex < 0) {
-        return false
+    const atIndex = jid.indexOf('@')
+    if (atIndex < 1) return false
+    const colonIndex = jid.indexOf(':')
+    if (colonIndex < 0 || colonIndex >= atIndex - 1) return false
+    let deviceId = 0
+    for (let i = colonIndex + 1; i < atIndex; i += 1) {
+        const digit = jid.charCodeAt(i) - 48
+        if (digit < 0 || digit > 9) return false
+        deviceId = deviceId * 10 + digit
+        if (deviceId > Number.MAX_SAFE_INTEGER) return false
     }
-    const deviceId = Number.parseInt(user.slice(colonIndex + 1), 10)
-    return Number.isSafeInteger(deviceId) && isHostedDeviceId(deviceId)
+    return isHostedDeviceId(deviceId)
 }
 
 export function buildDeviceJid(

--- a/src/signal/api/SignalDeviceSyncApi.ts
+++ b/src/signal/api/SignalDeviceSyncApi.ts
@@ -464,7 +464,9 @@ export class SignalDeviceSyncApi {
         }
 
         const parsedNormalizedUser = splitJid(normalizedUserJid)
-        const parsedRawUser = splitJid(rawUserJid)
+        const rawAtIndex = rawUserJid.indexOf('@')
+        const rawServer =
+            rawAtIndex >= 1 ? rawUserJid.slice(rawAtIndex + 1) : parsedNormalizedUser.server
         const dedup = new Set<string>()
         for (const deviceNode of getNodeChildrenByTag(deviceListNode, 'device')) {
             const parsedId = deviceNode.attrs.id
@@ -477,7 +479,7 @@ export class SignalDeviceSyncApi {
                 isHostedDeviceId(parsedId) || deviceNode.attrs.is_hosted === 'true'
             dedup.add(
                 buildDeviceJid(parsedNormalizedUser.user, parsedNormalizedUser.server, parsedId, {
-                    rawServer: parsedRawUser.server,
+                    rawServer,
                     isHosted: isHostedDevice
                 })
             )

--- a/src/signal/api/SignalDeviceSyncApi.ts
+++ b/src/signal/api/SignalDeviceSyncApi.ts
@@ -466,7 +466,9 @@ export class SignalDeviceSyncApi {
         const parsedNormalizedUser = splitJid(normalizedUserJid)
         const rawAtIndex = rawUserJid.indexOf('@')
         const rawServer =
-            rawAtIndex >= 1 ? rawUserJid.slice(rawAtIndex + 1) : parsedNormalizedUser.server
+            rawAtIndex >= 1 && rawAtIndex < rawUserJid.length - 1
+                ? rawUserJid.slice(rawAtIndex + 1)
+                : parsedNormalizedUser.server
         const dedup = new Set<string>()
         for (const deviceNode of getNodeChildrenByTag(deviceListNode, 'device')) {
             const parsedId = deviceNode.attrs.id


### PR DESCRIPTION
- Removed ~77k allocations on benchmarks
- add `isLidJid` and remove `splitJid` from group message dispatch addressing
- replace `parseInt` with manual `charCode` parsing in critical `jid.ts` paths
- optimize `toPhashCanonicalWid` to reduce overhead
- avoid `splitJid` in device-sync dedup flow
- add `--no-server-prof` to fake-server messaging benchmark

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JID parsing and validation to gracefully handle malformed identifiers and avoid errors.
  * Strengthened device ID parsing with stricter digit validation and numeric-range checks.
  * More reliable group addressing detection to prevent misclassification of participant addresses.

* **Performance**
  * Added an option to skip server profiling during benchmarks for faster test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->