### PR TITLE
feat(auth): persist mobile device fingerprint with credentials

### DIFF
--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -30,6 +30,7 @@
             "@transport/*": ["src/transport/*"],
             "@util/*": ["src/util/*"],
             "zapo-js": ["src/index.ts"],
+            "zapo-js/proto": ["src/proto.ts"],
             "zapo-js/*": ["src/*/index.ts"],
             "@zapo-js/*": ["packages/*/src"]
         }

--- a/packages/store-mongo/src/auth.store.ts
+++ b/packages/store-mongo/src/auth.store.ts
@@ -33,6 +33,10 @@ interface AuthDoc {
     ab_props_version: number | null
     connection_location: string | null
     account_creation_ts: number | null
+    device_info?: WaAuthCredentials['deviceInfo'] | null
+    push_name?: string | null
+    year_class?: number | null
+    mem_class?: number | null
 }
 
 const COLLECTION = 'auth_credentials'
@@ -91,7 +95,17 @@ export class WaAuthMongoStore extends BaseMongoStore implements WaAuthStore {
                 doc.ab_props_version !== null ? Number(doc.ab_props_version) : undefined,
             connectionLocation: doc.connection_location ?? undefined,
             accountCreationTs:
-                doc.account_creation_ts !== null ? Number(doc.account_creation_ts) : undefined
+                doc.account_creation_ts !== null ? Number(doc.account_creation_ts) : undefined,
+            deviceInfo: doc.device_info ?? undefined,
+            pushName: doc.push_name ?? undefined,
+            yearClass:
+                doc.year_class === null || doc.year_class === undefined
+                    ? undefined
+                    : Number(doc.year_class),
+            memClass:
+                doc.mem_class === null || doc.mem_class === undefined
+                    ? undefined
+                    : Number(doc.mem_class)
         }
     }
 
@@ -138,7 +152,11 @@ export class WaAuthMongoStore extends BaseMongoStore implements WaAuthStore {
                     props_version: credentials.propsVersion ?? null,
                     ab_props_version: credentials.abPropsVersion ?? null,
                     connection_location: credentials.connectionLocation ?? null,
-                    account_creation_ts: credentials.accountCreationTs ?? null
+                    account_creation_ts: credentials.accountCreationTs ?? null,
+                    device_info: credentials.deviceInfo ?? null,
+                    push_name: credentials.pushName ?? null,
+                    year_class: credentials.yearClass ?? null,
+                    mem_class: credentials.memClass ?? null
                 }
             },
             { upsert: true }

