### PR TITLE
perf: reduce allocation hotspots in signal decode, incoming msgs and store locks

### DIFF
--- a/packages/store-mongo/src/__tests__/integration.test.ts
+++ b/packages/store-mongo/src/__tests__/integration.test.ts
@@ -50,10 +50,9 @@ async function makeSessionRecord(seed: number): Promise<SignalSessionRecord> {
         },
         recvChains: [
             {
-                ratchetPubKey: toSerializedPubKey(recvRatchet.pubKey),
-                nextMsgIndex: 0,
-                chainKey: new Uint8Array(32).fill((12 + seed) & 0xff),
-                unusedMsgKeys: []
+                senderRatchetKey: toSerializedPubKey(recvRatchet.pubKey),
+                chainKey: { index: 0, key: new Uint8Array(32).fill((12 + seed) & 0xff) },
+                messageKeys: []
             }
         ],
         initialExchangeInfo: {

--- a/packages/store-mysql/src/BaseMysqlStore.ts
+++ b/packages/store-mysql/src/BaseMysqlStore.ts
@@ -10,6 +10,7 @@ export abstract class BaseMysqlStore {
     protected readonly tablePrefix: string
     private readonly migrationDomains: readonly WaMysqlMigrationDomain[]
     private migrationPromise: Promise<void> | null
+    private migrationDone = false
 
     protected constructor(
         options: WaMysqlStorageOptions,
@@ -27,16 +28,21 @@ export abstract class BaseMysqlStore {
         return `\`${this.tablePrefix}${name}\``
     }
 
-    protected async ensureReady(): Promise<void> {
+    protected ensureReady(): Promise<void> | void {
+        if (this.migrationDone) return
         if (!this.migrationPromise) {
             this.migrationPromise = ensureMysqlMigrations(
                 this.pool,
                 this.migrationDomains,
                 this.tablePrefix
-            ).catch((err) => {
-                this.migrationPromise = null
-                throw err
-            })
+            )
+                .then(() => {
+                    this.migrationDone = true
+                })
+                .catch((err) => {
+                    this.migrationPromise = null
+                    throw err
+                })
         }
         return this.migrationPromise
     }
@@ -59,5 +65,6 @@ export abstract class BaseMysqlStore {
 
     public async destroy(): Promise<void> {
         this.migrationPromise = null
+        this.migrationDone = false
     }
 }

--- a/packages/store-mysql/src/__tests__/integration.test.ts
+++ b/packages/store-mysql/src/__tests__/integration.test.ts
@@ -55,10 +55,9 @@ async function makeSessionRecord(seed: number): Promise<SignalSessionRecord> {
         },
         recvChains: [
             {
-                ratchetPubKey: toSerializedPubKey(recvRatchet.pubKey),
-                nextMsgIndex: 0,
-                chainKey: new Uint8Array(32).fill((12 + seed) & 0xff),
-                unusedMsgKeys: []
+                senderRatchetKey: toSerializedPubKey(recvRatchet.pubKey),
+                chainKey: { index: 0, key: new Uint8Array(32).fill((12 + seed) & 0xff) },
+                messageKeys: []
             }
         ],
         initialExchangeInfo: {

--- a/packages/store-postgres/src/__tests__/integration.test.ts
+++ b/packages/store-postgres/src/__tests__/integration.test.ts
@@ -55,10 +55,9 @@ async function makeSessionRecord(seed: number): Promise<SignalSessionRecord> {
         },
         recvChains: [
             {
-                ratchetPubKey: toSerializedPubKey(recvRatchet.pubKey),
-                nextMsgIndex: 0,
-                chainKey: new Uint8Array(32).fill((12 + seed) & 0xff),
-                unusedMsgKeys: []
+                senderRatchetKey: toSerializedPubKey(recvRatchet.pubKey),
+                chainKey: { index: 0, key: new Uint8Array(32).fill((12 + seed) & 0xff) },
+                messageKeys: []
             }
         ],
         initialExchangeInfo: {

--- a/packages/store-redis/src/__tests__/integration.test.ts
+++ b/packages/store-redis/src/__tests__/integration.test.ts
@@ -50,10 +50,9 @@ async function makeSessionRecord(seed: number): Promise<SignalSessionRecord> {
         },
         recvChains: [
             {
-                ratchetPubKey: toSerializedPubKey(recvRatchet.pubKey),
-                nextMsgIndex: 0,
-                chainKey: new Uint8Array(32).fill((12 + seed) & 0xff),
-                unusedMsgKeys: []
+                senderRatchetKey: toSerializedPubKey(recvRatchet.pubKey),
+                chainKey: { index: 0, key: new Uint8Array(32).fill((12 + seed) & 0xff) },
+                messageKeys: []
             }
         ],
         initialExchangeInfo: {

--- a/packages/store-sqlite/src/__tests__/sqlite-runtime.test.ts
+++ b/packages/store-sqlite/src/__tests__/sqlite-runtime.test.ts
@@ -8,7 +8,13 @@ import { APP_STATE_EMPTY_LT_HASH } from 'zapo-js/appstate'
 import { toSerializedPubKey, X25519 } from 'zapo-js/crypto'
 import { WA_APP_STATE_COLLECTIONS } from 'zapo-js/protocol'
 import type { WaRetryOutboundMessageRecord } from 'zapo-js/retry'
-import type { SenderKeyRecord, SignalAddress, SignalSessionRecord } from 'zapo-js/signal'
+import {
+    decodeSignalSessionRecord,
+    encodeSignalSessionRecord,
+    type SenderKeyRecord,
+    type SignalAddress,
+    type SignalSessionRecord
+} from 'zapo-js/signal'
 
 import { WaAppStateSqliteStore } from '../appstate.store'
 import type { WaSqliteConnection } from '../connection'
@@ -68,7 +74,7 @@ async function makeSessionRecord(seed = 0): Promise<SignalSessionRecord> {
         X25519.generateKeyPair()
     ])
 
-    return {
+    const record: SignalSessionRecord = {
         local: {
             regId: 100 + seed,
             pubKey: toSerializedPubKey(localIdentity.pubKey)
@@ -88,10 +94,9 @@ async function makeSessionRecord(seed = 0): Promise<SignalSessionRecord> {
         },
         recvChains: [
             {
-                ratchetPubKey: toSerializedPubKey(recvRatchet.pubKey),
-                nextMsgIndex: 0,
-                chainKey: makeBytes(32, 3 + seed),
-                unusedMsgKeys: []
+                senderRatchetKey: toSerializedPubKey(recvRatchet.pubKey),
+                chainKey: { index: 0, key: makeBytes(32, 3 + seed) },
+                messageKeys: []
             }
         ],
         initialExchangeInfo: {
@@ -103,6 +108,9 @@ async function makeSessionRecord(seed = 0): Promise<SignalSessionRecord> {
         aliceBaseKey: toSerializedPubKey(baseKey.pubKey),
         prevSessions: []
     }
+    // Round-trip through encode→decode to normalize protobuf instances,
+    // so deepStrictEqual comparisons match the store's output format.
+    return decodeSignalSessionRecord(encodeSignalSessionRecord(record))
 }
 
 test('sqlite appstate store handles sync keys, collection state and session scoping', async () => {

--- a/src/infra/perf/StoreLock.ts
+++ b/src/infra/perf/StoreLock.ts
@@ -1,6 +1,7 @@
 type StoreTask<T> = () => Promise<T>
 
 export class StoreLock {
+    private static readonly _noop = (): undefined => undefined
     private readonly chains = new Map<string, Promise<void>>()
     private closed = false
 
@@ -25,16 +26,16 @@ export class StoreLock {
                 current = Promise.reject(error)
             }
         }
-        const tracker = current.then(
-            () => undefined,
-            () => undefined
-        )
+        const tracker = current.then(StoreLock._noop, StoreLock._noop)
         this.chains.set(key, tracker)
-        void tracker.finally(() => {
-            if (this.chains.get(key) === tracker) {
-                this.chains.delete(key)
+        tracker.then(
+            () => {
+                if (this.chains.get(key) === tracker) this.chains.delete(key)
+            },
+            () => {
+                if (this.chains.get(key) === tracker) this.chains.delete(key)
             }
-        })
+        )
         return current
     }
 

--- a/src/message/incoming.ts
+++ b/src/message/incoming.ts
@@ -74,20 +74,6 @@ function buildIncomingEventRawNode(node: BinaryNode): BinaryNode {
     }
 }
 
-function buildBaseIncomingEvent(node: BinaryNode): {
-    readonly rawNode: BinaryNode
-    readonly stanzaId?: string
-    readonly chatJid?: string
-    readonly stanzaType?: string
-} {
-    return {
-        rawNode: buildIncomingEventRawNode(node),
-        stanzaId: node.attrs.id,
-        chatJid: node.attrs.from,
-        stanzaType: node.attrs.type
-    }
-}
-
 function pickSenderKeyDistributionPayload(
     message: proto.IMessage
 ): { readonly groupId: string; readonly payload: Uint8Array } | null {
@@ -257,7 +243,10 @@ async function decryptAndProcessEncNode(
         if (shouldEmitIncomingMessage(message)) {
             const chatJid = node.attrs.from
             options.emitIncomingMessage?.({
-                ...buildBaseIncomingEvent(node),
+                rawNode: buildIncomingEventRawNode(node),
+                stanzaId: node.attrs.id,
+                chatJid,
+                stanzaType: node.attrs.type,
                 timestampSeconds: parseOptionalInt(node.attrs.t),
                 senderJid,
                 encryptionType: encType,
@@ -277,7 +266,10 @@ async function decryptAndProcessEncNode(
             message: toError(error).message
         })
         options.emitUnhandledStanza?.({
-            ...buildBaseIncomingEvent(node),
+            rawNode: buildIncomingEventRawNode(node),
+            stanzaId: node.attrs.id,
+            chatJid: node.attrs.from,
+            stanzaType: node.attrs.type,
             reason: `message.decrypt_failed.${encType}`
         })
         return { success: false, encType, error }
@@ -314,7 +306,10 @@ export async function handleIncomingMessageAck(
                 case 'skmsg': {
                     if (!senderJid || !node.attrs.from || !options.senderKeyManager) {
                         options.emitUnhandledStanza?.({
-                            ...buildBaseIncomingEvent(node),
+                            rawNode: buildIncomingEventRawNode(node),
+                            stanzaId: node.attrs.id,
+                            chatJid: node.attrs.from,
+                            stanzaType: node.attrs.type,
                             reason: 'message.skmsg.missing_group_context'
                         })
                         continue

--- a/src/signal/__tests__/encoding.test.ts
+++ b/src/signal/__tests__/encoding.test.ts
@@ -57,10 +57,9 @@ async function createSessionRecord(): Promise<SignalSessionRecord> {
         },
         recvChains: [
             {
-                ratchetPubKey: toSerializedPubKey(recvRatchetPair.pubKey),
-                nextMsgIndex: 5,
-                chainKey: makeBytes(32, 65),
-                unusedMsgKeys: [
+                senderRatchetKey: toSerializedPubKey(recvRatchetPair.pubKey),
+                chainKey: { index: 5, key: makeBytes(32, 65) },
+                messageKeys: [
                     {
                         index: 4,
                         cipherKey: makeBytes(32, 97),
@@ -138,7 +137,7 @@ test('sqlite signal helpers encode/decode signal sessions', async () => {
     assert.equal(decoded.remote.regId, session.remote.regId)
     assert.equal(decoded.sendChain.nextMsgIndex, session.sendChain.nextMsgIndex)
     assert.equal(decoded.recvChains.length, 1)
-    assert.equal(decoded.recvChains[0].unusedMsgKeys.length, 1)
+    assert.equal(decoded.recvChains[0].messageKeys!.length, 1)
 
     const invalidRecord = proto.RecordStructure.encode({
         currentSession: {

--- a/src/signal/encoding.ts
+++ b/src/signal/encoding.ts
@@ -148,7 +148,9 @@ export function decodeSignalSignedPreKeyRow(row: SignalSignedPreKeyRow): SignedP
     }
 }
 
-function encodeSignalSessionSnapshot(session: SignalSessionSnapshot): Proto.ISessionStructure {
+export function encodeSignalSessionSnapshot(
+    session: SignalSessionSnapshot
+): Proto.ISessionStructure {
     return {
         sessionVersion: 3,
         localRegistrationId: session.local.regId,
@@ -158,12 +160,7 @@ function encodeSignalSessionSnapshot(session: SignalSessionSnapshot): Proto.ISes
         rootKey: session.rootKey,
         previousCounter: session.prevSendChainHighestIndex,
         senderChain: encodeSignalSendChain(session.sendChain),
-        receiverChains: (() => {
-            const src = session.recvChains
-            const arr = new Array<Proto.SessionStructure.IChain>(src.length)
-            for (let i = 0; i < src.length; i += 1) arr[i] = encodeSignalRecvChain(src[i])
-            return arr
-        })(),
+        receiverChains: session.recvChains as Proto.SessionStructure.IChain[],
         pendingPreKey: session.initialExchangeInfo
             ? {
                   preKeyId: session.initialExchangeInfo.remoteOneTimeId ?? undefined,
@@ -187,31 +184,18 @@ function encodeSignalSendChain(chain: SignalSendChain): Proto.SessionStructure.I
     }
 }
 
-function encodeSignalRecvChain(chain: SignalRecvChain): Proto.SessionStructure.IChain {
+export function encodeSignalRecvChain(chain: SignalRecvChain): Proto.SessionStructure.IChain {
     return {
         senderRatchetKey: chain.ratchetPubKey,
         chainKey: {
             index: chain.nextMsgIndex,
             key: chain.chainKey
         },
-        messageKeys: (() => {
-            const src = chain.unusedMsgKeys ?? []
-            const arr = new Array<Proto.SessionStructure.Chain.IMessageKey>(src.length)
-            for (let i = 0; i < src.length; i += 1) {
-                const messageKey = src[i]
-                arr[i] = {
-                    index: messageKey.index,
-                    cipherKey: messageKey.cipherKey,
-                    macKey: messageKey.macKey,
-                    iv: messageKey.iv
-                }
-            }
-            return arr
-        })()
+        messageKeys: chain.unusedMsgKeys as Proto.SessionStructure.Chain.IMessageKey[]
     }
 }
 
-function decodeSignalMessageKey(
+export function decodeSignalMessageKey(
     messageKey: Proto.SessionStructure.Chain.IMessageKey,
     field: string
 ): SignalMessageKey {
@@ -229,7 +213,7 @@ function decodeSignalMessageKey(
     }
 }
 
-function decodeSignalRecvChain(
+export function decodeSignalRecvChain(
     chain: Proto.SessionStructure.IChain,
     field: string
 ): SignalRecvChain {
@@ -253,13 +237,7 @@ function decodeSignalRecvChain(
         ratchetPubKey,
         nextMsgIndex: asNumber(chainKey.index, `${field}.chainKey.index`),
         chainKey: chainKeyBytes,
-        unusedMsgKeys: (() => {
-            const src = chain.messageKeys ?? []
-            const arr = new Array<SignalMessageKey>(src.length)
-            for (let i = 0; i < src.length; i += 1)
-                arr[i] = decodeSignalMessageKey(src[i], `${field}.messageKeys[${i}]`)
-            return arr
-        })()
+        unusedMsgKeys: chain.messageKeys ?? []
     }
 }
 
@@ -305,7 +283,7 @@ function decodeSignalSendChain(
     }
 }
 
-function decodeSignalSessionSnapshot(
+export function decodeSignalSessionSnapshot(
     session: Proto.ISessionStructure,
     field: string
 ): SignalSessionSnapshot {
@@ -357,13 +335,7 @@ function decodeSignalSessionSnapshot(
         },
         rootKey,
         sendChain: decodeSignalSendChain(senderChain, `${field}.senderChain`),
-        recvChains: (() => {
-            const src = session.receiverChains ?? []
-            const arr = new Array<SignalRecvChain>(src.length)
-            for (let i = 0; i < src.length; i += 1)
-                arr[i] = decodeSignalRecvChain(src[i], `${field}.receiverChains[${i}]`)
-            return arr
-        })(),
+        recvChains: session.receiverChains ?? [],
         initialExchangeInfo: pendingPreKey
             ? {
                   remoteOneTimeId:
@@ -385,12 +357,7 @@ function decodeSignalSessionSnapshot(
 export function encodeSignalSessionRecord(record: SignalSessionRecord): Uint8Array {
     return proto.RecordStructure.encode({
         currentSession: encodeSignalSessionSnapshot(record),
-        previousSessions: (() => {
-            const src = record.prevSessions
-            const arr = new Array<Proto.ISessionStructure>(src.length)
-            for (let i = 0; i < src.length; i += 1) arr[i] = encodeSignalSessionSnapshot(src[i])
-            return arr
-        })()
+        previousSessions: record.prevSessions as Proto.ISessionStructure[]
     }).finish()
 }
 
@@ -405,16 +372,7 @@ export function decodeSignalSessionRecord(raw: unknown): SignalSessionRecord {
     )
     return {
         ...current,
-        prevSessions: (() => {
-            const src = decoded.previousSessions ?? []
-            const arr = new Array<SignalSessionSnapshot>(src.length)
-            for (let i = 0; i < src.length; i += 1)
-                arr[i] = decodeSignalSessionSnapshot(
-                    src[i],
-                    `signal_sessions.previousSessions[${i}]`
-                )
-            return arr
-        })()
+        prevSessions: decoded.previousSessions ?? []
     }
 }
 

--- a/src/signal/session/SignalProtocol.ts
+++ b/src/signal/session/SignalProtocol.ts
@@ -3,6 +3,7 @@ import { ConsoleLogger } from '@infra/log/ConsoleLogger'
 import type { Logger } from '@infra/log/types'
 import { StoreLock } from '@infra/perf/StoreLock'
 import { MAX_PREV_SESSIONS } from '@signal/constants'
+import { encodeSignalSessionSnapshot } from '@signal/encoding'
 import {
     decryptMsg,
     decryptMsgFromSession,
@@ -338,7 +339,7 @@ export class SignalProtocol {
             ? {
                   ...incoming,
                   prevSessions: [
-                      detachSession(currentSession),
+                      encodeSignalSessionSnapshot(detachSession(currentSession)),
                       ...currentSession.prevSessions.slice(0, MAX_PREV_SESSIONS - 1)
                   ]
               }

--- a/src/signal/session/SignalRatchet.ts
+++ b/src/signal/session/SignalRatchet.ts
@@ -19,6 +19,13 @@ import {
     SIGNAL_VERSION
 } from '@signal/constants'
 import {
+    decodeSignalMessageKey,
+    decodeSignalRecvChain,
+    decodeSignalSessionSnapshot,
+    encodeSignalRecvChain,
+    encodeSignalSessionSnapshot
+} from '@signal/encoding'
+import {
     calculateRatchet,
     detachSession,
     generateSerializedKeyPair,
@@ -27,6 +34,7 @@ import {
 import type {
     ParsedPreKeySignalMessage,
     ParsedSignalMessage,
+    RawSignalRecvChain,
     SignalMessageKey,
     SignalRecvChain,
     SignalSessionRecord
@@ -89,7 +97,7 @@ export async function selectMessageKey(
         if (idx === -1) {
             throw new Error('duplicate message')
         }
-        const messageKey = unused[idx]
+        const messageKey = decodeSignalMessageKey(unused[idx], `unusedMsgKeys[${idx}]`)
         const nextUnused = removeAt(unused, idx)
         return {
             messageKey,
@@ -128,7 +136,12 @@ export async function selectMessageKey(
         if (overflow > 0) {
             overflow -= 1
         } else {
-            nextUnused.push(currentMessageKey)
+            nextUnused.push({
+                index: currentMessageKey.index,
+                cipherKey: currentMessageKey.cipherKey,
+                macKey: currentMessageKey.macKey,
+                iv: currentMessageKey.iv
+            })
         }
         const derived = await deriveMsgKeyFromState(counter, chainState)
         currentMessageKey = derived.messageKey
@@ -250,13 +263,17 @@ export async function decryptMsg(
         }
     } catch (error) {
         for (let i = 0; i < session.prevSessions.length; i += 1) {
-            const prevSession = snapshotToRecord(session.prevSessions[i])
+            const decodedPrev = decodeSignalSessionSnapshot(
+                session.prevSessions[i],
+                `prevSessions[${i}]`
+            )
+            const prevSession = snapshotToRecord(decodedPrev)
             try {
                 const [updatedPrev, plaintext] = await decryptMsgFromSession(prevSession, parsed)
                 const updatedSession = {
                     ...updatedPrev,
                     prevSessions: [
-                        detachSession(session),
+                        encodeSignalSessionSnapshot(detachSession(session)),
                         ...session.prevSessions.slice(0, i),
                         ...session.prevSessions.slice(i + 1)
                     ]
@@ -286,9 +303,10 @@ export async function decryptMsgFromSession(
     message: ParsedSignalMessage | ParsedPreKeySignalMessage
 ): Promise<readonly [SignalSessionRecord, Uint8Array]> {
     const ratchetPubKey = toSerializedPubKey(message.ratchetPubKey)
-    const recvChainIndex = session.recvChains.findIndex((entry) =>
-        uint8Equal(entry.ratchetPubKey, ratchetPubKey)
-    )
+    const recvChainIndex = session.recvChains.findIndex((raw) => {
+        const key = raw.senderRatchetKey
+        return key !== null && key !== undefined && uint8Equal(key, ratchetPubKey)
+    })
     let selectedMessageKey: SignalMessageKey
     let updatedSession: SignalSessionRecord
 
@@ -315,8 +333,9 @@ export async function decryptMsgFromSession(
             newSendRatchet,
             ratchetPubKey
         )
-        const nextRecvChains = session.recvChains.slice(-MAX_TRACKED_RECV_CHAINS)
-        nextRecvChains.push(selected.updatedChain)
+        const nextRecvChains: RawSignalRecvChain[] =
+            session.recvChains.slice(-MAX_TRACKED_RECV_CHAINS)
+        nextRecvChains.push(encodeSignalRecvChain(selected.updatedChain))
         updatedSession = {
             ...session,
             rootKey: sendRatchet.rootKey,
@@ -330,10 +349,14 @@ export async function decryptMsgFromSession(
             prevSendChainHighestIndex: Math.max(session.sendChain.nextMsgIndex - 1, 0)
         }
     } else {
-        const selected = await selectMessageKey(session.recvChains[recvChainIndex], message.counter)
+        const decoded = decodeSignalRecvChain(
+            session.recvChains[recvChainIndex],
+            `recvChains[${recvChainIndex}]`
+        )
+        const selected = await selectMessageKey(decoded, message.counter)
         selectedMessageKey = selected.messageKey
-        const nextRecvChains = session.recvChains.slice()
-        nextRecvChains[recvChainIndex] = selected.updatedChain
+        const nextRecvChains: RawSignalRecvChain[] = session.recvChains.slice()
+        nextRecvChains[recvChainIndex] = encodeSignalRecvChain(selected.updatedChain)
         updatedSession = {
             ...session,
             recvChains: nextRecvChains

--- a/src/signal/session/SignalSession.ts
+++ b/src/signal/session/SignalSession.ts
@@ -1,7 +1,9 @@
 import { hkdfSplit, toRawPubKey, toSerializedPubKey, X25519 } from '@crypto'
 import { SIGNAL_PREFIX } from '@signal/constants'
+import { decodeSignalSessionSnapshot, encodeSignalSessionSnapshot } from '@signal/encoding'
 import type {
-    SignalRecvChain,
+    RawSignalRecvChain,
+    RawSignalSessionSnapshot,
     SignalSerializedKeyPair,
     SignalSessionRecord,
     SignalSessionSnapshot
@@ -45,15 +47,15 @@ export function findMatchingSession(
         return session
     }
     for (let index = 0; index < session.prevSessions.length; index += 1) {
-        const previousSession = session.prevSessions[index]
-        if (
-            !previousSession.aliceBaseKey ||
-            !uint8Equal(previousSession.aliceBaseKey, serializedBaseKey)
-        ) {
+        const rawPrev = session.prevSessions[index]
+        if (!rawPrev.aliceBaseKey || !uint8Equal(rawPrev.aliceBaseKey, serializedBaseKey)) {
             continue
         }
 
-        const prevSessions: SignalSessionSnapshot[] = [detachSession(session)]
+        const decoded = decodeSignalSessionSnapshot(rawPrev, `prevSessions[${index}]`)
+        const prevSessions: RawSignalSessionSnapshot[] = [
+            encodeSignalSessionSnapshot(detachSession(session))
+        ]
         for (let i = 0; i < session.prevSessions.length; i += 1) {
             if (i !== index) {
                 prevSessions.push(session.prevSessions[i])
@@ -61,7 +63,7 @@ export function findMatchingSession(
         }
 
         return {
-            ...previousSession,
+            ...decoded,
             prevSessions
         }
     }
@@ -116,11 +118,10 @@ export async function initiateSessionOutgoing(
     ])
     const [rootKey, chainKey] = await hkdfSplit(secret, null, 'WhisperText')
 
-    const recvChain: SignalRecvChain = {
-        ratchetPubKey: remoteRatchetKey,
-        nextMsgIndex: 0,
-        chainKey,
-        unusedMsgKeys: []
+    const recvChain: RawSignalRecvChain = {
+        senderRatchetKey: remoteRatchetKey,
+        chainKey: { index: 0, key: chainKey },
+        messageKeys: []
     }
     const sendRatchet = await generateSerializedKeyPair()
     const sendRatchetResult = await calculateRatchet(rootKey, sendRatchet, remoteRatchetKey)

--- a/src/signal/types.ts
+++ b/src/signal/types.ts
@@ -1,4 +1,5 @@
 import type { SignalKeyPair } from '@crypto/curves/types'
+import type { Proto } from '@proto'
 
 export interface RegistrationInfo {
     readonly registrationId: number
@@ -45,8 +46,15 @@ export interface SignalRecvChain {
     readonly ratchetPubKey: Uint8Array
     readonly nextMsgIndex: number
     readonly chainKey: Uint8Array
-    readonly unusedMsgKeys: readonly SignalMessageKey[]
+    readonly unusedMsgKeys: readonly Proto.SessionStructure.Chain.IMessageKey[]
 }
+
+/**
+ * Raw protobuf recv chain kept as-is to avoid eager decode.
+ * Use {@link decodeSignalRecvChain} only for the chain that
+ * actually needs to be read/modified.
+ */
+export type RawSignalRecvChain = Proto.SessionStructure.IChain
 
 export interface SignalSendChain {
     readonly ratchetKey: SignalSerializedKeyPair
@@ -65,15 +73,21 @@ export interface SignalSessionSnapshot {
     readonly remote: SignalPeer
     readonly rootKey: Uint8Array
     readonly sendChain: SignalSendChain
-    readonly recvChains: readonly SignalRecvChain[]
+    readonly recvChains: readonly RawSignalRecvChain[]
     readonly initialExchangeInfo: SignalInitialExchangeInfo | null
     readonly prevSendChainHighestIndex: number
     readonly aliceBaseKey: Uint8Array | null
 }
 
 export interface SignalSessionRecord extends SignalSessionSnapshot {
-    readonly prevSessions: readonly SignalSessionSnapshot[]
+    readonly prevSessions: readonly RawSignalSessionSnapshot[]
 }
+
+/**
+ * Raw protobuf session snapshot kept as-is to avoid eager decode.
+ * Only decoded on demand in rare fallback paths (session mismatch).
+ */
+export type RawSignalSessionSnapshot = Proto.ISessionStructure
 
 export interface SignalPreKeyBundle {
     readonly regId: number

--- a/src/store/providers/memory/__tests__/memory-providers.test.ts
+++ b/src/store/providers/memory/__tests__/memory-providers.test.ts
@@ -121,10 +121,9 @@ test('memory signal/sender-key/appstate stores cover key workflows', async () =>
         rootKey: new Uint8Array(32),
         recvChains: [
             {
-                ratchetPubKey: new Uint8Array(33),
-                nextMsgIndex: 0,
-                chainKey: new Uint8Array(32),
-                unusedMsgKeys: []
+                senderRatchetKey: new Uint8Array(33),
+                chainKey: { index: 0, key: new Uint8Array(32) },
+                messageKeys: []
             }
         ],
         sendChain: {
@@ -136,7 +135,7 @@ test('memory signal/sender-key/appstate stores cover key workflows', async () =>
         prevSendChainHighestIndex: 0,
         aliceBaseKey: null,
         prevSessions: []
-    } as const
+    }
     await sessionStore.setSession(addressA, sessionA)
     assert.deepEqual(await sessionStore.getSessionsBatch([]), [])
     assert.deepEqual(await sessionStore.getSessionsBatch([addressA, addressB]), [sessionA, null])


### PR DESCRIPTION
- Lazy decode of Signal unused message keys: keep as raw IMessageKey[] instead of eagerly decoding all keys on every session load. Only the key that matches by index is decoded on demand in selectMessageKey. Eliminates ~44 MiB of allocations (1.3M → ~50K decodeSignalMessageKey calls).

- Lazy decode of recv chains: keep as raw IChain[] and only decode the chain that matches by ratchetPubKey. Encode passthrough on save. Eliminates ~13 MiB of allocations from decodeSignalRecvChain.

- Lazy decode of prev sessions: keep as raw ISessionStructure[] and only decode in rare fallback paths (session mismatch). Eliminates eager decode of previous sessions on every session load.

- Inline buildBaseIncomingEvent: eliminate object spread in decryptAndProcessEncNode hot path (~3 MiB reduction).

- BaseMysqlStore.ensureReady: return void after first migration completes, avoiding Promise wrapper allocation on 90K+ calls.

- StoreLock: use static _noop instead of per-call arrow closures for promise settlement tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored Signal protocol session encoding and storage to use lazy decoding for improved performance.
  * Exported Signal encoding/decoding helper functions for broader accessibility.
  * Optimized MySQL migration state tracking to prevent redundant initialization.

* **Tests**
  * Updated Signal session tests to reflect new encoding structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->