### PR TITLE
fix(signal): normalize prekey pub keys to raw 32 bytes on wire and on digest compare

### DIFF
--- a/src/signal/api/SignalDigestSyncApi.ts
+++ b/src/signal/api/SignalDigestSyncApi.ts
@@ -1,4 +1,5 @@
 import { sha1 } from '@crypto'
+import { toRawPubKey } from '@crypto/core/keys'
 import type { Logger } from '@infra/log/types'
 import { WA_DEFAULTS, WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
 import { decodeExactLength, parseUint } from '@signal/api/codec'
@@ -168,7 +169,12 @@ export class SignalDigestSyncApi {
                 preKeyCount: digest.preKeyIds.length
             }
         }
-        if (!uint8Equal(registrationInfo.identityKeyPair.pubKey, digest.identity)) {
+        if (
+            !uint8Equal(
+                toRawPubKey(registrationInfo.identityKeyPair.pubKey),
+                toRawPubKey(digest.identity)
+            )
+        ) {
             return {
                 valid: false,
                 shouldReupload: true,
@@ -178,7 +184,10 @@ export class SignalDigestSyncApi {
         }
         if (
             signedPreKey.keyId !== digest.signedKey.id ||
-            !uint8Equal(signedPreKey.keyPair.pubKey, digest.signedKey.publicKey) ||
+            !uint8Equal(
+                toRawPubKey(signedPreKey.keyPair.pubKey),
+                toRawPubKey(digest.signedKey.publicKey)
+            ) ||
             !uint8Equal(signedPreKey.signature, digest.signedKey.signature)
         ) {
             return {
@@ -191,8 +200,8 @@ export class SignalDigestSyncApi {
 
         const preKeys = await this.preKeyStore.getPreKeysById(digest.preKeyIds)
         const bytesToHash: Uint8Array[] = [
-            registrationInfo.identityKeyPair.pubKey,
-            signedPreKey.keyPair.pubKey,
+            toRawPubKey(registrationInfo.identityKeyPair.pubKey),
+            toRawPubKey(signedPreKey.keyPair.pubKey),
             signedPreKey.signature
         ]
         for (let index = 0; index < preKeys.length; index += 1) {
@@ -205,7 +214,7 @@ export class SignalDigestSyncApi {
                     preKeyCount: digest.preKeyIds.length
                 }
             }
-            bytesToHash.push(preKey.keyPair.pubKey)
+            bytesToHash.push(toRawPubKey(preKey.keyPair.pubKey))
         }
 
         const localHash = (await sha1(concatBytes(bytesToHash))).subarray(0, digest.hash.byteLength)

--- a/src/transport/node/builders/prekeys.ts
+++ b/src/transport/node/builders/prekeys.ts
@@ -1,3 +1,4 @@
+import { toRawPubKey } from '@crypto/core/keys'
 import { WA_DEFAULTS, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
 import { SIGNAL_KEY_BUNDLE_TYPE_BYTES } from '@signal/api/constants'
 import type { SignalMissingPreKeysTarget } from '@signal/api/SignalMissingPreKeysSyncApi'
@@ -19,7 +20,7 @@ function buildSignedPreKeyNode(signedPreKey: SignedPreKeyRecord) {
             {
                 tag: WA_NODE_TAGS.VALUE,
                 attrs: {},
-                content: signedPreKey.keyPair.pubKey
+                content: toRawPubKey(signedPreKey.keyPair.pubKey)
             },
             {
                 tag: WA_NODE_TAGS.SIGNATURE,
@@ -38,6 +39,11 @@ export function buildPreKeyUploadIq(
     const children: BinaryNode[] = []
     children.push(
         {
+            tag: WA_NODE_TAGS.IDENTITY,
+            attrs: {},
+            content: toRawPubKey(registrationInfo.identityKeyPair.pubKey)
+        },
+        {
             tag: WA_NODE_TAGS.REGISTRATION,
             attrs: {},
             content: intToBytes(4, registrationInfo.registrationId)
@@ -46,11 +52,6 @@ export function buildPreKeyUploadIq(
             tag: WA_NODE_TAGS.TYPE,
             attrs: {},
             content: SIGNAL_KEY_BUNDLE_TYPE_BYTES
-        },
-        {
-            tag: WA_NODE_TAGS.IDENTITY,
-            attrs: {},
-            content: registrationInfo.identityKeyPair.pubKey
         },
         {
             tag: WA_NODE_TAGS.LIST,
@@ -67,7 +68,7 @@ export function buildPreKeyUploadIq(
                     {
                         tag: WA_NODE_TAGS.VALUE,
                         attrs: {},
-                        content: record.keyPair.pubKey
+                        content: toRawPubKey(record.keyPair.pubKey)
                     }
                 ]
             }))


### PR DESCRIPTION
Prekey-bundle public keys arrive in two shapes depending on origin: the in-process X25519 generator yields 32 raw bytes, while keys imported from an external WhatsApp credential bundle land in storage as the libsignal 33-byte serialized form (`0x05 || raw32`). The wire format the server expects is the 32 raw bytes — confirmed byte-for-byte by the digest-fetch response, which echoes the stored identity and signed-prekey value as 32-byte payloads.

Two consequences were observed end-to-end:

1. The prekey upload IQ for a bundle-imported account emitted the `<skey><value>` body as 33 bytes (with the 0x05 prefix). The server silently dropped the upload and pushed back a `<count value='0'/>` notification, which in turn re-triggered the upload — leaving the account permanently unable to publish prekeys.

2. The local digest validation compared `signedPreKey.keyPair.pubKey` directly against `digest.signedKey.publicKey`. With the same length asymmetry as above, the byte-equality check always failed with `signed_prekey_mismatch`, which flipped `serverHasPreKeys` back to `false`. Every reconnect therefore re-uploaded all 812 prekeys.

The builder now passes `<identity>`, `<skey><value>` and each `<key><value>` through `toRawPubKey(...)` before serialization, which strips the 0x05 prefix when present and is a no-op on already-raw 32 byte buffers. The digest validator applies the same normalization on both sides of the public-key comparisons and on the inputs to the hash used for the bundle integrity check, so 32-raw and 33-prefixed representations of the same key compare equal.

Net effect:

- Multi-device companion sessions are unchanged: in-process keys are generated raw, so `toRawPubKey` is a no-op there.
- Mobile sessions seeded from an extracted bundle now publish prekeys on the first connect after seeding and skip re-upload on every subsequent reconnect, with `signal digest validated` on the warm path.