--- a/packages/store-mysql/src/auth.store.ts
+++ b/packages/store-mysql/src/auth.store.ts
@@ -22,7 +22,8 @@ export class WaAuthMysqlStore extends BaseMysqlStore implements WaAuthStore {
                     me_jid, me_lid, me_display_name, companion_enc_static,
                     platform, server_static_key, server_has_prekeys, routing_info,
                     last_success_ts, props_version, ab_props_version,
-                    connection_location, account_creation_ts
+                    connection_location, account_creation_ts,
+                    device_info, push_name, year_class, mem_class
              FROM ${this.t('auth_credentials')}
              WHERE session_id = ?`,
                 [this.sessionId]
@@ -72,7 +73,14 @@ export class WaAuthMysqlStore extends BaseMysqlStore implements WaAuthStore {
                 row.ab_props_version !== null ? Number(row.ab_props_version) : undefined,
             connectionLocation: (row.connection_location as string | null) ?? undefined,
             accountCreationTs:
-                row.account_creation_ts !== null ? Number(row.account_creation_ts) : undefined
+                row.account_creation_ts !== null ? Number(row.account_creation_ts) : undefined,
+            deviceInfo:
+                typeof row.device_info === 'string'
+                    ? (JSON.parse(row.device_info) as WaAuthCredentials['deviceInfo'])
+                    : undefined,
+            pushName: (row.push_name as string | null) ?? undefined,
+            yearClass: row.year_class !== null ? Number(row.year_class) : undefined,
+            memClass: row.mem_class !== null ? Number(row.mem_class) : undefined
         }
     }
 
@@ -87,8 +95,9 @@ export class WaAuthMysqlStore extends BaseMysqlStore implements WaAuthStore {
                 me_jid, me_lid, me_display_name, companion_enc_static,
                 platform, server_static_key, server_has_prekeys, routing_info,
                 last_success_ts, props_version, ab_props_version,
-                connection_location, account_creation_ts
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                connection_location, account_creation_ts,
+                device_info, push_name, year_class, mem_class
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON DUPLICATE KEY UPDATE
                 noise_pub_key = VALUES(noise_pub_key),
                 noise_priv_key = VALUES(noise_priv_key),
@@ -113,7 +122,11 @@ export class WaAuthMysqlStore extends BaseMysqlStore implements WaAuthStore {
                 props_version = VALUES(props_version),
                 ab_props_version = VALUES(ab_props_version),
                 connection_location = VALUES(connection_location),
-                account_creation_ts = VALUES(account_creation_ts)`,
+                account_creation_ts = VALUES(account_creation_ts),
+                device_info = VALUES(device_info),
+                push_name = VALUES(push_name),
+                year_class = VALUES(year_class),
+                mem_class = VALUES(mem_class)`,
             [
                 this.sessionId,
                 credentials.noiseKeyPair.pubKey,
@@ -145,7 +158,11 @@ export class WaAuthMysqlStore extends BaseMysqlStore implements WaAuthStore {
                 credentials.propsVersion ?? null,
                 credentials.abPropsVersion ?? null,
                 credentials.connectionLocation ?? null,
-                credentials.accountCreationTs ?? null
+                credentials.accountCreationTs ?? null,
+                credentials.deviceInfo ? JSON.stringify(credentials.deviceInfo) : null,
+                credentials.pushName ?? null,
+                credentials.yearClass ?? null,
+                credentials.memClass ?? null
             ]
         )
     }

--- a/packages/store-mysql/src/connection.ts
+++ b/packages/store-mysql/src/connection.ts
@@ -298,6 +298,17 @@ const MIGRATIONS: readonly Migration[] = [
                 INDEX idx_message_secrets_expires (session_id, expires_at_ms)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
         `
+    },
+    {
+        name: '0011_auth_credentials_mobile_transport',
+        domain: 'auth',
+        sql: `
+            ALTER TABLE \`__PREFIX__auth_credentials\`
+                ADD COLUMN device_info LONGTEXT,
+                ADD COLUMN push_name VARCHAR(255),
+                ADD COLUMN year_class BIGINT,
+                ADD COLUMN mem_class BIGINT
+        `
     }
 ]
 

