### PR TITLE
perf(crypto): migrate from WebCrypto subtle to node:crypto

### DIFF
--- a/bench/crypto-core.bench.ts
+++ b/bench/crypto-core.bench.ts
@@ -1,14 +1,6 @@
 import assert from 'node:assert/strict'
 
-import {
-    aesGcmDecrypt,
-    aesGcmEncrypt,
-    hkdf,
-    hmacSign,
-    importAesGcmKey,
-    importHmacKey,
-    sha256
-} from '@crypto/core'
+import { aesGcmDecrypt, aesGcmEncrypt, hkdf, hmacSha256Sign, sha256 } from '@crypto/core'
 import { toError } from '@util/primitives'
 
 import {
@@ -139,14 +131,12 @@ async function runBench(): Promise<void> {
     const plaintext = buildPatternBytes(config.payloadBytes)
     const nonce = buildPatternBytes(12)
 
-    const aesKeyRaw = buildPatternBytes(32)
-    const aesKey = await importAesGcmKey(aesKeyRaw, ['encrypt', 'decrypt'])
+    const aesKey = buildPatternBytes(32)
     const ciphertext = await aesGcmEncrypt(aesKey, nonce, plaintext)
     const decrypted = await aesGcmDecrypt(aesKey, nonce, ciphertext)
     assert.deepEqual(decrypted, plaintext)
 
-    const hmacKeyRaw = buildPatternBytes(32)
-    const hmacKey = await importHmacKey(hmacKeyRaw)
+    const hmacKey = buildPatternBytes(32)
 
     const results: TimedBenchmarkResult[] = []
     let validation: TimedBenchmarkValidationSummary | null = null
@@ -189,7 +179,7 @@ async function runBench(): Promise<void> {
 
     const runHmacOps = async (): Promise<void> => {
         for (let operation = 0; operation < config.operationsPerIteration; operation += 1) {
-            const signature = await hmacSign(hmacKey, plaintext)
+            const signature = await hmacSha256Sign(hmacKey, plaintext)
             if (signature.byteLength !== 32) {
                 throw new Error('hmac result mismatch')
             }

--- a/packages/fake-server/src/infra/WaFakeNoiseHandshake.ts
+++ b/packages/fake-server/src/infra/WaFakeNoiseHandshake.ts
@@ -1,19 +1,12 @@
 /** Responder-side Noise handshake primitives for fake server pipelines. */
 
-import {
-    aesGcmDecrypt,
-    aesGcmEncrypt,
-    type CryptoKey,
-    hkdfSplit,
-    importAesGcmKey,
-    sha256
-} from '../transport/crypto'
+import { aesGcmDecrypt, aesGcmEncrypt, hkdfSplit, sha256 } from '../transport/crypto'
 
 const EMPTY = new Uint8Array(0)
 
 export interface WaFakeNoiseHandshakeFinishKeys {
-    readonly recvKey: CryptoKey
-    readonly sendKey: CryptoKey
+    readonly recvKey: Uint8Array
+    readonly sendKey: Uint8Array
     readonly recvKeyBytes: Uint8Array
     readonly sendKeyBytes: Uint8Array
 }
@@ -21,14 +14,14 @@ export interface WaFakeNoiseHandshakeFinishKeys {
 export class WaFakeNoiseHandshake {
     private hash: Uint8Array = EMPTY
     private chainingKey: Uint8Array = EMPTY
-    private cipherKey: CryptoKey | null = null
+    private cipherKey: Uint8Array | null = null
     private nonceCounter = 0
 
     public async start(name: Uint8Array, prologue: Uint8Array): Promise<void> {
         const initialHash = name.byteLength === 32 ? name : await sha256(name)
         this.hash = initialHash
         this.chainingKey = initialHash
-        this.cipherKey = await importAesGcmKey(initialHash, ['encrypt', 'decrypt'])
+        this.cipherKey = initialHash
         this.nonceCounter = 0
         await this.authenticate(prologue)
     }
@@ -43,7 +36,7 @@ export class WaFakeNoiseHandshake {
     public async mixIntoKey(input: Uint8Array): Promise<void> {
         const [nextChainingKey, nextCipherMaterial] = await hkdfSplit(input, this.chainingKey, '')
         this.chainingKey = nextChainingKey
-        this.cipherKey = await importAesGcmKey(nextCipherMaterial, ['encrypt', 'decrypt'])
+        this.cipherKey = nextCipherMaterial
         this.nonceCounter = 0
     }
 
@@ -72,13 +65,9 @@ export class WaFakeNoiseHandshake {
     /** Derives transport keys (`first -> recv`, `second -> send` for responder role). */
     public async finish(): Promise<WaFakeNoiseHandshakeFinishKeys> {
         const [first, second] = await hkdfSplit(EMPTY, this.chainingKey, '')
-        const [recvKey, sendKey] = await Promise.all([
-            importAesGcmKey(first, ['decrypt']),
-            importAesGcmKey(second, ['encrypt'])
-        ])
         return {
-            recvKey,
-            sendKey,
+            recvKey: first,
+            sendKey: second,
             recvKeyBytes: first,
             sendKeyBytes: second
         }

--- a/packages/fake-server/src/infra/WaFakeTransport.ts
+++ b/packages/fake-server/src/infra/WaFakeTransport.ts
@@ -1,14 +1,14 @@
 /** Post-handshake Noise transport (AES-GCM with direction-specific counters). */
 
-import { aesGcmDecrypt, aesGcmEncrypt, type CryptoKey } from '../transport/crypto'
+import { aesGcmDecrypt, aesGcmEncrypt } from '../transport/crypto'
 
 export class WaFakeTransport {
-    private readonly recvKey: CryptoKey
-    private readonly sendKey: CryptoKey
+    private readonly recvKey: Uint8Array
+    private readonly sendKey: Uint8Array
     private sendCounter = 0
     private recvCounter = 0
 
-    public constructor(keys: { readonly recvKey: CryptoKey; readonly sendKey: CryptoKey }) {
+    public constructor(keys: { readonly recvKey: Uint8Array; readonly sendKey: Uint8Array }) {
         this.recvKey = keys.recvKey
         this.sendKey = keys.sendKey
     }

--- a/packages/fake-server/src/infra/__tests__/WaFakeNoiseHandshake.cross-check.test.ts
+++ b/packages/fake-server/src/infra/__tests__/WaFakeNoiseHandshake.cross-check.test.ts
@@ -5,7 +5,7 @@ import test from 'node:test'
 
 import { WaNoiseHandshake } from 'zapo-js/transport'
 
-import { aesGcmDecrypt, aesGcmEncrypt, type CryptoKey, X25519 } from '../../transport/crypto'
+import { aesGcmDecrypt, aesGcmEncrypt, X25519 } from '../../transport/crypto'
 import { proto } from '../../transport/protos'
 import { WaFakeNoiseHandshake } from '../WaFakeNoiseHandshake'
 
@@ -20,7 +20,7 @@ function buildNonce(counter: number): Uint8Array {
 }
 
 function encryptWithKey(
-    key: CryptoKey,
+    key: Uint8Array,
     counter: number,
     plaintext: Uint8Array
 ): Promise<Uint8Array> {
@@ -28,7 +28,7 @@ function encryptWithKey(
 }
 
 function decryptWithKey(
-    key: CryptoKey,
+    key: Uint8Array,
     counter: number,
     ciphertext: Uint8Array
 ): Promise<Uint8Array> {

--- a/packages/fake-server/src/protocol/auth/fake-primary-device.ts
+++ b/packages/fake-server/src/protocol/auth/fake-primary-device.ts
@@ -1,12 +1,6 @@
 /** Fake primary-device identity/signature helpers for pairing. */
 
-import {
-    hmacSign,
-    importHmacKey,
-    type SignalKeyPair,
-    X25519,
-    xeddsaSign
-} from '../../transport/crypto'
+import { hmacSha256Sign, type SignalKeyPair, X25519, xeddsaSign } from '../../transport/crypto'
 import { proto } from '../../transport/protos'
 
 const ADV_PREFIX_ACCOUNT_SIGNATURE = new Uint8Array([0x06, 0x00])
@@ -58,8 +52,7 @@ export async function buildAdvSignedDeviceIdentity(
         accountSignature
     }).finish()
 
-    const hmacKey = await importHmacKey(input.advSecretKey)
-    const hmac = await hmacSign(hmacKey, signedIdentity)
+    const hmac = await hmacSha256Sign(input.advSecretKey, signedIdentity)
 
     const wrapped = proto.ADVSignedDeviceIdentityHMAC.encode({
         details: signedIdentity,

--- a/packages/fake-server/src/protocol/signal/fake-app-state-crypto.ts
+++ b/packages/fake-server/src/protocol/signal/fake-app-state-crypto.ts
@@ -3,12 +3,9 @@
 import {
     aesCbcDecrypt,
     aesCbcEncrypt,
-    type CryptoKey,
     hkdf,
-    hmacSign,
-    importAesCbcKey,
-    importHmacKey,
-    importHmacSha512Key,
+    hmacSha256Sign,
+    hmacSha512Sign,
     randomBytesAsync
 } from '../../transport/crypto'
 import { proto, type Proto } from '../../transport/protos'
@@ -30,11 +27,11 @@ const KDF_INFO_PATCH_INTEGRITY = 'WhatsApp Patch Integrity'
 export const APP_STATE_EMPTY_LT_HASH = new Uint8Array(APP_STATE_LT_HASH_SIZE)
 
 export interface FakeAppStateDerivedKeys {
-    readonly indexHmacKey: CryptoKey
-    readonly valueEncryptionAesKey: CryptoKey
-    readonly valueMacHmacKey: CryptoKey
-    readonly snapshotMacHmacKey: CryptoKey
-    readonly patchMacHmacKey: CryptoKey
+    readonly indexHmacKey: Uint8Array
+    readonly valueEncryptionAesKey: Uint8Array
+    readonly valueMacHmacKey: Uint8Array
+    readonly snapshotMacHmacKey: Uint8Array
+    readonly patchMacHmacKey: Uint8Array
 }
 
 export interface FakeAppStateEncryptedMutation {
@@ -61,45 +58,24 @@ export class FakeAppStateCrypto {
             KDF_INFO_MUTATION_KEYS,
             APP_STATE_DERIVED_KEY_LENGTH
         )
-        const [
-            indexHmacKey,
-            valueEncryptionAesKey,
-            valueMacHmacKey,
-            snapshotMacHmacKey,
-            patchMacHmacKey
-        ] = await Promise.all([
-            importHmacKey(derived.subarray(0, APP_STATE_DERIVED_INDEX_KEY_END)),
-            importAesCbcKey(
-                derived.subarray(
-                    APP_STATE_DERIVED_INDEX_KEY_END,
-                    APP_STATE_DERIVED_VALUE_ENCRYPTION_KEY_END
-                )
-            ),
-            importHmacSha512Key(
-                derived.subarray(
-                    APP_STATE_DERIVED_VALUE_ENCRYPTION_KEY_END,
-                    APP_STATE_DERIVED_VALUE_MAC_KEY_END
-                )
-            ),
-            importHmacKey(
-                derived.subarray(
-                    APP_STATE_DERIVED_VALUE_MAC_KEY_END,
-                    APP_STATE_DERIVED_SNAPSHOT_MAC_KEY_END
-                )
-            ),
-            importHmacKey(
-                derived.subarray(
-                    APP_STATE_DERIVED_SNAPSHOT_MAC_KEY_END,
-                    APP_STATE_DERIVED_PATCH_MAC_KEY_END
-                )
-            )
-        ])
         return {
-            indexHmacKey,
-            valueEncryptionAesKey,
-            valueMacHmacKey,
-            snapshotMacHmacKey,
-            patchMacHmacKey
+            indexHmacKey: derived.subarray(0, APP_STATE_DERIVED_INDEX_KEY_END),
+            valueEncryptionAesKey: derived.subarray(
+                APP_STATE_DERIVED_INDEX_KEY_END,
+                APP_STATE_DERIVED_VALUE_ENCRYPTION_KEY_END
+            ),
+            valueMacHmacKey: derived.subarray(
+                APP_STATE_DERIVED_VALUE_ENCRYPTION_KEY_END,
+                APP_STATE_DERIVED_VALUE_MAC_KEY_END
+            ),
+            snapshotMacHmacKey: derived.subarray(
+                APP_STATE_DERIVED_VALUE_MAC_KEY_END,
+                APP_STATE_DERIVED_SNAPSHOT_MAC_KEY_END
+            ),
+            patchMacHmacKey: derived.subarray(
+                APP_STATE_DERIVED_SNAPSHOT_MAC_KEY_END,
+                APP_STATE_DERIVED_PATCH_MAC_KEY_END
+            )
         }
     }
 
@@ -120,7 +96,7 @@ export class FakeAppStateCrypto {
             throw new Error(`invalid IV length ${iv.byteLength}`)
         }
 
-        const indexMac = await hmacSign(derivedKeys.indexHmacKey, indexBytes)
+        const indexMac = await hmacSha256Sign(derivedKeys.indexHmacKey, indexBytes)
         const cipherText = await aesCbcEncrypt(derivedKeys.valueEncryptionAesKey, iv, encoded)
         const cipherWithIv = concatBytes([iv, cipherText])
         const associatedData = generateAssociatedData(input.operation, input.keyId)
@@ -178,7 +154,10 @@ export class FakeAppStateCrypto {
         if (syncActionData.version === null || syncActionData.version === undefined) {
             throw new Error('missing sync action version')
         }
-        const generatedIndexMac = await hmacSign(derivedKeys.indexHmacKey, syncActionData.index)
+        const generatedIndexMac = await hmacSha256Sign(
+            derivedKeys.indexHmacKey,
+            syncActionData.index
+        )
         if (!uint8Equal(generatedIndexMac, input.indexMac)) {
             throw new Error('mutation index MAC mismatch')
         }
@@ -203,7 +182,7 @@ export class FakeAppStateCrypto {
             intToBytesBe(8, version),
             new TextEncoder().encode(collectionName)
         ])
-        return hmacSign(derivedKeys.snapshotMacHmacKey, payload)
+        return hmacSha256Sign(derivedKeys.snapshotMacHmacKey, payload)
     }
 
     public async generatePatchMac(
@@ -220,7 +199,7 @@ export class FakeAppStateCrypto {
             intToBytesBe(8, version),
             new TextEncoder().encode(collectionName)
         ])
-        return hmacSign(derivedKeys.patchMacHmacKey, payload)
+        return hmacSha256Sign(derivedKeys.patchMacHmacKey, payload)
     }
 
     public async ltHashAdd(
@@ -259,13 +238,13 @@ export class FakeAppStateCrypto {
     }
 
     private async generateValueMac(
-        valueMacHmacKey: CryptoKey,
+        valueMacHmacKey: Uint8Array,
         associatedData: Uint8Array,
         cipherWithIv: Uint8Array
     ): Promise<Uint8Array> {
         const octetLength = new Uint8Array(APP_STATE_MAC_OCTET_LENGTH)
         octetLength[octetLength.length - 1] = associatedData.byteLength & 0xff
-        const full = await hmacSign(
+        const full = await hmacSha512Sign(
             valueMacHmacKey,
             concatBytes([associatedData, cipherWithIv, octetLength])
         )

--- a/packages/fake-server/src/protocol/signal/fake-peer-double-ratchet.ts
+++ b/packages/fake-server/src/protocol/signal/fake-peer-double-ratchet.ts
@@ -5,9 +5,7 @@ import {
     aesCbcEncrypt,
     hkdf,
     hkdfSplit,
-    hmacSign,
-    importAesCbcKey,
-    importHmacKey,
+    hmacSha256Sign,
     prependVersion,
     type SignalKeyPair,
     toRawPubKey,
@@ -162,11 +160,7 @@ export class FakePeerDoubleRatchet {
             this.sendChain.nextIndex,
             this.sendChain.chainKey
         )
-        const [cipherKey, macKey] = await Promise.all([
-            importAesCbcKey(messageKey.cipherKey),
-            importHmacKey(messageKey.macKey)
-        ])
-        const ciphertext = await aesCbcEncrypt(cipherKey, messageKey.iv, plaintext)
+        const ciphertext = await aesCbcEncrypt(messageKey.cipherKey, messageKey.iv, plaintext)
         const signalPayload = proto.SignalMessage.encode({
             ratchetKey: this.sendChain.ratchetPubSerialized,
             counter: messageKey.index,
@@ -179,7 +173,7 @@ export class FakePeerDoubleRatchet {
             this.remoteIdentityPubSerialized,
             versioned
         ])
-        const fullMac = await hmacSign(macKey, macInput)
+        const fullMac = await hmacSha256Sign(messageKey.macKey, macInput)
         const mac = fullMac.subarray(0, SIGNAL_MAC_SIZE)
         const inner = concatBytes([versioned, mac])
 
@@ -388,15 +382,13 @@ export class FakePeerDoubleRatchet {
             this.localIdentityPubSerialized,
             versionedBody
         ])
-        const macKeyHandle = await importHmacKey(messageKey.macKey)
-        const expectedFullMac = await hmacSign(macKeyHandle, macInput)
+        const expectedFullMac = await hmacSha256Sign(messageKey.macKey, macInput)
         const expectedMac = expectedFullMac.subarray(0, SIGNAL_MAC_SIZE)
         if (!uint8Equal(expectedMac, macBytes)) {
             throw new FakePeerDoubleRatchetError('signal message MAC mismatch')
         }
 
-        const cipherKeyHandle = await importAesCbcKey(messageKey.cipherKey)
-        const padded = await aesCbcDecrypt(cipherKeyHandle, messageKey.iv, ciphertext)
+        const padded = await aesCbcDecrypt(messageKey.cipherKey, messageKey.iv, ciphertext)
         return unpadPkcs7(padded)
     }
 
@@ -465,10 +457,9 @@ async function deriveMessageKey(
     index: number,
     chainKey: Uint8Array
 ): Promise<{ readonly nextChainKey: Uint8Array; readonly messageKey: DerivedMessageKey }> {
-    const hmacKey = await importHmacKey(chainKey)
     const [messageInputKey, nextChainRaw] = await Promise.all([
-        hmacSign(hmacKey, MESSAGE_KEY_LABEL),
-        hmacSign(hmacKey, CHAIN_KEY_LABEL)
+        hmacSha256Sign(chainKey, MESSAGE_KEY_LABEL),
+        hmacSha256Sign(chainKey, CHAIN_KEY_LABEL)
     ])
     const expanded = await hkdf(messageInputKey, null, 'WhisperMessageKeys', 80)
     return {

--- a/packages/fake-server/src/protocol/signal/fake-peer-group-recv-session.ts
+++ b/packages/fake-server/src/protocol/signal/fake-peer-group-recv-session.ts
@@ -3,9 +3,7 @@
 import {
     aesCbcDecrypt,
     hkdf,
-    hmacSign,
-    importAesCbcKey,
-    importHmacKey,
+    hmacSha256Sign,
     toRawPubKey,
     toSerializedPubKey,
     xeddsaVerify
@@ -130,10 +128,9 @@ export class FakePeerGroupRecvSession {
         let seed: Uint8Array | null = null
         let iteration = record.nextIteration
         while (iteration <= targetIteration) {
-            const hmacKeyHandle = await importHmacKey(chainKey)
             const [nextChainRaw, messageInputKey] = await Promise.all([
-                hmacSign(hmacKeyHandle, CHAIN_KEY_LABEL),
-                hmacSign(hmacKeyHandle, MESSAGE_KEY_LABEL)
+                hmacSha256Sign(chainKey, CHAIN_KEY_LABEL),
+                hmacSha256Sign(chainKey, MESSAGE_KEY_LABEL)
             ])
             const messageSeed = await hkdf(messageInputKey, null, WHISPER_GROUP_INFO, 50)
             if (iteration === targetIteration) {
@@ -150,8 +147,7 @@ export class FakePeerGroupRecvSession {
 
         const iv = seed.subarray(0, 16)
         const keyBytes = seed.subarray(16, 48)
-        const cipherKey = await importAesCbcKey(keyBytes)
-        const padded = await aesCbcDecrypt(cipherKey, iv, decoded.ciphertext)
+        const padded = await aesCbcDecrypt(keyBytes, iv, decoded.ciphertext)
         return unpadPkcs7(padded)
     }
 }

--- a/packages/fake-server/src/protocol/signal/fake-sender-key.ts
+++ b/packages/fake-server/src/protocol/signal/fake-sender-key.ts
@@ -3,9 +3,7 @@
 import {
     aesCbcEncrypt,
     hkdf,
-    hmacSign,
-    importAesCbcKey,
-    importHmacKey,
+    hmacSha256Sign,
     prependVersion,
     randomBytesAsync,
     type SignalKeyPair,
@@ -68,8 +66,7 @@ export class FakeSenderKey {
         )
 
         const { iv, cipherKey } = splitSenderKeyMessageSeed(messageKey.seed)
-        const cipherKeyHandle = await importAesCbcKey(cipherKey)
-        const ciphertext = await aesCbcEncrypt(cipherKeyHandle, iv, plaintext)
+        const ciphertext = await aesCbcEncrypt(cipherKey, iv, plaintext)
 
         const senderKeyMessage = proto.SenderKeyMessage.encode({
             id: this.state.id,
@@ -120,10 +117,9 @@ async function deriveSenderKeyMessageKey(
     readonly messageKey: DerivedSenderKeyMessage
     readonly nextChainKey: Uint8Array
 }> {
-    const hmacKey = await importHmacKey(chainKey)
     const [messageInputKey, nextChainRaw] = await Promise.all([
-        hmacSign(hmacKey, MESSAGE_KEY_LABEL),
-        hmacSign(hmacKey, CHAIN_KEY_LABEL)
+        hmacSha256Sign(chainKey, MESSAGE_KEY_LABEL),
+        hmacSha256Sign(chainKey, CHAIN_KEY_LABEL)
     ])
     const seed = await hkdf(messageInputKey, null, WHISPER_GROUP_INFO, 50)
     return {

--- a/packages/fake-server/src/transport/crypto.ts
+++ b/packages/fake-server/src/transport/crypto.ts
@@ -14,11 +14,8 @@ export {
     Ed25519,
     hkdf,
     hkdfSplit,
-    hmacSign,
-    importAesCbcKey,
-    importAesGcmKey,
-    importHmacKey,
-    importHmacSha512Key,
+    hmacSha256Sign,
+    hmacSha512Sign,
     prependVersion,
     randomBytesAsync,
     readVersionedContent,
@@ -30,5 +27,5 @@ export {
     xeddsaSign,
     xeddsaVerify
 } from 'zapo-js/crypto'
-export type { CryptoKey, SignalKeyPair } from 'zapo-js/crypto'
+export type { SignalKeyPair } from 'zapo-js/crypto'
 export { WaMediaCrypto } from 'zapo-js/media'

--- a/src/appstate/WaAppStateCrypto.ts
+++ b/src/appstate/WaAppStateCrypto.ts
@@ -15,11 +15,8 @@ import { hkdf } from '@crypto/core/hkdf'
 import {
     aesCbcDecrypt,
     aesCbcEncrypt,
-    type CryptoKey,
-    hmacSign,
-    importAesCbcKey,
-    importHmacKey,
-    importHmacSha512Key
+    hmacSha256Sign,
+    hmacSha512Sign
 } from '@crypto/core/primitives'
 import { randomBytesAsync } from '@crypto/core/random'
 import { proto, type Proto } from '@proto'
@@ -37,11 +34,11 @@ import { setBoundedMapEntry } from '@util/collections'
 import { normalizeNonNegativeInteger } from '@util/primitives'
 
 interface WaAppStateDerivedKeys {
-    readonly indexHmacKey: CryptoKey
-    readonly valueEncryptionAesKey: CryptoKey
-    readonly valueMacHmacKey: CryptoKey
-    readonly snapshotMacHmacKey: CryptoKey
-    readonly patchMacHmacKey: CryptoKey
+    readonly indexHmacKey: Uint8Array
+    readonly valueEncryptionAesKey: Uint8Array
+    readonly valueMacHmacKey: Uint8Array
+    readonly snapshotMacHmacKey: Uint8Array
+    readonly patchMacHmacKey: Uint8Array
 }
 
 interface WaAppStateEncryptedMutation {
@@ -99,55 +96,31 @@ export class WaAppStateCrypto {
             WA_APP_STATE_KDF_INFO.MUTATION_KEYS,
             APP_STATE_DERIVED_KEY_LENGTH
         )
-        const [
-            indexHmacKey,
-            valueEncryptionAesKey,
-            valueMacHmacKey,
-            snapshotMacHmacKey,
-            patchMacHmacKey
-        ] = await Promise.all([
-            importHmacKey(derived.subarray(0, APP_STATE_DERIVED_INDEX_KEY_END)),
-            importAesCbcKey(
-                derived.subarray(
-                    APP_STATE_DERIVED_INDEX_KEY_END,
-                    APP_STATE_DERIVED_VALUE_ENCRYPTION_KEY_END
-                )
-            ),
-            importHmacSha512Key(
-                derived.subarray(
-                    APP_STATE_DERIVED_VALUE_ENCRYPTION_KEY_END,
-                    APP_STATE_DERIVED_VALUE_MAC_KEY_END
-                )
-            ),
-            importHmacKey(
-                derived.subarray(
-                    APP_STATE_DERIVED_VALUE_MAC_KEY_END,
-                    APP_STATE_DERIVED_SNAPSHOT_MAC_KEY_END
-                )
-            ),
-            importHmacKey(
-                derived.subarray(
-                    APP_STATE_DERIVED_SNAPSHOT_MAC_KEY_END,
-                    APP_STATE_DERIVED_PATCH_MAC_KEY_END
-                )
-            )
-        ])
         const keys: WaAppStateDerivedKeys = {
-            indexHmacKey,
-            valueEncryptionAesKey,
-            valueMacHmacKey,
-            snapshotMacHmacKey,
-            patchMacHmacKey
+            indexHmacKey: derived.subarray(0, APP_STATE_DERIVED_INDEX_KEY_END),
+            valueEncryptionAesKey: derived.subarray(
+                APP_STATE_DERIVED_INDEX_KEY_END,
+                APP_STATE_DERIVED_VALUE_ENCRYPTION_KEY_END
+            ),
+            valueMacHmacKey: derived.subarray(
+                APP_STATE_DERIVED_VALUE_ENCRYPTION_KEY_END,
+                APP_STATE_DERIVED_VALUE_MAC_KEY_END
+            ),
+            snapshotMacHmacKey: derived.subarray(
+                APP_STATE_DERIVED_VALUE_MAC_KEY_END,
+                APP_STATE_DERIVED_SNAPSHOT_MAC_KEY_END
+            ),
+            patchMacHmacKey: derived.subarray(
+                APP_STATE_DERIVED_SNAPSHOT_MAC_KEY_END,
+                APP_STATE_DERIVED_PATCH_MAC_KEY_END
+            )
         }
         this.touchDerivedKeysCacheEntry(cacheKey, keys)
         return keys
     }
 
-    public async generateIndexMac(
-        indexHmacKey: CryptoKey,
-        indexBytes: Uint8Array
-    ): Promise<Uint8Array> {
-        return hmacSign(indexHmacKey, indexBytes)
+    public generateIndexMac(indexHmacKey: Uint8Array, indexBytes: Uint8Array): Promise<Uint8Array> {
+        return hmacSha256Sign(indexHmacKey, indexBytes)
     }
 
     public async encryptMutation(args: {
@@ -265,7 +238,7 @@ export class WaAppStateCrypto {
             intToBytes(8, version),
             TEXT_ENCODER.encode(collectionName)
         ])
-        return hmacSign(derivedKeys.snapshotMacHmacKey, payload)
+        return hmacSha256Sign(derivedKeys.snapshotMacHmacKey, payload)
     }
 
     public async generatePatchMac(
@@ -282,7 +255,7 @@ export class WaAppStateCrypto {
             intToBytes(8, version),
             TEXT_ENCODER.encode(collectionName)
         ])
-        return hmacSign(derivedKeys.patchMacHmacKey, payload)
+        return hmacSha256Sign(derivedKeys.patchMacHmacKey, payload)
     }
 
     public async ltHashAdd(
@@ -377,13 +350,13 @@ export class WaAppStateCrypto {
     }
 
     private async generateValueMac(
-        valueMacHmacKey: CryptoKey,
+        valueMacHmacKey: Uint8Array,
         associatedData: Uint8Array,
         cipherWithIv: Uint8Array
     ): Promise<Uint8Array> {
         const octetLength = new Uint8Array(APP_STATE_MAC_OCTET_LENGTH)
         octetLength[octetLength.length - 1] = associatedData.byteLength & 0xff
-        const full = await hmacSign(
+        const full = await hmacSha512Sign(
             valueMacHmacKey,
             concatBytes([associatedData, cipherWithIv, octetLength])
         )

--- a/src/auth/pairing/pairing-code-crypto.ts
+++ b/src/auth/pairing/pairing-code-crypto.ts
@@ -3,8 +3,7 @@ import {
     aesCtrEncrypt,
     aesGcmEncrypt,
     hkdf,
-    importAesGcmKey,
-    pbkdf2DeriveAesCtrKey,
+    pbkdf2Sha256,
     randomBytesAsync
 } from '@crypto'
 import type { SignalKeyPair } from '@crypto/curves/types'
@@ -14,6 +13,7 @@ import { concatBytes, TEXT_ENCODER } from '@util/bytes'
 
 export const CROCKFORD_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTVWXYZ'
 export const PBKDF2_ITERATIONS = 2 << 16
+const PAIRING_AES_KEY_BYTES = 32
 
 function bytesToCrockford(bytes: Uint8Array): string {
     let bitCount = 0
@@ -66,12 +66,13 @@ export async function createCompanionHello(
         normalizedCustomCode !== null ? Promise.resolve(null) : randomBytesAsync(5)
     ])
     const pairingCode = normalizedCustomCode ?? bytesToCrockford(codeBytes!)
-    const cipher = await pbkdf2DeriveAesCtrKey(
+    const cipherKey = await pbkdf2Sha256(
         TEXT_ENCODER.encode(pairingCode),
         salt,
-        PBKDF2_ITERATIONS
+        PBKDF2_ITERATIONS,
+        PAIRING_AES_KEY_BYTES
     )
-    const encrypted = await aesCtrEncrypt(cipher, counter, companionEphemeralKeyPair.pubKey)
+    const encrypted = await aesCtrEncrypt(cipherKey, counter, companionEphemeralKeyPair.pubKey)
 
     return {
         pairingCode,
@@ -94,13 +95,14 @@ export async function completeCompanionFinish(args: {
     if (args.wrappedPrimaryEphemeralPub.length <= 48) {
         throw new Error('invalid wrapped primary payload')
     }
-    const pairingCipher = await pbkdf2DeriveAesCtrKey(
+    const pairingCipherKey = await pbkdf2Sha256(
         TEXT_ENCODER.encode(args.pairingCode),
         args.wrappedPrimaryEphemeralPub.subarray(0, 32),
-        PBKDF2_ITERATIONS
+        PBKDF2_ITERATIONS,
+        PAIRING_AES_KEY_BYTES
     )
     const primaryEphemeralPub = await aesCtrDecrypt(
-        pairingCipher,
+        pairingCipherKey,
         args.wrappedPrimaryEphemeralPub.subarray(32, 48),
         args.wrappedPrimaryEphemeralPub.subarray(48)
     )
@@ -115,13 +117,12 @@ export async function completeCompanionFinish(args: {
         randomBytesAsync(12)
     ])
 
-    const bundleEncryptionKeyRaw = await hkdf(
+    const bundleEncryptionKey = await hkdf(
         sharedEphemeral,
         bundleSalt,
         WA_PAIRING_KDF_INFO.LINK_CODE_BUNDLE,
         32
     )
-    const bundleEncryptionKey = await importAesGcmKey(bundleEncryptionKeyRaw, ['encrypt'])
 
     const plaintextBundle = concatBytes([
         args.registrationIdentityKeyPair.pubKey,

--- a/src/client/tokens/cs-token.ts
+++ b/src/client/tokens/cs-token.ts
@@ -1,35 +1,34 @@
-import { type CryptoKey, hmacSign, importHmacKey } from '@crypto/core'
+import { hmacSha256Sign } from '@crypto/core'
 import { TEXT_ENCODER } from '@util/bytes'
 import { setBoundedMapEntry } from '@util/collections'
 
 const CS_TOKEN_CACHE_MAX = 5
 
 export class CsTokenGenerator {
-    private cachedKey: CryptoKey | null
     private cachedSalt: Uint8Array | null
     private readonly cache: Map<string, Uint8Array>
 
     public constructor() {
-        this.cachedKey = null
         this.cachedSalt = null
         this.cache = new Map()
     }
 
     public async generate(nctSalt: Uint8Array, accountLid: string): Promise<Uint8Array> {
+        if (!this.isSameSalt(nctSalt)) {
+            this.cachedSalt = nctSalt
+            this.cache.clear()
+        }
         const cached = this.cache.get(accountLid)
-        if (cached && this.isSameSalt(nctSalt)) {
+        if (cached) {
             return cached
         }
 
-        const key = await this.resolveKey(nctSalt)
-        const result = await hmacSign(key, TEXT_ENCODER.encode(accountLid))
-
+        const result = await hmacSha256Sign(nctSalt, TEXT_ENCODER.encode(accountLid))
         setBoundedMapEntry(this.cache, accountLid, result, CS_TOKEN_CACHE_MAX)
         return result
     }
 
     public invalidate(): void {
-        this.cachedKey = null
         this.cachedSalt = null
         this.cache.clear()
     }
@@ -44,15 +43,5 @@ export class CsTokenGenerator {
             }
         }
         return true
-    }
-
-    private async resolveKey(salt: Uint8Array): Promise<CryptoKey> {
-        if (this.cachedKey && this.isSameSalt(salt)) {
-            return this.cachedKey
-        }
-        this.cachedKey = await importHmacKey(salt)
-        this.cachedSalt = salt
-        this.cache.clear()
-        return this.cachedKey
     }
 }

--- a/src/client/tokens/cs-token.ts
+++ b/src/client/tokens/cs-token.ts
@@ -14,16 +14,19 @@ export class CsTokenGenerator {
     }
 
     public async generate(nctSalt: Uint8Array, accountLid: string): Promise<Uint8Array> {
+        if (this.isSameSalt(nctSalt)) {
+            const cached = this.cache.get(accountLid)
+            if (cached) {
+                return cached
+            }
+        }
+
+        const result = await hmacSha256Sign(nctSalt, TEXT_ENCODER.encode(accountLid))
+
         if (!this.isSameSalt(nctSalt)) {
             this.cachedSalt = nctSalt
             this.cache.clear()
         }
-        const cached = this.cache.get(accountLid)
-        if (cached) {
-            return cached
-        }
-
-        const result = await hmacSha256Sign(nctSalt, TEXT_ENCODER.encode(accountLid))
         setBoundedMapEntry(this.cache, accountLid, result, CS_TOKEN_CACHE_MAX)
         return result
     }

--- a/src/crypto/core/__tests__/core.test.ts
+++ b/src/crypto/core/__tests__/core.test.ts
@@ -10,14 +10,7 @@ import {
     versionByte
 } from '@crypto/core/keys'
 import { buildNonce } from '@crypto/core/nonce'
-import {
-    aesGcmDecrypt,
-    aesGcmEncrypt,
-    hmacSign,
-    importAesGcmKey,
-    importHmacKey,
-    sha256
-} from '@crypto/core/primitives'
+import { aesGcmDecrypt, aesGcmEncrypt, hmacSha256Sign, sha256 } from '@crypto/core/primitives'
 import { randomBytesAsync, randomFillAsync, randomIntAsync } from '@crypto/core/random'
 import { assertByteLength, bytesToBase64UrlSafe, decodeBase64Url } from '@util/bytes'
 
@@ -54,17 +47,16 @@ test('nonce and versioned key helpers enforce protocol constraints', () => {
 
 test('primitive crypto functions encrypt/decrypt and sign deterministically', async () => {
     const keyRaw = new Uint8Array(32).fill(4)
-    const key = await importAesGcmKey(keyRaw, ['encrypt', 'decrypt'])
     const nonce = new Uint8Array(12).fill(5)
     const plaintext = new Uint8Array([1, 2, 3, 4, 5])
 
-    const ciphertext = await aesGcmEncrypt(key, nonce, plaintext)
-    const decrypted = await aesGcmDecrypt(key, nonce, ciphertext)
+    const ciphertext = await aesGcmEncrypt(keyRaw, nonce, plaintext)
+    const decrypted = await aesGcmDecrypt(keyRaw, nonce, ciphertext)
     assert.deepEqual(decrypted, plaintext)
 
-    const hmacKey = await importHmacKey(new Uint8Array(32).fill(6))
-    const sig1 = await hmacSign(hmacKey, new Uint8Array([1, 2]))
-    const sig2 = await hmacSign(hmacKey, new Uint8Array([1, 2]))
+    const hmacKey = new Uint8Array(32).fill(6)
+    const sig1 = await hmacSha256Sign(hmacKey, new Uint8Array([1, 2]))
+    const sig2 = await hmacSha256Sign(hmacKey, new Uint8Array([1, 2]))
     assert.deepEqual(sig1, sig2)
 
     const digest = await sha256(new Uint8Array([7]))

--- a/src/crypto/core/hkdf.ts
+++ b/src/crypto/core/hkdf.ts
@@ -1,27 +1,18 @@
-import { webcrypto } from 'node:crypto'
+import { hkdfSync } from 'node:crypto'
 
 import { EMPTY_BYTES, TEXT_ENCODER, toBytesView } from '@util/bytes'
 
-export async function hkdf(
+export function hkdf(
     ikm: Uint8Array,
     salt: Uint8Array | null,
     info: Uint8Array | string,
     outLength: number
 ): Promise<Uint8Array> {
-    const key = await webcrypto.subtle.importKey('raw', ikm, 'HKDF', false, ['deriveBits'])
     const infoBytes =
         typeof info === 'string' ? (info === '' ? EMPTY_BYTES : TEXT_ENCODER.encode(info)) : info
-    const bits = await webcrypto.subtle.deriveBits(
-        {
-            name: 'HKDF',
-            hash: 'SHA-256',
-            salt: salt ?? EMPTY_BYTES,
-            info: infoBytes
-        },
-        key,
-        outLength * 8
+    return Promise.resolve(
+        toBytesView(hkdfSync('sha256', ikm, salt ?? EMPTY_BYTES, infoBytes, outLength))
     )
-    return toBytesView(bits)
 }
 
 export async function hkdfSplit(

--- a/src/crypto/core/index.ts
+++ b/src/crypto/core/index.ts
@@ -14,21 +14,18 @@ export {
 export { buildNonce } from '@crypto/core/nonce'
 export { randomBytesAsync, randomFillAsync, randomIntAsync } from '@crypto/core/random'
 export {
-    type CryptoKey,
     sha1,
     sha256,
     sha512,
-    importAesGcmKey,
+    md5Bytes,
     aesGcmEncrypt,
     aesGcmDecrypt,
-    importAesCbcKey,
     aesCbcEncrypt,
     aesCbcDecrypt,
-    importHmacKey,
-    importHmacSha512Key,
-    hmacSign,
-    pbkdf2DeriveAesCtrKey,
     aesCtrEncrypt,
-    aesCtrDecrypt
+    aesCtrDecrypt,
+    hmacSha256Sign,
+    hmacSha512Sign,
+    pbkdf2Sha256
 } from '@crypto/core/primitives'
 export { xeddsaSign, xeddsaVerify } from '@crypto/core/xeddsa'

--- a/src/crypto/core/primitives.ts
+++ b/src/crypto/core/primitives.ts
@@ -1,36 +1,33 @@
 /**
- * Low-level crypto primitives using WebCrypto API
+ * Low-level crypto primitives backed by node:crypto sync APIs.
+ *
+ * Promise<T> signatures keep the facade async-first while the work runs sync
+ * under the hood. Keys are passed as raw bytes — no opaque key handles in the API.
  */
 
-import { createHash, webcrypto } from 'node:crypto'
+import { createCipheriv, createDecipheriv, createHash, createHmac, pbkdf2 } from 'node:crypto'
+import { promisify } from 'node:util'
 
-import { EMPTY_BYTES, toBytesView } from '@util/bytes'
+import { concatBytes, EMPTY_BYTES, toBytesView } from '@util/bytes'
 
-/**
- * Re-exported CryptoKey type so consumers don't need to import from 'node:crypto'
- */
-export type CryptoKey = webcrypto.CryptoKey
+const AES_GCM_TAG_LENGTH = 16
 
-type HashAlgorithm = 'SHA-1' | 'SHA-256' | 'SHA-512'
-
-async function digestBytes(algorithm: HashAlgorithm, value: Uint8Array): Promise<Uint8Array> {
-    return toBytesView(await webcrypto.subtle.digest(algorithm, value))
-}
+const pbkdf2Async = promisify(pbkdf2)
 
 // ============================================
 // Hash functions
 // ============================================
 
-export async function sha256(value: Uint8Array): Promise<Uint8Array> {
-    return digestBytes('SHA-256', value)
+export function sha1(value: Uint8Array): Promise<Uint8Array> {
+    return Promise.resolve(toBytesView(createHash('sha1').update(value).digest()))
 }
 
-export async function sha1(value: Uint8Array): Promise<Uint8Array> {
-    return digestBytes('SHA-1', value)
+export function sha256(value: Uint8Array): Promise<Uint8Array> {
+    return Promise.resolve(toBytesView(createHash('sha256').update(value).digest()))
 }
 
-export async function sha512(value: Uint8Array): Promise<Uint8Array> {
-    return digestBytes('SHA-512', value)
+export function sha512(value: Uint8Array): Promise<Uint8Array> {
+    return Promise.resolve(toBytesView(createHash('sha512').update(value).digest()))
 }
 
 export function md5Bytes(input: string | Uint8Array): Uint8Array {
@@ -41,139 +38,129 @@ export function md5Bytes(input: string | Uint8Array): Uint8Array {
 // AES-GCM (for Noise protocol)
 // ============================================
 
-export async function importAesGcmKey(
-    raw: Uint8Array,
-    usages: ('encrypt' | 'decrypt')[]
-): Promise<webcrypto.CryptoKey> {
-    return webcrypto.subtle.importKey('raw', raw, 'AES-GCM', false, usages)
-}
-
-export async function aesGcmEncrypt(
-    key: webcrypto.CryptoKey,
+export function aesGcmEncrypt(
+    key: Uint8Array,
     nonce: Uint8Array,
     plaintext: Uint8Array,
     aad: Uint8Array = EMPTY_BYTES
 ): Promise<Uint8Array> {
-    return toBytesView(
-        await webcrypto.subtle.encrypt(
-            { name: 'AES-GCM', iv: nonce, additionalData: aad },
-            key,
-            plaintext
-        )
-    )
+    const cipher = createCipheriv('aes-256-gcm', key, nonce)
+    if (aad.length > 0) {
+        cipher.setAAD(aad)
+    }
+    const head = cipher.update(plaintext)
+    const tail = cipher.final()
+    const tag = cipher.getAuthTag()
+    return Promise.resolve(concatBytes([head, tail, tag]))
 }
 
-export async function aesGcmDecrypt(
-    key: webcrypto.CryptoKey,
+export function aesGcmDecrypt(
+    key: Uint8Array,
     nonce: Uint8Array,
     ciphertext: Uint8Array,
     aad: Uint8Array = EMPTY_BYTES
 ): Promise<Uint8Array> {
-    return toBytesView(
-        await webcrypto.subtle.decrypt(
-            { name: 'AES-GCM', iv: nonce, additionalData: aad },
-            key,
-            ciphertext
-        )
-    )
+    const tagOffset = ciphertext.length - AES_GCM_TAG_LENGTH
+    const tag = ciphertext.subarray(tagOffset)
+    const ct = ciphertext.subarray(0, tagOffset)
+    const decipher = createDecipheriv('aes-256-gcm', key, nonce)
+    if (aad.length > 0) {
+        decipher.setAAD(aad)
+    }
+    decipher.setAuthTag(tag)
+    const head = decipher.update(ct)
+    const tail = decipher.final()
+    if (tail.length === 0) {
+        return Promise.resolve(toBytesView(head))
+    }
+    return Promise.resolve(concatBytes([head, tail]))
 }
 
 // ============================================
 // AES-CBC (for Signal protocol)
 // ============================================
 
-export async function importAesCbcKey(keyBytes: Uint8Array): Promise<webcrypto.CryptoKey> {
-    return webcrypto.subtle.importKey('raw', keyBytes, { name: 'AES-CBC', length: 256 }, false, [
-        'encrypt',
-        'decrypt'
-    ])
-}
-
-export async function aesCbcEncrypt(
-    key: webcrypto.CryptoKey,
+export function aesCbcEncrypt(
+    key: Uint8Array,
     iv: Uint8Array,
     plaintext: Uint8Array
 ): Promise<Uint8Array> {
-    return toBytesView(await webcrypto.subtle.encrypt({ name: 'AES-CBC', iv }, key, plaintext))
+    const cipher = createCipheriv('aes-256-cbc', key, iv)
+    const head = cipher.update(plaintext)
+    const tail = cipher.final()
+    if (tail.length === 0) {
+        return Promise.resolve(toBytesView(head))
+    }
+    return Promise.resolve(concatBytes([head, tail]))
 }
 
-export async function aesCbcDecrypt(
-    key: webcrypto.CryptoKey,
+export function aesCbcDecrypt(
+    key: Uint8Array,
     iv: Uint8Array,
     ciphertext: Uint8Array
 ): Promise<Uint8Array> {
-    return toBytesView(await webcrypto.subtle.decrypt({ name: 'AES-CBC', iv }, key, ciphertext))
-}
-
-// ============================================
-// HMAC-SHA256 (for Signal protocol)
-// ============================================
-
-export async function importHmacKey(keyBytes: Uint8Array): Promise<webcrypto.CryptoKey> {
-    return webcrypto.subtle.importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, [
-        'sign'
-    ])
-}
-
-export async function importHmacSha512Key(keyBytes: Uint8Array): Promise<webcrypto.CryptoKey> {
-    return webcrypto.subtle.importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-512' }, false, [
-        'sign'
-    ])
-}
-
-export async function hmacSign(key: webcrypto.CryptoKey, data: Uint8Array): Promise<Uint8Array> {
-    return toBytesView(await webcrypto.subtle.sign('HMAC', key, data))
-}
-
-// ============================================
-// PBKDF2 → AES-CTR (for pairing code crypto)
-// ============================================
-
-export async function pbkdf2DeriveAesCtrKey(
-    password: Uint8Array,
-    salt: Uint8Array,
-    iterations: number
-): Promise<CryptoKey> {
-    const imported = await webcrypto.subtle.importKey('raw', password, { name: 'PBKDF2' }, false, [
-        'deriveKey'
-    ])
-    return webcrypto.subtle.deriveKey(
-        {
-            name: 'PBKDF2',
-            hash: 'SHA-256',
-            salt,
-            iterations
-        },
-        imported,
-        {
-            name: 'AES-CTR',
-            length: 256
-        },
-        false,
-        ['encrypt', 'decrypt']
-    )
+    const decipher = createDecipheriv('aes-256-cbc', key, iv)
+    const head = decipher.update(ciphertext)
+    const tail = decipher.final()
+    if (tail.length === 0) {
+        return Promise.resolve(toBytesView(head))
+    }
+    return Promise.resolve(concatBytes([head, tail]))
 }
 
 // ============================================
 // AES-CTR (for pairing code crypto)
 // ============================================
 
-export async function aesCtrEncrypt(
-    key: CryptoKey,
+export function aesCtrEncrypt(
+    key: Uint8Array,
     counter: Uint8Array,
     plaintext: Uint8Array
 ): Promise<Uint8Array> {
-    return toBytesView(
-        await webcrypto.subtle.encrypt({ name: 'AES-CTR', counter, length: 64 }, key, plaintext)
-    )
+    const cipher = createCipheriv('aes-256-ctr', key, counter)
+    const head = cipher.update(plaintext)
+    const tail = cipher.final()
+    if (tail.length === 0) {
+        return Promise.resolve(toBytesView(head))
+    }
+    return Promise.resolve(concatBytes([head, tail]))
 }
 
-export async function aesCtrDecrypt(
-    key: CryptoKey,
+export function aesCtrDecrypt(
+    key: Uint8Array,
     counter: Uint8Array,
     ciphertext: Uint8Array
 ): Promise<Uint8Array> {
-    return toBytesView(
-        await webcrypto.subtle.decrypt({ name: 'AES-CTR', counter, length: 64 }, key, ciphertext)
-    )
+    const decipher = createDecipheriv('aes-256-ctr', key, counter)
+    const head = decipher.update(ciphertext)
+    const tail = decipher.final()
+    if (tail.length === 0) {
+        return Promise.resolve(toBytesView(head))
+    }
+    return Promise.resolve(concatBytes([head, tail]))
+}
+
+// ============================================
+// HMAC (for Signal protocol, app-state, reporting tokens, etc.)
+// ============================================
+
+export function hmacSha256Sign(key: Uint8Array, data: Uint8Array): Promise<Uint8Array> {
+    return Promise.resolve(toBytesView(createHmac('sha256', key).update(data).digest()))
+}
+
+export function hmacSha512Sign(key: Uint8Array, data: Uint8Array): Promise<Uint8Array> {
+    return Promise.resolve(toBytesView(createHmac('sha512', key).update(data).digest()))
+}
+
+// ============================================
+// PBKDF2-SHA256 (for pairing code crypto)
+// ============================================
+
+export async function pbkdf2Sha256(
+    password: Uint8Array,
+    salt: Uint8Array,
+    iterations: number,
+    length: number
+): Promise<Uint8Array> {
+    return toBytesView(await pbkdf2Async(password, salt, iterations, length, 'sha256'))
 }

--- a/src/crypto/curves/Ed25519.ts
+++ b/src/crypto/curves/Ed25519.ts
@@ -1,49 +1,59 @@
-import { webcrypto } from 'node:crypto'
+import {
+    createPrivateKey,
+    createPublicKey,
+    generateKeyPair,
+    sign as nodeSign,
+    verify as nodeVerify
+} from 'node:crypto'
+import { promisify } from 'node:util'
 
-import { ED25519_PKCS8_PREFIX } from '@crypto/curves/constants'
-import { pkcs8FromRawPrivate, type SignalKeyPair, type SubtleKeyPair } from '@crypto/curves/types'
-import { assertByteLength, decodeBase64Url, toBytesView } from '@util/bytes'
+import { ED25519_PKCS8_PREFIX, ED25519_SPKI_PREFIX } from '@crypto/curves/constants'
+import { pkcs8FromRawPrivate, type SignalKeyPair } from '@crypto/curves/types'
+import { assertByteLength, concatBytes, decodeBase64Url, toBytesView } from '@util/bytes'
+
+const generateKeyPairAsync = promisify(generateKeyPair)
+const signAsync = promisify(nodeSign)
+const verifyAsync = promisify(nodeVerify)
+
+function ed25519PrivateKeyObject(privKey: Uint8Array) {
+    return createPrivateKey({
+        key: pkcs8FromRawPrivate(ED25519_PKCS8_PREFIX, privKey) as Buffer,
+        format: 'der',
+        type: 'pkcs8'
+    })
+}
+
+function ed25519PublicKeyObject(pubKey: Uint8Array) {
+    return createPublicKey({
+        key: concatBytes([ED25519_SPKI_PREFIX, pubKey]) as Buffer,
+        format: 'der',
+        type: 'spki'
+    })
+}
 
 export class Ed25519 {
     static async generateKeyPair(): Promise<SignalKeyPair> {
-        const keys = (await webcrypto.subtle.generateKey({ name: 'Ed25519' }, true, [
-            'sign',
-            'verify'
-        ])) as SubtleKeyPair
-        const privateJwk = await webcrypto.subtle.exportKey('jwk', keys.privateKey)
+        const { privateKey } = await generateKeyPairAsync('ed25519')
+        const jwk = privateKey.export({ format: 'jwk' })
         return {
-            pubKey: decodeBase64Url(privateJwk.x, 'ed25519 public key'),
-            privKey: decodeBase64Url(privateJwk.d, 'ed25519 private key')
+            pubKey: decodeBase64Url(jwk.x, 'ed25519 public key'),
+            privKey: decodeBase64Url(jwk.d, 'ed25519 private key')
         }
     }
 
     static async keyPairFromPrivateKey(privKey: Uint8Array): Promise<SignalKeyPair> {
         assertByteLength(privKey, 32, 'ed25519 private key must be 32 bytes')
-        const privateKey = await webcrypto.subtle.importKey(
-            'pkcs8',
-            pkcs8FromRawPrivate(ED25519_PKCS8_PREFIX, privKey),
-            { name: 'Ed25519' },
-            true,
-            ['sign']
-        )
-        const privateJwk = await webcrypto.subtle.exportKey('jwk', privateKey)
+        const jwk = ed25519PrivateKeyObject(privKey).export({ format: 'jwk' })
         return {
-            pubKey: decodeBase64Url(privateJwk.x, 'ed25519 public key'),
-            privKey: decodeBase64Url(privateJwk.d, 'ed25519 private key')
+            pubKey: decodeBase64Url(jwk.x, 'ed25519 public key'),
+            privKey
         }
     }
 
     static async sign(message: Uint8Array, privKey: Uint8Array): Promise<Uint8Array> {
         assertByteLength(privKey, 32, 'ed25519 private key must be 32 bytes')
-        const privateKey = await webcrypto.subtle.importKey(
-            'pkcs8',
-            pkcs8FromRawPrivate(ED25519_PKCS8_PREFIX, privKey),
-            { name: 'Ed25519' },
-            false,
-            ['sign']
-        )
-        const signature = await webcrypto.subtle.sign('Ed25519', privateKey, message)
-        return toBytesView(signature)
+        const sig = await signAsync(null, message, ed25519PrivateKeyObject(privKey))
+        return toBytesView(sig)
     }
 
     static async verify(
@@ -52,13 +62,6 @@ export class Ed25519 {
         pubKey: Uint8Array
     ): Promise<boolean> {
         assertByteLength(pubKey, 32, 'ed25519 public key must be 32 bytes')
-        const publicKey = await webcrypto.subtle.importKey(
-            'raw',
-            pubKey,
-            { name: 'Ed25519' },
-            false,
-            ['verify']
-        )
-        return webcrypto.subtle.verify('Ed25519', publicKey, signature, message)
+        return verifyAsync(null, message, ed25519PublicKeyObject(pubKey), signature)
     }
 }

--- a/src/crypto/curves/X25519.ts
+++ b/src/crypto/curves/X25519.ts
@@ -1,13 +1,13 @@
-import { createPrivateKey, createPublicKey, diffieHellman, webcrypto } from 'node:crypto'
+import { createPrivateKey, createPublicKey, diffieHellman, generateKeyPair } from 'node:crypto'
+import { promisify } from 'node:util'
+
+const generateKeyPairAsync = promisify(generateKeyPair)
 
 import { X25519_PKCS8_PREFIX, X25519_SPKI_PREFIX } from '@crypto/curves/constants'
-import { pkcs8FromRawPrivate, type SignalKeyPair, type SubtleKeyPair } from '@crypto/curves/types'
+import { pkcs8FromRawPrivate, type SignalKeyPair } from '@crypto/curves/types'
 import { FE_ONE } from '@crypto/math/constants'
 import { fe, feAdd, feFromBytes, feInv, feMul, fePack, feSub } from '@crypto/math/fe'
-import { assertByteLength, decodeBase64Url, toBytesView } from '@util/bytes'
-import { isBunRuntime } from '@util/runtime'
-
-const IS_BUN = isBunRuntime()
+import { assertByteLength, concatBytes, decodeBase64Url, toBytesView } from '@util/bytes'
 
 // Pre-allocated temps for montgomeryToEdwardsPublic (safe: single-threaded)
 const _mx = fe()
@@ -51,70 +51,51 @@ export function montgomeryToEdwardsPublic(curvePublicKey: Uint8Array, signBit: n
     return encoded
 }
 
+function x25519PrivateKeyObject(privKey: Uint8Array) {
+    return createPrivateKey({
+        key: pkcs8FromRawPrivate(X25519_PKCS8_PREFIX, privKey) as Buffer,
+        format: 'der',
+        type: 'pkcs8'
+    })
+}
+
+function x25519PublicKeyObject(pubKey: Uint8Array) {
+    return createPublicKey({
+        key: concatBytes([X25519_SPKI_PREFIX, pubKey]) as Buffer,
+        format: 'der',
+        type: 'spki'
+    })
+}
+
 export class X25519 {
     static async generateKeyPair(): Promise<SignalKeyPair> {
-        const keys = (await webcrypto.subtle.generateKey({ name: 'X25519' }, true, [
-            'deriveBits'
-        ])) as SubtleKeyPair
-        const privateJwk = await webcrypto.subtle.exportKey('jwk', keys.privateKey)
+        const { privateKey } = await generateKeyPairAsync('x25519')
+        const jwk = privateKey.export({ format: 'jwk' })
         return {
-            pubKey: decodeBase64Url(privateJwk.x, 'x25519 public key'),
-            privKey: decodeBase64Url(privateJwk.d, 'x25519 private key')
+            pubKey: decodeBase64Url(jwk.x, 'x25519 public key'),
+            privKey: decodeBase64Url(jwk.d, 'x25519 private key')
         }
     }
 
     static async keyPairFromPrivateKey(privKey: Uint8Array): Promise<SignalKeyPair> {
         assertByteLength(privKey, 32, 'x25519 private key must be 32 bytes')
-        const privateKey = await webcrypto.subtle.importKey(
-            'pkcs8',
-            pkcs8FromRawPrivate(X25519_PKCS8_PREFIX, privKey),
-            { name: 'X25519' },
-            true,
-            ['deriveBits']
-        )
-        const privateJwk = await webcrypto.subtle.exportKey('jwk', privateKey)
+        const jwk = x25519PrivateKeyObject(privKey).export({ format: 'jwk' })
         return {
-            pubKey: decodeBase64Url(privateJwk.x, 'x25519 public key'),
-            privKey: decodeBase64Url(privateJwk.d, 'x25519 private key')
+            pubKey: decodeBase64Url(jwk.x, 'x25519 public key'),
+            privKey
         }
     }
 
     static async scalarMult(privKey: Uint8Array, pubKey: Uint8Array): Promise<Uint8Array> {
         assertByteLength(privKey, 32, 'x25519 private key must be 32 bytes')
         assertByteLength(pubKey, 32, 'x25519 public key must be 32 bytes')
-
-        // TODO: When Bun supports deriveBits with X25519 change to Async Web Crypto API
-        // https://github.com/oven-sh/bun/pull/29152
-        if (IS_BUN) {
-            const spki = new Uint8Array(X25519_SPKI_PREFIX.length + 32)
-            spki.set(X25519_SPKI_PREFIX, 0)
-            spki.set(pubKey, X25519_SPKI_PREFIX.length)
-            const shared = diffieHellman({
-                privateKey: createPrivateKey({
-                    key: pkcs8FromRawPrivate(X25519_PKCS8_PREFIX, privKey) as Buffer,
-                    format: 'der',
-                    type: 'pkcs8'
-                }),
-                publicKey: createPublicKey({ key: spki as Buffer, format: 'der', type: 'spki' })
-            })
-            return toBytesView(shared)
-        }
-
-        const [privateKey, publicKey] = await Promise.all([
-            webcrypto.subtle.importKey(
-                'pkcs8',
-                pkcs8FromRawPrivate(X25519_PKCS8_PREFIX, privKey),
-                { name: 'X25519' },
-                false,
-                ['deriveBits']
-            ),
-            webcrypto.subtle.importKey('raw', pubKey, { name: 'X25519' }, false, [])
-        ])
-        const sharedBits = await webcrypto.subtle.deriveBits(
-            { name: 'X25519', public: publicKey },
-            privateKey,
-            256
+        return Promise.resolve(
+            toBytesView(
+                diffieHellman({
+                    privateKey: x25519PrivateKeyObject(privKey),
+                    publicKey: x25519PublicKeyObject(pubKey)
+                })
+            )
         )
-        return toBytesView(sharedBits)
     }
 }

--- a/src/crypto/curves/constants.ts
+++ b/src/crypto/curves/constants.ts
@@ -3,3 +3,4 @@ import { hexToBytes } from '@util/bytes'
 export const X25519_PKCS8_PREFIX = hexToBytes('302e020100300506032b656e04220420')
 export const X25519_SPKI_PREFIX = hexToBytes('302a300506032b656e032100')
 export const ED25519_PKCS8_PREFIX = hexToBytes('302e020100300506032b657004220420')
+export const ED25519_SPKI_PREFIX = hexToBytes('302a300506032b6570032100')

--- a/src/crypto/curves/types.ts
+++ b/src/crypto/curves/types.ts
@@ -1,13 +1,6 @@
-import type { webcrypto } from 'node:crypto'
-
 export interface SignalKeyPair {
     readonly pubKey: Uint8Array
     readonly privKey: Uint8Array
-}
-
-export interface SubtleKeyPair {
-    readonly privateKey: webcrypto.CryptoKey
-    readonly publicKey: webcrypto.CryptoKey
 }
 
 export function pkcs8FromRawPrivate(prefix: Uint8Array, raw: Uint8Array): Uint8Array {

--- a/src/media/WaMediaCrypto.ts
+++ b/src/media/WaMediaCrypto.ts
@@ -7,15 +7,7 @@ import { join } from 'node:path'
 import { PassThrough, type Readable, type Writable } from 'node:stream'
 
 import { hkdf } from '@crypto/core/hkdf'
-import {
-    aesCbcDecrypt,
-    aesCbcEncrypt,
-    type CryptoKey,
-    hmacSign,
-    importAesCbcKey,
-    importHmacKey,
-    sha256
-} from '@crypto/core/primitives'
+import { aesCbcDecrypt, aesCbcEncrypt, hmacSha256Sign, sha256 } from '@crypto/core/primitives'
 import { randomBytesAsync } from '@crypto/core/random'
 import {
     ENC_KEY_END,
@@ -54,7 +46,7 @@ const AES_BLOCK_SIZE = 16
 const PKCS7_FULL_BLOCK = new Uint8Array(AES_BLOCK_SIZE).fill(AES_BLOCK_SIZE)
 
 async function aesCbcEncryptChunk(
-    key: CryptoKey,
+    key: Uint8Array,
     iv: Uint8Array,
     chunk: Uint8Array,
     isFinal: boolean
@@ -74,7 +66,7 @@ async function aesCbcEncryptChunk(
 }
 
 async function aesCbcDecryptChunk(
-    key: CryptoKey,
+    key: Uint8Array,
     iv: Uint8Array,
     ciphertext: Uint8Array,
     isFinal: boolean
@@ -98,8 +90,7 @@ async function computeFirstFrameSidecar(
 ): Promise<Uint8Array> {
     const aligned = Math.ceil(firstFrameLength / AES_BLOCK_SIZE) * AES_BLOCK_SIZE
     const slice = ivCiphertext.subarray(0, IV_SIZE + aligned)
-    const key = await importHmacKey(macKey)
-    const digest = await hmacSign(key, slice)
+    const digest = await hmacSha256Sign(macKey, slice)
     return digest.subarray(0, SIDECAR_HMAC_SIZE)
 }
 
@@ -192,14 +183,10 @@ export class WaMediaCrypto {
         options?: { readonly sidecar?: boolean; readonly firstFrameLength?: number }
     ): Promise<WaMediaEncryptionResult> {
         const keys = await WaMediaCrypto.deriveKeys(mediaType, mediaKey)
-        const [aesKey, hmacKey] = await Promise.all([
-            importAesCbcKey(keys.encKey),
-            importHmacKey(keys.macKey)
-        ])
-        const ciphertext = await aesCbcEncrypt(aesKey, keys.iv, plaintext)
+        const ciphertext = await aesCbcEncrypt(keys.encKey, keys.iv, plaintext)
         const ivCiphertext = concatBytes([keys.iv, ciphertext])
 
-        const mac = await hmacSign(hmacKey, ivCiphertext)
+        const mac = await hmacSha256Sign(keys.macKey, ivCiphertext)
         const signature = mac.subarray(0, HMAC_TRUNCATED_SIZE)
         const ciphertextHmac = concatBytes([ciphertext, signature])
 
@@ -254,10 +241,6 @@ export class WaMediaCrypto {
         }
 
         const keys = await WaMediaCrypto.deriveKeys(mediaType, mediaKey)
-        const [aesKey, hmacKey] = await Promise.all([
-            importAesCbcKey(keys.encKey),
-            importHmacKey(keys.macKey)
-        ])
         const ciphertext = ciphertextHmac.subarray(
             0,
             ciphertextHmac.byteLength - HMAC_TRUNCATED_SIZE
@@ -266,14 +249,14 @@ export class WaMediaCrypto {
         const ivCiphertext = concatBytes([keys.iv, ciphertext])
 
         if (!skipMacVerification) {
-            const mac = await hmacSign(hmacKey, ivCiphertext)
+            const mac = await hmacSha256Sign(keys.macKey, ivCiphertext)
             const signature = mac.subarray(0, HMAC_TRUNCATED_SIZE)
             if (!uint8TimingSafeEqual(signature, expectedMac)) {
                 throw new Error('media MAC mismatch')
             }
         }
 
-        const plaintext = await aesCbcDecrypt(aesKey, keys.iv, ciphertext)
+        const plaintext = await aesCbcDecrypt(keys.encKey, keys.iv, ciphertext)
         const fileSha256 = await sha256(plaintext)
         if (expectedFileSha256 && !uint8Equal(fileSha256, expectedFileSha256)) {
             throw new Error('plaintext file hash mismatch')
@@ -365,7 +348,7 @@ async function pumpEncryption(
     readonly streamingSidecar?: Uint8Array
     readonly firstFrameSidecar?: Uint8Array
 }> {
-    const aesKey = await importAesCbcKey(keys.encKey)
+    const aesKey = keys.encKey
     const plainHash = createHash('sha256')
     const encHash = createHash('sha256')
     const hmac = createHmac('sha256', keys.macKey)
@@ -445,8 +428,7 @@ async function pumpEncryption(
         let firstFrameSidecar: Uint8Array | undefined
         if (ffTarget > 0) {
             const ivCiphertextSlice = concatBytes(ffChunks)
-            const ffKey = await importHmacKey(keys.macKey)
-            const ffDigest = await hmacSign(ffKey, ivCiphertextSlice)
+            const ffDigest = await hmacSha256Sign(keys.macKey, ivCiphertextSlice)
             firstFrameSidecar = ffDigest.subarray(0, SIDECAR_HMAC_SIZE)
         }
 
@@ -505,7 +487,7 @@ async function pumpEncryptionToWritable(
     readonly streamingSidecar?: Uint8Array
     readonly firstFrameSidecar?: Uint8Array
 }> {
-    const aesKey = await importAesCbcKey(keys.encKey)
+    const aesKey = keys.encKey
     const plainHash = createHash('sha256')
     const encHash = createHash('sha256')
     const hmac = createHmac('sha256', keys.macKey)
@@ -585,8 +567,7 @@ async function pumpEncryptionToWritable(
         let firstFrameSidecar: Uint8Array | undefined
         if (ffTarget > 0) {
             const ivCiphertextSlice = concatBytes(ffChunks)
-            const ffKey = await importHmacKey(keys.macKey)
-            const ffDigest = await hmacSign(ffKey, ivCiphertextSlice)
+            const ffDigest = await hmacSha256Sign(keys.macKey, ivCiphertextSlice)
             firstFrameSidecar = ffDigest.subarray(0, SIDECAR_HMAC_SIZE)
         }
 
@@ -610,7 +591,7 @@ async function pumpDecryption(
     keys: WaMediaDerivedKeys,
     options: WaMediaDecryptReadableOptions
 ): Promise<{ readonly fileSha256: Uint8Array; readonly fileEncSha256: Uint8Array }> {
-    const aesKey = await importAesCbcKey(keys.encKey)
+    const aesKey = keys.encKey
     const plainHash = createHash('sha256')
     const encHash = createHash('sha256')
     const hmac = createHmac('sha256', keys.macKey)

--- a/src/message/__tests__/message.test.ts
+++ b/src/message/__tests__/message.test.ts
@@ -331,7 +331,7 @@ test('addon crypto helpers encrypt/decrypt payloads and validate aad', async () 
                 iv,
                 additionalData: new Uint8Array([1, 2, 3])
             }),
-        /The operation failed|decrypt/i
+        /The operation failed|decrypt|unable to authenticate/i
     )
 
     await assert.rejects(

--- a/src/message/addon-crypto.ts
+++ b/src/message/addon-crypto.ts
@@ -1,5 +1,5 @@
 import type { WaAddonKind } from '@client/types'
-import { aesGcmDecrypt, aesGcmEncrypt, importAesGcmKey, sha256 } from '@crypto'
+import { aesGcmDecrypt, aesGcmEncrypt, sha256 } from '@crypto'
 import { unwrapMessage } from '@message/content'
 import {
     assertMessageSecret,
@@ -56,10 +56,9 @@ export async function encryptAddonPayload(input: {
         modificationSender: input.modificationSender,
         modificationType: input.modificationType
     })
-    const key = await importAesGcmKey(secret, ['encrypt'])
     const iv = assertAddonIv(input.iv)
     const additionalData = resolveAddonAdditionalData(input)
-    return aesGcmEncrypt(key, iv, toBytesView(input.payload), additionalData)
+    return aesGcmEncrypt(secret, iv, toBytesView(input.payload), additionalData)
 }
 
 export async function decryptAddonPayload(input: {
@@ -79,10 +78,9 @@ export async function decryptAddonPayload(input: {
         modificationSender: input.modificationSender,
         modificationType: input.modificationType
     })
-    const key = await importAesGcmKey(secret, ['decrypt'])
     const iv = assertAddonIv(input.iv)
     const additionalData = resolveAddonAdditionalData(input)
-    return aesGcmDecrypt(key, iv, toBytesView(input.ciphertext), additionalData)
+    return aesGcmDecrypt(secret, iv, toBytesView(input.ciphertext), additionalData)
 }
 
 export interface WaIdentifiedEncAddon {

--- a/src/message/reporting-token.ts
+++ b/src/message/reporting-token.ts
@@ -1,4 +1,4 @@
-import { hkdf, hmacSign, importHmacKey } from '@crypto'
+import { hkdf, hmacSha256Sign } from '@crypto'
 import { proto, type Proto } from '@proto'
 import type { BinaryNode } from '@transport/types'
 import { base64ToBytesChecked, concatBytes, EMPTY_BYTES, TEXT_ENCODER } from '@util/bytes'
@@ -110,11 +110,9 @@ export async function buildReportingTokenArtifacts(
         secretInfo,
         WA_REPORTING_TOKEN_KEY_BYTES
     )
-    const hmacKey = await importHmacKey(reportingTokenKey)
-    const reportingToken = (await hmacSign(hmacKey, reportingTokenContent)).subarray(
-        0,
-        WA_REPORTING_TOKEN_BYTES
-    )
+    const reportingToken = (
+        await hmacSha256Sign(reportingTokenKey, reportingTokenContent)
+    ).subarray(0, WA_REPORTING_TOKEN_BYTES)
 
     const version = input.version ?? WA_REPORTING_TOKEN_VERSION
     return {

--- a/src/signal/crypto/WaAdvSignature.ts
+++ b/src/signal/crypto/WaAdvSignature.ts
@@ -1,4 +1,4 @@
-import { hmacSign, importHmacKey, toRawPubKey, xeddsaSign, xeddsaVerify } from '@crypto'
+import { hmacSha256Sign, toRawPubKey, xeddsaSign, xeddsaVerify } from '@crypto'
 import type { SignalKeyPair } from '@crypto/curves/types'
 import {
     ADV_PREFIX_ACCOUNT_SIGNATURE,
@@ -38,10 +38,9 @@ export async function generateDeviceSignature(
     return xeddsaSign(identityKeyPair.privKey, message)
 }
 
-export async function computeAdvIdentityHmac(
+export function computeAdvIdentityHmac(
     secretKey: Uint8Array,
     details: Uint8Array
 ): Promise<Uint8Array> {
-    const key = await importHmacKey(secretKey)
-    return hmacSign(key, details)
+    return hmacSha256Sign(secretKey, details)
 }

--- a/src/signal/group/SenderKeyChain.ts
+++ b/src/signal/group/SenderKeyChain.ts
@@ -1,4 +1,4 @@
-import { type CryptoKey, hkdf, hmacSign, importHmacKey } from '@crypto'
+import { hkdf, hmacSha256Sign } from '@crypto'
 import {
     CHAIN_KEY_LABEL,
     MAX_UNUSED_KEYS,
@@ -8,11 +8,6 @@ import {
 } from '@signal/constants'
 import type { SenderKeyRecord, SenderMessageKey } from '@signal/types'
 import { assertByteLength, removeAt } from '@util/bytes'
-
-interface SenderChainState {
-    readonly chainKey: Uint8Array
-    readonly hmacKey: CryptoKey
-}
 
 export interface SenderKeyMessageKeyDerivation {
     readonly nextChainKey: Uint8Array
@@ -52,9 +47,9 @@ export async function selectMessageKey(
         }
     }
 
-    let chainState = await createSenderChainState(senderKey.chainKey)
-    const firstDerived = await deriveSenderKeyMsgKeyFromState(senderKey.iteration, chainState)
-    chainState = firstDerived.nextState
+    let chainKey = ensureChainKey(senderKey.chainKey)
+    const firstDerived = await deriveSenderKeyMsgKeyFromChainKey(senderKey.iteration, chainKey)
+    chainKey = firstDerived.nextChainKey
     let messageKey = firstDerived.messageKey
     if (delta === 0) {
         return {
@@ -62,7 +57,7 @@ export async function selectMessageKey(
             updatedRecord: {
                 ...senderKey,
                 iteration: targetIteration + 1,
-                chainKey: chainState.chainKey,
+                chainKey,
                 unusedMessageKeys: currentUnused
             }
         }
@@ -82,8 +77,8 @@ export async function selectMessageKey(
             nextUnused.push(messageKey)
         }
 
-        const derived = await deriveSenderKeyMsgKeyFromState(iteration, chainState)
-        chainState = derived.nextState
+        const derived = await deriveSenderKeyMsgKeyFromChainKey(iteration, chainKey)
+        chainKey = derived.nextChainKey
         messageKey = derived.messageKey
     }
 
@@ -92,7 +87,7 @@ export async function selectMessageKey(
         updatedRecord: {
             ...senderKey,
             iteration: targetIteration + 1,
-            chainKey: chainState.chainKey,
+            chainKey,
             unusedMessageKeys: nextUnused
         }
     }
@@ -102,40 +97,26 @@ export async function deriveSenderKeyMsgKey(
     iteration: number,
     chainKey: Uint8Array
 ): Promise<SenderKeyMessageKeyDerivation> {
-    const state = await createSenderChainState(chainKey)
-    const derived = await deriveSenderKeyMsgKeyFromState(iteration, state)
-    return {
-        nextChainKey: derived.nextState.chainKey,
-        messageKey: derived.messageKey
-    }
+    return deriveSenderKeyMsgKeyFromChainKey(iteration, ensureChainKey(chainKey))
 }
 
-async function createSenderChainState(chainKey: Uint8Array): Promise<SenderChainState> {
+function ensureChainKey(chainKey: Uint8Array): Uint8Array {
     assertByteLength(chainKey, 32, 'sender key chainKey must be 32 bytes')
-    return {
-        chainKey,
-        hmacKey: await importHmacKey(chainKey)
-    }
+    return chainKey
 }
 
-async function deriveSenderKeyMsgKeyFromState(
+async function deriveSenderKeyMsgKeyFromChainKey(
     iteration: number,
-    state: SenderChainState
-): Promise<{ readonly nextState: SenderChainState; readonly messageKey: SenderMessageKey }> {
+    chainKey: Uint8Array
+): Promise<SenderKeyMessageKeyDerivation> {
     const [nextChainRaw, messageInputKey] = await Promise.all([
-        hmacSign(state.hmacKey, CHAIN_KEY_LABEL),
-        hmacSign(state.hmacKey, MESSAGE_KEY_LABEL)
+        hmacSha256Sign(chainKey, CHAIN_KEY_LABEL),
+        hmacSha256Sign(chainKey, MESSAGE_KEY_LABEL)
     ])
     const nextChainKey = nextChainRaw.subarray(0, 32)
-    const [nextHmacKey, messageSeed] = await Promise.all([
-        importHmacKey(nextChainKey),
-        hkdf(messageInputKey, null, WHISPER_GROUP_INFO, 50)
-    ])
+    const messageSeed = await hkdf(messageInputKey, null, WHISPER_GROUP_INFO, 50)
     return {
-        nextState: {
-            chainKey: nextChainKey,
-            hmacKey: nextHmacKey
-        },
+        nextChainKey,
         messageKey: {
             iteration,
             seed: messageSeed

--- a/src/signal/group/SenderKeyManager.ts
+++ b/src/signal/group/SenderKeyManager.ts
@@ -1,7 +1,6 @@
 import {
     aesCbcDecrypt,
     aesCbcEncrypt,
-    importAesCbcKey,
     prependVersion,
     randomBytesAsync,
     randomIntAsync,
@@ -44,17 +43,14 @@ function extractAesCbcParams(seed: Uint8Array): {
     }
 }
 
-async function aesCbcEncryptFromSeed(seed: Uint8Array, plaintext: Uint8Array): Promise<Uint8Array> {
+function aesCbcEncryptFromSeed(seed: Uint8Array, plaintext: Uint8Array): Promise<Uint8Array> {
     const { keyBytes, iv } = extractAesCbcParams(seed)
-    return aesCbcEncrypt(await importAesCbcKey(keyBytes), iv, plaintext)
+    return aesCbcEncrypt(keyBytes, iv, plaintext)
 }
 
-async function aesCbcDecryptFromSeed(
-    seed: Uint8Array,
-    ciphertext: Uint8Array
-): Promise<Uint8Array> {
+function aesCbcDecryptFromSeed(seed: Uint8Array, ciphertext: Uint8Array): Promise<Uint8Array> {
     const { keyBytes, iv } = extractAesCbcParams(seed)
-    return aesCbcDecrypt(await importAesCbcKey(keyBytes), iv, ciphertext)
+    return aesCbcDecrypt(keyBytes, iv, ciphertext)
 }
 
 export class SenderKeyManager {

--- a/src/signal/session/SignalRatchet.ts
+++ b/src/signal/session/SignalRatchet.ts
@@ -1,11 +1,8 @@
 import {
     aesCbcDecrypt,
     aesCbcEncrypt,
-    type CryptoKey,
     hkdf,
-    hmacSign,
-    importAesCbcKey,
-    importHmacKey,
+    hmacSha256Sign,
     prependVersion,
     toSerializedPubKey
 } from '@crypto'
@@ -54,11 +51,6 @@ export interface DecryptOutcome {
     } | null
 }
 
-interface DerivedChainState {
-    readonly chainKey: Uint8Array
-    readonly hmacKey: CryptoKey
-}
-
 export function splitMsgKey(index: number, bytes: Uint8Array): SignalMessageKey {
     if (bytes.length < 80) {
         throw new Error('invalid message key length')
@@ -75,12 +67,7 @@ export async function deriveMsgKey(
     index: number,
     chainKey: Uint8Array
 ): Promise<{ readonly nextChainKey: Uint8Array; readonly messageKey: SignalMessageKey }> {
-    const state = await createDerivedChainState(chainKey)
-    const derived = await deriveMsgKeyFromState(index, state)
-    return {
-        nextChainKey: derived.nextState.chainKey,
-        messageKey: derived.messageKey
-    }
+    return deriveMsgKeyFromChainKey(index, chainKey)
 }
 
 export async function selectMessageKey(
@@ -110,17 +97,17 @@ export async function selectMessageKey(
         }
     }
 
-    let chainState = await createDerivedChainState(chain.chainKey)
-    const first = await deriveMsgKeyFromState(chain.nextMsgIndex, chainState)
+    let chainKey = chain.chainKey
+    const first = await deriveMsgKeyFromChainKey(chain.nextMsgIndex, chainKey)
     let currentMessageKey = first.messageKey
-    chainState = first.nextState
+    chainKey = first.nextChainKey
     if (delta === 0) {
         return {
             messageKey: currentMessageKey,
             updatedChain: {
                 ratchetPubKey: chain.ratchetPubKey,
                 nextMsgIndex: targetCounter + 1,
-                chainKey: chainState.chainKey,
+                chainKey,
                 unusedMsgKeys: unused
             }
         }
@@ -143,9 +130,9 @@ export async function selectMessageKey(
                 iv: currentMessageKey.iv
             })
         }
-        const derived = await deriveMsgKeyFromState(counter, chainState)
+        const derived = await deriveMsgKeyFromChainKey(counter, chainKey)
         currentMessageKey = derived.messageKey
-        chainState = derived.nextState
+        chainKey = derived.nextChainKey
     }
 
     return {
@@ -153,39 +140,24 @@ export async function selectMessageKey(
         updatedChain: {
             ratchetPubKey: chain.ratchetPubKey,
             nextMsgIndex: targetCounter + 1,
-            chainKey: chainState.chainKey,
+            chainKey,
             unusedMsgKeys: nextUnused
         }
     }
 }
 
-async function createDerivedChainState(chainKey: Uint8Array): Promise<DerivedChainState> {
-    return {
-        chainKey,
-        hmacKey: await importHmacKey(chainKey)
-    }
-}
-
-async function deriveMsgKeyFromState(
+async function deriveMsgKeyFromChainKey(
     index: number,
-    state: DerivedChainState
-): Promise<{ readonly nextState: DerivedChainState; readonly messageKey: SignalMessageKey }> {
-    const nextChainRawPromise = hmacSign(state.hmacKey, CHAIN_KEY_LABEL)
-    const messageInputKeyPromise = hmacSign(state.hmacKey, MESSAGE_KEY_LABEL)
+    chainKey: Uint8Array
+): Promise<{ readonly nextChainKey: Uint8Array; readonly messageKey: SignalMessageKey }> {
     const [nextChainRaw, messageInputKey] = await Promise.all([
-        nextChainRawPromise,
-        messageInputKeyPromise
+        hmacSha256Sign(chainKey, CHAIN_KEY_LABEL),
+        hmacSha256Sign(chainKey, MESSAGE_KEY_LABEL)
     ])
     const nextChainKey = nextChainRaw.subarray(0, 32)
-    const [nextHmacKey, expanded] = await Promise.all([
-        importHmacKey(nextChainKey),
-        hkdf(messageInputKey, null, 'WhisperMessageKeys', 80)
-    ])
+    const expanded = await hkdf(messageInputKey, null, 'WhisperMessageKeys', 80)
     return {
-        nextState: {
-            chainKey: nextChainKey,
-            hmacKey: nextHmacKey
-        },
+        nextChainKey,
         messageKey: splitMsgKey(index, expanded)
     }
 }
@@ -198,11 +170,7 @@ export async function encryptMsg(
         session.sendChain.nextMsgIndex,
         session.sendChain.chainKey
     )
-    const [cipherKey, macKey] = await Promise.all([
-        importAesCbcKey(messageKey.cipherKey),
-        importHmacKey(messageKey.macKey)
-    ])
-    const ciphertext = await aesCbcEncrypt(cipherKey, messageKey.iv, plaintext)
+    const ciphertext = await aesCbcEncrypt(messageKey.cipherKey, messageKey.iv, plaintext)
 
     const signalPayload = proto.SignalMessage.encode({
         ratchetKey: session.sendChain.ratchetKey.pubKey,
@@ -216,7 +184,7 @@ export async function encryptMsg(
         session.remote.pubKey,
         versionedSignalPayload
     ])
-    const mac = await hmacSign(macKey, macInput)
+    const mac = await hmacSha256Sign(messageKey.macKey, macInput)
     const signalMessage = concatBytes([versionedSignalPayload, mac.subarray(0, SIGNAL_MAC_SIZE)])
 
     let type: 'msg' | 'pkmsg' = 'msg'
@@ -363,10 +331,6 @@ export async function decryptMsgFromSession(
         }
     }
 
-    const [cipherKey, macKey] = await Promise.all([
-        importAesCbcKey(selectedMessageKey.cipherKey),
-        importHmacKey(selectedMessageKey.macKey)
-    ])
     const payloadWithoutMac = message.versionContentMac.subarray(
         0,
         message.versionContentMac.length - SIGNAL_MAC_SIZE
@@ -376,7 +340,7 @@ export async function decryptMsgFromSession(
         session.local.pubKey,
         payloadWithoutMac
     ])
-    const expectedMac = await hmacSign(macKey, expectedMacInput)
+    const expectedMac = await hmacSha256Sign(selectedMessageKey.macKey, expectedMacInput)
     const receivedMac = message.versionContentMac.subarray(
         message.versionContentMac.length - SIGNAL_MAC_SIZE
     )
@@ -384,6 +348,10 @@ export async function decryptMsgFromSession(
         throw new Error('invalid message mac')
     }
 
-    const plaintext = await aesCbcDecrypt(cipherKey, selectedMessageKey.iv, message.ciphertext)
+    const plaintext = await aesCbcDecrypt(
+        selectedMessageKey.cipherKey,
+        selectedMessageKey.iv,
+        message.ciphertext
+    )
     return [updatedSession, plaintext]
 }

--- a/src/transport/noise/WaNoiseHandshake.ts
+++ b/src/transport/noise/WaNoiseHandshake.ts
@@ -1,19 +1,11 @@
-import {
-    aesGcmDecrypt,
-    aesGcmEncrypt,
-    buildNonce,
-    type CryptoKey,
-    hkdfSplit,
-    importAesGcmKey,
-    sha256
-} from '@crypto'
+import { aesGcmDecrypt, aesGcmEncrypt, buildNonce, hkdfSplit, sha256 } from '@crypto'
 import { WaNoiseSocket } from '@transport/noise/WaNoiseSocket'
 import { concatBytes, EMPTY_BYTES } from '@util/bytes'
 
 export class WaNoiseHandshake {
     private handshakeHash: Uint8Array
     private chainingKey: Uint8Array
-    private cipherKey: CryptoKey | null
+    private cipherKey: Uint8Array | null
     private nonce: number
 
     public constructor() {
@@ -27,7 +19,7 @@ export class WaNoiseHandshake {
         const hashInput = protocolName.length === 32 ? protocolName : await sha256(protocolName)
         this.handshakeHash = hashInput
         this.chainingKey = hashInput
-        this.cipherKey = await importAesGcmKey(this.handshakeHash, ['encrypt', 'decrypt'])
+        this.cipherKey = this.handshakeHash
         await this.authenticate(prologue)
     }
 
@@ -39,7 +31,7 @@ export class WaNoiseHandshake {
         this.nonce = 0
         const [newChainingKey, nextCipherKey] = await hkdfSplit(keyMaterial, this.chainingKey, '')
         this.chainingKey = newChainingKey
-        this.cipherKey = await importAesGcmKey(nextCipherKey, ['encrypt', 'decrypt'])
+        this.cipherKey = nextCipherKey
     }
 
     public async encrypt(plaintext: Uint8Array): Promise<Uint8Array> {
@@ -63,11 +55,7 @@ export class WaNoiseHandshake {
     }
 
     public async finish(): Promise<WaNoiseSocket> {
-        const [writeKeyRaw, readKeyRaw] = await hkdfSplit(EMPTY_BYTES, this.chainingKey, '')
-        const [writeKey, readKey] = await Promise.all([
-            importAesGcmKey(writeKeyRaw, ['encrypt']),
-            importAesGcmKey(readKeyRaw, ['decrypt'])
-        ])
+        const [writeKey, readKey] = await hkdfSplit(EMPTY_BYTES, this.chainingKey, '')
         this.handshakeHash = EMPTY_BYTES
         this.chainingKey = EMPTY_BYTES
         this.cipherKey = null

--- a/src/transport/noise/WaNoiseSocket.ts
+++ b/src/transport/noise/WaNoiseSocket.ts
@@ -1,12 +1,12 @@
-import { aesGcmDecrypt, aesGcmEncrypt, buildNonce, type CryptoKey } from '@crypto'
+import { aesGcmDecrypt, aesGcmEncrypt, buildNonce } from '@crypto'
 
 export class WaNoiseSocket {
-    private readonly encryptKey: CryptoKey
-    private readonly decryptKey: CryptoKey
+    private readonly encryptKey: Uint8Array
+    private readonly decryptKey: Uint8Array
     private writeCounter: number
     private readCounter: number
 
-    public constructor(encryptKey: CryptoKey, decryptKey: CryptoKey) {
+    public constructor(encryptKey: Uint8Array, decryptKey: Uint8Array) {
         this.encryptKey = encryptKey
         this.decryptKey = decryptKey
         this.writeCounter = 0


### PR DESCRIPTION
Replaces the WebCrypto subtle-based primitives in @crypto/core with direct node:crypto calls. AES/HMAC/HKDF/hashes run sync (no async variant exists) wrapped in Promise.resolve to keep the facade async. Ed25519 sign/verify/keygen, X25519 keygen and PBKDF2 use the libuv callback variant via promisify so concurrent calls parallelize on the thread pool.

API surface change: the import*Key functions, hmacSign, the CryptoKey re-export and pbkdf2DeriveAesCtrKey are removed. AES/HMAC functions now take Uint8Array keys directly. New names: hmacSha256Sign, hmacSha512Sign, pbkdf2Sha256.

X25519 drops the Bun-specific diffieHellman branch — the same path runs on both runtimes now.

Measured against the fake-server messaging bench (100 contacts × 2 dev, 2 groups × 50 members, 200 msgs per scenario):

  scenario       subtle    final    speedup
  SEND 1:1       7.28s     2.32s    3.14x
  RECV 1:1       3.79s     1.28s    2.96x
  SEND group     6.91s     3.04s    2.27x
  RECV group     4.27s     1.62s    2.64x
  total run      31.9s     13.8s    2.31x

CPU profile shows the entire subtle plumbing (webidl normalize, defineCryptoKeyProperties, jobPromise, BufferSource converters, subtle.encrypt/decrypt/sign/verify/deriveBits) drops to 0% self-time post-migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal cryptographic operations through improved key handling and more efficient primitive implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->