### PR TITLE
feat(client): add mobile email registration coordinator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ node_modules
 example.js
 AGENTS.md
 logs.txt
-deobfuscated
+wa-web
+wa-mob
 coverage
 *.heap**
 *.cpuprofile

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,8 @@ module.exports = [
         ignores: [
             'dist/**',
             'packages/*/dist/**',
-            'deobfuscated/**',
+            'wa-web/**',
+            'wa-mob/**',
             'coverage/**',
             'proto/index.js',
             'proto/index.d.ts',

--- a/packages/fake-server/src/protocol/auth/pair-device.ts
+++ b/packages/fake-server/src/protocol/auth/pair-device.ts
@@ -1,4 +1,4 @@
-/** Pairing IQ builders/parsers (source: `WAWebHandlePairDevice*`, `/deobfuscated`). */
+/** Pairing IQ builders/parsers (source: `WAWebHandlePairDevice*`, `/wa-web`). */
 
 import type { BinaryNode } from '../../transport/codec'
 

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -12,6 +12,7 @@ import type { WaConnectionManager } from '@client/connection/WaConnectionManager
 import type { WaReceiptQueue } from '@client/connection/WaReceiptQueue'
 import type { WaAppStateMutationCoordinator } from '@client/coordinators/WaAppStateMutationCoordinator'
 import type { WaBusinessCoordinator } from '@client/coordinators/WaBusinessCoordinator'
+import type { WaEmailCoordinator } from '@client/coordinators/WaEmailCoordinator'
 import type { WaGroupCoordinator } from '@client/coordinators/WaGroupCoordinator'
 import type { WaIncomingNodeCoordinator } from '@client/coordinators/WaIncomingNodeCoordinator'
 import type { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
@@ -123,6 +124,7 @@ export class WaClient extends EventEmitter {
     public readonly privacyCoordinator!: WaPrivacyCoordinator
     public readonly profileCoordinator!: WaProfileCoordinator
     public readonly businessCoordinator!: WaBusinessCoordinator
+    public readonly emailCoordinator!: WaEmailCoordinator
     private readonly passiveTasks!: WaPassiveTasksCoordinator
     private readonly keepAlive!: WaKeepAlive
     private readonly receiptQueue!: WaReceiptQueue
@@ -712,6 +714,9 @@ export class WaClient extends EventEmitter {
     }
     public get business(): WaBusinessCoordinator {
         return this.businessCoordinator
+    }
+    public get email(): WaEmailCoordinator {
+        return this.emailCoordinator
     }
 
     public async logout(reason: WaLogoutReason = WA_LOGOUT_REASONS.USER_INITIATED): Promise<void> {

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -10,6 +10,10 @@ import {
     type WaBusinessCoordinator
 } from '@client/coordinators/WaBusinessCoordinator'
 import {
+    createEmailCoordinator,
+    type WaEmailCoordinator
+} from '@client/coordinators/WaEmailCoordinator'
+import {
     createGroupCoordinator,
     type WaGroupCoordinator
 } from '@client/coordinators/WaGroupCoordinator'
@@ -149,6 +153,7 @@ interface WaClientDependencies {
     readonly privacyCoordinator: WaPrivacyCoordinator
     readonly profileCoordinator: WaProfileCoordinator
     readonly businessCoordinator: WaBusinessCoordinator
+    readonly emailCoordinator: WaEmailCoordinator
     readonly receiptQueue: WaReceiptQueue
     readonly connectionManager: WaConnectionManager
     readonly trustedContactToken: WaTrustedContactTokenCoordinator
@@ -539,6 +544,10 @@ export function buildWaClientDependencies(input: {
     })
 
     const businessCoordinator = createBusinessCoordinator({
+        queryWithContext: runtime.queryWithContext
+    })
+
+    const emailCoordinator = createEmailCoordinator({
         queryWithContext: runtime.queryWithContext
     })
 
@@ -1103,6 +1112,7 @@ export function buildWaClientDependencies(input: {
         privacyCoordinator,
         profileCoordinator,
         businessCoordinator,
+        emailCoordinator,
         receiptQueue,
         connectionManager,
         trustedContactToken,

--- a/src/client/coordinators/WaBusinessCoordinator.ts
+++ b/src/client/coordinators/WaBusinessCoordinator.ts
@@ -7,10 +7,9 @@ import {
     buildUpdateCoverPhotoIq,
     type WaEditBusinessProfileInput
 } from '@transport/node/builders/business'
-import { findNodeChild, getNodeChildren } from '@transport/node/helpers'
+import { findNodeChild, getNodeChildren, getNodeTextContent } from '@transport/node/helpers'
 import { assertIqResult } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
-import { TEXT_DECODER } from '@util/bytes'
 import { longToNumber } from '@util/primitives'
 
 export interface WaBusinessCategory {
@@ -82,13 +81,6 @@ interface WaBusinessCoordinatorOptions {
     ) => Promise<BinaryNode>
 }
 
-function readTextContent(node: BinaryNode): string | undefined {
-    const content = node.content
-    if (content instanceof Uint8Array) return TEXT_DECODER.decode(content)
-    if (typeof content === 'string') return content
-    return undefined
-}
-
 function parseBusinessProfiles(result: BinaryNode): readonly WaBusinessProfileResult[] {
     const bizNode = findNodeChild(result, 'business_profile')
     if (!bizNode) {
@@ -133,7 +125,7 @@ function parseBusinessProfiles(result: BinaryNode): readonly WaBusinessProfileRe
 
         for (let j = 0; j < children.length; j += 1) {
             const child = children[j]
-            const text = readTextContent(child)
+            const text = getNodeTextContent(child)
 
             switch (child.tag) {
                 case 'description':
@@ -189,7 +181,7 @@ function parseBusinessCategories(node: BinaryNode): WaBusinessCategory[] {
         if (child.tag !== 'category') continue
         const id = child.attrs.id as string | undefined
         if (!id) continue
-        categories[count] = { id, name: readTextContent(child) ?? '' }
+        categories[count] = { id, name: getNodeTextContent(child) ?? '' }
         count += 1
     }
     categories.length = count
@@ -229,7 +221,7 @@ function parseProfileOptions(node: BinaryNode): Record<string, string> {
     const options: Record<string, string> = {}
     for (let i = 0; i < children.length; i += 1) {
         const child = children[i]
-        const text = readTextContent(child)
+        const text = getNodeTextContent(child)
         if (text !== undefined) {
             options[child.tag] = text
         }

--- a/src/client/coordinators/WaEmailCoordinator.ts
+++ b/src/client/coordinators/WaEmailCoordinator.ts
@@ -1,0 +1,122 @@
+import { WA_EMAIL_TAGS, type WaEmailContext } from '@protocol/email'
+import {
+    buildConfirmEmailIq,
+    buildGetEmailIq,
+    type BuildRequestEmailVerificationCodeInput,
+    buildRequestEmailVerificationCodeIq,
+    buildSetEmailIq,
+    buildVerifyEmailCodeIq
+} from '@transport/node/builders/email'
+import { findNodeChild, getNodeTextContent } from '@transport/node/helpers'
+import { assertIqResult } from '@transport/node/query'
+import type { BinaryNode } from '@transport/types'
+
+export interface WaEmailStatus {
+    readonly email: string | null
+    readonly verified: boolean
+    readonly confirmed: boolean
+}
+
+export interface WaEmailVerifyCodeResult {
+    readonly verified: boolean
+    readonly autoVerifyFailed: boolean
+    readonly email: string | null
+}
+
+export interface WaEmailCoordinator {
+    readonly getStatus: () => Promise<WaEmailStatus>
+    readonly setEmail: (email: string, context?: WaEmailContext) => Promise<WaEmailStatus>
+    readonly requestVerificationCode: (
+        input: BuildRequestEmailVerificationCodeInput
+    ) => Promise<void>
+    readonly verifyCode: (code: string) => Promise<WaEmailVerifyCodeResult>
+    readonly confirm: (context?: WaEmailContext) => Promise<void>
+}
+
+export interface WaEmailCoordinatorOptions {
+    readonly queryWithContext: (
+        context: string,
+        node: BinaryNode,
+        timeoutMs?: number,
+        contextData?: Readonly<Record<string, unknown>>
+    ) => Promise<BinaryNode>
+}
+
+export function createEmailCoordinator(options: WaEmailCoordinatorOptions): WaEmailCoordinator {
+    const { queryWithContext } = options
+
+    return {
+        getStatus: async () => {
+            const result = await queryWithContext('email.getStatus', buildGetEmailIq())
+            assertIqResult(result, 'email.getStatus')
+            return parseEmailStatus(result)
+        },
+
+        setEmail: async (email, context) => {
+            const result = await queryWithContext(
+                'email.set',
+                buildSetEmailIq(email, context),
+                undefined,
+                context !== undefined ? { context } : {}
+            )
+            assertIqResult(result, 'email.set')
+            return parseEmailStatus(result)
+        },
+
+        requestVerificationCode: async (input) => {
+            const result = await queryWithContext(
+                'email.requestCode',
+                buildRequestEmailVerificationCodeIq(input),
+                undefined,
+                { languageCode: input.languageCode, localeCode: input.localeCode }
+            )
+            assertIqResult(result, 'email.requestCode')
+        },
+
+        verifyCode: async (code) => {
+            const result = await queryWithContext('email.verifyCode', buildVerifyEmailCodeIq(code))
+            assertIqResult(result, 'email.verifyCode')
+            return parseVerifyCodeResult(result)
+        },
+
+        confirm: async (context) => {
+            const result = await queryWithContext(
+                'email.confirm',
+                buildConfirmEmailIq(context),
+                undefined,
+                context !== undefined ? { context } : {}
+            )
+            assertIqResult(result, 'email.confirm')
+        }
+    }
+}
+
+function parseEmailStatus(result: BinaryNode): WaEmailStatus {
+    const emailNode = findNodeChild(result, WA_EMAIL_TAGS.EMAIL)
+    if (!emailNode) {
+        return { email: null, verified: false, confirmed: false }
+    }
+    const verifiedAttr = emailNode.attrs.verified
+    const addressNode = findNodeChild(emailNode, WA_EMAIL_TAGS.EMAIL_ADDRESS)
+    const confirmedNode = findNodeChild(emailNode, WA_EMAIL_TAGS.CONFIRMED)
+    return {
+        email: addressNode ? (getNodeTextContent(addressNode) ?? null) : null,
+        verified: verifiedAttr === 'true',
+        confirmed: confirmedNode ? getNodeTextContent(confirmedNode) === 'true' : false
+    }
+}
+
+function parseVerifyCodeResult(result: BinaryNode): WaEmailVerifyCodeResult {
+    const emailNode = findNodeChild(result, WA_EMAIL_TAGS.EMAIL)
+    if (!emailNode) {
+        return { verified: false, autoVerifyFailed: false, email: null }
+    }
+    const doVerify = emailNode.attrs.do_verify
+    const autoVerifyNode = findNodeChild(emailNode, WA_EMAIL_TAGS.AUTO_VERIFY)
+    const addressNode = findNodeChild(emailNode, WA_EMAIL_TAGS.EMAIL_ADDRESS)
+    return {
+        verified: doVerify === 'true',
+        autoVerifyFailed: autoVerifyNode ? getNodeTextContent(autoVerifyNode) === 'fail' : false,
+        email: addressNode ? (getNodeTextContent(addressNode) ?? null) : null
+    }
+}

--- a/src/client/coordinators/__tests__/email-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/email-coordinator.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createEmailCoordinator } from '@client/coordinators/WaEmailCoordinator'
+import { WA_EMAIL_CONTEXTS, WA_EMAIL_ERROR_CODES, WA_EMAIL_TAGS } from '@protocol/constants'
+import type { BinaryNode } from '@transport/types'
+
+function iqResult(content?: readonly BinaryNode[]): BinaryNode {
+    return { tag: 'iq', attrs: { type: 'result' }, content }
+}
+
+function iqError(code: number, text = 'oops'): BinaryNode {
+    return {
+        tag: 'iq',
+        attrs: { type: 'error' },
+        content: [{ tag: 'error', attrs: { code: String(code), text } }]
+    }
+}
+
+test('email coordinator parses get/set status with email_address and confirmed children', async () => {
+    const calls: Array<{ context: string; node: BinaryNode }> = []
+    const coordinator = createEmailCoordinator({
+        queryWithContext: async (context, node) => {
+            calls.push({ context, node })
+            return iqResult([
+                {
+                    tag: WA_EMAIL_TAGS.EMAIL,
+                    attrs: { verified: 'true' },
+                    content: [
+                        {
+                            tag: WA_EMAIL_TAGS.EMAIL_ADDRESS,
+                            attrs: {},
+                            content: 'foo@bar.com'
+                        },
+                        { tag: WA_EMAIL_TAGS.CONFIRMED, attrs: {}, content: 'true' }
+                    ]
+                }
+            ])
+        }
+    })
+
+    const status = await coordinator.getStatus()
+    assert.deepEqual(status, { email: 'foo@bar.com', verified: true, confirmed: true })
+    assert.equal(calls[0].context, 'email.getStatus')
+    assert.equal(calls[0].node.attrs.type, 'get')
+
+    const setStatus = await coordinator.setEmail('foo@bar.com', WA_EMAIL_CONTEXTS.ONBOARDING)
+    assert.equal(setStatus.email, 'foo@bar.com')
+    assert.equal(calls[1].context, 'email.set')
+    assert.equal(calls[1].node.attrs.type, 'set')
+})
+
+test('email coordinator returns empty status when no email child is present', async () => {
+    const coordinator = createEmailCoordinator({
+        queryWithContext: async () => iqResult()
+    })
+    const status = await coordinator.getStatus()
+    assert.deepEqual(status, { email: null, verified: false, confirmed: false })
+})
+
+test('email coordinator parses verifyCode result and detects auto_verify=fail', async () => {
+    const coordinator = createEmailCoordinator({
+        queryWithContext: async () =>
+            iqResult([
+                {
+                    tag: WA_EMAIL_TAGS.EMAIL,
+                    attrs: { do_verify: 'true' },
+                    content: [
+                        { tag: WA_EMAIL_TAGS.AUTO_VERIFY, attrs: {}, content: 'fail' },
+                        {
+                            tag: WA_EMAIL_TAGS.EMAIL_ADDRESS,
+                            attrs: {},
+                            content: 'foo@bar.com'
+                        }
+                    ]
+                }
+            ])
+    })
+
+    const result = await coordinator.verifyCode('123456')
+    assert.deepEqual(result, {
+        verified: true,
+        autoVerifyFailed: true,
+        email: 'foo@bar.com'
+    })
+})
+
+test('email coordinator surfaces server iq error with code in message', async () => {
+    const coordinator = createEmailCoordinator({
+        queryWithContext: async () => iqError(WA_EMAIL_ERROR_CODES.CODE_INCORRECT, 'bad')
+    })
+
+    await assert.rejects(coordinator.verifyCode('999999'), (err) => {
+        assert.ok(err instanceof Error)
+        assert.match(err.message, /email\.verifyCode/)
+        assert.match(err.message, new RegExp(String(WA_EMAIL_ERROR_CODES.CODE_INCORRECT)))
+        assert.match(err.message, /bad/)
+        return true
+    })
+})
+
+test('email coordinator requestVerificationCode and confirm pass through to queryWithContext', async () => {
+    const calls: Array<{ context: string; node: BinaryNode }> = []
+    const coordinator = createEmailCoordinator({
+        queryWithContext: async (context, node) => {
+            calls.push({ context, node })
+            return iqResult()
+        }
+    })
+
+    await coordinator.requestVerificationCode({ languageCode: 'pt', localeCode: 'BR' })
+    await coordinator.confirm(WA_EMAIL_CONTEXTS.SETTINGS)
+
+    assert.equal(calls[0].context, 'email.requestCode')
+    assert.equal(calls[0].node.attrs.type, 'set')
+    assert.equal(calls[1].context, 'email.confirm')
+    assert.equal(calls[1].node.attrs.type, 'set')
+})

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -64,6 +64,14 @@ export {
 export type { WaPrivacyCategory, WaPrivacySettingName, WaPrivacyValue } from '@protocol/privacy'
 export { WA_DEFAULTS } from '@protocol/defaults'
 export {
+    WA_EMAIL_CONTEXTS,
+    WA_EMAIL_ERROR_CODES,
+    WA_EMAIL_LIMITS,
+    WA_EMAIL_TAGS,
+    WA_EMAIL_XMLNS
+} from '@protocol/email'
+export type { WaEmailContext, WaEmailErrorCode } from '@protocol/email'
+export {
     AB_PROP_CONFIGS,
     resolveAbPropNameByCode,
     WA_ABPROPS_PROTOCOL_VERSION,

--- a/src/protocol/email.ts
+++ b/src/protocol/email.ts
@@ -1,0 +1,38 @@
+export const WA_EMAIL_XMLNS = 'urn:xmpp:whatsapp:account'
+
+export const WA_EMAIL_TAGS = Object.freeze({
+    EMAIL: 'email',
+    EMAIL_ADDRESS: 'email_address',
+    VERIFY_EMAIL: 'verify_email',
+    CONFIRM_EMAIL: 'confirm_email',
+    CONTEXT: 'context',
+    CODE: 'code',
+    LG: 'lg',
+    LC: 'lc',
+    AUTO_VERIFY: 'auto_verify',
+    CONFIRMED: 'confirmed'
+} as const)
+
+export const WA_EMAIL_CONTEXTS = Object.freeze({
+    ONBOARDING: 'onboarding',
+    SETTINGS: 'settings'
+} as const)
+
+export type WaEmailContext = (typeof WA_EMAIL_CONTEXTS)[keyof typeof WA_EMAIL_CONTEXTS]
+
+export const WA_EMAIL_LIMITS = Object.freeze({
+    EMAIL_MAX_LENGTH: 320,
+    CODE_LENGTH: 6,
+    LOCALE_MIN_LENGTH: 2,
+    LOCALE_MAX_LENGTH: 3
+} as const)
+
+export const WA_EMAIL_ERROR_CODES = Object.freeze({
+    FORBIDDEN: 403,
+    LOCKOUT: 534,
+    CODE_EXPIRED: 535,
+    CODE_INCORRECT: 536,
+    TOO_MANY_RETRIES: 537
+} as const)
+
+export type WaEmailErrorCode = (typeof WA_EMAIL_ERROR_CODES)[keyof typeof WA_EMAIL_ERROR_CODES]

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -3,6 +3,9 @@ import test from 'node:test'
 
 import {
     WA_DEFAULTS,
+    WA_EMAIL_CONTEXTS,
+    WA_EMAIL_TAGS,
+    WA_EMAIL_XMLNS,
     WA_NODE_TAGS,
     WA_PRIVACY_CATEGORIES,
     WA_PRIVACY_TAGS,
@@ -22,6 +25,13 @@ import {
     buildNewsletterMetadataSyncIq
 } from '@transport/node/builders/account-sync'
 import { buildRemoveCompanionDeviceIq } from '@transport/node/builders/device'
+import {
+    buildConfirmEmailIq,
+    buildGetEmailIq,
+    buildRequestEmailVerificationCodeIq,
+    buildSetEmailIq,
+    buildVerifyEmailCodeIq
+} from '@transport/node/builders/email'
 import { buildAckNode, buildIqResultNode, buildReceiptNode } from '@transport/node/builders/global'
 import {
     buildCreateGroupIq,
@@ -1050,4 +1060,83 @@ test('message builders include edit mediatype and meta node when provided', () =
     })
     assert.ok(Array.isArray(retry.content))
     assert.equal(retry.content[0].attrs.mediatype, 'document')
+})
+
+test('email builders produce account namespace iq stanzas', () => {
+    const get = buildGetEmailIq()
+    assert.equal(get.attrs.type, 'get')
+    assert.equal(get.attrs.to, WA_DEFAULTS.HOST_DOMAIN)
+    assert.equal(get.attrs.xmlns, WA_EMAIL_XMLNS)
+    assert.ok(Array.isArray(get.content))
+    assert.equal(get.content[0].tag, WA_EMAIL_TAGS.EMAIL)
+    assert.equal(get.content[0].content, undefined)
+
+    const setNoCtx = buildSetEmailIq('foo@bar.com')
+    assert.equal(setNoCtx.attrs.type, 'set')
+    assert.equal(setNoCtx.attrs.xmlns, WA_EMAIL_XMLNS)
+    assert.ok(Array.isArray(setNoCtx.content))
+    const setEmailNode = setNoCtx.content[0]
+    assert.equal(setEmailNode.tag, WA_EMAIL_TAGS.EMAIL)
+    assert.ok(Array.isArray(setEmailNode.content))
+    assert.equal(setEmailNode.content.length, 1)
+    assert.equal(setEmailNode.content[0].tag, WA_EMAIL_TAGS.EMAIL_ADDRESS)
+    assert.equal(setEmailNode.content[0].content, 'foo@bar.com')
+
+    const setWithCtx = buildSetEmailIq('a@b.co', WA_EMAIL_CONTEXTS.ONBOARDING)
+    assert.ok(Array.isArray(setWithCtx.content))
+    assert.ok(Array.isArray(setWithCtx.content[0].content))
+    const ctxChildren = setWithCtx.content[0].content
+    assert.equal(ctxChildren.length, 2)
+    assert.equal(ctxChildren[0].tag, WA_EMAIL_TAGS.CONTEXT)
+    assert.equal(ctxChildren[0].content, 'onboarding')
+    assert.equal(ctxChildren[1].tag, WA_EMAIL_TAGS.EMAIL_ADDRESS)
+
+    assert.throws(() => buildSetEmailIq(''), /email length must be between/)
+    assert.throws(() => buildSetEmailIq('x'.repeat(321)), /email length must be between/)
+
+    const requestCode = buildRequestEmailVerificationCodeIq({
+        languageCode: 'pt',
+        localeCode: 'BR'
+    })
+    assert.equal(requestCode.attrs.type, 'set')
+    assert.ok(Array.isArray(requestCode.content))
+    const verifyEmail = requestCode.content[0]
+    assert.equal(verifyEmail.tag, WA_EMAIL_TAGS.VERIFY_EMAIL)
+    assert.ok(Array.isArray(verifyEmail.content))
+    assert.equal(verifyEmail.content[0].tag, WA_EMAIL_TAGS.LG)
+    assert.equal(verifyEmail.content[0].content, 'pt')
+    assert.equal(verifyEmail.content[1].tag, WA_EMAIL_TAGS.LC)
+    assert.equal(verifyEmail.content[1].content, 'BR')
+
+    assert.throws(
+        () => buildRequestEmailVerificationCodeIq({ languageCode: 'p', localeCode: 'BR' }),
+        /languageCode/
+    )
+    assert.throws(
+        () => buildRequestEmailVerificationCodeIq({ languageCode: 'pt', localeCode: 'BRAA' }),
+        /localeCode/
+    )
+
+    const verify = buildVerifyEmailCodeIq('123456')
+    assert.equal(verify.attrs.type, 'set')
+    assert.ok(Array.isArray(verify.content))
+    const verifyChild = verify.content[0]
+    assert.equal(verifyChild.tag, WA_EMAIL_TAGS.VERIFY_EMAIL)
+    assert.ok(Array.isArray(verifyChild.content))
+    assert.equal(verifyChild.content[0].tag, WA_EMAIL_TAGS.CODE)
+    assert.equal(verifyChild.content[0].content, '123456')
+
+    assert.throws(() => buildVerifyEmailCodeIq('12345'), /6 chars/)
+
+    const confirmNoCtx = buildConfirmEmailIq()
+    assert.equal(confirmNoCtx.attrs.type, 'set')
+    assert.ok(Array.isArray(confirmNoCtx.content))
+    assert.equal(confirmNoCtx.content[0].tag, WA_EMAIL_TAGS.CONFIRM_EMAIL)
+    assert.equal(confirmNoCtx.content[0].content, undefined)
+
+    const confirmWithCtx = buildConfirmEmailIq(WA_EMAIL_CONTEXTS.SETTINGS)
+    assert.ok(Array.isArray(confirmWithCtx.content))
+    assert.ok(Array.isArray(confirmWithCtx.content[0].content))
+    assert.equal(confirmWithCtx.content[0].content[0].tag, WA_EMAIL_TAGS.CONTEXT)
+    assert.equal(confirmWithCtx.content[0].content[0].content, 'settings')
 })

--- a/src/transport/node/builders/email.ts
+++ b/src/transport/node/builders/email.ts
@@ -1,0 +1,91 @@
+import { WA_DEFAULTS } from '@protocol/defaults'
+import {
+    WA_EMAIL_LIMITS,
+    WA_EMAIL_TAGS,
+    WA_EMAIL_XMLNS,
+    type WaEmailContext
+} from '@protocol/email'
+import { buildIqNode } from '@transport/node/query'
+import type { BinaryNode } from '@transport/types'
+
+export function buildGetEmailIq(): BinaryNode {
+    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
+        { tag: WA_EMAIL_TAGS.EMAIL, attrs: {} }
+    ])
+}
+
+export function buildSetEmailIq(email: string, context?: WaEmailContext): BinaryNode {
+    if (email.length === 0 || email.length > WA_EMAIL_LIMITS.EMAIL_MAX_LENGTH) {
+        throw new Error(
+            `email length must be between 1 and ${WA_EMAIL_LIMITS.EMAIL_MAX_LENGTH} chars`
+        )
+    }
+    const emailChildren: BinaryNode[] = []
+    if (context !== undefined) {
+        emailChildren.push({ tag: WA_EMAIL_TAGS.CONTEXT, attrs: {}, content: context })
+    }
+    emailChildren.push({ tag: WA_EMAIL_TAGS.EMAIL_ADDRESS, attrs: {}, content: email })
+    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
+        { tag: WA_EMAIL_TAGS.EMAIL, attrs: {}, content: emailChildren }
+    ])
+}
+
+export interface BuildRequestEmailVerificationCodeInput {
+    readonly languageCode: string
+    readonly localeCode: string
+}
+
+export function buildRequestEmailVerificationCodeIq(
+    input: BuildRequestEmailVerificationCodeInput
+): BinaryNode {
+    assertLocaleField('languageCode', input.languageCode)
+    assertLocaleField('localeCode', input.localeCode)
+    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
+        {
+            tag: WA_EMAIL_TAGS.VERIFY_EMAIL,
+            attrs: {},
+            content: [
+                { tag: WA_EMAIL_TAGS.LG, attrs: {}, content: input.languageCode },
+                { tag: WA_EMAIL_TAGS.LC, attrs: {}, content: input.localeCode }
+            ]
+        }
+    ])
+}
+
+export function buildVerifyEmailCodeIq(code: string): BinaryNode {
+    if (code.length !== WA_EMAIL_LIMITS.CODE_LENGTH) {
+        throw new Error(`verification code must be exactly ${WA_EMAIL_LIMITS.CODE_LENGTH} chars`)
+    }
+    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
+        {
+            tag: WA_EMAIL_TAGS.VERIFY_EMAIL,
+            attrs: {},
+            content: [{ tag: WA_EMAIL_TAGS.CODE, attrs: {}, content: code }]
+        }
+    ])
+}
+
+export function buildConfirmEmailIq(context?: WaEmailContext): BinaryNode {
+    const children: BinaryNode[] | undefined =
+        context !== undefined
+            ? [{ tag: WA_EMAIL_TAGS.CONTEXT, attrs: {}, content: context }]
+            : undefined
+    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
+        {
+            tag: WA_EMAIL_TAGS.CONFIRM_EMAIL,
+            attrs: {},
+            ...(children !== undefined ? { content: children } : {})
+        }
+    ])
+}
+
+function assertLocaleField(field: string, value: string): void {
+    if (
+        value.length < WA_EMAIL_LIMITS.LOCALE_MIN_LENGTH ||
+        value.length > WA_EMAIL_LIMITS.LOCALE_MAX_LENGTH
+    ) {
+        throw new Error(
+            `${field} must be between ${WA_EMAIL_LIMITS.LOCALE_MIN_LENGTH} and ${WA_EMAIL_LIMITS.LOCALE_MAX_LENGTH} chars`
+        )
+    }
+}

--- a/src/transport/node/helpers.ts
+++ b/src/transport/node/helpers.ts
@@ -153,6 +153,13 @@ export function decodeNodeContentUtf8OrBytes(
     throw new Error(`node ${field} has no binary content`)
 }
 
+export function getNodeTextContent(node: BinaryNode): string | undefined {
+    const content = node.content
+    if (content instanceof Uint8Array) return TEXT_DECODER.decode(content)
+    if (typeof content === 'string') return content
+    return undefined
+}
+
 export function decodeNodeContentBase64OrBytes(
     value: BinaryNode['content'],
     field: string


### PR DESCRIPTION
Adds the mobile-flow email registration IQ surface over `urn:xmpp:whatsapp:account`: get/set email, request verification code, verify code, and confirm. Exposes `client.email.*` via a new `WaEmailCoordinator` wired through `buildWaClientDependencies`.

Also extracts the duplicated `readTextContent` helper into `@transport/node/helpers` as `getNodeTextContent`, reused by both the business and email coordinators.

Drive-by: rename references from `deobfuscated/` to `wa-web/` and `wa-mob/` in .gitignore, eslint ignores, and a fake-server doc comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email management functionality to the client, including the ability to check email status, set an email address, request and verify verification codes, and confirm email addresses.

* **Tests**
  * Added comprehensive test coverage for email functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->