--- a/packages/store-postgres/src/auth.store.ts
+++ b/packages/store-postgres/src/auth.store.ts
@@ -23,7 +23,8 @@ export class WaAuthPgStore extends BasePgStore implements WaAuthStore {
                     me_jid, me_lid, me_display_name, companion_enc_static,
                     platform, server_static_key, server_has_prekeys, routing_info,
                     last_success_ts, props_version, ab_props_version,
-                    connection_location, account_creation_ts
+                    connection_location, account_creation_ts,
+                    device_info, push_name, year_class, mem_class
              FROM ${this.t('auth_credentials')}
              WHERE session_id = $1`,
                 values: [this.sessionId]
@@ -73,7 +74,14 @@ export class WaAuthPgStore extends BasePgStore implements WaAuthStore {
                 row.ab_props_version !== null ? Number(row.ab_props_version) : undefined,
             connectionLocation: (row.connection_location as string | null) ?? undefined,
             accountCreationTs:
-                row.account_creation_ts !== null ? Number(row.account_creation_ts) : undefined
+                row.account_creation_ts !== null ? Number(row.account_creation_ts) : undefined,
+            deviceInfo:
+                typeof row.device_info === 'string'
+                    ? (JSON.parse(row.device_info) as WaAuthCredentials['deviceInfo'])
+                    : undefined,
+            pushName: (row.push_name as string | null) ?? undefined,
+            yearClass: row.year_class !== null ? Number(row.year_class) : undefined,
+            memClass: row.mem_class !== null ? Number(row.mem_class) : undefined
         }
     }
 
@@ -89,8 +97,9 @@ export class WaAuthPgStore extends BasePgStore implements WaAuthStore {
                 me_jid, me_lid, me_display_name, companion_enc_static,
                 platform, server_static_key, server_has_prekeys, routing_info,
                 last_success_ts, props_version, ab_props_version,
-                connection_location, account_creation_ts
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)
+                connection_location, account_creation_ts,
+                device_info, push_name, year_class, mem_class
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29)
             ON CONFLICT (session_id) DO UPDATE SET
                 noise_pub_key = EXCLUDED.noise_pub_key,
                 noise_priv_key = EXCLUDED.noise_priv_key,
@@ -115,7 +124,11 @@ export class WaAuthPgStore extends BasePgStore implements WaAuthStore {
                 props_version = EXCLUDED.props_version,
                 ab_props_version = EXCLUDED.ab_props_version,
                 connection_location = EXCLUDED.connection_location,
-                account_creation_ts = EXCLUDED.account_creation_ts`,
+                account_creation_ts = EXCLUDED.account_creation_ts,
+                device_info = EXCLUDED.device_info,
+                push_name = EXCLUDED.push_name,
+                year_class = EXCLUDED.year_class,
+                mem_class = EXCLUDED.mem_class`,
             values: [
                 this.sessionId,
                 credentials.noiseKeyPair.pubKey,
@@ -143,7 +156,11 @@ export class WaAuthPgStore extends BasePgStore implements WaAuthStore {
                 credentials.propsVersion ?? null,
                 credentials.abPropsVersion ?? null,
                 credentials.connectionLocation ?? null,
-                credentials.accountCreationTs ?? null
+                credentials.accountCreationTs ?? null,
+                credentials.deviceInfo ? JSON.stringify(credentials.deviceInfo) : null,
+                credentials.pushName ?? null,
+                credentials.yearClass ?? null,
+                credentials.memClass ?? null
             ]
         })
     }

--- a/packages/store-postgres/src/connection.ts
+++ b/packages/store-postgres/src/connection.ts
@@ -314,6 +314,16 @@ const MIGRATIONS: readonly Migration[] = [
             CREATE INDEX IF NOT EXISTS "__PREFIX__idx_message_secrets_expires"
                 ON "__PREFIX__message_secrets_cache" (session_id, expires_at_ms)
         `
+    },
+    {
+        name: '0011_auth_credentials_mobile_transport',
+        domain: 'auth',
+        sql: `
+            ALTER TABLE "__PREFIX__auth_credentials" ADD COLUMN IF NOT EXISTS device_info TEXT;
+            ALTER TABLE "__PREFIX__auth_credentials" ADD COLUMN IF NOT EXISTS push_name TEXT;
+            ALTER TABLE "__PREFIX__auth_credentials" ADD COLUMN IF NOT EXISTS year_class BIGINT;
+            ALTER TABLE "__PREFIX__auth_credentials" ADD COLUMN IF NOT EXISTS mem_class BIGINT
+        `
     }
 ]
 

--- a/packages/store-redis/src/auth.store.ts
+++ b/packages/store-redis/src/auth.store.ts
@@ -104,7 +104,15 @@ export class WaAuthRedisStore extends BaseRedisStore implements WaAuthStore {
             accountCreationTs:
                 toStringOrNull(data.account_creation_ts) !== null
                     ? Number(data.account_creation_ts)
-                    : undefined
+                    : undefined,
+            deviceInfo:
+                toStringOrNull(data.device_info) !== null
+                    ? (JSON.parse(data.device_info) as WaAuthCredentials['deviceInfo'])
+                    : undefined,
+            pushName: toStringOrNull(data.push_name) ?? undefined,
+            yearClass:
+                toStringOrNull(data.year_class) !== null ? Number(data.year_class) : undefined,
+            memClass: toStringOrNull(data.mem_class) !== null ? Number(data.mem_class) : undefined
         }
     }
 
