### PR TITLE
perf: reduce transient allocations in crypto/codec hot paths

### DIFF
--- a/packages/fake-server/src/infra/__tests__/WaFakeNoiseHandshake.cross-check.test.ts
+++ b/packages/fake-server/src/infra/__tests__/WaFakeNoiseHandshake.cross-check.test.ts
@@ -114,10 +114,10 @@ test('XX handshake: client (lib) and server (fake) agree on transport keys', asy
     const messageB = new Uint8Array([0xff, 0xee, 0xdd])
 
     const ctFromServer = await encryptWithKey(serverKeys.sendKey, 0, messageA)
-    const decodedByClient = await clientSocket.decrypt(buildNonce(0), ctFromServer)
+    const decodedByClient = await clientSocket.decrypt(ctFromServer)
     assert.deepEqual(Array.from(decodedByClient), Array.from(messageA))
 
-    const ctFromClient = await clientSocket.encrypt(buildNonce(0), messageB)
+    const ctFromClient = await clientSocket.encrypt(messageB)
     const decodedByServer = await decryptWithKey(serverKeys.recvKey, 0, ctFromClient)
     assert.deepEqual(Array.from(decodedByServer), Array.from(messageB))
 })

--- a/packages/fake-server/src/infra/__tests__/WaFakeTransport.cross-check.test.ts
+++ b/packages/fake-server/src/infra/__tests__/WaFakeTransport.cross-check.test.ts
@@ -84,12 +84,6 @@ async function runXxHandshake(): Promise<{
     return { clientSocket, serverTransport }
 }
 
