### PR TITLE
feat(client): handle mobile-flow registration notifications for code and account takeover

### DIFF
--- a/examples/wa-mobile-from-core-bundle.ts
+++ b/examples/wa-mobile-from-core-bundle.ts
@@ -1,0 +1,315 @@
+import { randomBytes } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+
+import { createSqliteStore } from '@zapo-js/store-sqlite'
+
+import { createPinoLogger, createStore, WaClient } from '../src'
+import { persistCredentials } from '../src/auth/credentials-flow'
+import type { WaAuthCredentials, WaMobileTransportDeviceInfo } from '../src/auth/types'
+import { base64ToBytes } from '../src/util/bytes'
+
+interface CoreBundle {
+    readonly captured_at: number
+    readonly register: {
+        readonly parsed: {
+            readonly login?: string
+            readonly lid?: string
+            readonly new_jid?: string
+            readonly status?: string
+            readonly edge_routing_info?: string
+            readonly server_time?: number
+        }
+        readonly raw: string
+    }
+    readonly keys: {
+        readonly generation?: string
+        readonly noise: { priv_b64: string; pub_b64: string }
+        readonly identity: { priv_b64: string; pub_b64: string; pub_prefixed_b64?: string }
+        readonly signedPreKey: { id: number; priv_b64: string; pub_b64: string; sig_b64: string }
+        readonly regId: { regId: number }
+        readonly deviceInfo?: {
+            manufacturer?: string | null
+            device?: string | null
+            model?: string | null
+            deviceBoard?: string | null
+            osVersion?: string | null
+            osBuildNumber?: string | null
+            appVersion?: string | null
+            mcc?: string | null
+            mnc?: string | null
+            localeLanguageIso6391?: string | null
+            localeCountryIso31661Alpha2?: string | null
+            yearClass?: number | null
+            memClass?: number | null
+            pushName?: string | null
+            phoneId?: string | null
+        }
+    }
+}
+
+function requireBundleDeviceInfo(
+    bundle: CoreBundle
+): NonNullable<CoreBundle['keys']['deviceInfo']> {
+    const d = bundle.keys.deviceInfo
+    if (!d) {
+        throw new Error(
+            'bundle missing keys.deviceInfo — re-run core/ pipeline after updating wa-key-extract.js'
+        )
+    }
+    return d
+}
+
+function deviceInfoFromBundle(bundle: CoreBundle): WaMobileTransportDeviceInfo {
+    const d = requireBundleDeviceInfo(bundle)
+    const required = (name: keyof typeof d): string => {
+        const value = d[name]
+        if (typeof value !== 'string' || value.length === 0) {
+            throw new Error(`bundle deviceInfo.${String(name)} missing or empty`)
+        }
+        return value
+    }
+    const optionalString = (name: keyof typeof d): string | undefined => {
+        const value = d[name]
+        return typeof value === 'string' && value.length > 0 ? value : undefined
+    }
+    return {
+        manufacturer: required('manufacturer'),
+        device: required('device'),
+        osVersion: required('osVersion'),
+        osBuildNumber: required('osBuildNumber'),
+        appVersion: required('appVersion'),
+        mcc: optionalString('mcc'),
+        mnc: optionalString('mnc'),
+        localeLanguageIso6391: optionalString('localeLanguageIso6391'),
+        localeCountryIso31661Alpha2: optionalString('localeCountryIso31661Alpha2'),
+        deviceBoard: optionalString('deviceBoard'),
+        deviceModelType: optionalString('model'),
+        phoneId: optionalString('phoneId')
+    }
+}
+
+function transportOptionsFromBundle(bundle: CoreBundle): {
+    deviceInfo: WaMobileTransportDeviceInfo
+    pushName?: string
+    yearClass?: number
+    memClass?: number
+} {
+    const d = requireBundleDeviceInfo(bundle)
+    const deviceInfo = deviceInfoFromBundle(bundle)
+    const pushName =
+        typeof d.pushName === 'string' && d.pushName.length > 0 ? d.pushName : undefined
+    const yearClass = typeof d.yearClass === 'number' ? d.yearClass : undefined
+    const memClass = typeof d.memClass === 'number' ? d.memClass : undefined
+    return { deviceInfo, pushName, yearClass, memClass }
+}
+
+function parseArgs(): {
+    bundlePath: string
+    sessionId: string
+} {
+    const argv = process.argv.slice(2)
+    const get = (flag: string): string | undefined => {
+        const i = argv.indexOf(flag)
+        return i >= 0 ? argv[i + 1] : undefined
+    }
+    const bundlePath = get('--bundle')
+    if (!bundlePath) {
+        console.error(
+            'usage: pnpm tsx examples/wa-mobile-from-core-bundle.ts ' +
+                '--bundle <acct_*.json> [--session <id>]'
+        )
+        process.exit(1)
+    }
+    return {
+        bundlePath: resolve(bundlePath),
+        sessionId: get('--session') ?? `mobile_${Date.now()}`
+    }
+}
+
+function credentialsFromBundle(bundle: CoreBundle): WaAuthCredentials {
+    const { keys, register } = bundle
+    const reg = register.parsed
+    if (!reg.login) {
+        throw new Error('bundle missing register.parsed.login — not a successful /v2/register')
+    }
+    if (!keys.regId || typeof keys.regId.regId !== 'number') {
+        throw new Error('bundle missing keys.regId.regId — Frida extraction failed?')
+    }
+    const transport = transportOptionsFromBundle(bundle)
+    return {
+        noiseKeyPair: {
+            privKey: base64ToBytes(keys.noise.priv_b64),
+            pubKey: base64ToBytes(keys.noise.pub_b64)
+        },
+        registrationInfo: {
+            registrationId: keys.regId.regId,
+            identityKeyPair: {
+                privKey: base64ToBytes(keys.identity.priv_b64),
+                pubKey: base64ToBytes(keys.identity.pub_b64)
+            }
+        },
+        signedPreKey: {
+            keyId: keys.signedPreKey.id,
+            keyPair: {
+                privKey: base64ToBytes(keys.signedPreKey.priv_b64),
+                pubKey: base64ToBytes(keys.signedPreKey.pub_b64)
+            },
+            signature: base64ToBytes(keys.signedPreKey.sig_b64),
+            uploaded: true
+        },
+        advSecretKey: new Uint8Array(randomBytes(32)),
+        meJid: reg.new_jid ?? `${reg.login}@s.whatsapp.net`,
+        meLid: reg.lid ? `${reg.lid}@lid` : undefined,
+        routingInfo: reg.edge_routing_info ? base64ToBytes(reg.edge_routing_info) : undefined,
+        lastSuccessTs: reg.server_time,
+        serverHasPreKeys: false,
+        platform: 'android',
+        deviceInfo: transport.deviceInfo,
+        ...(transport.pushName !== undefined ? { pushName: transport.pushName } : {}),
+        ...(transport.yearClass !== undefined ? { yearClass: transport.yearClass } : {}),
+        ...(transport.memClass !== undefined ? { memClass: transport.memClass } : {})
+    }
+}
+
+function transportOptionsFromCredentials(creds: WaAuthCredentials): {
+    deviceInfo: WaMobileTransportDeviceInfo
+    pushName?: string
+    yearClass?: number
+    memClass?: number
+} | null {
+    if (!creds.deviceInfo) return null
+    return {
+        deviceInfo: creds.deviceInfo,
+        ...(creds.pushName !== undefined ? { pushName: creds.pushName } : {}),
+        ...(creds.yearClass !== undefined ? { yearClass: creds.yearClass } : {}),
+        ...(creds.memClass !== undefined ? { memClass: creds.memClass } : {})
+    }
+}
+
+async function main(): Promise<void> {
+    const { bundlePath, sessionId } = parseArgs()
+    const bundle = JSON.parse(readFileSync(bundlePath, 'utf-8')) as CoreBundle
+
+    const authPath = resolve(process.cwd(), '.auth', `core_${sessionId}.sqlite`)
+    await mkdir(dirname(authPath), { recursive: true })
+
+    const logger = await createPinoLogger({ level: 'trace', pretty: true })
+    const store = createStore({
+        backends: { sqlite: createSqliteStore({ path: authPath, driver: 'auto' }) },
+        providers: {
+            auth: 'sqlite',
+            signal: 'sqlite',
+            senderKey: 'sqlite',
+            appState: 'sqlite',
+            messages: 'sqlite',
+            threads: 'sqlite',
+            contacts: 'sqlite',
+            privacyToken: 'sqlite',
+            identity: 'sqlite',
+            preKey: 'sqlite',
+            session: 'sqlite'
+        }
+    })
+
+    const session = store.session(sessionId)
+    let existing = await session.auth.load()
+    if (existing?.meJid) {
+        console.log(
+            `[from-bundle] session already seeded (meJid=${existing.meJid}), skipping import`
+        )
+    } else {
+        const creds = credentialsFromBundle(bundle)
+        await persistCredentials(
+            {
+                logger,
+                authStore: session.auth,
+                signalStore: session.signal,
+                preKeyStore: session.preKey
+            },
+            creds
+        )
+        existing = creds
+        console.log(
+            `[from-bundle] imported meJid=${creds.meJid} meLid=${creds.meLid ?? '-'} ` +
+                `regId=${creds.registrationInfo.registrationId} routing=${creds.routingInfo ? 'yes' : 'no'}`
+        )
+    }
+
+    // Prefer the device fingerprint persisted with credentials so subsequent
+    // runs are fingerprint-stable even if the bundle file moved or rotated.
+    const transportOptions =
+        (existing && transportOptionsFromCredentials(existing)) ??
+        transportOptionsFromBundle(bundle)
+
+    const client = new WaClient(
+        {
+            store,
+            sessionId,
+            connectTimeoutMs: 15_000,
+            nodeQueryTimeoutMs: 30_000,
+            mobileTransport: { ...transportOptions, passive: false }
+        },
+        logger
+    )
+    client.on('connection', (event) => console.log('[connection]', event))
+    client.on('message', async (event) => {
+        console.log('[message] from', event.senderJid, 'in', event.chatJid)
+        console.dir(event.message, { depth: null })
+
+        if (
+            event.message &&
+            (event.message?.conversation === 'ping' ||
+                event.message?.extendedTextMessage?.text === 'ping')
+        ) {
+            const nowSeconds = Date.now() / 1_000
+            const deltaSeconds =
+                event.timestampSeconds === undefined ? 0 : nowSeconds - event.timestampSeconds
+
+            await client.sendMessage(event.chatJid!, {
+                conversation: `pong ${deltaSeconds.toFixed(3)}`
+            })
+            await client.chat.setChatMute(event.chatJid!, false)
+        }
+    })
+
+    client.on('registration_code_received', ({ code, expiryMs, fromDeviceId }) => {
+        console.log('registration code received', { code, expiryMs, fromDeviceId })
+    })
+
+    client.on(
+        'account_takeover_notice',
+        ({
+            serverToken,
+            attemptTimestampMs,
+            newDeviceName,
+            newDevicePlatform,
+            newDeviceAppVersion
+        }) => {
+            console.log('account takeover notice detected', {
+                serverToken,
+                attemptTimestampMs,
+                newDeviceName,
+                newDevicePlatform,
+                newDeviceAppVersion
+            })
+        }
+    )
+
+    console.log(`[from-bundle] connecting WaClient (session=${sessionId}) in mobile mode…`)
+    await client.connect()
+    console.log('[from-bundle] connected — idling. Ctrl-C to exit.')
+
+    const shutdown = async (): Promise<void> => {
+        await client.disconnect().catch(() => undefined)
+        process.exit(0)
+    }
+    process.on('SIGINT', () => void shutdown())
+    process.on('SIGTERM', () => void shutdown())
+}
+
+main().catch((err: unknown) => {
+    console.error('[from-bundle] failed:', err)
+    process.exit(1)
+})

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -298,6 +298,8 @@ function createIncomingNodeRuntime(input: {
         emitIncomingFailure: (event) => emitEvent('failure', event),
         emitIncomingErrorStanza: (event) => emitEvent('stanza_error', event),
         emitIncomingNotification: (event) => emitEvent('notification', event),
+        emitRegistrationCode: (event) => emitEvent('registration_code_received', event),
+        emitAccountTakeoverNotice: (event) => emitEvent('account_takeover_notice', event),
         emitGroupEvent: (event) => {
             emitEvent('group_event', event)
             void messageDispatch.mutateParticipantsCacheFromGroupEvent(event).catch((error) => {

--- a/src/client/__tests__/incoming.test.ts
+++ b/src/client/__tests__/incoming.test.ts
@@ -4,10 +4,16 @@ import test from 'node:test'
 import {
     createIncomingFailureHandler,
     createIncomingNotificationHandler,
-    createIncomingReceiptHandler
+    createIncomingReceiptHandler,
+    createIncomingRegistrationNotificationHandler
 } from '@client/incoming'
+import type { WaAccountTakeoverNoticeEvent, WaRegistrationCodeEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
-import { WA_DISCONNECT_REASONS } from '@protocol/constants'
+import {
+    WA_DISCONNECT_REASONS,
+    WA_NOTIFICATION_TYPES,
+    WA_REGISTRATION_NOTIFICATION_TAGS
+} from '@protocol/constants'
 import type { BinaryNode } from '@transport/types'
 
 function createLogger(): Logger {
@@ -186,6 +192,133 @@ test('failure handler maps auth reasons to logout disconnect flow', async () => 
             code: 401
         }
     ])
+})
+
+test('registration notification handler emits registration_code event and acks', async () => {
+    const sent: BinaryNode[] = []
+    const codes: WaRegistrationCodeEvent[] = []
+    const takeovers: WaAccountTakeoverNoticeEvent[] = []
+    const handler = createIncomingRegistrationNotificationHandler({
+        logger: createLogger(),
+        sendNode: async (node) => {
+            sent.push(node)
+        },
+        emitRegistrationCode: (event) => {
+            codes.push(event)
+        },
+        emitAccountTakeoverNotice: (event) => {
+            takeovers.push(event)
+        }
+    })
+
+    const handled = await handler({
+        tag: 'notification',
+        attrs: {
+            id: 'reg-1',
+            from: 's.whatsapp.net',
+            type: WA_NOTIFICATION_TYPES.REGISTRATION
+        },
+        content: [
+            {
+                tag: WA_REGISTRATION_NOTIFICATION_TAGS.WA_OLD_REGISTRATION,
+                attrs: {
+                    code: '987654',
+                    expiry_t: '1700000123',
+                    device_id: 'OTHER_DEVICE'
+                }
+            }
+        ]
+    })
+
+    assert.equal(handled, true)
+    assert.equal(codes.length, 1)
+    assert.equal(codes[0].code, '987654')
+    assert.equal(codes[0].expiryTimestampMs, 1700000123 * 1000)
+    assert.equal(codes[0].fromDeviceId, 'OTHER_DEVICE')
+    assert.equal(takeovers.length, 0)
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].tag, 'ack')
+    assert.equal(sent[0].attrs.type, WA_NOTIFICATION_TYPES.REGISTRATION)
+    assert.equal(sent[0].attrs.id, 'reg-1')
+    assert.equal(sent[0].attrs.class, 'notification')
+})
+
+test('registration notification handler emits account_takeover_notice for device_logout child', async () => {
+    const sent: BinaryNode[] = []
+    const codes: WaRegistrationCodeEvent[] = []
+    const takeovers: WaAccountTakeoverNoticeEvent[] = []
+    const handler = createIncomingRegistrationNotificationHandler({
+        logger: createLogger(),
+        sendNode: async (node) => {
+            sent.push(node)
+        },
+        emitRegistrationCode: (event) => {
+            codes.push(event)
+        },
+        emitAccountTakeoverNotice: (event) => {
+            takeovers.push(event)
+        }
+    })
+
+    const handled = await handler({
+        tag: 'notification',
+        attrs: {
+            id: 'reg-2',
+            from: 's.whatsapp.net',
+            type: WA_NOTIFICATION_TYPES.REGISTRATION
+        },
+        content: [
+            {
+                tag: WA_REGISTRATION_NOTIFICATION_TAGS.DEVICE_LOGOUT,
+                attrs: {
+                    id: 'logout-xyz',
+                    t: '1700000456'
+                }
+            }
+        ]
+    })
+
+    assert.equal(handled, true)
+    assert.equal(codes.length, 0)
+    assert.equal(takeovers.length, 1)
+    assert.equal(takeovers[0].serverToken, 'logout-xyz')
+    assert.equal(takeovers[0].attemptTimestampMs, 1700000456 * 1000)
+    assert.equal(sent.length, 1)
+})
+
+test('registration notification handler defers to default handler for unrecognized payloads', async () => {
+    const sent: BinaryNode[] = []
+    const codes: WaRegistrationCodeEvent[] = []
+    const takeovers: WaAccountTakeoverNoticeEvent[] = []
+    const handler = createIncomingRegistrationNotificationHandler({
+        logger: createLogger(),
+        sendNode: async (node) => {
+            sent.push(node)
+        },
+        emitRegistrationCode: (event) => {
+            codes.push(event)
+        },
+        emitAccountTakeoverNotice: (event) => {
+            takeovers.push(event)
+        }
+    })
+
+    const handledOther = await handler({
+        tag: 'notification',
+        attrs: { id: 'x', from: 's.whatsapp.net', type: 'server_sync' }
+    })
+    assert.equal(handledOther, false)
+
+    const handledUnknownChild = await handler({
+        tag: 'notification',
+        attrs: { id: 'r', from: 's.whatsapp.net', type: WA_NOTIFICATION_TYPES.REGISTRATION },
+        content: [{ tag: 'unknown', attrs: {} }]
+    })
+    assert.equal(handledUnknownChild, false)
+
+    assert.equal(codes.length, 0)
+    assert.equal(takeovers.length, 0)
+    assert.equal(sent.length, 0)
 })
 
 test('failure handler maps disconnect-only reasons without clearing credentials', async () => {

--- a/src/client/coordinators/WaIncomingNodeCoordinator.ts
+++ b/src/client/coordinators/WaIncomingNodeCoordinator.ts
@@ -7,10 +7,12 @@ import {
     createIncomingGroupNotificationHandler,
     createIncomingNotificationHandler,
     createIncomingReceiptHandler,
+    createIncomingRegistrationNotificationHandler,
     createInfoBulletinNotificationEvent,
     createUnhandledIncomingNodeEvent
 } from '@client/incoming'
 import type {
+    WaAccountTakeoverNoticeEvent,
     WaGroupEvent,
     WaIncomingBaseEvent,
     WaIncomingCallEvent,
@@ -21,7 +23,8 @@ import type {
     WaIncomingNotificationEvent,
     WaIncomingPresenceEvent,
     WaIncomingReceiptEvent,
-    WaIncomingUnhandledStanzaEvent
+    WaIncomingUnhandledStanzaEvent,
+    WaRegistrationCodeEvent
 } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import {
@@ -70,6 +73,8 @@ interface WaIncomingNodeRuntime {
     readonly emitIncomingFailure: (event: WaIncomingFailureEvent) => void
     readonly emitIncomingErrorStanza: (event: WaIncomingBaseEvent) => void
     readonly emitIncomingNotification: (event: WaIncomingNotificationEvent) => void
+    readonly emitRegistrationCode: (event: WaRegistrationCodeEvent) => void
+    readonly emitAccountTakeoverNotice: (event: WaAccountTakeoverNoticeEvent) => void
     readonly emitGroupEvent: (event: WaGroupEvent) => void
     readonly emitUnhandledIncomingNode: (event: WaIncomingUnhandledStanzaEvent) => void
     readonly syncAppState: () => Promise<void>
@@ -256,6 +261,16 @@ export class WaIncomingNodeCoordinator {
                 sendNode: runtime.sendNode,
                 emitGroupEvent: runtime.emitGroupEvent,
                 emitUnhandledStanza: runtime.emitUnhandledIncomingNode
+            })
+        })
+        this.registerIncomingHandler({
+            tag: WA_NODE_TAGS.NOTIFICATION,
+            subtype: WA_NOTIFICATION_TYPES.REGISTRATION,
+            handler: createIncomingRegistrationNotificationHandler({
+                logger: this.logger,
+                sendNode: runtime.sendNode,
+                emitRegistrationCode: runtime.emitRegistrationCode,
+                emitAccountTakeoverNotice: runtime.emitAccountTakeoverNotice
             })
         })
         this.registerIncomingHandler({

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -58,6 +58,8 @@ function createIncomingRuntime() {
             emitIncomingFailure: () => undefined,
             emitIncomingErrorStanza: () => undefined,
             emitIncomingNotification: () => undefined,
+            emitRegistrationCode: () => undefined,
+            emitAccountTakeoverNotice: () => undefined,
             emitGroupEvent: () => undefined,
             emitUnhandledIncomingNode: (event: unknown) => {
                 unhandled.push(event)

--- a/src/client/events/__tests__/events.test.ts
+++ b/src/client/events/__tests__/events.test.ts
@@ -4,7 +4,12 @@ import test from 'node:test'
 import { parseChatEventFromAppStateMutation } from '@client/events/chat'
 import { parseGroupNotificationEvents } from '@client/events/group'
 import { parsePrivacyTokenNotification } from '@client/events/privacy-token'
-import { WA_NOTIFICATION_TYPES, WA_PRIVACY_TOKEN_TAGS } from '@protocol/constants'
+import { parseRegistrationNotification } from '@client/events/registration'
+import {
+    WA_NOTIFICATION_TYPES,
+    WA_PRIVACY_TOKEN_TAGS,
+    WA_REGISTRATION_NOTIFICATION_TAGS
+} from '@protocol/constants'
 
 test('chat event parser maps app-state mutation to chat actions', () => {
     const parsed = parseChatEventFromAppStateMutation({
@@ -119,6 +124,97 @@ test('privacy token parser keeps valid token entries and skips malformed payload
     assert.equal(parsed[0].type, 'trusted_contact')
     assert.equal(parsed[0].timestampS, 42)
     assert.deepEqual(parsed[0].tokenBytes, validTokenBytes)
+})
+
+test('registration parser extracts wa_old_registration code with expiry and from-device id', () => {
+    const parsed = parseRegistrationNotification({
+        tag: 'notification',
+        attrs: {
+            type: WA_NOTIFICATION_TYPES.REGISTRATION,
+            id: 'r-1',
+            from: 's.whatsapp.net'
+        },
+        content: [
+            {
+                tag: WA_REGISTRATION_NOTIFICATION_TAGS.WA_OLD_REGISTRATION,
+                attrs: {
+                    code: '123456',
+                    expiry_t: '1730000000',
+                    device_id: 'AAAAAAAAAAAAAAAAAAAAAA'
+                }
+            }
+        ]
+    })
+
+    assert.ok(parsed)
+    assert.equal(parsed?.kind, 'registration_code')
+    if (parsed?.kind === 'registration_code') {
+        assert.equal(parsed.code, '123456')
+        assert.equal(parsed.expiryTimestampMs, 1730000000 * 1000)
+        assert.equal(parsed.fromDeviceId, 'AAAAAAAAAAAAAAAAAAAAAA')
+    }
+})
+
+test('registration parser extracts account_takeover_notice from device_logout child', () => {
+    const parsed = parseRegistrationNotification({
+        tag: 'notification',
+        attrs: { type: WA_NOTIFICATION_TYPES.REGISTRATION },
+        content: [
+            {
+                tag: WA_REGISTRATION_NOTIFICATION_TAGS.DEVICE_LOGOUT,
+                attrs: {
+                    id: 'logout-1',
+                    t: '1700000000',
+                    device: 'iPhone 15',
+                    new_device_platform: 'iphone',
+                    new_device_app_version: '24.10.0'
+                }
+            }
+        ]
+    })
+
+    assert.ok(parsed)
+    assert.equal(parsed?.kind, 'account_takeover_notice')
+    if (parsed?.kind === 'account_takeover_notice') {
+        assert.equal(parsed.serverToken, 'logout-1')
+        assert.equal(parsed.attemptTimestampMs, 1700000000 * 1000)
+        assert.equal(parsed.newDeviceName, 'iPhone 15')
+        assert.equal(parsed.newDevicePlatform, 'iphone')
+        assert.equal(parsed.newDeviceAppVersion, '24.10.0')
+    }
+})
+
+test('registration parser returns null when child tag is unknown or attrs are missing', () => {
+    assert.equal(
+        parseRegistrationNotification({
+            tag: 'notification',
+            attrs: { type: WA_NOTIFICATION_TYPES.REGISTRATION },
+            content: [{ tag: 'unknown_child', attrs: {} }]
+        }),
+        null
+    )
+
+    assert.equal(
+        parseRegistrationNotification({
+            tag: 'notification',
+            attrs: { type: WA_NOTIFICATION_TYPES.REGISTRATION },
+            content: [
+                {
+                    tag: WA_REGISTRATION_NOTIFICATION_TAGS.WA_OLD_REGISTRATION,
+                    attrs: { code: '123456', expiry_t: '1' }
+                }
+            ]
+        }),
+        null
+    )
+
+    assert.equal(
+        parseRegistrationNotification({
+            tag: 'notification',
+            attrs: { type: WA_NOTIFICATION_TYPES.REGISTRATION }
+        }),
+        null
+    )
 })
 
 test('privacy token parser rejects non-numeric token timestamp', () => {

--- a/src/client/events/registration.ts
+++ b/src/client/events/registration.ts
@@ -1,0 +1,65 @@
+import { WA_REGISTRATION_NOTIFICATION_TAGS } from '@protocol/notification'
+import { getFirstNodeChild } from '@transport/node/helpers'
+import type { BinaryNode } from '@transport/types'
+import { parseOptionalInt } from '@util/primitives'
+
+export interface ParsedRegistrationCode {
+    readonly kind: 'registration_code'
+    readonly code: string
+    readonly expiryTimestampMs: number
+    readonly fromDeviceId: string
+}
+
+export interface ParsedAccountTakeoverNotice {
+    readonly kind: 'account_takeover_notice'
+    readonly serverToken: string
+    readonly attemptTimestampMs: number
+    readonly newDeviceName?: string
+    readonly newDevicePlatform?: string
+    readonly newDeviceAppVersion?: string
+}
+
+export type ParsedRegistrationNotification =
+    | ParsedRegistrationCode
+    | ParsedAccountTakeoverNotice
+    | null
+
+export function parseRegistrationNotification(node: BinaryNode): ParsedRegistrationNotification {
+    const firstChild = getFirstNodeChild(node)
+    if (!firstChild) {
+        return null
+    }
+
+    if (firstChild.tag === WA_REGISTRATION_NOTIFICATION_TAGS.WA_OLD_REGISTRATION) {
+        const code = firstChild.attrs.code
+        const expirySeconds = parseOptionalInt(firstChild.attrs.expiry_t)
+        const fromDeviceId = firstChild.attrs.device_id
+        if (!code || expirySeconds === undefined || !fromDeviceId) {
+            return null
+        }
+        return {
+            kind: 'registration_code',
+            code,
+            expiryTimestampMs: expirySeconds * 1000,
+            fromDeviceId
+        }
+    }
+
+    if (firstChild.tag === WA_REGISTRATION_NOTIFICATION_TAGS.DEVICE_LOGOUT) {
+        const serverToken = firstChild.attrs.id
+        const tSeconds = parseOptionalInt(firstChild.attrs.t)
+        if (!serverToken || tSeconds === undefined) {
+            return null
+        }
+        return {
+            kind: 'account_takeover_notice',
+            serverToken,
+            attemptTimestampMs: tSeconds * 1000,
+            newDeviceName: firstChild.attrs.device,
+            newDevicePlatform: firstChild.attrs.new_device_platform,
+            newDeviceAppVersion: firstChild.attrs.new_device_app_version
+        }
+    }
+
+    return null
+}

--- a/src/client/incoming.ts
+++ b/src/client/incoming.ts
@@ -1,11 +1,14 @@
 import { parseGroupNotificationEvents } from '@client/events/group'
+import { parseRegistrationNotification } from '@client/events/registration'
 import type {
+    WaAccountTakeoverNoticeEvent,
     WaGroupEvent,
     WaIncomingBaseEvent,
     WaIncomingFailureEvent,
     WaIncomingNotificationEvent,
     WaIncomingReceiptEvent,
-    WaIncomingUnhandledStanzaEvent
+    WaIncomingUnhandledStanzaEvent,
+    WaRegistrationCodeEvent
 } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import { WA_DISCONNECT_REASONS, WA_NODE_TAGS, WA_NOTIFICATION_TYPES } from '@protocol/constants'
@@ -47,6 +50,11 @@ type IncomingNotificationHandlerOptions = IncomingAckRuntime & {
 type IncomingGroupNotificationHandlerOptions = IncomingAckRuntime & {
     readonly emitGroupEvent: (event: WaGroupEvent) => void
     readonly emitUnhandledStanza: (event: WaIncomingUnhandledStanzaEvent) => void
+}
+
+type IncomingRegistrationNotificationHandlerOptions = IncomingAckRuntime & {
+    readonly emitRegistrationCode: (event: WaRegistrationCodeEvent) => void
+    readonly emitAccountTakeoverNotice: (event: WaAccountTakeoverNoticeEvent) => void
 }
 
 const FAILURE_REASON_TO_DISCONNECT: Readonly<Record<number, WaDisconnectReason>> = {
@@ -316,6 +324,50 @@ export function createIncomingNotificationHandler(
                 })
             })
         }
+        return true
+    }
+}
+
+export function createIncomingRegistrationNotificationHandler(
+    options: IncomingRegistrationNotificationHandlerOptions
+): (node: BinaryNode) => Promise<boolean> {
+    return async (node: BinaryNode): Promise<boolean> => {
+        if (node.attrs.type !== WA_NOTIFICATION_TYPES.REGISTRATION) {
+            return false
+        }
+
+        const parsed = parseRegistrationNotification(node)
+        if (!parsed) {
+            return false
+        }
+
+        const baseEvent = createIncomingBaseEvent(node)
+        if (parsed.kind === 'registration_code') {
+            options.emitRegistrationCode({
+                ...baseEvent,
+                code: parsed.code,
+                expiryTimestampMs: parsed.expiryTimestampMs,
+                fromDeviceId: parsed.fromDeviceId
+            })
+        } else {
+            options.emitAccountTakeoverNotice({
+                ...baseEvent,
+                serverToken: parsed.serverToken,
+                attemptTimestampMs: parsed.attemptTimestampMs,
+                newDeviceName: parsed.newDeviceName,
+                newDevicePlatform: parsed.newDevicePlatform,
+                newDeviceAppVersion: parsed.newDeviceAppVersion
+            })
+        }
+
+        await sendSafeAck(
+            options.logger,
+            options.sendNode,
+            buildAckNode({
+                kind: 'notification',
+                node
+            })
+        )
         return true
     }
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -236,6 +236,20 @@ export interface WaIncomingNotificationEvent extends WaIncomingBaseEvent {
     readonly details?: Readonly<Record<string, unknown>>
 }
 
+export interface WaRegistrationCodeEvent extends WaIncomingBaseEvent {
+    readonly code: string
+    readonly expiryTimestampMs: number
+    readonly fromDeviceId: string
+}
+
+export interface WaAccountTakeoverNoticeEvent extends WaIncomingBaseEvent {
+    readonly serverToken: string
+    readonly attemptTimestampMs: number
+    readonly newDeviceName?: string
+    readonly newDevicePlatform?: string
+    readonly newDeviceAppVersion?: string
+}
+
 export type WaAddonKind = 'reaction' | 'poll_vote' | 'event_response' | 'comment'
 
 export interface WaIncomingAddonEvent extends WaIncomingBaseEvent {
@@ -446,6 +460,8 @@ export interface WaClientEventMap {
     readonly chatstate: (event: WaIncomingChatstateEvent) => void
     readonly call: (event: WaIncomingCallEvent) => void
     readonly notification: (event: WaIncomingNotificationEvent) => void
+    readonly registration_code_received: (event: WaRegistrationCodeEvent) => void
+    readonly account_takeover_notice: (event: WaAccountTakeoverNoticeEvent) => void
     readonly failure: (event: WaIncomingFailureEvent) => void
     readonly stanza_error: (event: WaIncomingBaseEvent) => void
     readonly stanza_unhandled: (event: WaIncomingUnhandledStanzaEvent) => void

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -42,7 +42,11 @@ export {
     WA_DIRTY_TYPES,
     WA_SUPPORTED_DIRTY_TYPES
 } from '@protocol/dirty'
-export { WA_GROUP_NOTIFICATION_TAGS, WA_NOTIFICATION_TYPES } from '@protocol/notification'
+export {
+    WA_GROUP_NOTIFICATION_TAGS,
+    WA_NOTIFICATION_TYPES,
+    WA_REGISTRATION_NOTIFICATION_TAGS
+} from '@protocol/notification'
 export {
     WA_PRIVACY_TOKEN_NOTIFICATION_TYPE,
     WA_PRIVACY_TOKEN_TAGS,

--- a/src/protocol/notification.ts
+++ b/src/protocol/notification.ts
@@ -2,7 +2,13 @@ export const WA_NOTIFICATION_TYPES = Object.freeze({
     GROUP: 'w:gp2',
     ENCRYPT: 'encrypt',
     DEVICES: 'devices',
-    SERVER: 'server'
+    SERVER: 'server',
+    REGISTRATION: 'registration'
+} as const)
+
+export const WA_REGISTRATION_NOTIFICATION_TAGS = Object.freeze({
+    WA_OLD_REGISTRATION: 'wa_old_registration',
+    DEVICE_LOGOUT: 'device_logout'
 } as const)
 
 export const WA_GROUP_NOTIFICATION_TAGS = Object.freeze({


### PR DESCRIPTION
Adds a dedicated handler for `<notification type="registration">` stanzas that the server only delivers to mobile/primary clients (the runtime introduced in #40/#42). WA Web companions never see them — they're tied to the registered phone-number device.

Two children are recognized, matching the WA Android handler:

- `<wa_old_registration code expiry_t device_id>` -> emits `registration_code_received` so the app can surface the verification code another device requested for the same number.
- `<device_logout id t [device,new_device_platform,new_device_app_version]>` -> emits `account_takeover_notice` (matching the APK's `AccountLogoutRequestEventData`), signalling that another device is taking over the account. This is distinct from the existing 401 logout path on `<failure>`; it carries the new-device metadata used by the takeover overlay before the socket is force-closed.

The handler is registered with subtype `registration` ahead of the generic notification fallback, so the proper ack is sent and unrecognized children gracefully defer to the default handler.