@@ -144,6 +152,18 @@ export class WaAuthRedisStore extends BaseRedisStore implements WaAuthStore {
         }
         if (credentials.accountCreationTs !== undefined) {
             fields.account_creation_ts = String(credentials.accountCreationTs)
+        }
+        if (credentials.deviceInfo !== undefined) {
+            fields.device_info = JSON.stringify(credentials.deviceInfo)
+        }
+        if (credentials.pushName !== undefined) {
+            fields.push_name = credentials.pushName
+        }
+        if (credentials.yearClass !== undefined) {
+            fields.year_class = String(credentials.yearClass)
+        }
+        if (credentials.memClass !== undefined) {
+            fields.mem_class = String(credentials.memClass)
         }
 
         const pipeline = this.redis.pipeline()

--- a/packages/store-sqlite/src/auth.store.ts
+++ b/packages/store-sqlite/src/auth.store.ts
@@ -45,7 +45,11 @@ export class WaAuthSqliteStore extends BaseSqliteStore implements WaAuthStore {
                 props_version,
                 ab_props_version,
                 connection_location,
-                account_creation_ts
+                account_creation_ts,
+                device_info,
+                push_name,
+                year_class,
+                mem_class
             FROM auth_credentials
             WHERE session_id = ?`,
             [this.options.sessionId]
@@ -56,6 +60,7 @@ export class WaAuthSqliteStore extends BaseSqliteStore implements WaAuthStore {
         }
 
         const signedIdentityBytes = asOptionalBytes(row.signed_identity)
+        const deviceInfoJson = asOptionalString(row.device_info)
 
         return {
             noiseKeyPair: {
@@ -94,7 +99,13 @@ export class WaAuthSqliteStore extends BaseSqliteStore implements WaAuthStore {
             propsVersion: asOptionalNumber(row.props_version),
             abPropsVersion: asOptionalNumber(row.ab_props_version),
             connectionLocation: asOptionalString(row.connection_location),
-            accountCreationTs: asOptionalNumber(row.account_creation_ts)
+            accountCreationTs: asOptionalNumber(row.account_creation_ts),
+            deviceInfo: deviceInfoJson
+                ? (JSON.parse(deviceInfoJson) as WaAuthCredentials['deviceInfo'])
+                : undefined,
+            pushName: asOptionalString(row.push_name),
+            yearClass: asOptionalNumber(row.year_class),
+            memClass: asOptionalNumber(row.mem_class)
         }
     }
 
@@ -126,9 +137,13 @@ export class WaAuthSqliteStore extends BaseSqliteStore implements WaAuthStore {
                     props_version,
                     ab_props_version,
                     connection_location,
-                    account_creation_ts
+                    account_creation_ts,
+                    device_info,
+                    push_name,
+                    year_class,
+                    mem_class
                 ) VALUES (
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
                 )
                 ON CONFLICT(session_id) DO UPDATE SET
                     noise_pub_key=excluded.noise_pub_key,
@@ -154,7 +169,11 @@ export class WaAuthSqliteStore extends BaseSqliteStore implements WaAuthStore {
                     props_version=excluded.props_version,
                     ab_props_version=excluded.ab_props_version,
                     connection_location=excluded.connection_location,
-                    account_creation_ts=excluded.account_creation_ts`,
+                    account_creation_ts=excluded.account_creation_ts,
+                    device_info=excluded.device_info,
+                    push_name=excluded.push_name,
+                    year_class=excluded.year_class,
+                    mem_class=excluded.mem_class`,
                 [
                     this.options.sessionId,
                     credentials.noiseKeyPair.pubKey,
@@ -186,7 +205,11 @@ export class WaAuthSqliteStore extends BaseSqliteStore implements WaAuthStore {
                     credentials.propsVersion ?? null,
                     credentials.abPropsVersion ?? null,
                     credentials.connectionLocation ?? null,
-                    credentials.accountCreationTs ?? null
+                    credentials.accountCreationTs ?? null,
+                    credentials.deviceInfo ? JSON.stringify(credentials.deviceInfo) : null,
+                    credentials.pushName ?? null,
+                    credentials.yearClass ?? null,
+                    credentials.memClass ?? null
                 ]
             )
         })

--- a/packages/store-sqlite/src/migrations.ts
+++ b/packages/store-sqlite/src/migrations.ts
@@ -347,6 +347,18 @@ const SQLITE_MIGRATIONS: readonly WaSqliteMigration[] = [
                     ON message_secrets_cache (session_id, expires_at_ms);
             `)
         }
