### PR TITLE
fix(client): correct offline resume semantics and drop batch loop

### DIFF
--- a/src/client/coordinators/WaIncomingNodeCoordinator.ts
+++ b/src/client/coordinators/WaIncomingNodeCoordinator.ts
@@ -394,11 +394,13 @@ export class WaIncomingNodeCoordinator {
                 )
                 if (child.tag === 'offline_preview') {
                     this.offlineResume.handleOfflinePreview(
-                        parseOptionalInt(child.attrs.message) ?? 0
+                        parseOptionalInt(child.attrs.count) ?? 0
                     )
                 }
                 if (child.tag === 'offline') {
-                    this.offlineResume.handleOfflineComplete()
+                    this.offlineResume.handleOfflineComplete(
+                        parseOptionalInt(child.attrs.count) ?? 0
+                    )
                 }
                 handled = true
             }

--- a/src/client/coordinators/WaOfflineResumeCoordinator.ts
+++ b/src/client/coordinators/WaOfflineResumeCoordinator.ts
@@ -6,7 +6,6 @@ import { toError } from '@util/primitives'
 
 const WA_OFFLINE_RESUME = Object.freeze({
     BATCH_SIZE: 200,
-    BATCH_DEBOUNCE_MS: 100,
     STANZA_TIMEOUT_MS: 60_000
 } as const)
 