-function buildNonce(counter: number): Uint8Array {
-    const nonce = new Uint8Array(12)
-    new DataView(nonce.buffer).setUint32(8, counter, false)
-    return nonce
-}
-
 test('post-handshake transport: server encrypts, client decrypts (3 frames in a row)', async () => {
     const { clientSocket, serverTransport } = await runXxHandshake()
 
@@ -101,7 +95,7 @@ test('post-handshake transport: server encrypts, client decrypts (3 frames in a 
 
     for (let i = 0; i < messages.length; i += 1) {
         const ct = await serverTransport.encryptFrame(messages[i])
-        const decoded = await clientSocket.decrypt(buildNonce(i), ct)
+        const decoded = await clientSocket.decrypt(ct)
         assert.deepEqual(Array.from(decoded), Array.from(messages[i]))
     }
 })
@@ -116,7 +110,7 @@ test('post-handshake transport: client encrypts, server decrypts (3 frames in a 
     ]
 
     for (let i = 0; i < messages.length; i += 1) {
-        const ct = await clientSocket.encrypt(buildNonce(i), messages[i])
+        const ct = await clientSocket.encrypt(messages[i])
         const decoded = await serverTransport.decryptFrame(ct)
         assert.deepEqual(Array.from(decoded), Array.from(messages[i]))
     }
@@ -129,11 +123,11 @@ test('post-handshake transport: bidirectional interleaved frames stay aligned', 
     const ctsFromClient: Uint8Array[] = []
     for (let i = 0; i < 4; i += 1) {
         ctsFromServer.push(await serverTransport.encryptFrame(new Uint8Array([0x10 + i])))
-        ctsFromClient.push(await clientSocket.encrypt(buildNonce(i), new Uint8Array([0x20 + i])))
+        ctsFromClient.push(await clientSocket.encrypt(new Uint8Array([0x20 + i])))
     }
 
     for (let i = 0; i < 4; i += 1) {
-        const fromServer = await clientSocket.decrypt(buildNonce(i), ctsFromServer[i])
+        const fromServer = await clientSocket.decrypt(ctsFromServer[i])
         const fromClient = await serverTransport.decryptFrame(ctsFromClient[i])
         assert.deepEqual(Array.from(fromServer), [0x10 + i])
         assert.deepEqual(Array.from(fromClient), [0x20 + i])

--- a/src/appstate/WaAppStateCrypto.ts
+++ b/src/appstate/WaAppStateCrypto.ts
@@ -233,12 +233,11 @@ export class WaAppStateCrypto {
         collectionName: string
     ): Promise<Uint8Array> {
         const derivedKeys = await this.deriveKeys(keyData)
-        const payload = concatBytes([
+        return hmacSha256Sign(derivedKeys.snapshotMacHmacKey, [
             ltHash,
             intToBytes(8, version),
             TEXT_ENCODER.encode(collectionName)
         ])
-        return hmacSha256Sign(derivedKeys.snapshotMacHmacKey, payload)
     }
 
     public async generatePatchMac(
@@ -249,13 +248,12 @@ export class WaAppStateCrypto {
         collectionName: string
     ): Promise<Uint8Array> {
         const derivedKeys = await this.deriveKeys(keyData)
-        const payload = concatBytes([
+        return hmacSha256Sign(derivedKeys.patchMacHmacKey, [
             snapshotMac,
             ...valueMacs,
             intToBytes(8, version),
             TEXT_ENCODER.encode(collectionName)
         ])
-        return hmacSha256Sign(derivedKeys.patchMacHmacKey, payload)
     }
 
     public async ltHashAdd(

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -61,7 +61,7 @@ import {
     buildMetaNode
 } from '@transport/node/builders/message'
 import type { BinaryNode } from '@transport/types'
-import { bytesToHex, concatBytes, TEXT_ENCODER } from '@util/bytes'
+import { bytesToHex, TEXT_ENCODER } from '@util/bytes'
 import { toError } from '@util/primitives'
 
 interface WaMessageDispatchCoordinatorOptions {
@@ -1146,22 +1146,20 @@ export class WaMessageDispatchCoordinator {
             )
             if (this.mobileMessageIdFormat) {
                 dv.setBigUint64(0, BigInt(Date.now()), false)
-                const entropy = concatBytes([
+                const digest = md5Bytes([
                     timestampBytes,
                     TEXT_ENCODER.encode(meUserJid),
                     await randomBytesAsync(16)
                 ])
-                const digest = md5Bytes(entropy)
                 digest[0] = 0xac
                 return bytesToHex(digest).toUpperCase()
             }
             dv.setBigUint64(0, BigInt(Math.floor(Date.now() / 1_000)), false)
-            const entropy = concatBytes([
+            const digest = await sha256([
                 timestampBytes,
                 TEXT_ENCODER.encode(meUserJid),
                 await randomBytesAsync(8)
             ])
-            const digest = await sha256(entropy)
             return `3EB0${bytesToHex(digest.subarray(0, 9)).toUpperCase()}`
         } catch (error) {
             this.logger.warn('failed to generate message id, falling back to random', {

--- a/src/crypto/core/index.ts
+++ b/src/crypto/core/index.ts
@@ -11,7 +11,7 @@ export {
     prependVersion,
     readVersionedContent
 } from '@crypto/core/keys'
-export { buildNonce } from '@crypto/core/nonce'
+export { buildNonce, writeNonceCounter } from '@crypto/core/nonce'
 export { randomBytesAsync, randomFillAsync, randomIntAsync } from '@crypto/core/random'
 export {
     sha1,

--- a/src/crypto/core/nonce.ts
+++ b/src/crypto/core/nonce.ts
@@ -5,6 +5,9 @@ export function buildNonce(counter: number): Uint8Array {
 }
 
 export function writeNonceCounter(out: Uint8Array, counter: number): void {
+    if (out.length < 12) {
+        throw new Error(`nonce buffer must be at least 12 bytes, got ${out.length}`)
+    }
     if (counter > 0xffffffff) {
         throw new Error('nonce counter overflow: exceeds uint32 range')
     }

--- a/src/crypto/core/nonce.ts
+++ b/src/crypto/core/nonce.ts
@@ -1,17 +1,15 @@
-/**
- * Builds a 12-byte nonce for AES-GCM encryption with counter in the last 4 bytes.
- * Allocates a new buffer per call because concurrent Noise encrypt/decrypt operations
- * may hold references to different nonces simultaneously.
- * Throws if counter exceeds uint32 range to prevent nonce reuse.
- */
 export function buildNonce(counter: number): Uint8Array {
+    const nonce = new Uint8Array(12)
+    writeNonceCounter(nonce, counter)
+    return nonce
+}
+
+export function writeNonceCounter(out: Uint8Array, counter: number): void {
     if (counter > 0xffffffff) {
         throw new Error('nonce counter overflow: exceeds uint32 range')
     }
-    const nonce = new Uint8Array(12)
-    nonce[8] = (counter >>> 24) & 0xff
-    nonce[9] = (counter >>> 16) & 0xff
-    nonce[10] = (counter >>> 8) & 0xff
-    nonce[11] = counter & 0xff
-    return nonce
+    out[8] = (counter >>> 24) & 0xff
+    out[9] = (counter >>> 16) & 0xff
+    out[10] = (counter >>> 8) & 0xff
+    out[11] = counter & 0xff
 }

--- a/src/crypto/core/primitives.ts
+++ b/src/crypto/core/primitives.ts
@@ -5,7 +5,14 @@
  * under the hood. Keys are passed as raw bytes — no opaque key handles in the API.
  */
 
-import { createCipheriv, createDecipheriv, createHash, createHmac, pbkdf2 } from 'node:crypto'
+import {
+    createCipheriv,
+    createDecipheriv,
+    createHash,
+    createHmac,
+    type KeyObject,
+    pbkdf2
+} from 'node:crypto'
 import { promisify } from 'node:util'
 
 import { concatBytes, EMPTY_BYTES, toBytesView } from '@util/bytes'
@@ -14,32 +21,67 @@ const AES_GCM_TAG_LENGTH = 16
 
 const pbkdf2Async = promisify(pbkdf2)
 
+/**
+ * Hash/HMAC input — either a single buffer or a list of parts to be fed
+ * sequentially into the streaming digest. Accepting parts directly avoids
+ * the caller having to `concatBytes([...])` first only to pass a single
+ * buffer in (the concat allocates a fresh Uint8Array of the combined size).
+ */
+export type HashInput = Uint8Array | readonly Uint8Array[]
+
+type Digestable = ReturnType<typeof createHash> | ReturnType<typeof createHmac>
+
+function feed<T extends Digestable>(target: T, input: HashInput): T {
+    if (Array.isArray(input)) {
+        for (let i = 0; i < input.length; i += 1) {
+            target.update(input[i])
+        }
+    } else {
+        target.update(input as Uint8Array)
+    }
+    return target
+}
+
 // ============================================
 // Hash functions
 // ============================================
 
-export function sha1(value: Uint8Array): Promise<Uint8Array> {
-    return Promise.resolve(toBytesView(createHash('sha1').update(value).digest()))
+export function sha1(value: HashInput): Promise<Uint8Array> {
+    return Promise.resolve(toBytesView(feed(createHash('sha1'), value).digest()))
 }
 
-export function sha256(value: Uint8Array): Promise<Uint8Array> {
-    return Promise.resolve(toBytesView(createHash('sha256').update(value).digest()))
+export function sha256(value: HashInput): Promise<Uint8Array> {
+    return Promise.resolve(toBytesView(feed(createHash('sha256'), value).digest()))
 }
 
-export function sha512(value: Uint8Array): Promise<Uint8Array> {
-    return Promise.resolve(toBytesView(createHash('sha512').update(value).digest()))
+export function sha512(value: HashInput): Promise<Uint8Array> {
+    return Promise.resolve(toBytesView(feed(createHash('sha512'), value).digest()))
 }
 
-export function md5Bytes(input: string | Uint8Array): Uint8Array {
-    return toBytesView(createHash('md5').update(input).digest())
+export function md5Bytes(input: string | HashInput): Uint8Array {
+    const hash = createHash('md5')
+    if (typeof input === 'string') {
+        hash.update(input)
+    } else {
+        feed(hash, input)
+    }
+    return toBytesView(hash.digest())
 }
 
 // ============================================
 // AES-GCM (for Noise protocol)
 // ============================================
 
+/**
+ * Symmetric AES key as raw bytes or a pre-wrapped `KeyObject`. Long-lived
+ * keys (e.g. Noise session keys) should be wrapped once via
+ * `createSecretKey` and passed as `KeyObject` so node:crypto skips the
+ * implicit per-call wrap inside `createCipheriv`.
+ */
+export type AesKey = Uint8Array | KeyObject
+
 export function aesGcmEncrypt(
-    key: Uint8Array,
+    key: AesKey,
     nonce: Uint8Array,
     plaintext: Uint8Array,
     aad: Uint8Array = EMPTY_BYTES
@@ -55,7 +97,7 @@ export function aesGcmEncrypt(
 }
 
 export function aesGcmDecrypt(
-    key: Uint8Array,
+    key: AesKey,
     nonce: Uint8Array,
     ciphertext: Uint8Array,
     aad: Uint8Array = EMPTY_BYTES
@@ -144,12 +186,12 @@ export function aesCtrDecrypt(
 // HMAC (for Signal protocol, app-state, reporting tokens, etc.)
 // ============================================
 
-export function hmacSha256Sign(key: Uint8Array, data: Uint8Array): Promise<Uint8Array> {
-    return Promise.resolve(toBytesView(createHmac('sha256', key).update(data).digest()))
+export function hmacSha256Sign(key: Uint8Array, data: HashInput): Promise<Uint8Array> {
+    return Promise.resolve(toBytesView(feed(createHmac('sha256', key), data).digest()))
 }
 
-export function hmacSha512Sign(key: Uint8Array, data: Uint8Array): Promise<Uint8Array> {
-    return Promise.resolve(toBytesView(createHmac('sha512', key).update(data).digest()))
+export function hmacSha512Sign(key: Uint8Array, data: HashInput): Promise<Uint8Array> {
+    return Promise.resolve(toBytesView(feed(createHmac('sha512', key), data).digest()))
 }
 
 // ============================================

--- a/src/crypto/core/xeddsa.ts
+++ b/src/crypto/core/xeddsa.ts
@@ -46,17 +46,14 @@ export async function xeddsaSign(privateKey: Uint8Array, message: Uint8Array): P
     const pubKeySignBit = encodedPublic[31] & 0x80
 
     const randomSuffix = await randomBytesAsync(64)
-    const hashInput = concatBytes([
-        PREFIX_SIGNATURE_RANDOM,
-        clampedPrivateKey,
-        message,
-        randomSuffix
-    ])
-    const r = modGroup(bytesToBigIntLE(await sha512(hashInput)))
+    const r = modGroup(
+        bytesToBigIntLE(
+            await sha512([PREFIX_SIGNATURE_RANDOM, clampedPrivateKey, message, randomSuffix])
+        )
+    )
     const encodedR = encodeExtendedPoint(scalarMultBase(r))
 
-    const hInput = concatBytes([encodedR, encodedPublic, message])
-    const h = modGroup(bytesToBigIntLE(await sha512(hInput)))
+    const h = modGroup(bytesToBigIntLE(await sha512([encodedR, encodedPublic, message])))
     const s = modGroup(r + h * privateScalar)
 
     const encodedS = bigIntToBytesLE(s, 32)

--- a/src/media/WaMediaCrypto.ts
+++ b/src/media/WaMediaCrypto.ts
@@ -85,12 +85,12 @@ async function aesCbcDecryptChunk(
 
 async function computeFirstFrameSidecar(
     macKey: Uint8Array,
-    ivCiphertext: Uint8Array,
+    iv: Uint8Array,
+    ciphertext: Uint8Array,
     firstFrameLength: number
 ): Promise<Uint8Array> {
     const aligned = Math.ceil(firstFrameLength / AES_BLOCK_SIZE) * AES_BLOCK_SIZE
-    const slice = ivCiphertext.subarray(0, IV_SIZE + aligned)
-    const digest = await hmacSha256Sign(macKey, slice)
+    const digest = await hmacSha256Sign(macKey, [iv, ciphertext.subarray(0, aligned)])
     return digest.subarray(0, SIDECAR_HMAC_SIZE)
 }
 
@@ -184,9 +184,8 @@ export class WaMediaCrypto {
     ): Promise<WaMediaEncryptionResult> {
         const keys = await WaMediaCrypto.deriveKeys(mediaType, mediaKey)
         const ciphertext = await aesCbcEncrypt(keys.encKey, keys.iv, plaintext)
-        const ivCiphertext = concatBytes([keys.iv, ciphertext])
 
-        const mac = await hmacSha256Sign(keys.macKey, ivCiphertext)
+        const mac = await hmacSha256Sign(keys.macKey, [keys.iv, ciphertext])
         const signature = mac.subarray(0, HMAC_TRUNCATED_SIZE)
         const ciphertextHmac = concatBytes([ciphertext, signature])
 
@@ -203,7 +202,8 @@ export class WaMediaCrypto {
             options?.firstFrameLength !== undefined
                 ? await computeFirstFrameSidecar(
                       keys.macKey,
-                      ivCiphertext,
+                      keys.iv,
+                      ciphertext,
                       options.firstFrameLength
                   )
                 : undefined
@@ -246,10 +246,9 @@ export class WaMediaCrypto {
             ciphertextHmac.byteLength - HMAC_TRUNCATED_SIZE
         )
         const expectedMac = ciphertextHmac.subarray(ciphertextHmac.byteLength - HMAC_TRUNCATED_SIZE)
-        const ivCiphertext = concatBytes([keys.iv, ciphertext])
 
         if (!skipMacVerification) {
-            const mac = await hmacSha256Sign(keys.macKey, ivCiphertext)
+            const mac = await hmacSha256Sign(keys.macKey, [keys.iv, ciphertext])
             const signature = mac.subarray(0, HMAC_TRUNCATED_SIZE)
             if (!uint8TimingSafeEqual(signature, expectedMac)) {
                 throw new Error('media MAC mismatch')
@@ -427,8 +426,7 @@ async function pumpEncryption(
 
         let firstFrameSidecar: Uint8Array | undefined
         if (ffTarget > 0) {
-            const ivCiphertextSlice = concatBytes(ffChunks)
-            const ffDigest = await hmacSha256Sign(keys.macKey, ivCiphertextSlice)
+            const ffDigest = await hmacSha256Sign(keys.macKey, ffChunks)
             firstFrameSidecar = ffDigest.subarray(0, SIDECAR_HMAC_SIZE)
         }
 
@@ -566,8 +564,7 @@ async function pumpEncryptionToWritable(
 
         let firstFrameSidecar: Uint8Array | undefined
         if (ffTarget > 0) {
-            const ivCiphertextSlice = concatBytes(ffChunks)
-            const ffDigest = await hmacSha256Sign(keys.macKey, ivCiphertextSlice)
+            const ffDigest = await hmacSha256Sign(keys.macKey, ffChunks)
             firstFrameSidecar = ffDigest.subarray(0, SIDECAR_HMAC_SIZE)
         }
 

--- a/src/message/icdc.ts
+++ b/src/message/icdc.ts
@@ -3,7 +3,6 @@ import type { Proto } from '@proto'
 import { parseSignalAddressFromJid } from '@protocol/jid'
 import type { SignalAddress } from '@signal/types'
 import type { WaIdentityStore } from '@store/contracts/identity.store'
-import { concatBytes } from '@util/bytes'
 
 const ICDC_DEFAULT_HASH_LENGTH = 8
 const ICDC_FRESHNESS_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1_000
@@ -27,8 +26,7 @@ export async function computeDeviceKeyHash(
         rawKeys[i] =
             identityKeys[i].byteLength === 33 ? toRawPubKey(identityKeys[i]) : identityKeys[i]
     }
-    const combined = concatBytes(rawKeys)
-    const hash = await sha256(combined)
+    const hash = await sha256(rawKeys)
     return hash.subarray(0, length)
 }
 

--- a/src/message/phash.ts
+++ b/src/message/phash.ts
@@ -33,7 +33,13 @@ export async function computePhashV2(participants: readonly string[]): Promise<s
     let off = 0
     for (let i = 0; i < n; i += 1) {
         OFFSETS[i] = off
-        off = writeCanonicalUtf8(SCRATCH, off, participants[i])
+        const nextOff = writeCanonicalUtf8(SCRATCH, off, participants[i])
+        if (nextOff > SCRATCH.length) {
+            throw new Error(
+                `phash canonical buffer overflow at participant ${i}: needs ${nextOff} bytes, scratch is ${SCRATCH.length}`
+            )
+        }
+        off = nextOff
     }
     OFFSETS[n] = off
 

--- a/src/message/phash.ts
+++ b/src/message/phash.ts
@@ -1,33 +1,77 @@
 import { sha256 } from '@crypto/core'
-import { bytesToBase64, TEXT_ENCODER } from '@util/bytes'
+import { WA_DEFAULTS } from '@protocol/constants'
+import { bytesToBase64 } from '@util/bytes'
+
+const PHASH_DIGEST_PREFIX = 6
+
+const CHAR_DOT = 0x2e
+const CHAR_ZERO = 0x30
+const CHAR_COLON = 0x3a
+const CHAR_AT = 0x40
+const CHAR_C = 0x63
+const CHAR_U = 0x75
+const CHAR_S = 0x73
+
+const MAX_PARTICIPANTS = 2048
+const PER_WID_BYTES = 96
+
+// Module scratch reused across calls. Safe because every call's sync
+// prep + `sha256(parts).update(...)` consumes the bytes before the
+// awaited `Promise.resolve(...)` yields — the next call's overwrite
+// can't reach an in-flight digest.
+const SCRATCH = new Uint8Array(MAX_PARTICIPANTS * PER_WID_BYTES)
+const OFFSETS = new Uint32Array(MAX_PARTICIPANTS + 1)
+const ORDER = new Uint32Array(MAX_PARTICIPANTS)
 
 export async function computePhashV2(participants: readonly string[]): Promise<string> {
-    if (participants.length === 0) {
-        return '2:'
+    if (participants.length === 0) return '2:'
+    const n = participants.length
+    if (n > MAX_PARTICIPANTS) {
+        throw new Error(`phash participant count ${n} exceeds MAX_PARTICIPANTS ${MAX_PARTICIPANTS}`)
     }
 
-    const canonical = new Array<string>(participants.length)
-    for (let i = 0; i < participants.length; i += 1)
-        canonical[i] = toPhashCanonicalWid(participants[i])
-    const joined = canonical.sort().join('')
-    const digest = await sha256(TEXT_ENCODER.encode(joined))
-    return `2:${bytesToBase64(digest.subarray(0, 6))}`
+    let off = 0
+    for (let i = 0; i < n; i += 1) {
+        OFFSETS[i] = off
+        off = writeCanonicalUtf8(SCRATCH, off, participants[i])
+    }
+    OFFSETS[n] = off
+
+    for (let i = 0; i < n; i += 1) ORDER[i] = i
+    ORDER.subarray(0, n).sort((a, b) => compareScratchSlice(SCRATCH, OFFSETS, a, b))
+
+    const parts = new Array<Uint8Array>(n)
+    for (let i = 0; i < n; i += 1) {
+        const idx = ORDER[i]
+        parts[i] = SCRATCH.subarray(OFFSETS[idx], OFFSETS[idx + 1])
+    }
+    const digest = await sha256(parts)
+    return `2:${bytesToBase64(digest.subarray(0, PHASH_DIGEST_PREFIX))}`
 }
 
-function toPhashCanonicalWid(jid: string): string {
+function writeCanonicalUtf8(out: Uint8Array, start: number, jid: string): number {
     const atIndex = jid.indexOf('@')
-    if (atIndex < 1 || atIndex >= jid.length - 1) return jid
+    if (atIndex < 1 || atIndex >= jid.length - 1) {
+        return writeAscii(out, start, jid, 0, jid.length)
+    }
+
     const colonIndex = jid.indexOf(':', 0)
     const userEnd = colonIndex >= 0 && colonIndex < atIndex ? colonIndex : atIndex
     const hasZeroAgent =
-        userEnd >= 2 && jid.charCodeAt(userEnd - 2) === 46 && jid.charCodeAt(userEnd - 1) === 48
+        userEnd >= 2 &&
+        jid.charCodeAt(userEnd - 2) === CHAR_DOT &&
+        jid.charCodeAt(userEnd - 1) === CHAR_ZERO
     const baseUserEnd = hasZeroAgent ? userEnd - 2 : userEnd
-    const baseUser = jid.slice(0, baseUserEnd)
+
+    let off = writeAscii(out, start, jid, 0, baseUserEnd)
+    out[off++] = CHAR_DOT
+    out[off++] = CHAR_ZERO
+    out[off++] = CHAR_COLON
 
     let device = 0
     if (colonIndex >= 0 && colonIndex < atIndex) {
         for (let i = colonIndex + 1; i < atIndex; i += 1) {
-            const digit = jid.charCodeAt(i) - 48
+            const digit = jid.charCodeAt(i) - CHAR_ZERO
             if (digit < 0 || digit > 9) {
                 device = 0
                 break
@@ -39,16 +83,76 @@ function toPhashCanonicalWid(jid: string): string {
             }
         }
     }
+    off = writeUintAscii(out, off, device)
+    out[off++] = CHAR_AT
 
     const serverStart = atIndex + 1
     const serverLen = jid.length - serverStart
     const isCUs =
         serverLen === 4 &&
-        jid.charCodeAt(serverStart) === 99 &&
-        jid.charCodeAt(serverStart + 1) === 46 &&
-        jid.charCodeAt(serverStart + 2) === 117 &&
-        jid.charCodeAt(serverStart + 3) === 115
-    const normalizedServer = isCUs ? 's.whatsapp.net' : jid.slice(serverStart)
+        jid.charCodeAt(serverStart) === CHAR_C &&
+        jid.charCodeAt(serverStart + 1) === CHAR_DOT &&
+        jid.charCodeAt(serverStart + 2) === CHAR_U &&
+        jid.charCodeAt(serverStart + 3) === CHAR_S
+    if (isCUs) {
+        off = writeAscii(out, off, WA_DEFAULTS.HOST_DOMAIN, 0, WA_DEFAULTS.HOST_DOMAIN.length)
+    } else {
+        off = writeAscii(out, off, jid, serverStart, jid.length)
+    }
+    return off
+}
 
-    return `${baseUser}.0:${device}@${normalizedServer}`
+function writeAscii(
+    out: Uint8Array,
+    outOff: number,
+    str: string,
+    start: number,
+    end: number
+): number {
+    for (let i = start; i < end; i += 1) {
+        out[outOff + (i - start)] = str.charCodeAt(i)
+    }
+    return outOff + (end - start)
+}
+
+function writeUintAscii(out: Uint8Array, off: number, value: number): number {
+    if (value === 0) {
+        out[off] = CHAR_ZERO
+        return off + 1
+    }
+    let temp = value
+    let digits = 0
+    while (temp > 0) {
+        digits += 1
+        temp = (temp - (temp % 10)) / 10
+    }
+    let cursor = off + digits - 1
+    let v = value
+    while (v > 0) {
+        out[cursor] = CHAR_ZERO + (v % 10)
+        cursor -= 1
+        v = (v - (v % 10)) / 10
+    }
+    return off + digits
+}
+
+function compareScratchSlice(
+    scratch: Uint8Array,
+    offsets: Uint32Array,
+    a: number,
+    b: number
+): number {
+    const aStart = offsets[a]
+    const aEnd = offsets[a + 1]
+    const bStart = offsets[b]
+    const bEnd = offsets[b + 1]
+    const aLen = aEnd - aStart
+    const bLen = bEnd - bStart
+    const cmpLen = aLen < bLen ? aLen : bLen
+    for (let k = 0; k < cmpLen; k += 1) {
+        const av = scratch[aStart + k]
+        const bv = scratch[bStart + k]
+        if (av !== bv) return av - bv
+    }
+    return aLen - bLen
 }

--- a/src/signal/api/SignalDigestSyncApi.ts
+++ b/src/signal/api/SignalDigestSyncApi.ts
@@ -21,7 +21,7 @@ import {
 } from '@transport/node/helpers'
 import { parseIqError } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
-import { concatBytes, uint8Equal } from '@util/bytes'
+import { uint8Equal } from '@util/bytes'
 
 interface SignalDigestSyncApiOptions {
     readonly logger: Logger
@@ -217,7 +217,7 @@ export class SignalDigestSyncApi {
             bytesToHash.push(toRawPubKey(preKey.keyPair.pubKey))
         }
 
-        const localHash = (await sha1(concatBytes(bytesToHash))).subarray(0, digest.hash.byteLength)
+        const localHash = (await sha1(bytesToHash)).subarray(0, digest.hash.byteLength)
         if (!uint8Equal(localHash, digest.hash)) {
             return {
                 valid: false,

--- a/src/signal/session/SignalProtocol.ts
+++ b/src/signal/session/SignalProtocol.ts
@@ -17,7 +17,6 @@ import {
     requireSignedPreKey
 } from '@signal/session/SignalSerializer'
 import {
-    detachSession,
     findMatchingSession,
     generateSerializedKeyPair,
     initiateSessionIncoming,
@@ -339,7 +338,7 @@ export class SignalProtocol {
             ? {
                   ...incoming,
                   prevSessions: [
-                      encodeSignalSessionSnapshot(detachSession(currentSession)),
+                      encodeSignalSessionSnapshot(currentSession),
                       ...currentSession.prevSessions.slice(0, MAX_PREV_SESSIONS - 1)
                   ]
               }

--- a/src/signal/session/SignalRatchet.ts
+++ b/src/signal/session/SignalRatchet.ts
@@ -24,7 +24,6 @@ import {
 } from '@signal/encoding'
 import {
     calculateRatchet,
-    detachSession,
     generateSerializedKeyPair,
     snapshotToRecord
 } from '@signal/session/SignalSession'
@@ -179,12 +178,11 @@ export async function encryptMsg(
         ciphertext
     }).finish()
     const versionedSignalPayload = prependVersion(signalPayload, SIGNAL_VERSION)
-    const macInput = concatBytes([
+    const mac = await hmacSha256Sign(messageKey.macKey, [
         session.local.pubKey,
         session.remote.pubKey,
         versionedSignalPayload
     ])
-    const mac = await hmacSha256Sign(messageKey.macKey, macInput)
     const signalMessage = concatBytes([versionedSignalPayload, mac.subarray(0, SIGNAL_MAC_SIZE)])
 
     let type: 'msg' | 'pkmsg' = 'msg'
@@ -241,7 +239,7 @@ export async function decryptMsg(
                 const updatedSession = {
                     ...updatedPrev,
                     prevSessions: [
-                        encodeSignalSessionSnapshot(detachSession(session)),
+                        encodeSignalSessionSnapshot(session),
                         ...session.prevSessions.slice(0, i),
                         ...session.prevSessions.slice(i + 1)
                     ]
@@ -335,12 +333,11 @@ export async function decryptMsgFromSession(
         0,
         message.versionContentMac.length - SIGNAL_MAC_SIZE
     )
-    const expectedMacInput = concatBytes([
+    const expectedMac = await hmacSha256Sign(selectedMessageKey.macKey, [
         session.remote.pubKey,
         session.local.pubKey,
         payloadWithoutMac
     ])
-    const expectedMac = await hmacSha256Sign(selectedMessageKey.macKey, expectedMacInput)
     const receivedMac = message.versionContentMac.subarray(
         message.versionContentMac.length - SIGNAL_MAC_SIZE
     )

--- a/src/signal/session/SignalSession.ts
+++ b/src/signal/session/SignalSession.ts
@@ -29,12 +29,6 @@ export function snapshotToRecord(snapshot: SignalSessionSnapshot): SignalSession
     }
 }
 
-export function detachSession(session: SignalSessionRecord): SignalSessionSnapshot {
-    const { prevSessions, ...snapshot } = session
-    void prevSessions
-    return snapshot
-}
-
 export function findMatchingSession(
     session: SignalSessionRecord | null,
     sessionBaseKey: Uint8Array
@@ -53,9 +47,7 @@ export function findMatchingSession(
         }
 
         const decoded = decodeSignalSessionSnapshot(rawPrev, `prevSessions[${index}]`)
-        const prevSessions: RawSignalSessionSnapshot[] = [
-            encodeSignalSessionSnapshot(detachSession(session))
-        ]
+        const prevSessions: RawSignalSessionSnapshot[] = [encodeSignalSessionSnapshot(session)]
         for (let i = 0; i < session.prevSessions.length; i += 1) {
             if (i !== index) {
                 prevSessions.push(session.prevSessions[i])

--- a/src/transport/binary/decoder.ts
+++ b/src/transport/binary/decoder.ts
@@ -99,6 +99,9 @@ function parsePacked(reader: ByteReader, alphabet: readonly string[]): string {
     const odd = (lengthByte & 0x80) !== 0
     const byteCount = lengthByte & 0x7f
     const outLength = byteCount * 2 - (odd ? 1 : 0)
+    if (outLength < 0) {
+        throw new Error(`invalid packed length byte 0x${lengthByte.toString(16)}`)
+    }
 
     let outIndex = 0
     for (let i = 0; i < byteCount; i += 1) {

--- a/src/transport/binary/decoder.ts
+++ b/src/transport/binary/decoder.ts
@@ -87,31 +87,36 @@ class ByteReader {
     }
 }
 
+// Reusable scratch buffer for nibble/hex unpack. Max output is
+// `(0x7f) * 2 = 254` bytes (length byte holds the packed-byte count in
+// its low 7 bits, each byte unpacks to ≤2 chars). Single-threaded JS +
+// non-reentrant decoder makes module-level reuse safe — `TextDecoder`
+// copies into the returned string before we touch the buffer again.
+const PACKED_SCRATCH = new Uint8Array(256)
+
 function parsePacked(reader: ByteReader, alphabet: readonly string[]): string {
     const lengthByte = reader.readUint8()
     const odd = (lengthByte & 0x80) !== 0
     const byteCount = lengthByte & 0x7f
     const outLength = byteCount * 2 - (odd ? 1 : 0)
 
-    const buf = new Uint8Array(outLength)
     let outIndex = 0
-
     for (let i = 0; i < byteCount; i += 1) {
         const packed = reader.readUint8()
         const high = (packed >>> 4) & 0x0f
         const low = packed & 0x0f
 
         if (outIndex < outLength) {
-            buf[outIndex] = alphabet[high].charCodeAt(0)
+            PACKED_SCRATCH[outIndex] = alphabet[high].charCodeAt(0)
             outIndex += 1
         }
         if (outIndex < outLength) {
-            buf[outIndex] = alphabet[low].charCodeAt(0)
+            PACKED_SCRATCH[outIndex] = alphabet[low].charCodeAt(0)
             outIndex += 1
         }
     }
 
-    return TEXT_DECODER.decode(buf)
+    return TEXT_DECODER.decode(PACKED_SCRATCH.subarray(0, outLength))
 }
 
 function readBinary(reader: ByteReader, token: number): Uint8Array {

--- a/src/transport/noise/WaNoiseHandshake.ts
+++ b/src/transport/noise/WaNoiseHandshake.ts
@@ -1,6 +1,6 @@
 import { aesGcmDecrypt, aesGcmEncrypt, buildNonce, hkdfSplit, sha256 } from '@crypto'
 import { WaNoiseSocket } from '@transport/noise/WaNoiseSocket'
-import { concatBytes, EMPTY_BYTES } from '@util/bytes'
+import { EMPTY_BYTES } from '@util/bytes'
 
 export class WaNoiseHandshake {
     private handshakeHash: Uint8Array
@@ -24,7 +24,7 @@ export class WaNoiseHandshake {
     }
 
     public async authenticate(data: Uint8Array): Promise<void> {
-        this.handshakeHash = await sha256(concatBytes([this.handshakeHash, data]))
+        this.handshakeHash = await sha256([this.handshakeHash, data])
     }
 
     public async mixIntoKey(keyMaterial: Uint8Array): Promise<void> {

--- a/src/transport/noise/WaNoiseSession.ts
+++ b/src/transport/noise/WaNoiseSession.ts
@@ -141,7 +141,7 @@ export class WaNoiseSession {
         }
         let encryptPromise: Promise<Uint8Array>
         try {
-            encryptPromise = socket.encrypt(socket.reserveWriteNonce(), frame)
+            encryptPromise = socket.encrypt(frame)
         } catch (error) {
             return Promise.reject(error)
         }
@@ -218,11 +218,11 @@ export class WaNoiseSession {
         frames: readonly Uint8Array[]
     ): Promise<readonly Uint8Array[]> {
         if (frames.length === 1) {
-            return [await socket.decrypt(socket.reserveReadNonce(), frames[0])]
+            return [await socket.decrypt(frames[0])]
         }
         const pending = new Array<Promise<Uint8Array>>(frames.length)
         for (let i = 0; i < frames.length; i++) {
-            pending[i] = socket.decrypt(socket.reserveReadNonce(), frames[i])
+            pending[i] = socket.decrypt(frames[i])
         }
         return Promise.all(pending)
     }

--- a/src/transport/noise/WaNoiseSocket.ts
+++ b/src/transport/noise/WaNoiseSocket.ts
@@ -1,39 +1,29 @@
-import { aesGcmDecrypt, aesGcmEncrypt, buildNonce } from '@crypto'
+import { createSecretKey, type KeyObject } from 'node:crypto'
+
+import { aesGcmDecrypt, aesGcmEncrypt, writeNonceCounter } from '@crypto'
 
 export class WaNoiseSocket {
-    private readonly encryptKey: Uint8Array
-    private readonly decryptKey: Uint8Array
+    private readonly encryptKey: KeyObject
+    private readonly decryptKey: KeyObject
     private writeCounter: number
     private readCounter: number
+    private readonly writeNonceScratch: Uint8Array = new Uint8Array(12)
+    private readonly readNonceScratch: Uint8Array = new Uint8Array(12)
 
     public constructor(encryptKey: Uint8Array, decryptKey: Uint8Array) {
-        this.encryptKey = encryptKey
-        this.decryptKey = decryptKey
+        this.encryptKey = createSecretKey(encryptKey)
+        this.decryptKey = createSecretKey(decryptKey)
         this.writeCounter = 0
         this.readCounter = 0
     }
 
-    public reserveWriteNonce(): Uint8Array {
-        return buildNonce(this.writeCounter++)
+    public encrypt(frame: Uint8Array, additionalData?: Uint8Array): Promise<Uint8Array> {
+        writeNonceCounter(this.writeNonceScratch, this.writeCounter++)
+        return aesGcmEncrypt(this.encryptKey, this.writeNonceScratch, frame, additionalData)
     }
 
-    public encrypt(
-        nonce: Uint8Array,
-        frame: Uint8Array,
-        additionalData?: Uint8Array
-    ): Promise<Uint8Array> {
-        return aesGcmEncrypt(this.encryptKey, nonce, frame, additionalData)
-    }
-
-    public reserveReadNonce(): Uint8Array {
-        return buildNonce(this.readCounter++)
-    }
-
-    public decrypt(
-        nonce: Uint8Array,
-        frame: Uint8Array,
-        additionalData?: Uint8Array
-    ): Promise<Uint8Array> {
-        return aesGcmDecrypt(this.decryptKey, nonce, frame, additionalData)
+    public decrypt(frame: Uint8Array, additionalData?: Uint8Array): Promise<Uint8Array> {
+        writeNonceCounter(this.readNonceScratch, this.readCounter++)
+        return aesGcmDecrypt(this.decryptKey, this.readNonceScratch, frame, additionalData)
     }
 }


### PR DESCRIPTION
- streaming HashInput in primitives.ts (sha1/256/512, hmac, md5 accept Uint8Array | Uint8Array[])
- migrate concat-then-hash sites in SignalRatchet/Noise/xeddsa/appstate/digest-sync/dispatch/icdc/media
- parsePacked nibble/hex unpack uses module-level scratch buffer
- remove detachSession (no-op spread that built a Snapshot from Record)
- WaNoiseSocket caches AES-GCM cipher KeyObject + reuses 12-byte nonce scratch
- aesGcm primitives accept Uint8Array | KeyObject
- computePhashV2 uses module scratch + streaming sha256 + ASCII byte writes (no joined string, no per-canonical alloc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signal session snapshot handling during key-exchange to prevent session mismatch issues.

* **Chores / Improvements**
  * Reduced cryptographic intermediate allocations for better performance and memory use.
  * Simplified nonce handling in transport for more robust encryption/decryption flows.
  * Reworked device/phash and media hashing paths for faster, lower-allocation processing.
  * Removed an obsolete session detachment utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->