+    },
+    {
+        id: '0011_auth_credentials_mobile_transport',
+        domain: 'auth',
+        up: (db) => {
+            db.exec(`
+                ALTER TABLE auth_credentials ADD COLUMN device_info TEXT;
+                ALTER TABLE auth_credentials ADD COLUMN push_name TEXT;
+                ALTER TABLE auth_credentials ADD COLUMN year_class INTEGER;
+                ALTER TABLE auth_credentials ADD COLUMN mem_class INTEGER;
+            `)
+        }
     }
 ]
 

--- a/src/auth/__tests__/credentials-flow.test.ts
+++ b/src/auth/__tests__/credentials-flow.test.ts
@@ -164,3 +164,61 @@ test('buildCommsConfig maps ws proxy agent when provided', () => {
     assert.equal(config.agent, wsAgent)
     wsAgent.destroy()
 })
+
+test('buildCommsConfig falls back to credentials.deviceInfo when mobileTransport option is absent', () => {
+    const credentials: WaAuthCredentials = {
+        ...createCredentials(),
+        deviceInfo: {
+            manufacturer: 'Google',
+            device: 'panther',
+            osVersion: '14',
+            osBuildNumber: 'AP3A',
+            appVersion: '2.26.15.11'
+        },
+        pushName: 'tester',
+        yearClass: 2022,
+        memClass: 4096
+    }
+    const config = buildCommsConfig(
+        createLogger(),
+        credentials,
+        { url: 'wss://web.whatsapp.com/ws/chat' },
+        { requireFullSync: false }
+    )
+    assert.equal(config.url, 'tcp://g.whatsapp.net:443')
+    assert.ok(config.rawWebSocketConstructor, 'expected mobile raw socket ctor')
+    assert.equal(config.noise?.isRegistered, true)
+    assert.ok(config.noise?.loginPayload, 'expected login payload')
+})
+
+test('buildCommsConfig prefers explicit mobileTransport option over credentials.deviceInfo', () => {
+    const credentials: WaAuthCredentials = {
+        ...createCredentials(),
+        deviceInfo: {
+            manufacturer: 'Google',
+            device: 'panther',
+            osVersion: '14',
+            osBuildNumber: 'AP3A',
+            appVersion: '2.26.15.11'
+        }
+    }
+    const config = buildCommsConfig(
+        createLogger(),
+        credentials,
+        { url: 'wss://web.whatsapp.com/ws/chat' },
+        {
+            requireFullSync: false,
+            mobileTransport: {
+                deviceInfo: {
+                    manufacturer: 'Xiaomi',
+                    device: 'redfin',
+                    osVersion: '13',
+                    osBuildNumber: 'TQ3A',
+                    appVersion: '2.26.16.0'
+                },
+                tcpUrl: 'tcp://override.example:443'
+            }
+        }
+    )
+    assert.equal(config.url, 'tcp://override.example:443')
+})

--- a/src/auth/credentials-flow.ts
+++ b/src/auth/credentials-flow.ts
@@ -1,4 +1,9 @@
-import type { WaAuthClientOptions, WaAuthCredentials, WaAuthSocketOptions } from '@auth/types'
+import type {
+    WaAuthClientOptions,
+    WaAuthCredentials,
+    WaAuthSocketOptions,
+    WaMobileTransportOptions
+} from '@auth/types'
 import { randomBytesAsync, toRawPubKey, xeddsaVerify } from '@crypto'
 import { toSerializedPubKey } from '@crypto/core/keys'
 import { X25519 } from '@crypto/curves/X25519'
@@ -65,6 +70,18 @@ export async function persistCredentials(
     await args.authStore.save(credentials)
 }
 