@@ -32,20 +31,16 @@ export class WaOfflineResumeCoordinator {
     private readonly logger: Logger
     private readonly runtime: WaOfflineResumeRuntime
     private state: WaOfflineResumeState
-    private totalMessages: number
-    private pendingMessages: number
-    private batchInFlight: boolean
-    private batchDebounce: ReturnType<typeof setTimeout> | null
+    private totalStanzas: number
+    private pendingStanzas: number
     private stanzaTimeout: ReturnType<typeof setTimeout> | null
 
     public constructor(options: WaOfflineResumeCoordinatorOptions) {
         this.logger = options.logger
         this.runtime = options.runtime
         this.state = WA_OFFLINE_RESUME_STATE.INIT
-        this.totalMessages = 0
-        this.pendingMessages = 0
-        this.batchInFlight = false
-        this.batchDebounce = null
+        this.totalStanzas = 0
+        this.pendingStanzas = 0
         this.stanzaTimeout = null
     }
 
@@ -57,93 +52,70 @@ export class WaOfflineResumeCoordinator {
         return this.state === WA_OFFLINE_RESUME_STATE.RESUMING
     }
 
-    public handleOfflinePreview(messageCount: number): void {
+    public handleOfflinePreview(stanzaCount: number): void {
         this.clearTimers()
         this.state = WA_OFFLINE_RESUME_STATE.RESUMING
-        this.totalMessages = messageCount
-        this.pendingMessages = messageCount
-        this.batchInFlight = false
+        this.totalStanzas = stanzaCount
+        this.pendingStanzas = stanzaCount
         this.logger.info('offline resume started', {
-            totalMessages: messageCount
+            totalStanzas: stanzaCount
         })
         this.runtime.emitOfflineResume({
             status: 'resuming',
-            totalMessages: messageCount,
-            remainingMessages: messageCount,
+            totalStanzas: stanzaCount,
+            remainingStanzas: stanzaCount,
             forced: false
         })
-        this.resetBatchDebounce()
+        void this.sendOfflineBatch()
         this.resetStanzaTimeout()
     }
 
-    public handleOfflineComplete(): void {
+    public handleOfflineComplete(serverStanzaCount: number): void {
         if (this.state !== WA_OFFLINE_RESUME_STATE.RESUMING) {
             return
         }
-        this.completeResume(false)
+        this.completeResume(false, serverStanzaCount)
     }
 
     public trackOfflineStanza(): void {
         if (this.state !== WA_OFFLINE_RESUME_STATE.RESUMING) {
             return
         }
-        this.pendingMessages = Math.max(0, this.pendingMessages - 1)
-        this.resetBatchDebounce()
+        this.pendingStanzas = Math.max(0, this.pendingStanzas - 1)
         this.resetStanzaTimeout()
     }
 
     public reset(): void {
         this.clearTimers()
         this.state = WA_OFFLINE_RESUME_STATE.INIT
-        this.totalMessages = 0
-        this.pendingMessages = 0
-        this.batchInFlight = false
+        this.totalStanzas = 0
+        this.pendingStanzas = 0
     }
 
-    private completeResume(forced: boolean): void {
+    private completeResume(forced: boolean, serverStanzaCount?: number): void {
         this.clearTimers()
         this.state = WA_OFFLINE_RESUME_STATE.COMPLETE
         this.logger.info('offline resume complete', {
-            totalMessages: this.totalMessages,
-            remainingMessages: this.pendingMessages,
+            totalStanzas: this.totalStanzas,
+            remainingStanzas: this.pendingStanzas,
+            serverStanzaCount,
             forced
         })
         this.runtime.emitOfflineResume({
             status: 'complete',
-            totalMessages: this.totalMessages,
-            remainingMessages: this.pendingMessages,
+            totalStanzas: this.totalStanzas,
+            remainingStanzas: this.pendingStanzas,
             forced
         })
     }
 
-    private resetBatchDebounce(): void {
-        if (this.batchDebounce !== null) {
-            clearTimeout(this.batchDebounce)
-        }
-        this.batchDebounce = setTimeout(() => {
-            this.batchDebounce = null
-            if (this.state === WA_OFFLINE_RESUME_STATE.RESUMING && !this.batchInFlight) {
-                void this.sendOfflineBatch()
-            }
-        }, WA_OFFLINE_RESUME.BATCH_DEBOUNCE_MS)
-    }
-
     private async sendOfflineBatch(): Promise<void> {
-        if (this.state !== WA_OFFLINE_RESUME_STATE.RESUMING || this.batchInFlight) {
-            return
-        }
-        this.batchInFlight = true
         try {
             await this.runtime.sendNode(buildOfflineBatchNode(WA_OFFLINE_RESUME.BATCH_SIZE))
-            this.logger.debug('sent offline batch request', {
-                pending: this.pendingMessages
-            })
         } catch (err: unknown) {
             this.logger.warn('offline batch request failed', {
                 message: toError(err).message
             })
-        } finally {
-            this.batchInFlight = false
         }
     }
 
@@ -155,8 +127,8 @@ export class WaOfflineResumeCoordinator {
             this.stanzaTimeout = null
             if (this.state === WA_OFFLINE_RESUME_STATE.RESUMING) {
                 this.logger.warn('offline resume forced complete due to stanza timeout', {
-                    totalMessages: this.totalMessages,
-                    remainingMessages: this.pendingMessages
+                    totalStanzas: this.totalStanzas,
+                    remainingStanzas: this.pendingStanzas
                 })
                 this.completeResume(true)
             }
@@ -164,10 +136,6 @@ export class WaOfflineResumeCoordinator {
     }
 
     private clearTimers(): void {
-        if (this.batchDebounce !== null) {
-            clearTimeout(this.batchDebounce)
-            this.batchDebounce = null
-        }
         if (this.stanzaTimeout !== null) {
             clearTimeout(this.stanzaTimeout)
             this.stanzaTimeout = null

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -229,8 +229,8 @@ test('incoming node coordinator emits info bulletin notifications and forwards o
         runtime,
         offlineResume: {
             trackOfflineStanza() {},
-            handleOfflinePreview(messageCount: number) {
-                previewCounts.push(messageCount)
+            handleOfflinePreview(stanzaCount: number) {
+                previewCounts.push(stanzaCount)
             },
             handleOfflineComplete() {
                 offlineCompleteCalls += 1
@@ -251,7 +251,7 @@ test('incoming node coordinator emits info bulletin notifications and forwards o
             {
                 tag: 'offline_preview',
                 attrs: {
-                    count: '1',
+                    count: '5',
                     message: '3',
                     t: '123'
                 }
@@ -259,13 +259,13 @@ test('incoming node coordinator emits info bulletin notifications and forwards o
             {
                 tag: 'offline',
                 attrs: {
-                    count: '3'
+                    count: '5'
                 }
             }
         ]
     })
 
-    assert.deepEqual(previewCounts, [3])
+    assert.deepEqual(previewCounts, [5])
     assert.equal(offlineCompleteCalls, 1)
     assert.equal(notifications.length, 2)
     assert.deepEqual(notifications[0], {
@@ -279,7 +279,7 @@ test('incoming node coordinator emits info bulletin notifications and forwards o
                 {
                     tag: 'offline_preview',
                     attrs: {
-                        count: '1',
+                        count: '5',
                         message: '3',
                         t: '123'
                     }
@@ -287,7 +287,7 @@ test('incoming node coordinator emits info bulletin notifications and forwards o
                 {
                     tag: 'offline',
                     attrs: {
-                        count: '3'
+                        count: '5'
                     }
                 }
             ]
@@ -298,7 +298,7 @@ test('incoming node coordinator emits info bulletin notifications and forwards o
         notificationType: 'ib.offline_preview',
         classification: 'info_bulletin',
         details: {
-            count: 1,
+            count: 5,
             message: 3,
             receipt: undefined,
             notification: undefined,
@@ -316,7 +316,7 @@ test('incoming node coordinator emits info bulletin notifications and forwards o
                 {
                     tag: 'offline_preview',
                     attrs: {
-                        count: '1',
+                        count: '5',
                         message: '3',
                         t: '123'
                     }
@@ -324,7 +324,7 @@ test('incoming node coordinator emits info bulletin notifications and forwards o
                 {
                     tag: 'offline',
                     attrs: {
-                        count: '3'
+                        count: '5'
                     }
                 }
             ]
@@ -335,7 +335,7 @@ test('incoming node coordinator emits info bulletin notifications and forwards o
         notificationType: 'ib.offline',
         classification: 'info_bulletin',
         details: {
-            count: 3,
+            count: 5,
             message: undefined,
             receipt: undefined,
             notification: undefined,

--- a/src/client/coordinators/__tests__/offline-resume-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/offline-resume-coordinator.test.ts
@@ -23,9 +23,7 @@ async function flushMicrotasks(): Promise<void> {
     await Promise.resolve()
 }
 
-test('offline resume coordinator emits preview event and requests offline batches', async (t) => {
-    t.mock.timers.enable({ apis: ['setTimeout'] })
-
+test('offline resume coordinator emits preview event and requests a single offline batch', async () => {
     const sentNodes: BinaryNode[] = []
     const emittedEvents: WaOfflineResumeEvent[] = []
     const coordinator = new WaOfflineResumeCoordinator({
@@ -41,24 +39,23 @@ test('offline resume coordinator emits preview event and requests offline batche
     })
 
     coordinator.handleOfflinePreview(3)
+    await flushMicrotasks()
 
     assert.equal(coordinator.isResuming, true)
     assert.deepEqual(emittedEvents, [
         {
             status: 'resuming',
-            totalMessages: 3,
-            remainingMessages: 3,
+            totalStanzas: 3,
+            remainingStanzas: 3,
             forced: false
         }
     ])
-
-    t.mock.timers.tick(100)
-    await flushMicrotasks()
-
     assert.deepEqual(sentNodes, [buildOfflineBatchNode(200)])
+
+    coordinator.reset()
 })
 
-test('offline resume coordinator decrements pending messages and force completes on timeout', async (t) => {
+test('offline resume coordinator decrements pending stanzas and force completes on timeout', async (t) => {
     t.mock.timers.enable({ apis: ['setTimeout'] })
 
     const emittedEvents: WaOfflineResumeEvent[] = []
@@ -80,8 +77,8 @@ test('offline resume coordinator decrements pending messages and force completes
     assert.equal(coordinator.isComplete, true)
     assert.deepEqual(emittedEvents[1], {
         status: 'complete',
-        totalMessages: 2,
-        remainingMessages: 1,
+        totalStanzas: 2,
+        remainingStanzas: 1,
         forced: true
     })
 })
@@ -100,13 +97,13 @@ test('offline resume coordinator completes when offline completion bulletin arri
 
     coordinator.handleOfflinePreview(1)
     coordinator.trackOfflineStanza()
-    coordinator.handleOfflineComplete()
+    coordinator.handleOfflineComplete(1)
 
     assert.equal(coordinator.isComplete, true)
     assert.deepEqual(emittedEvents[1], {
         status: 'complete',
-        totalMessages: 1,
-        remainingMessages: 0,
+        totalStanzas: 1,
+        remainingStanzas: 0,
         forced: false
     })
 })

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -458,8 +458,8 @@ export interface WaClientEventMap {
 
 export interface WaOfflineResumeEvent {
     readonly status: 'resuming' | 'complete'
-    readonly totalMessages: number
-    readonly remainingMessages: number
+    readonly totalStanzas: number
+    readonly remainingStanzas: number
     readonly forced: boolean
 }
 


### PR DESCRIPTION
Read attrs.count (total stanza count) from <offline_preview> and propagate the count from <offline> completion bulletin, matching /deobfuscated and parity with Baileys. Send a single offline_batch on preview instead of debouncing repeated batch requests, which caused decrypt-pipeline storms on accounts with thousands of pending offline stanzas.

Rename WaOfflineResumeEvent.totalMessages/remainingMessages to totalStanzas/remainingStanzas to reflect actual semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized offline message recovery by enabling immediate batch request processing, reducing synchronization delays when transitioning back online.
  * Refined progress tracking during offline message recovery with improved accuracy and more granular metrics.
  * Enhanced offline synchronization handling for better overall reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->