### PR TITLE
feat(transport): add WhatsApp Android primary runtime

### DIFF
--- a/src/appstate/WaAppStateSyncClient.ts
+++ b/src/appstate/WaAppStateSyncClient.ts
@@ -16,6 +16,7 @@ import type {
     WaAppStateSyncResult
 } from '@appstate/types'
 import { WaAppStateCrypto } from '@appstate/WaAppStateCrypto'
+import { randomBytesAsync, randomIntAsync } from '@crypto'
 import type { Logger } from '@infra/log/types'
 import { proto, type Proto } from '@proto'
 import {
@@ -60,6 +61,7 @@ interface WaAppStateSyncClientOptions {
     readonly defaultTimeoutMs?: number
     readonly onMissingKeys?: (event: WaAppStateMissingKeysEvent) => Promise<void>
     readonly skipMacVerification?: boolean
+    readonly mobilePrimary?: boolean
 }
 
 export class WaAppStateMissingKeyError extends Error {
@@ -87,6 +89,7 @@ export class WaAppStateSyncClient {
     private readonly defaultTimeoutMs: number
     private readonly onMissingKeys?: (event: WaAppStateMissingKeysEvent) => Promise<void>
     private readonly crypto: WaAppStateCrypto
+    private readonly mobilePrimary: boolean
     private syncContext: {
         readonly keys: Map<string, Uint8Array | null>
         readonly collections: Map<AppStateCollectionName, WaAppStateCollectionStoreState>
@@ -104,6 +107,7 @@ export class WaAppStateSyncClient {
         this.onMissingKeys = options.onMissingKeys
 
         this.crypto = new WaAppStateCrypto(undefined, options.skipMacVerification === true)
+        this.mobilePrimary = options.mobilePrimary ?? false
         this.syncContext = null
         this.syncPromise = null
     }
@@ -111,6 +115,29 @@ export class WaAppStateSyncClient {
     public async exportState(): Promise<WaAppStateStoreData> {
         this.logger.trace('app-state export requested')
         return this.store.exportData()
+    }
+
+    public async ensureInitialSyncKey(): Promise<WaAppStateSyncKey> {
+        const existing = await this.store.getActiveSyncKey()
+        if (existing) {
+            return existing
+        }
+        const keyIdBytes = await randomBytesAsync(2)
+        const keyData = await randomBytesAsync(32)
+        const rawId = await randomIntAsync(0, 0xffff_ffff)
+        const key: WaAppStateSyncKey = {
+            keyId: keyIdBytes,
+            keyData,
+            timestamp: Date.now(),
+            fingerprint: { rawId, currentIndex: 0, deviceIndexes: [0] }
+        }
+        await this.store.upsertSyncKeys([key])
+        this.crypto.clearCache()
+        this.logger.info('app-state initial sync key generated (mobile primary)', {
+            keyId: bytesToHex(keyIdBytes),
+            rawId
+        })
+        return key
     }
 
     public async importSyncKeys(keys: readonly WaAppStateSyncKey[]): Promise<number> {
@@ -439,7 +466,7 @@ export class WaAppStateSyncClient {
             content: [
                 {
                     tag: WA_NODE_TAGS.SYNC,
-                    attrs: {},
+                    attrs: this.mobilePrimary ? { data_namespace: '3' } : {},
                     content: collectionNodes
                 }
             ]

--- a/src/appstate/__tests__/appstate.test.ts
+++ b/src/appstate/__tests__/appstate.test.ts
@@ -473,3 +473,25 @@ test('appstate sync client marks empty successful bootstrap as initialized for n
     assert.deepEqual(returnSnapshotByCall, ['true', 'false'])
     assert.deepEqual(versionByCall, ['0', '0'])
 })
+
+test('ensureInitialSyncKey mints a 32-byte key with fingerprint when store is empty', async () => {
+    const store = new WaAppStateMemoryStore()
+    const client = new WaAppStateSyncClient({
+        logger: createNoopLogger(),
+        query: async () => ({ tag: 'iq', attrs: {} }),
+        store
+    })
+
+    assert.equal(await store.getActiveSyncKey(), null)
+    const first = await client.ensureInitialSyncKey()
+    assert.equal(first.keyId.length, 2)
+    assert.equal(first.keyData.length, 32)
+    assert.ok(first.fingerprint)
+    assert.equal(first.fingerprint?.currentIndex, 0)
+    assert.deepEqual(first.fingerprint?.deviceIndexes, [0])
+    assert.ok(typeof first.fingerprint?.rawId === 'number')
+
+    const second = await client.ensureInitialSyncKey()
+    assert.deepEqual(second.keyId, first.keyId)
+    assert.deepEqual(second.keyData, first.keyData)
+})

--- a/src/auth/WaAuthClient.ts
+++ b/src/auth/WaAuthClient.ts
@@ -140,6 +140,7 @@ export class WaAuthClient {
             deviceOsDisplayName: this.options.deviceOsDisplayName,
             requireFullSync: this.options.requireFullSync,
             version: this.options.version,
+            mobileTransport: this.options.mobileTransport,
             noiseTrustedRootCa: overrides.noiseTrustedRootCa,
             disableNoiseCertificateChainVerification:
                 overrides.disableNoiseCertificateChainVerification ??

--- a/src/auth/credentials-flow.ts
+++ b/src/auth/credentials-flow.ts
@@ -8,6 +8,8 @@ import { createAndStoreInitialKeys } from '@signal/registration/utils'
 import type { WaAuthStore } from '@store/contracts/auth.store'
 import type { WaPreKeyStore } from '@store/contracts/pre-key.store'
 import type { WaSignalStore } from '@store/contracts/signal.store'
+import { WaMobileTcpSocketCtor } from '@transport/node/WaMobileTcpSocket'
+import { buildMobileLoginPayload } from '@transport/noise/WaMobileClientPayload'
 import { toProxyAgent, toProxyDispatcher } from '@transport/proxy'
 import type { WaCommsConfig, WaNoiseTrustedRootCa } from '@transport/types'
 import { toError } from '@util/primitives'
@@ -69,7 +71,7 @@ export function buildCommsConfig(
     socketOptions: WaAuthSocketOptions,
     clientOptions: Pick<
         WaAuthClientOptions,
-        'deviceBrowser' | 'deviceOsDisplayName' | 'requireFullSync' | 'version'
+        'deviceBrowser' | 'deviceOsDisplayName' | 'requireFullSync' | 'version' | 'mobileTransport'
     > & {
         readonly noiseTrustedRootCa?: WaNoiseTrustedRootCa
         readonly disableNoiseCertificateChainVerification?: boolean
@@ -79,11 +81,54 @@ export function buildCommsConfig(
     const registered = meJid !== null && meJid !== undefined
     const loginIdentity = registered ? getLoginIdentity(meJid) : null
     const wsProxy = socketOptions.proxy?.ws
+    const mobileTransport = clientOptions.mobileTransport
     logger.debug('building comms config from credentials', {
         registered,
         hasServerStaticKey:
-            credentials.serverStaticKey !== null && credentials.serverStaticKey !== undefined
+            credentials.serverStaticKey !== null && credentials.serverStaticKey !== undefined,
+        mobile: Boolean(mobileTransport)
     })
+
+    if (mobileTransport) {
+        if (wsProxy) {
+            throw new Error(
+                'mobileTransport does not support socketOptions.proxy.ws — remove the proxy option or open an issue to add TCP proxy support'
+            )
+        }
+        if (!loginIdentity) {
+            throw new Error(
+                'mobileTransport requires registered credentials (meJid) — run the mobile bridge flow first'
+            )
+        }
+        const loginPayload = buildMobileLoginPayload({
+            username: loginIdentity.username,
+            device: loginIdentity.device,
+            passive: mobileTransport.passive ?? false,
+            deviceInfo: mobileTransport.deviceInfo,
+            pushName: mobileTransport.pushName,
+            yearClass: mobileTransport.yearClass,
+            memClass: mobileTransport.memClass
+        })
+        return {
+            url: mobileTransport.tcpUrl ?? 'tcp://g.whatsapp.net:443',
+            rawWebSocketConstructor: WaMobileTcpSocketCtor,
+            connectTimeoutMs: socketOptions.connectTimeoutMs,
+            reconnectIntervalMs: socketOptions.reconnectIntervalMs,
+            timeoutIntervalMs: socketOptions.timeoutIntervalMs,
+            maxReconnectAttempts: socketOptions.maxReconnectAttempts,
+            noise: {
+                clientStaticKeyPair: credentials.noiseKeyPair,
+                isRegistered: true,
+                serverStaticKey: credentials.serverStaticKey,
+                routingInfo: credentials.routingInfo,
+                trustedRootCa: clientOptions.noiseTrustedRootCa,
+                verifyCertificateChain: clientOptions.disableNoiseCertificateChainVerification
+                    ? false
+                    : undefined,
+                loginPayload
+            }
+        }
+    }
 
     return {
         url: socketOptions.url,

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -1,7 +1,10 @@
 import type { SignalKeyPair } from '@crypto/curves/types'
 import type { Proto } from '@proto'
 import type { RegistrationInfo, SignedPreKeyRecord } from '@signal/types'
+import type { WaMobileTransportDeviceInfo } from '@transport/noise/WaMobileClientPayload'
 import type { WaCommsConfig, WaProxyTransport } from '@transport/types'
+
+export type { WaMobileTransportDeviceInfo } from '@transport/noise/WaMobileClientPayload'
 
 export interface WaAuthCredentials {
     readonly noiseKeyPair: SignalKeyPair
@@ -46,6 +49,16 @@ export interface WaAuthClientOptions {
     readonly requireFullSync?: boolean
     readonly version?: string
     readonly dangerous?: WaAuthDangerousOptions
+    readonly mobileTransport?: WaMobileTransportOptions
+}
+
+export interface WaMobileTransportOptions {
+    readonly deviceInfo: WaMobileTransportDeviceInfo
+    readonly tcpUrl?: string
+    readonly passive?: boolean
+    readonly pushName?: string
+    readonly yearClass?: number
+    readonly memClass?: number
 }
 
 export interface WaAuthDangerousOptions {

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -377,7 +377,8 @@ export function buildWaClientDependencies(input: {
         sendNode: async (node) => nodeTransport.sendNode(node),
         logger,
         defaultTimeoutMs: options.nodeQueryTimeoutMs,
-        hostDomain: WA_DEFAULTS.HOST_DOMAIN
+        hostDomain: WA_DEFAULTS.HOST_DOMAIN,
+        mobileIqIdFormat: options.mobileTransport !== undefined
     })
     const keepAlive = new WaKeepAlive({
         logger,
@@ -482,7 +483,8 @@ export function buildWaClientDependencies(input: {
             devicePlatform: options.devicePlatform,
             requireFullSync: options.requireFullSync,
             version: options.version,
-            dangerous: options.dangerous
+            dangerous: options.dangerous,
+            mobileTransport: options.mobileTransport
         },
         {
             logger,
@@ -631,7 +633,8 @@ export function buildWaClientDependencies(input: {
                 })
             )
         },
-        getIcdcHashLength: () => abPropsCoordinator.getConfigValue('md_icdc_hash_length')
+        getIcdcHashLength: () => abPropsCoordinator.getConfigValue('md_icdc_hash_length'),
+        mobileMessageIdFormat: options.mobileTransport !== undefined
     })
 
     const retryCoordinator = new WaRetryCoordinator({
@@ -660,7 +663,8 @@ export function buildWaClientDependencies(input: {
         onMissingKeys: async ({ keyIds }) => {
             await messageDispatch.requestAppStateSyncKeys(keyIds)
         },
-        skipMacVerification: options.dangerous?.disableAppStateMacVerification
+        skipMacVerification: options.dangerous?.disableAppStateMacVerification,
+        mobilePrimary: options.mobileTransport !== undefined
     })
 
     const appStateMutations = new WaAppStateMutationCoordinator({
@@ -1056,7 +1060,9 @@ export function buildWaClientDependencies(input: {
             receiptQueue,
             getCurrentCredentials,
             abPropsCoordinator
-        })
+        }),
+        mobilePrimary: options.mobileTransport !== undefined,
+        appStateSync
     })
 
     return {

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -4,6 +4,7 @@ import type { AppStateSyncKeyProtocol } from '@client/messaging/key-protocol'
 import type { GroupParticipantsCache } from '@client/messaging/participants'
 import type { WaGroupEvent, WaSendMessageOptions, WaSignalMessagePublishInput } from '@client/types'
 import { randomBytesAsync, sha256 } from '@crypto'
+import { md5Bytes } from '@crypto/core/primitives'
 import type { Logger } from '@infra/log/types'
 import { PromiseDedup } from '@infra/perf/PromiseDedup'
 import { ensureMessageSecret } from '@message'
@@ -85,6 +86,7 @@ interface WaMessageDispatchCoordinatorOptions {
     readonly resolvePrivacyTokenNode: (recipientJid: string) => Promise<BinaryNode | null>
     readonly onDirectMessageSent: (recipientJid: string) => void
     readonly getIcdcHashLength?: () => number
+    readonly mobileMessageIdFormat?: boolean
 }
 
 type GroupAddressingMode = 'pn' | 'lid'
@@ -120,6 +122,7 @@ export class WaMessageDispatchCoordinator {
     private readonly resolvePrivacyTokenNode: (recipientJid: string) => Promise<BinaryNode | null>
     private readonly onDirectMessageSent: (recipientJid: string) => void
     private readonly getIcdcHashLength: (() => number) | undefined
+    private readonly mobileMessageIdFormat: boolean
     private readonly icdcDedup = new PromiseDedup()
     private readonly privacyTokenDedup = new PromiseDedup()
     private readonly distributionDedup = new PromiseDedup()
@@ -146,6 +149,7 @@ export class WaMessageDispatchCoordinator {
         this.resolvePrivacyTokenNode = options.resolvePrivacyTokenNode
         this.onDirectMessageSent = options.onDirectMessageSent
         this.getIcdcHashLength = options.getIcdcHashLength
+        this.mobileMessageIdFormat = options.mobileMessageIdFormat ?? false
     }
 
     public async publishMessageNode(
@@ -1134,14 +1138,24 @@ export class WaMessageDispatchCoordinator {
     private async generateOutgoingMessageId(): Promise<string> {
         try {
             const meUserJid = toUserJid(this.requireCurrentMeJid('sendMessage'))
-            const timestampSeconds = Math.floor(Date.now() / 1_000)
             const timestampBytes = new Uint8Array(8)
-            new DataView(
+            const dv = new DataView(
                 timestampBytes.buffer,
                 timestampBytes.byteOffset,
                 timestampBytes.byteLength
-            ).setBigUint64(0, BigInt(timestampSeconds), false)
-
+            )
+            if (this.mobileMessageIdFormat) {
+                dv.setBigUint64(0, BigInt(Date.now()), false)
+                const entropy = concatBytes([
+                    timestampBytes,
+                    TEXT_ENCODER.encode(meUserJid),
+                    await randomBytesAsync(16)
+                ])
+                const digest = md5Bytes(entropy)
+                digest[0] = 0xac
+                return bytesToHex(digest).toUpperCase()
+            }
+            dv.setBigUint64(0, BigInt(Math.floor(Date.now() / 1_000)), false)
             const entropy = concatBytes([
                 timestampBytes,
                 TEXT_ENCODER.encode(meUserJid),
@@ -1150,9 +1164,14 @@ export class WaMessageDispatchCoordinator {
             const digest = await sha256(entropy)
             return `3EB0${bytesToHex(digest.subarray(0, 9)).toUpperCase()}`
         } catch (error) {
-            this.logger.warn('failed to generate sha256 message id, falling back to random id', {
+            this.logger.warn('failed to generate message id, falling back to random', {
                 message: toError(error).message
             })
+            if (this.mobileMessageIdFormat) {
+                const bytes = await randomBytesAsync(16)
+                bytes[0] = 0xac
+                return bytesToHex(bytes).toUpperCase()
+            }
             return `3EB0${bytesToHex(await randomBytesAsync(8)).toUpperCase()}`
         }
     }
@@ -1186,10 +1205,10 @@ export class WaMessageDispatchCoordinator {
         }
     }
 
-    private getEncodedSignedDeviceIdentity(): Uint8Array {
+    private getEncodedSignedDeviceIdentity(): Uint8Array | undefined {
         const signedIdentity = this.getCurrentSignedIdentity()
         if (!signedIdentity) {
-            throw new Error('missing signed identity for pkmsg fanout')
+            return undefined
         }
         return proto.ADVSignedDeviceIdentity.encode(signedIdentity).finish()
     }

--- a/src/client/coordinators/WaPassiveTasksCoordinator.ts
+++ b/src/client/coordinators/WaPassiveTasksCoordinator.ts
@@ -1,3 +1,4 @@
+import type { WaAppStateSyncClient } from '@appstate/WaAppStateSyncClient'
 import type { WaAuthCredentials } from '@auth/types'
 import type { Logger } from '@infra/log/types'
 import { WA_DEFAULTS } from '@protocol/constants'
@@ -44,6 +45,8 @@ export class WaPassiveTasksCoordinator {
     private readonly signedPreKeyRotationIntervalMs: number
     private readonly signedPreKeyServerErrorBackoffMs: number
     private readonly runtime: WaPassiveTasksRuntime
+    private readonly mobilePrimary: boolean
+    private readonly appStateSync?: WaAppStateSyncClient
     private passiveTasksPromise: Promise<void> | null
 
     public constructor(options: {
@@ -55,6 +58,8 @@ export class WaPassiveTasksCoordinator {
         readonly signedPreKeyRotationIntervalMs?: number
         readonly signedPreKeyServerErrorBackoffMs?: number
         readonly runtime: WaPassiveTasksRuntime
+        readonly mobilePrimary?: boolean
+        readonly appStateSync?: WaAppStateSyncClient
     }) {
         this.logger = options.logger
         this.signalStore = options.signalStore
@@ -66,6 +71,8 @@ export class WaPassiveTasksCoordinator {
         this.signedPreKeyServerErrorBackoffMs =
             options.signedPreKeyServerErrorBackoffMs ?? SIGNAL_SIGNED_PREKEY_SERVER_ERROR_BACKOFF_MS
         this.runtime = options.runtime
+        this.mobilePrimary = options.mobilePrimary ?? false
+        this.appStateSync = options.appStateSync
         this.passiveTasksPromise = null
     }
 
@@ -113,6 +120,14 @@ export class WaPassiveTasksCoordinator {
         }
 
         this.runtime.syncAbProps()
+
+        if (this.mobilePrimary && this.appStateSync) {
+            await this.appStateSync.ensureInitialSyncKey().catch((error) => {
+                this.logger.warn('app-state initial key generation failed', {
+                    message: toError(error).message
+                })
+            })
+        }
 
         await this.runtime.sendPresenceAvailable().catch((error) => {
             this.logger.warn('presence available send failed', {
@@ -197,7 +212,12 @@ export class WaPassiveTasksCoordinator {
         }
 
         const lastPreKeyId = preKeys[preKeys.length - 1].keyId
-        const uploadNode = buildPreKeyUploadIq(registrationInfo, signedPreKey, preKeys)
+        const uploadNode = buildPreKeyUploadIq(
+            registrationInfo,
+            signedPreKey,
+            preKeys,
+            this.mobilePrimary ? { opMode: 'set' } : undefined
+        )
         const response = await this.runtime.queryWithContext(
             'prekeys.upload',
             uploadNode,

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -98,7 +98,11 @@ function createGroupEvent(input: {
 }
 
 function createMessageDispatchCoordinator(
-    participantsStore: WaParticipantsMemoryStore
+    participantsStore: WaParticipantsMemoryStore,
+    overrides?: {
+        readonly getCurrentMeJid?: () => string | null
+        readonly mobileMessageIdFormat?: boolean
+    }
 ): WaMessageDispatchCoordinator {
     const participantsCache = createGroupParticipantsCache({
         participantsStore,
@@ -124,11 +128,12 @@ function createMessageDispatchCoordinator(
         messageSecretStore: {
             set: async (_id: string, _entry: { secret: Uint8Array; senderJid: string }) => {}
         } as never,
-        getCurrentMeJid: () => null,
+        getCurrentMeJid: overrides?.getCurrentMeJid ?? (() => null),
         getCurrentMeLid: () => null,
         getCurrentSignedIdentity: () => null,
         resolvePrivacyTokenNode: async () => null,
-        onDirectMessageSent: () => undefined
+        onDirectMessageSent: () => undefined,
+        mobileMessageIdFormat: overrides?.mobileMessageIdFormat
     })
 }
 
@@ -606,6 +611,48 @@ test('message dispatch coordinator handles linked and modify participant cache e
     )
     assert.equal(await participantsStore.getGroupParticipants('uncached@g.us'), null)
 
+    await participantsStore.destroy()
+})
+
+test('mobile message id format: AC + 30 hex chars uppercase', async () => {
+    const participantsStore = new WaParticipantsMemoryStore(60_000)
+    const coordinator = createMessageDispatchCoordinator(participantsStore, {
+        getCurrentMeJid: () => '5596965746475@s.whatsapp.net',
+        mobileMessageIdFormat: true
+    })
+    const gen = coordinator as unknown as {
+        generateOutgoingMessageId(): Promise<string>
+    }
+    const seen = new Set<string>()
+    for (let i = 0; i < 5; i += 1) {
+        const id = await gen.generateOutgoingMessageId()
+        assert.match(id, /^AC[0-9A-F]{30}$/, `id '${id}' does not match mobile format`)
+        seen.add(id)
+    }
+    assert.equal(seen.size, 5)
+    await participantsStore.destroy()
+})
+
+test('web message id format stays 3EB0 + 18 hex chars when mobile flag unset', async () => {
+    const participantsStore = new WaParticipantsMemoryStore(60_000)
+    const coordinator = createMessageDispatchCoordinator(participantsStore, {
+        getCurrentMeJid: () => '5596965746475@s.whatsapp.net'
+    })
+    const gen = coordinator as unknown as {
+        generateOutgoingMessageId(): Promise<string>
+    }
+    const id = await gen.generateOutgoingMessageId()
+    assert.match(id, /^3EB0[0-9A-F]{18}$/, `id '${id}' does not match web format`)
+    await participantsStore.destroy()
+})
+
+test('encoded signed device identity returns undefined on primary (no blob stored)', async () => {
+    const participantsStore = new WaParticipantsMemoryStore(60_000)
+    const coordinator = createMessageDispatchCoordinator(participantsStore)
+    const accessor = coordinator as unknown as {
+        getEncodedSignedDeviceIdentity(): Uint8Array | undefined
+    }
+    assert.equal(accessor.getEncodedSignedDeviceIdentity(), undefined)
     await participantsStore.destroy()
 })
 

--- a/src/crypto/core/primitives.ts
+++ b/src/crypto/core/primitives.ts
@@ -33,7 +33,7 @@ export async function sha512(value: Uint8Array): Promise<Uint8Array> {
     return digestBytes('SHA-512', value)
 }
 
-export function md5Bytes(input: string): Uint8Array {
+export function md5Bytes(input: string | Uint8Array): Uint8Array {
     return toBytesView(createHash('md5').update(input).digest())
 }
 

--- a/src/protocol/nodes.ts
+++ b/src/protocol/nodes.ts
@@ -32,6 +32,7 @@ export const WA_NODE_TAGS = Object.freeze({
     DESCRIPTION: 'description',
     MY_ADDONS: 'my_addons',
     KEY: 'key',
+    OP: 'op',
     REGISTRATION: 'registration',
     TYPE: 'type',
     IDENTITY: 'identity',

--- a/src/transport/WaComms.ts
+++ b/src/transport/WaComms.ts
@@ -72,7 +72,9 @@ export class WaComms {
                 protocols: this.config.protocols,
                 dispatcher: this.config.dispatcher,
                 agent: this.config.agent,
-                timeoutIntervalMs: this.config.timeoutIntervalMs
+                headers: this.config.headers,
+                timeoutIntervalMs: this.config.timeoutIntervalMs,
+                rawWebSocketConstructor: this.config.rawWebSocketConstructor
             },
             logger
         )

--- a/src/transport/WaWebSocket.ts
+++ b/src/transport/WaWebSocket.ts
@@ -107,6 +107,7 @@ export class WaWebSocket {
     private readonly socketUrls: readonly string[]
     private readonly logger: Logger
     private readonly webSocketCtor: RawWebSocketConstructor
+    private readonly customWebSocketCtor: boolean
     private readonly socketRuntime: SocketRuntime
     private readonly connectingSockets: Set<RawWebSocket>
     private handlers: WaSocketHandlers
@@ -121,7 +122,8 @@ export class WaWebSocket {
         })
         this.socketUrls = resolveSocketUrls(config)
         this.logger = logger
-        this.webSocketCtor = resolveWebSocketConstructor()
+        this.webSocketCtor = config.rawWebSocketConstructor ?? resolveWebSocketConstructor()
+        this.customWebSocketCtor = Boolean(config.rawWebSocketConstructor)
         this.socketRuntime = resolveSocketRuntime()
         this.connectingSockets = new Set<RawWebSocket>()
         this.handlers = {}
@@ -502,6 +504,13 @@ export class WaWebSocket {
         const headers = this.config.headers
         const dispatcher = this.config.dispatcher
         const agent = this.config.agent
+        if (this.customWebSocketCtor) {
+            return new this.webSocketCtor(url, this.config.protocols, {
+                headers,
+                dispatcher,
+                agent
+            })
+        }
         let hasHeaders = false
         if (headers) {
             for (const key in headers) {

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -36,4 +36,10 @@ export { WaWebSocket } from '@transport/WaWebSocket'
 export { WaKeepAlive } from '@transport/keepalive/WaKeepAlive'
 export { WaNodeOrchestrator } from '@transport/node/WaNodeOrchestrator'
 export { WaNodeTransport } from '@transport/node/WaNodeTransport'
+export { WaMobileTcpSocket, WaMobileTcpSocketCtor } from '@transport/node/WaMobileTcpSocket'
+export { buildMobileLoginPayload } from '@transport/noise/WaMobileClientPayload'
+export type {
+    WaMobileLoginPayloadConfig,
+    WaMobileTransportDeviceInfo
+} from '@transport/noise/WaMobileClientPayload'
 export { assertIqResult, buildIqNode, parseIqError, queryWithContext } from '@transport/node/query'

--- a/src/transport/node/WaMobileTcpSocket.ts
+++ b/src/transport/node/WaMobileTcpSocket.ts
@@ -1,0 +1,128 @@
+import { connect as netConnect, type Socket as NetSocket } from 'node:net'
+
+import { WA_READY_STATES } from '@protocol/constants'
+import type {
+    RawWebSocket,
+    RawWebSocketConstructor,
+    WaRawWebSocketInit,
+    WebSocketEventLike
+} from '@transport/types'
+import { TEXT_ENCODER } from '@util/bytes'
+
+export class WaMobileTcpSocket implements RawWebSocket {
+    public binaryType = 'arraybuffer'
+    public readyState: number = WA_READY_STATES.CONNECTING
+    public onopen: ((event: WebSocketEventLike) => void) | null = null
+    public onclose: ((event: WebSocketEventLike) => void) | null = null
+    public onerror: ((event: WebSocketEventLike) => void) | null = null
+    public onmessage: ((event: WebSocketEventLike) => void) | null = null
+
+    private readonly socket: NetSocket
+    private closedCode = 1000
+    private closedReason = ''
+    private closedClean = true
+    private forceCloseTimer: NodeJS.Timeout | null = null
+
+    public constructor(url: string, _protocols?: unknown, _options?: WaRawWebSocketInit) {
+        const { host, port } = parseTcpUrl(url)
+        this.socket = netConnect({ host, port })
+
+        this.socket.on('connect', () => {
+            if (this.readyState !== WA_READY_STATES.CONNECTING) return
+            this.readyState = WA_READY_STATES.OPEN
+            this.onopen?.({})
+        })
+
+        this.socket.on('data', (chunk: Uint8Array) => {
+            if (!this.onmessage || this.readyState !== WA_READY_STATES.OPEN) return
+            const copy = new Uint8Array(chunk.byteLength)
+            copy.set(chunk)
+            this.onmessage({ data: copy })
+        })
+
+        this.socket.on('error', (err: Error) => {
+            this.closedClean = false
+            this.closedReason = err.message
+            this.onerror?.({ reason: err.message })
+        })
+
+        this.socket.on('close', (hadError: boolean) => {
+            this.readyState = WA_READY_STATES.CLOSED
+            if (this.forceCloseTimer) {
+                clearTimeout(this.forceCloseTimer)
+                this.forceCloseTimer = null
+            }
+            if (hadError) this.closedClean = false
+            this.onclose?.({
+                code: this.closedCode,
+                reason: this.closedReason,
+                wasClean: this.closedClean
+            })
+        })
+    }
+
+    public send(data: string | ArrayBuffer | Uint8Array): void {
+        if (this.readyState !== WA_READY_STATES.OPEN) {
+            throw new Error('WaMobileTcpSocket: send() called on non-OPEN socket')
+        }
+        let bytes: Uint8Array
+        if (typeof data === 'string') {
+            bytes = TEXT_ENCODER.encode(data)
+        } else if (data instanceof Uint8Array) {
+            bytes = data
+        } else {
+            bytes = new Uint8Array(data)
+        }
+        this.socket.write(bytes)
+    }
+
+    public close(code?: number, reason?: string): void {
+        if (this.readyState === WA_READY_STATES.CLOSED) return
+        this.readyState = WA_READY_STATES.CLOSING
+        this.closedCode = code ?? 1000
+        this.closedReason = reason ?? ''
+        this.socket.end()
+        this.forceCloseTimer = setTimeout(() => {
+            this.forceCloseTimer = null
+            if (this.readyState !== WA_READY_STATES.CLOSED) {
+                this.socket.destroy()
+            }
+        }, 5_000)
+        this.forceCloseTimer.unref()
+    }
+}
+
+function parseTcpUrl(url: string): { host: string; port: number } {
+    let work = url
+    if (work.startsWith('tcp://')) {
+        work = work.slice('tcp://'.length)
+    }
+    const queryIdx = work.indexOf('?')
+    if (queryIdx >= 0) {
+        work = work.slice(0, queryIdx)
+    }
+    const slash = work.indexOf('/')
+    if (slash >= 0) {
+        work = work.slice(0, slash)
+    }
+    const colon = work.lastIndexOf(':')
+    const host = colon === -1 ? work : work.slice(0, colon)
+    if (host.length === 0) {
+        throw new Error(`WaMobileTcpSocket: invalid host in ${JSON.stringify(url)}`)
+    }
+    if (colon === -1) {
+        return { host, port: 443 }
+    }
+    const portText = work.slice(colon + 1)
+    if (!/^\d+$/.test(portText)) {
+        throw new Error(`WaMobileTcpSocket: invalid port in ${JSON.stringify(url)}`)
+    }
+    const port = Number(portText)
+    if (port < 1 || port > 65_535) {
+        throw new Error(`WaMobileTcpSocket: port out of range in ${JSON.stringify(url)}`)
+    }
+    return { host, port }
+}
+
+export const WaMobileTcpSocketCtor: RawWebSocketConstructor =
+    WaMobileTcpSocket as unknown as RawWebSocketConstructor

--- a/src/transport/node/WaNodeOrchestrator.ts
+++ b/src/transport/node/WaNodeOrchestrator.ts
@@ -3,7 +3,7 @@ import { WA_DEFAULTS, WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/cons
 import type { BinaryNode } from '@transport/types'
 import { toError } from '@util/primitives'
 
-import { createNodeIdGenerator, type NodeIdGenerator } from './helpers'
+import { createMobileNodeIdGenerator, createNodeIdGenerator, type NodeIdGenerator } from './helpers'
 
 interface PendingNodeQuery {
     readonly resolve: (value: BinaryNode) => void
@@ -16,6 +16,7 @@ interface WaNodeOrchestratorOptions {
     readonly sendNode: (node: BinaryNode) => Promise<void>
     readonly defaultTimeoutMs?: number
     readonly hostDomain?: string
+    readonly mobileIqIdFormat?: boolean
 }
 
 export class WaNodeOrchestrator {
@@ -23,6 +24,7 @@ export class WaNodeOrchestrator {
     private readonly sendNodeFn: (node: BinaryNode) => Promise<void>
     private readonly defaultTimeoutMs: number
     private readonly hostDomain: string
+    private readonly mobileIqIdFormat: boolean
     private idGenerator: NodeIdGenerator | null
     private idGeneratorReady: Promise<NodeIdGenerator> | null
     private readonly pendingQueries: Map<string, PendingNodeQuery>
@@ -32,6 +34,7 @@ export class WaNodeOrchestrator {
         this.sendNodeFn = options.sendNode
         this.defaultTimeoutMs = options.defaultTimeoutMs ?? WA_DEFAULTS.NODE_QUERY_TIMEOUT_MS
         this.hostDomain = options.hostDomain ?? WA_DEFAULTS.HOST_DOMAIN
+        this.mobileIqIdFormat = options.mobileIqIdFormat === true
         this.idGenerator = null
         this.idGeneratorReady = null
         this.pendingQueries = new Map()
@@ -165,6 +168,13 @@ export class WaNodeOrchestrator {
 
     private async getIdGenerator(): Promise<NodeIdGenerator> {
         if (this.idGenerator) {
+            return this.idGenerator
+        }
+        if (this.mobileIqIdFormat) {
+            this.idGenerator = createMobileNodeIdGenerator()
+            this.logger.debug('generated stanza prefix (mobile)', {
+                prefix: this.idGenerator.prefix
+            })
             return this.idGenerator
         }
         if (!this.idGeneratorReady) {

--- a/src/transport/node/__tests__/WaMobileTcpSocket.test.ts
+++ b/src/transport/node/__tests__/WaMobileTcpSocket.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { WA_READY_STATES } from '@protocol/constants'
+import { WaMobileTcpSocket, WaMobileTcpSocketCtor } from '@transport/node/WaMobileTcpSocket'
+
+test('WaMobileTcpSocketCtor exposes the class identity for RawWebSocketConstructor wiring', () => {
+    assert.equal(WaMobileTcpSocketCtor, WaMobileTcpSocket)
+})
+
+test('WaMobileTcpSocket starts in CONNECTING and marks binaryType=arraybuffer', () => {
+    const socket = new WaMobileTcpSocket('tcp://127.0.0.1:1')
+    assert.equal(socket.readyState, WA_READY_STATES.CONNECTING)
+    assert.equal(socket.binaryType, 'arraybuffer')
+    socket.close()
+})
+
+test('WaMobileTcpSocket.send throws when readyState is not OPEN', () => {
+    const socket = new WaMobileTcpSocket('tcp://127.0.0.1:1')
+    assert.throws(() => socket.send(new Uint8Array([0])), /non-OPEN/)
+    assert.throws(() => socket.send('hello'), /non-OPEN/)
+    socket.close()
+})
+
+test('WaMobileTcpSocket rejects malformed port in url', () => {
+    assert.throws(() => new WaMobileTcpSocket('tcp://127.0.0.1:notaport'), /invalid port/)
+    assert.throws(() => new WaMobileTcpSocket('tcp://127.0.0.1:123abc'), /invalid port/)
+    assert.throws(() => new WaMobileTcpSocket('tcp://127.0.0.1:-1'), /invalid port/)
+    assert.throws(() => new WaMobileTcpSocket('tcp://127.0.0.1:0'), /port out of range/)
+    assert.throws(() => new WaMobileTcpSocket('tcp://127.0.0.1:70000'), /port out of range/)
+})
+
+test('WaMobileTcpSocket rejects empty host', () => {
+    assert.throws(() => new WaMobileTcpSocket('tcp://:443'), /invalid host/)
+    assert.throws(() => new WaMobileTcpSocket('tcp://'), /invalid host/)
+})
+
+test('WaMobileTcpSocket accepts tcp:// scheme, bare host:port, trailing slash and query string', () => {
+    const unreachable = (url: string): void => {
+        const sock = new WaMobileTcpSocket(url)
+        sock.onerror = () => undefined
+        sock.close()
+    }
+    unreachable('tcp://127.0.0.1:1')
+    unreachable('127.0.0.1:1')
+    unreachable('tcp://127.0.0.1:1/ignored')
+    unreachable('tcp://127.0.0.1:1?ED=CAUIAggS')
+})
+
+test('WaMobileTcpSocket.close is idempotent when already CLOSED', () => {
+    const socket = new WaMobileTcpSocket('tcp://127.0.0.1:1')
+    socket.onerror = () => undefined
+    socket.close()
+    socket.close()
+    assert.ok(
+        socket.readyState === WA_READY_STATES.CLOSING ||
+            socket.readyState === WA_READY_STATES.CLOSED
+    )
+})

--- a/src/transport/node/__tests__/helpers.test.ts
+++ b/src/transport/node/__tests__/helpers.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createMobileNodeIdGenerator, createNodeIdGenerator } from '@transport/node/helpers'
+
+test('createNodeIdGenerator produces a random prefix and monotonic counter', async () => {
+    const gen = await createNodeIdGenerator()
+    assert.match(gen.prefix, /^\d+\.\d+-$/)
+    const first = gen.next()
+    const second = gen.next()
+    assert.equal(first, `${gen.prefix}1`)
+    assert.equal(second, `${gen.prefix}2`)
+})
+
+test('createMobileNodeIdGenerator matches WA Android C08170Ng.A0E format', () => {
+    const gen = createMobileNodeIdGenerator()
+    assert.equal(gen.prefix, '0')
+    const ids: string[] = []
+    for (let i = 0; i < 260; i++) ids.push(gen.next())
+    assert.equal(ids[0], '00')
+    assert.equal(ids[1], '01')
+    assert.equal(ids[15], '0f')
+    assert.equal(ids[16], '010')
+    assert.equal(ids[255], '0ff')
+    assert.equal(ids[256], '0100')
+})
+
+test('createMobileNodeIdGenerator wraps at 65536', () => {
+    const gen = createMobileNodeIdGenerator()
+    for (let i = 0; i < 65535; i++) gen.next()
+    assert.equal(gen.next(), '0ffff')
+    assert.equal(gen.next(), '00')
+})

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -955,6 +955,27 @@ test('prekeys builders include expected key material and targets', () => {
 
     assert.equal(upload.tag, 'iq')
     assert.equal(upload.attrs.type, 'set')
+    assert.ok(Array.isArray(upload.content))
+    assert.notEqual(upload.content[0].tag, 'op')
+
+    const uploadMobile = buildPreKeyUploadIq(
+        registrationInfo,
+        signedPreKey,
+        [
+            {
+                keyId: 12,
+                keyPair: {
+                    pubKey: new Uint8Array(32).fill(7),
+                    privKey: new Uint8Array(32).fill(8)
+                },
+                uploaded: false
+            }
+        ],
+        { opMode: 'set' }
+    )
+    assert.ok(Array.isArray(uploadMobile.content))
+    assert.equal(uploadMobile.content[0].tag, 'op')
+    assert.equal(uploadMobile.content[0].attrs.mode, 'set')
 
     const fetch = buildMissingPreKeysFetchIq([
         {

--- a/src/transport/node/builders/prekeys.ts
+++ b/src/transport/node/builders/prekeys.ts
@@ -3,6 +3,7 @@ import { SIGNAL_KEY_BUNDLE_TYPE_BYTES } from '@signal/api/constants'
 import type { SignalMissingPreKeysTarget } from '@signal/api/SignalMissingPreKeysSyncApi'
 import type { PreKeyRecord, RegistrationInfo, SignedPreKeyRecord } from '@signal/types'
 import { buildIqNode } from '@transport/node/query'
+import type { BinaryNode } from '@transport/types'
 import { intToBytes } from '@util/bytes'
 
 function buildSignedPreKeyNode(signedPreKey: SignedPreKeyRecord) {
@@ -32,9 +33,17 @@ function buildSignedPreKeyNode(signedPreKey: SignedPreKeyRecord) {
 export function buildPreKeyUploadIq(
     registrationInfo: RegistrationInfo,
     signedPreKey: SignedPreKeyRecord,
-    preKeys: readonly PreKeyRecord[]
+    preKeys: readonly PreKeyRecord[],
+    options?: { readonly opMode?: 'set' | 'add' }
 ) {
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.SIGNAL, [
+    const children: BinaryNode[] = []
+    if (options?.opMode) {
+        children.push({
+            tag: WA_NODE_TAGS.OP,
+            attrs: { mode: options.opMode }
+        })
+    }
+    children.push(
         {
             tag: WA_NODE_TAGS.REGISTRATION,
             attrs: {},
@@ -71,7 +80,8 @@ export function buildPreKeyUploadIq(
             }))
         },
         buildSignedPreKeyNode(signedPreKey)
-    ])
+    )
+    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.SIGNAL, children)
 }
 
 export function buildSignedPreKeyRotateIq(signedPreKey: SignedPreKeyRecord) {

--- a/src/transport/node/helpers.ts
+++ b/src/transport/node/helpers.ts
@@ -186,3 +186,15 @@ export async function createNodeIdGenerator(): Promise<NodeIdGenerator> {
         }
     }
 }
+
+export function createMobileNodeIdGenerator(): NodeIdGenerator {
+    let counter = 0
+    return {
+        prefix: '0',
+        next(): string {
+            const id = `0${counter.toString(16)}`
+            counter = (counter + 1) & 0xffff
+            return id
+        }
+    }
+}

--- a/src/transport/noise/WaMobileClientPayload.ts
+++ b/src/transport/noise/WaMobileClientPayload.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from 'node:crypto'
+
+import { type Proto, proto } from '@proto'
+
+export interface WaMobileTransportDeviceInfo {
+    readonly manufacturer: string
+    readonly device: string
+    readonly osVersion: string
+    readonly osBuildNumber: string
+    readonly appVersion: string
+    readonly mcc?: string
+    readonly mnc?: string
+    readonly localeLanguageIso6391?: string
+    readonly localeCountryIso31661Alpha2?: string
+    readonly phoneId?: string
+    readonly deviceBoard?: string
+    readonly deviceModelType?: string
+}
+
+export interface WaMobileLoginPayloadConfig {
+    readonly username: number
+    readonly device?: number
+    readonly passive?: boolean
+    readonly pull?: boolean
+    readonly deviceInfo: WaMobileTransportDeviceInfo
+    readonly lidDbMigrated?: boolean
+    readonly connectReason?: Proto.ClientPayload.ConnectReason
+    readonly connectType?: Proto.ClientPayload.ConnectType
+    readonly pushName?: string
+    readonly yearClass?: number
+    readonly memClass?: number
+}
+
+interface ParsedAppVersion {
+    readonly primary: number
+    readonly secondary: number
+    readonly tertiary: number
+    readonly quaternary?: number
+}
+
+function parseAppVersion(version: string): ParsedAppVersion {
+    const parts = version.split('.')
+    const at = (i: number): number | undefined => {
+        const n = Number(parts[i])
+        return Number.isFinite(n) ? n : undefined
+    }
+    return {
+        primary: at(0) ?? 2,
+        secondary: at(1) ?? 0,
+        tertiary: at(2) ?? 0,
+        quaternary: at(3)
+    }
+}
+
+export function buildMobileLoginPayload(config: WaMobileLoginPayloadConfig): Uint8Array {
+    if (!Number.isSafeInteger(config.username) || config.username <= 0) {
+        throw new Error('mobile login payload requires a valid numeric username')
+    }
+    const info = config.deviceInfo
+    const version = parseAppVersion(info.appVersion)
+
+    const userAgent = {
+        platform: proto.ClientPayload.UserAgent.Platform.ANDROID,
+        releaseChannel: proto.ClientPayload.UserAgent.ReleaseChannel.RELEASE,
+        appVersion: version,
+        mcc: info.mcc ?? '000',
+        mnc: info.mnc ?? '000',
+        osVersion: info.osVersion,
+        manufacturer: info.manufacturer,
+        device: info.device,
+        osBuildNumber: info.osBuildNumber,
+        phoneId: info.phoneId ?? randomUUID(),
+        localeLanguageIso6391: info.localeLanguageIso6391 ?? 'en',
+        localeCountryIso31661Alpha2: info.localeCountryIso31661Alpha2 ?? 'US',
+        deviceType: proto.ClientPayload.UserAgent.DeviceType.PHONE,
+        deviceBoard: info.deviceBoard,
+        deviceModelType: info.deviceModelType
+    } as typeof proto.ClientPayload.prototype.userAgent
+
+    return proto.ClientPayload.encode({
+        passive: config.passive === true,
+        pull: config.pull ?? true,
+        product: proto.ClientPayload.Product.WHATSAPP,
+        connectType: config.connectType ?? proto.ClientPayload.ConnectType.CELLULAR_UNKNOWN,
+        connectReason: config.connectReason ?? proto.ClientPayload.ConnectReason.USER_ACTIVATED,
+        userAgent,
+        username: config.username,
+        device: config.device ?? 0,
+        lidDbMigrated: config.lidDbMigrated === true,
+        pushName: config.pushName,
+        yearClass: config.yearClass,
+        memClass: config.memClass
+    }).finish()
+}

--- a/src/transport/noise/__tests__/WaMobileClientPayload.test.ts
+++ b/src/transport/noise/__tests__/WaMobileClientPayload.test.ts
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { proto } from '@proto'
+import {
+    buildMobileLoginPayload,
+    type WaMobileTransportDeviceInfo
+} from '@transport/noise/WaMobileClientPayload'
+
+const BASE_DEVICE: WaMobileTransportDeviceInfo = {
+    manufacturer: 'motorola',
+    device: 'moto_g52',
+    osVersion: '12',
+    osBuildNumber: 'S1SRS32.38-132-8',
+    appVersion: '2.26.15.11',
+    mcc: '724',
+    mnc: '03',
+    localeLanguageIso6391: 'pt',
+    localeCountryIso31661Alpha2: 'BR',
+    phoneId: '00000000-0000-0000-0000-000000000001'
+}
+
+test('buildMobileLoginPayload emits an ANDROID userAgent with primary flags', () => {
+    const bytes = buildMobileLoginPayload({
+        username: 5511987654321,
+        deviceInfo: BASE_DEVICE
+    })
+    const payload = proto.ClientPayload.decode(bytes)
+    assert.equal(payload.passive, false)
+    assert.equal(payload.pull, true)
+    assert.equal(payload.device, 0)
+    assert.equal(String(payload.username), '5511987654321')
+    const ua = payload.userAgent
+    assert.ok(ua, 'userAgent is set')
+    assert.equal(ua.platform, proto.ClientPayload.UserAgent.Platform.ANDROID)
+    assert.equal(ua.releaseChannel, proto.ClientPayload.UserAgent.ReleaseChannel.RELEASE)
+    assert.equal(ua.manufacturer, 'motorola')
+    assert.equal(ua.device, 'moto_g52')
+    assert.equal(ua.osVersion, '12')
+    assert.equal(ua.osBuildNumber, 'S1SRS32.38-132-8')
+    assert.equal(ua.mcc, '724')
+    assert.equal(ua.mnc, '03')
+    assert.equal(ua.localeLanguageIso6391, 'pt')
+    assert.equal(ua.localeCountryIso31661Alpha2, 'BR')
+    assert.equal(ua.phoneId, '00000000-0000-0000-0000-000000000001')
+    assert.ok(ua.appVersion, 'appVersion parsed')
+    assert.equal(ua.appVersion.primary, 2)
+    assert.equal(ua.appVersion.secondary, 26)
+    assert.equal(ua.appVersion.tertiary, 15)
+})
+
+test('buildMobileLoginPayload sets passive=true when requested', () => {
+    const bytes = buildMobileLoginPayload({
+        username: 5511987654321,
+        passive: true,
+        deviceInfo: BASE_DEVICE
+    })
+    const payload = proto.ClientPayload.decode(bytes)
+    assert.equal(payload.passive, true)
+})
+
+test('buildMobileLoginPayload defaults missing mcc/mnc and generates a phoneId', () => {
+    const partial: WaMobileTransportDeviceInfo = {
+        manufacturer: BASE_DEVICE.manufacturer,
+        device: BASE_DEVICE.device,
+        osVersion: BASE_DEVICE.osVersion,
+        osBuildNumber: BASE_DEVICE.osBuildNumber,
+        appVersion: BASE_DEVICE.appVersion,
+        localeLanguageIso6391: BASE_DEVICE.localeLanguageIso6391,
+        localeCountryIso31661Alpha2: BASE_DEVICE.localeCountryIso31661Alpha2
+    }
+    const bytes = buildMobileLoginPayload({
+        username: 5511987654321,
+        deviceInfo: partial
+    })
+    const payload = proto.ClientPayload.decode(bytes)
+    const ua = payload.userAgent
+    assert.ok(ua)
+    assert.equal(ua.mcc, '000')
+    assert.equal(ua.mnc, '000')
+    assert.match(ua.phoneId ?? '', /^[0-9a-f-]{36}$/)
+})
+
+test('buildMobileLoginPayload rejects non-positive usernames', () => {
+    assert.throws(
+        () => buildMobileLoginPayload({ username: 0, deviceInfo: BASE_DEVICE }),
+        /valid numeric username/
+    )
+    assert.throws(
+        () => buildMobileLoginPayload({ username: -1, deviceInfo: BASE_DEVICE }),
+        /valid numeric username/
+    )
+})
+
+test('buildMobileLoginPayload honours custom device slot', () => {
+    const bytes = buildMobileLoginPayload({
+        username: 5511987654321,
+        device: 2,
+        deviceInfo: BASE_DEVICE
+    })
+    const payload = proto.ClientPayload.decode(bytes)
+    assert.equal(payload.device, 2)
+})
+
+test('buildMobileLoginPayload populates quaternary app version when present', () => {
+    const bytes = buildMobileLoginPayload({
+        username: 5511987654321,
+        deviceInfo: { ...BASE_DEVICE, appVersion: '2.26.15.11' }
+    })
+    const payload = proto.ClientPayload.decode(bytes)
+    assert.ok(payload.userAgent?.appVersion)
+    assert.equal(payload.userAgent.appVersion.primary, 2)
+    assert.equal(payload.userAgent.appVersion.secondary, 26)
+    assert.equal(payload.userAgent.appVersion.tertiary, 15)
+    assert.equal(payload.userAgent.appVersion.quaternary, 11)
+})
+
+test('buildMobileLoginPayload leaves quaternary unset when version has 3 parts', () => {
+    const bytes = buildMobileLoginPayload({
+        username: 5511987654321,
+        deviceInfo: { ...BASE_DEVICE, appVersion: '2.26.15' }
+    })
+    const payload = proto.ClientPayload.decode(bytes)
+    assert.ok(payload.userAgent?.appVersion)
+    assert.ok(!payload.userAgent.appVersion.quaternary)
+})
+
+test('buildMobileLoginPayload sets deviceType=PHONE and product=WHATSAPP explicitly', () => {
+    const bytes = buildMobileLoginPayload({
+        username: 5511987654321,
+        deviceInfo: BASE_DEVICE
+    })
+    const payload = proto.ClientPayload.decode(bytes)
+    assert.equal(payload.product, proto.ClientPayload.Product.WHATSAPP)
+    assert.equal(payload.userAgent?.deviceType, proto.ClientPayload.UserAgent.DeviceType.PHONE)
+})
+
+test('buildMobileLoginPayload forwards deviceBoard and deviceModelType from deviceInfo', () => {
+    const bytes = buildMobileLoginPayload({
+        username: 5511987654321,
+        deviceInfo: {
+            ...BASE_DEVICE,
+            deviceBoard: 'MSM8953',
+            deviceModelType: 'moto g(52)'
+        }
+    })
+    const payload = proto.ClientPayload.decode(bytes)
+    assert.equal(payload.userAgent?.deviceBoard, 'MSM8953')
+    assert.equal(payload.userAgent?.deviceModelType, 'moto g(52)')
+})
+
+test('buildMobileLoginPayload forwards pushName, yearClass and memClass when provided', () => {
+    const bytes = buildMobileLoginPayload({
+        username: 5511987654321,
+        deviceInfo: BASE_DEVICE,
+        pushName: 'Test User',
+        yearClass: 2016,
+        memClass: 256
+    })
+    const payload = proto.ClientPayload.decode(bytes)
+    assert.equal(payload.pushName, 'Test User')
+    assert.equal(payload.yearClass, 2016)
+    assert.equal(payload.memClass, 256)
+})
+
+test('buildMobileLoginPayload omits pushName/yearClass/memClass when absent', () => {
+    const bytes = buildMobileLoginPayload({
+        username: 5511987654321,
+        deviceInfo: BASE_DEVICE
+    })
+    const payload = proto.ClientPayload.decode(bytes)
+    assert.ok(!payload.pushName)
+    assert.ok(!payload.yearClass)
+    assert.ok(!payload.memClass)
+})

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -36,6 +36,7 @@ export interface WaSocketConfig {
     readonly dispatcher?: WaProxyDispatcher
     readonly agent?: WaProxyAgent
     readonly timeoutIntervalMs?: number
+    readonly rawWebSocketConstructor?: RawWebSocketConstructor
 }
 
 export interface WaSocketHandlers {


### PR DESCRIPTION
WaClient can now connect as a mobile primary via plain-TCP + Noise, using credentials extracted from a live WA install. Web transport remains the default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile transport support: TCP-based mobile connectivity, mobile-specific device info, and mobile-aware sync/prekey behavior.
  * Option to supply a custom raw WebSocket constructor.

* **Behavior Changes**
  * Mobile-specific ID and message ID formats when mobile mode is enabled.
  * App-state client can initialize and persist an initial sync key.

* **Tests**
  * Extensive tests for mobile payloads, TCP socket, ID generators, and app-state sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->