### PR TITLE
fix(transport): route encrypt/dirty/status iqs through mobile system id pool

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -178,7 +178,7 @@ export class WaClient extends EventEmitter {
             base,
             runtime: {
                 sendNode: (node) => this.sendNode(node),
-                query: (node, timeoutMs) => this.query(node, timeoutMs),
+                query: (node, timeoutMs, options) => this.query(node, timeoutMs, options),
                 queryWithContext: this.queryWithContext.bind(this),
                 syncAppState: () => this.syncAppState().then(() => {}),
                 syncAppStateWithOptions: (syncOptions) => this.syncAppState(syncOptions),
@@ -270,13 +270,14 @@ export class WaClient extends EventEmitter {
 
     public async query(
         node: BinaryNode,
-        timeoutMs: number = this.options.iqTimeoutMs ?? WA_DEFAULTS.IQ_TIMEOUT_MS
+        timeoutMs: number = this.options.iqTimeoutMs ?? WA_DEFAULTS.IQ_TIMEOUT_MS,
+        options: { readonly useSystemId?: boolean } = {}
     ): Promise<BinaryNode> {
         if (!this.connectionManager.isConnected()) {
             throw new Error('client is not connected')
         }
         this.logger.debug('wa client query', { tag: node.tag, id: node.attrs.id, timeoutMs })
-        return this.nodeOrchestrator.query(node, timeoutMs)
+        return this.nodeOrchestrator.query(node, timeoutMs, options)
     }
 
     public registerIncomingHandler(registration: WaIncomingNodeHandlerRegistration): () => void {
@@ -570,10 +571,11 @@ export class WaClient extends EventEmitter {
         context: string,
         node: BinaryNode,
         timeoutMs: number = this.options.iqTimeoutMs ?? WA_DEFAULTS.IQ_TIMEOUT_MS,
-        contextData: Readonly<Record<string, unknown>> = {}
+        contextData: Readonly<Record<string, unknown>> = {},
+        options: { readonly useSystemId?: boolean } = {}
     ): Promise<BinaryNode> {
         return queryNodeWithContext(
-            async (queryNode, queryTimeoutMs) => this.query(queryNode, queryTimeoutMs),
+            async (queryNode, queryTimeoutMs) => this.query(queryNode, queryTimeoutMs, options),
             this.logger,
             context,
             node,

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -95,12 +95,17 @@ interface WaClientBase {
 
 interface WaClientBuildRuntime {
     readonly sendNode: (node: BinaryNode) => Promise<void>
-    readonly query: (node: BinaryNode, timeoutMs?: number) => Promise<BinaryNode>
+    readonly query: (
+        node: BinaryNode,
+        timeoutMs?: number,
+        options?: { readonly useSystemId?: boolean }
+    ) => Promise<BinaryNode>
     readonly queryWithContext: (
         context: string,
         node: BinaryNode,
         timeoutMs?: number,
-        contextData?: Readonly<Record<string, unknown>>
+        contextData?: Readonly<Record<string, unknown>>,
+        options?: { readonly useSystemId?: boolean }
     ) => Promise<BinaryNode>
     readonly syncAppState: () => Promise<void>
     readonly syncAppStateWithOptions: (
@@ -321,7 +326,8 @@ function createPassiveTasksRuntime(input: {
         context: string,
         node: BinaryNode,
         timeoutMs?: number,
-        contextData?: Readonly<Record<string, unknown>>
+        contextData?: Readonly<Record<string, unknown>>,
+        options?: { readonly useSystemId?: boolean }
     ) => Promise<BinaryNode>
     readonly authClient: WaAuthClient
     readonly nodeOrchestrator: WaNodeOrchestrator
@@ -438,9 +444,12 @@ export function buildWaClientDependencies(input: {
         },
         logger
     )
+    const signalSystemQuery: WaClientBuildRuntime['query'] = (node, timeoutMs) =>
+        runtime.query(node, timeoutMs, { useSystemId: true })
+
     const signalDigestSync = new SignalDigestSyncApi({
         logger,
-        query: runtime.query,
+        query: signalSystemQuery,
         signalStore: sessionStore.signal,
         preKeyStore: sessionStore.preKey,
         defaultTimeoutMs: options.signalFetchKeyBundlesTimeoutMs
@@ -455,24 +464,24 @@ export function buildWaClientDependencies(input: {
     })
     const signalIdentitySync = new SignalIdentitySyncApi({
         logger,
-        query: runtime.query,
+        query: signalSystemQuery,
         identityStore: sessionStore.identity,
         defaultTimeoutMs: options.signalFetchKeyBundlesTimeoutMs
     })
     const signalMissingPreKeysSync = new SignalMissingPreKeysSyncApi({
         logger,
-        query: runtime.query,
+        query: signalSystemQuery,
         defaultTimeoutMs: options.signalFetchKeyBundlesTimeoutMs
     })
     const signalRotateKey = new SignalRotateKeyApi({
         logger,
-        query: runtime.query,
+        query: signalSystemQuery,
         signalStore: sessionStore.signal,
         defaultTimeoutMs: options.signalFetchKeyBundlesTimeoutMs
     })
     const signalSessionSync = new SignalSessionSyncApi({
         logger,
-        query: runtime.query,
+        query: signalSystemQuery,
         defaultTimeoutMs: options.signalFetchKeyBundlesTimeoutMs
     })
 

--- a/src/client/coordinators/WaPassiveTasksCoordinator.ts
+++ b/src/client/coordinators/WaPassiveTasksCoordinator.ts
@@ -24,7 +24,8 @@ type WaPassiveTasksRuntime = {
         context: string,
         node: BinaryNode,
         timeoutMs?: number,
-        contextData?: Readonly<Record<string, unknown>>
+        contextData?: Readonly<Record<string, unknown>>,
+        options?: { readonly useSystemId?: boolean }
     ) => Promise<BinaryNode>
     readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly persistServerHasPreKeys: (serverHasPreKeys: boolean) => Promise<void>
@@ -212,12 +213,7 @@ export class WaPassiveTasksCoordinator {
         }
 
         const lastPreKeyId = preKeys[preKeys.length - 1].keyId
-        const uploadNode = buildPreKeyUploadIq(
-            registrationInfo,
-            signedPreKey,
-            preKeys,
-            this.mobilePrimary ? { opMode: 'set' } : undefined
-        )
+        const uploadNode = buildPreKeyUploadIq(registrationInfo, signedPreKey, preKeys)
         const response = await this.runtime.queryWithContext(
             'prekeys.upload',
             uploadNode,
@@ -225,7 +221,8 @@ export class WaPassiveTasksCoordinator {
             {
                 count: preKeys.length,
                 lastPreKeyId
-            }
+            },
+            this.mobilePrimary ? { useSystemId: true } : undefined
         )
         if (response.attrs.type === 'result') {
             // Mark uploaded key first so the serverHasPreKeys flag never commits ahead of local key progress.

--- a/src/client/coordinators/WaProfileCoordinator.ts
+++ b/src/client/coordinators/WaProfileCoordinator.ts
@@ -60,7 +60,8 @@ interface WaProfileCoordinatorOptions {
         context: string,
         node: BinaryNode,
         timeoutMs?: number,
-        contextData?: Readonly<Record<string, unknown>>
+        contextData?: Readonly<Record<string, unknown>>,
+        options?: { readonly useSystemId?: boolean }
     ) => Promise<BinaryNode>
     readonly generateSid: () => Promise<string>
 }
@@ -252,7 +253,9 @@ export function createProfileCoordinator(
 
         setStatus: async (text) => {
             const node = buildSetStatusIq(text)
-            const result = await queryWithContext('profile.setStatus', node)
+            const result = await queryWithContext('profile.setStatus', node, undefined, undefined, {
+                useSystemId: true
+            })
             assertIqResult(result, 'profile.setStatus')
         },
 

--- a/src/client/dirty.ts
+++ b/src/client/dirty.ts
@@ -35,7 +35,8 @@ interface WaDirtySyncRuntime {
         context: string,
         node: BinaryNode,
         timeoutMs?: number,
-        contextData?: Readonly<Record<string, unknown>>
+        contextData?: Readonly<Record<string, unknown>>,
+        options?: { readonly useSystemId?: boolean }
     ) => Promise<BinaryNode>
     readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly syncAppState: () => Promise<void>
@@ -373,7 +374,8 @@ async function clearDirtyBits(
             WA_DEFAULTS.IQ_TIMEOUT_MS,
             {
                 count: dirtyBits.length
-            }
+            },
+            { useSystemId: true }
         )
         runtime.logger.info('dirty bits cleared', {
             count: dirtyBits.length

--- a/src/transport/node/WaNodeOrchestrator.ts
+++ b/src/transport/node/WaNodeOrchestrator.ts
@@ -110,8 +110,12 @@ export class WaNodeOrchestrator {
         await this.sendNodeFn(outbound)
     }
 
-    public async query(node: BinaryNode, timeoutMs = this.defaultTimeoutMs): Promise<BinaryNode> {
-        const outbound = await this.withAutoId(node)
+    public async query(
+        node: BinaryNode,
+        timeoutMs = this.defaultTimeoutMs,
+        options: { readonly useSystemId?: boolean } = {}
+    ): Promise<BinaryNode> {
+        const outbound = await this.withAutoId(node, options.useSystemId === true)
         const id = outbound.attrs.id
         if (!id) {
             throw new Error('query node id is required')
@@ -151,12 +155,14 @@ export class WaNodeOrchestrator {
         })
     }
 
-    private async withAutoId(node: BinaryNode): Promise<BinaryNode> {
+    private async withAutoId(node: BinaryNode, useSystemId = false): Promise<BinaryNode> {
         if (node.attrs.id) {
             return node
         }
-        const generatedId = (await this.getIdGenerator()).next()
-        this.logger.trace('generated stanza id', { id: generatedId })
+        const generator = await this.getIdGenerator()
+        const generatedId =
+            useSystemId && generator.nextSystem ? generator.nextSystem() : generator.next()
+        this.logger.trace('generated stanza id', { id: generatedId, system: useSystemId })
         return {
             ...node,
             attrs: {

--- a/src/transport/node/__tests__/helpers.test.ts
+++ b/src/transport/node/__tests__/helpers.test.ts
@@ -31,3 +31,23 @@ test('createMobileNodeIdGenerator wraps at 65536', () => {
     assert.equal(gen.next(), '0ffff')
     assert.equal(gen.next(), '00')
 })
+
+test('createMobileNodeIdGenerator nextSystem produces pure-hex ids without prefix', () => {
+    const gen = createMobileNodeIdGenerator()
+    assert.equal(typeof gen.nextSystem, 'function')
+    const ids: string[] = []
+    for (let i = 0; i < 260; i++) ids.push(gen.nextSystem!())
+    assert.equal(ids[0], '1')
+    assert.equal(ids[14], 'f')
+    assert.equal(ids[15], '10')
+    assert.equal(ids[254], 'ff')
+    assert.equal(ids[255], '100')
+})
+
+test('createMobileNodeIdGenerator next and nextSystem track independent counters', () => {
+    const gen = createMobileNodeIdGenerator()
+    assert.equal(gen.next(), '00')
+    assert.equal(gen.nextSystem!(), '1')
+    assert.equal(gen.next(), '01')
+    assert.equal(gen.nextSystem!(), '2')
+})

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -958,24 +958,17 @@ test('prekeys builders include expected key material and targets', () => {
     assert.ok(Array.isArray(upload.content))
     assert.notEqual(upload.content[0].tag, 'op')
 
-    const uploadMobile = buildPreKeyUploadIq(
-        registrationInfo,
-        signedPreKey,
-        [
-            {
-                keyId: 12,
-                keyPair: {
-                    pubKey: new Uint8Array(32).fill(7),
-                    privKey: new Uint8Array(32).fill(8)
-                },
-                uploaded: false
-            }
-        ],
-        { opMode: 'set' }
-    )
+    const uploadMobile = buildPreKeyUploadIq(registrationInfo, signedPreKey, [
+        {
+            keyId: 12,
+            keyPair: {
+                pubKey: new Uint8Array(32).fill(7),
+                privKey: new Uint8Array(32).fill(8)
+            },
+            uploaded: false
+        }
+    ])
     assert.ok(Array.isArray(uploadMobile.content))
-    assert.equal(uploadMobile.content[0].tag, 'op')
-    assert.equal(uploadMobile.content[0].attrs.mode, 'set')
 
     const fetch = buildMissingPreKeysFetchIq([
         {

--- a/src/transport/node/builders/prekeys.ts
+++ b/src/transport/node/builders/prekeys.ts
@@ -33,16 +33,9 @@ function buildSignedPreKeyNode(signedPreKey: SignedPreKeyRecord) {
 export function buildPreKeyUploadIq(
     registrationInfo: RegistrationInfo,
     signedPreKey: SignedPreKeyRecord,
-    preKeys: readonly PreKeyRecord[],
-    options?: { readonly opMode?: 'set' | 'add' }
+    preKeys: readonly PreKeyRecord[]
 ) {
     const children: BinaryNode[] = []
-    if (options?.opMode) {
-        children.push({
-            tag: WA_NODE_TAGS.OP,
-            attrs: { mode: options.opMode }
-        })
-    }
     children.push(
         {
             tag: WA_NODE_TAGS.REGISTRATION,

--- a/src/transport/node/helpers.ts
+++ b/src/transport/node/helpers.ts
@@ -10,6 +10,7 @@ const NODE_ID_PREFIX_SEED = new Uint8Array(4)
 export interface NodeIdGenerator {
     readonly prefix: string
     next(): string
+    nextSystem?(): string
 }
 
 export function getNodeChildren(node: BinaryNode): readonly BinaryNode[] {
@@ -188,13 +189,18 @@ export async function createNodeIdGenerator(): Promise<NodeIdGenerator> {
 }
 
 export function createMobileNodeIdGenerator(): NodeIdGenerator {
-    let counter = 0
+    let featureCounter = 0
+    let systemCounter = 0
     return {
         prefix: '0',
         next(): string {
-            const id = `0${counter.toString(16)}`
-            counter = (counter + 1) & 0xffff
+            const id = `0${featureCounter.toString(16)}`
+            featureCounter = (featureCounter + 1) & 0xffff
             return id
+        },
+        nextSystem(): string {
+            systemCounter = (systemCounter + 1) & 0xffff
+            return systemCounter.toString(16)
         }
     }
 }


### PR DESCRIPTION
Mobile sessions emit two parallel iq-id formats: a system pool of pure hex ("1","2","f","10","ff",…) for connection/signal-level stanzas, and a feature pool prefixed with "0" ("00","01","0f","010",…) for app features. The "0" prefix on the feature pool keeps the two counter ranges from colliding in the shared response callback map.

zapo's mobile generator was emitting the "0"-prefix format for every outgoing iq, including stanzas that must use the system pool. As a result the prekey upload (and other encrypt-namespace iqs) hung — the server never matched the response back to the pending request.

The mobile id generator now keeps both counters internally and exposes a nextSystem() function alongside next(). Orchestrator, client and queryWithContext accept a { useSystemId } option that selects the system pool when available and falls back to next() for generators that don't implement it (multi-device companion path is unaffected).

System callsites converted:
  - prekey upload (encrypt)
  - signed-prekey rotate (encrypt)
  - identity / session / digest / missing-prekey fetch (encrypt)
  - dirty-bits clear (urn:xmpp:whatsapp:dirty)
  - profile.setStatus (status)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced query execution mechanism with system ID support across client operations, enabling improved routing of system-level queries through the runtime layer.

* **Tests**
  * Added test coverage for system ID generation and interleaved counter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->