+function mobileTransportFromCredentials(
+    credentials: WaAuthCredentials
+): WaMobileTransportOptions | undefined {
+    if (!credentials.deviceInfo) return undefined
+    return {
+        deviceInfo: credentials.deviceInfo,
+        ...(credentials.pushName !== undefined ? { pushName: credentials.pushName } : {}),
+        ...(credentials.yearClass !== undefined ? { yearClass: credentials.yearClass } : {}),
+        ...(credentials.memClass !== undefined ? { memClass: credentials.memClass } : {})
+    }
+}
+
 export function buildCommsConfig(
     logger: Logger,
     credentials: WaAuthCredentials,
@@ -81,15 +98,25 @@ export function buildCommsConfig(
     const registered = meJid !== null && meJid !== undefined
     const loginIdentity = registered ? getLoginIdentity(meJid) : null
     const wsProxy = socketOptions.proxy?.ws
-    const mobileTransport = clientOptions.mobileTransport
+    // Resolve the effective mobile transport: explicit option wins, otherwise
+    // synthesize one from persisted credentials.deviceInfo so a registered
+    // mobile session boots in mobile mode without the caller re-passing
+    // deviceInfo on every `new WaClient(...)` call.
+    const effectiveMobileTransport =
+        clientOptions.mobileTransport ?? mobileTransportFromCredentials(credentials)
     logger.debug('building comms config from credentials', {
         registered,
         hasServerStaticKey:
             credentials.serverStaticKey !== null && credentials.serverStaticKey !== undefined,
-        mobile: Boolean(mobileTransport)
+        mobile: Boolean(effectiveMobileTransport),
+        mobileSource: clientOptions.mobileTransport
+            ? 'option'
+            : effectiveMobileTransport
+              ? 'credentials'
+              : 'none'
     })
 
-    if (mobileTransport) {
+    if (effectiveMobileTransport) {
         if (wsProxy) {
             throw new Error(
                 'mobileTransport does not support socketOptions.proxy.ws — remove the proxy option or open an issue to add TCP proxy support'
@@ -103,14 +130,14 @@ export function buildCommsConfig(
         const loginPayload = buildMobileLoginPayload({
             username: loginIdentity.username,
             device: loginIdentity.device,
-            passive: mobileTransport.passive ?? false,
-            deviceInfo: mobileTransport.deviceInfo,
-            pushName: mobileTransport.pushName,
-            yearClass: mobileTransport.yearClass,
-            memClass: mobileTransport.memClass
+            passive: effectiveMobileTransport.passive ?? false,
+            deviceInfo: effectiveMobileTransport.deviceInfo,
+            pushName: effectiveMobileTransport.pushName,
+            yearClass: effectiveMobileTransport.yearClass,
+            memClass: effectiveMobileTransport.memClass
         })
         return {
-            url: mobileTransport.tcpUrl ?? 'tcp://g.whatsapp.net:443',
+            url: effectiveMobileTransport.tcpUrl ?? 'tcp://g.whatsapp.net:443',
             rawWebSocketConstructor: WaMobileTcpSocketCtor,
             connectTimeoutMs: socketOptions.connectTimeoutMs,
             reconnectIntervalMs: socketOptions.reconnectIntervalMs,

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -25,6 +25,10 @@ export interface WaAuthCredentials {
     readonly abPropsVersion?: number
     readonly connectionLocation?: string
     readonly accountCreationTs?: number
+    readonly deviceInfo?: WaMobileTransportDeviceInfo
+    readonly pushName?: string
+    readonly yearClass?: number
+    readonly memClass?: number
 }
 
 export type WaAuthSocketOptions = Pick<


### PR DESCRIPTION
Adds optional deviceInfo/pushName/yearClass/memClass fields to WaAuthCredentials and persists them across all five storage backends (sqlite, postgres, mysql, mongo, redis) so a registered mobile session boots in mobile mode without re-passing the fingerprint on every WaClient construction.

- Schema migrations 0011 for sqlite/postgres/mysql add device_info (TEXT/JSON), push_name, year_class, mem_class columns. Mongo/redis are schema-flexible — only doc/hash field additions.
- buildCommsConfig now falls back to credentials.deviceInfo when clientOptions.mobileTransport is absent. Explicit option still wins.
- Tests cover both fallback and override paths.
- examples/tsconfig.json: add explicit zapo-js/proto path mapping to fix tsc resolution under examples/ (mirrors packages/tsconfig.paths.json).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mobile sessions now automatically recover device configuration from stored credentials, eliminating the need to re-supply information on reconnection.
  * Extended credential persistence across all supported databases to include device and system information.

* **Tests**
  * Added tests validating mobile transport configuration behavior and credential-based device recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->