### PR TITLE
feat(client): add newsletter (channels) support

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -16,6 +16,7 @@ import type { WaEmailCoordinator } from '@client/coordinators/WaEmailCoordinator
 import type { WaGroupCoordinator } from '@client/coordinators/WaGroupCoordinator'
 import type { WaIncomingNodeCoordinator } from '@client/coordinators/WaIncomingNodeCoordinator'
 import type { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
+import type { WaNewsletterCoordinator } from '@client/coordinators/WaNewsletterCoordinator'
 import type { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTasksCoordinator'
 import type { WaPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordinator'
 import type { WaProfileCoordinator } from '@client/coordinators/WaProfileCoordinator'
@@ -121,6 +122,7 @@ export class WaClient extends EventEmitter {
     public readonly messageDispatch!: WaMessageDispatchCoordinator
     public readonly messageClient!: WaMessageClient
     public readonly groupCoordinator!: WaGroupCoordinator
+    public readonly newsletterCoordinator!: WaNewsletterCoordinator
     public readonly privacyCoordinator!: WaPrivacyCoordinator
     public readonly profileCoordinator!: WaProfileCoordinator
     public readonly businessCoordinator!: WaBusinessCoordinator
@@ -705,6 +707,9 @@ export class WaClient extends EventEmitter {
     }
     public get group(): WaGroupCoordinator {
         return this.groupCoordinator
+    }
+    public get newsletter(): WaNewsletterCoordinator {
+        return this.newsletterCoordinator
     }
     public get privacy(): WaPrivacyCoordinator {
         return this.privacyCoordinator

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -19,6 +19,10 @@ import {
 } from '@client/coordinators/WaGroupCoordinator'
 import { WaIncomingNodeCoordinator } from '@client/coordinators/WaIncomingNodeCoordinator'
 import { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
+import {
+    createNewsletterCoordinator,
+    type WaNewsletterCoordinator
+} from '@client/coordinators/WaNewsletterCoordinator'
 import { WaOfflineResumeCoordinator } from '@client/coordinators/WaOfflineResumeCoordinator'
 import { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTasksCoordinator'
 import {
@@ -51,7 +55,8 @@ import type {
     WaClientEventMap,
     WaClientOptions,
     WaIncomingMessageEvent,
-    WaIncomingUnhandledStanzaEvent
+    WaIncomingUnhandledStanzaEvent,
+    WaNewsletterEventAction
 } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import type { WaMediaConn } from '@media/types'
@@ -62,11 +67,12 @@ import {
     getWaCompanionPlatformId,
     WA_DEFAULTS,
     WA_DISCONNECT_REASONS,
+    WA_NEWSLETTER_NOTIFICATION_TAGS,
     WA_NODE_TAGS,
     WA_NOTIFICATION_TYPES,
     WA_PRIVACY_TOKEN_NOTIFICATION_TYPE
 } from '@protocol/constants'
-import { parseSignalAddressFromJid, toUserJid } from '@protocol/jid'
+import { isNewsletterJid, parseSignalAddressFromJid, toUserJid } from '@protocol/jid'
 import type { WaConnectionCode, WaConnectionOpenReason, WaDisconnectReason } from '@protocol/stream'
 import { createOutboundRetryTracker } from '@retry/tracker'
 import type { WaRetryDecryptFailureContext } from '@retry/types'
@@ -150,6 +156,7 @@ interface WaClientDependencies {
     readonly incomingNode: WaIncomingNodeCoordinator
     readonly passiveTasks: WaPassiveTasksCoordinator
     readonly groupCoordinator: WaGroupCoordinator
+    readonly newsletterCoordinator: WaNewsletterCoordinator
     readonly privacyCoordinator: WaPrivacyCoordinator
     readonly profileCoordinator: WaProfileCoordinator
     readonly businessCoordinator: WaBusinessCoordinator
@@ -534,6 +541,18 @@ export function buildWaClientDependencies(input: {
         queryWithContext: runtime.queryWithContext
     })
 
+    const newsletterCoordinator = createNewsletterCoordinator({
+        mexSocket: { query: runtime.query },
+        sendNode: runtime.sendNode,
+        publishMessageNode: (node, opts) => messageDispatch.publishMessageNode(node, opts),
+        queryWithContext: runtime.queryWithContext,
+        generateStanzaId: () => messageDispatch.generateOutgoingMessageId(),
+        mediaTransfer,
+        getMediaConn: () => getClientMediaConn(mediaMessageBuildOptions),
+        getAbPropString: (name) => abPropsCoordinator.getConfigValue<string>(name),
+        logger
+    })
+
     const privacyCoordinator = createPrivacyCoordinator({
         queryWithContext: runtime.queryWithContext
     })
@@ -653,6 +672,10 @@ export function buildWaClientDependencies(input: {
                 })
             )
         },
+        sendNewsletterMessage: (newsletterJid, content, sendOptions) =>
+            newsletterCoordinator.sendMessage(newsletterJid, content, {
+                stanzaId: sendOptions.id
+            }),
         getIcdcHashLength: () => abPropsCoordinator.getConfigValue('md_icdc_hash_length'),
         mobileMessageIdFormat: options.mobileTransport !== undefined
     })
@@ -768,6 +791,7 @@ export function buildWaClientDependencies(input: {
                 .handleIncomingMessageEvent(event)
                 .catch((err) => runtime.handleError(toError(err)))
         },
+        emitNewsletterReaction: (event) => runtime.emitEvent('newsletter_reaction', event),
         emitUnhandledStanza: (event: WaIncomingUnhandledStanzaEvent) =>
             runtime.emitEvent('stanza_unhandled', event)
     }
@@ -779,7 +803,8 @@ export function buildWaClientDependencies(input: {
                 queryWithContext: runtime.queryWithContext,
                 getCurrentCredentials,
                 syncAppState: runtime.syncAppState,
-                generateUsyncSid
+                generateUsyncSid,
+                newsletterListSubscribed: () => newsletterCoordinator.listSubscribed()
             },
             dirtyBits
         )
@@ -813,6 +838,35 @@ export function buildWaClientDependencies(input: {
             handleClientDirtyBits,
             incomingMessageAckOptions
         })
+    })
+
+    incomingNode.registerIncomingHandler({
+        tag: WA_NODE_TAGS.NOTIFICATION,
+        subtype: WA_NOTIFICATION_TYPES.NEWSLETTER,
+        prepend: true,
+        // eslint-disable-next-line @typescript-eslint/require-await
+        handler: async (node) => {
+            const newsletterJid = node.attrs.from
+            if (!newsletterJid || !isNewsletterJid(newsletterJid)) {
+                return false
+            }
+            const firstChild = getFirstNodeChild(node)
+            const childTag = firstChild?.tag
+            const action: WaNewsletterEventAction =
+                childTag === WA_NEWSLETTER_NOTIFICATION_TAGS.LIVE_UPDATES
+                    ? 'live_updates'
+                    : 'unknown'
+            runtime.emitEvent('newsletter_event', {
+                rawNode: node,
+                stanzaId: node.attrs.id,
+                chatJid: newsletterJid,
+                stanzaType: node.attrs.type,
+                newsletterJid,
+                action,
+                subType: childTag
+            })
+            return false
+        }
     })
 
     incomingNode.registerIncomingHandler({
@@ -1109,6 +1163,7 @@ export function buildWaClientDependencies(input: {
         incomingNode,
         passiveTasks,
         groupCoordinator,
+        newsletterCoordinator,
         privacyCoordinator,
         profileCoordinator,
         businessCoordinator,

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -663,3 +663,60 @@ test('clearStoredState respects logoutStoreClear domain toggles', async () => {
         'threads'
     ])
 })
+
+test('uploadNewsletterMedia builds plaintext URL and parses response', async () => {
+    const { uploadNewsletterMedia } = await import('@client/newsletter/media-upload')
+    const captured: { url?: string; method?: string; body?: Uint8Array } = {}
+    const responseBody = new TextEncoder().encode(
+        JSON.stringify({
+            url: 'https://media.example/blob',
+            direct_path: '/v/abc/def',
+            handle: 'HANDLE-1',
+            metadata_url: 'https://meta.example/m'
+        })
+    )
+    const mediaTransfer = {
+        uploadStream: async (request: { url: string; method?: string; body: Uint8Array }) => {
+            captured.url = request.url
+            captured.method = request.method
+            captured.body = request.body
+            return {
+                url: request.url,
+                status: 200,
+                ok: true,
+                headers: {},
+                body: null
+            }
+        },
+        readResponseBytes: async () => responseBody
+    } as unknown as Parameters<typeof uploadNewsletterMedia>[0]['mediaTransfer']
+
+    const result = await uploadNewsletterMedia(
+        { mediaTransfer, logger: createLogger() },
+        {
+            mediaKind: 'image',
+            media: new Uint8Array([1, 2, 3, 4]),
+            mimetype: 'image/jpeg',
+            mediaConn: {
+                auth: 'AUTH-TOKEN',
+                expiresAtMs: Date.now() + 60_000,
+                hosts: [{ hostname: 'mmg.whatsapp.net', isFallback: false }]
+            }
+        }
+    )
+
+    assert.ok(captured.url)
+    assert.match(
+        captured.url ?? '',
+        /^https:\/\/mmg\.whatsapp\.net\/newsletter\/newsletter-image\//
+    )
+    assert.match(captured.url ?? '', /\?auth=AUTH-TOKEN&token=/)
+    assert.equal(captured.method, 'POST')
+    assert.deepEqual(captured.body, new Uint8Array([1, 2, 3, 4]))
+    assert.equal(result.url, 'https://media.example/blob')
+    assert.equal(result.directPath, '/v/abc/def')
+    assert.equal(result.handle, 'HANDLE-1')
+    assert.equal(result.metadataUrl, 'https://meta.example/m')
+    assert.equal(result.fileLength, 4)
+    assert.equal(result.fileSha256.byteLength, 32)
+})

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -25,6 +25,7 @@ import {
 } from '@message/reporting-token'
 import type {
     WaEncryptedMessageInput,
+    WaMessageBuildResult,
     WaMessagePublishOptions,
     WaMessagePublishResult,
     WaSendMessageContent,
@@ -36,6 +37,7 @@ import { WA_DEFAULTS } from '@protocol/constants'
 import {
     isGroupJid,
     isLidJid,
+    isNewsletterJid,
     normalizeDeviceJid,
     normalizeRecipientJid,
     parseJidFull,
@@ -72,7 +74,7 @@ interface WaMessageDispatchCoordinatorOptions {
     readonly fanoutResolver: DeviceFanoutResolver
     readonly participantsCache: GroupParticipantsCache
     readonly appStateSyncKeyProtocol: AppStateSyncKeyProtocol
-    readonly buildMessageContent: (content: WaSendMessageContent) => Promise<Proto.IMessage>
+    readonly buildMessageContent: (content: WaSendMessageContent) => Promise<WaMessageBuildResult>
     readonly senderKeyManager: SenderKeyManager
     readonly signalProtocol: SignalProtocol
     readonly signalStore: WaSignalStore
@@ -85,6 +87,11 @@ interface WaMessageDispatchCoordinatorOptions {
     readonly getCurrentSignedIdentity: () => Proto.IADVSignedDeviceIdentity | null | undefined
     readonly resolvePrivacyTokenNode: (recipientJid: string) => Promise<BinaryNode | null>
     readonly onDirectMessageSent: (recipientJid: string) => void
+    readonly sendNewsletterMessage?: (
+        newsletterJid: string,
+        content: WaSendMessageContent,
+        options: WaSendMessageOptions
+    ) => Promise<WaMessagePublishResult>
     readonly getIcdcHashLength?: () => number
     readonly mobileMessageIdFormat?: boolean
 }
@@ -105,7 +112,9 @@ export class WaMessageDispatchCoordinator {
     private readonly fanoutResolver: DeviceFanoutResolver
     private readonly participantsCache: GroupParticipantsCache
     private readonly appStateSyncKeyProtocol: AppStateSyncKeyProtocol
-    private readonly buildMessageContent: (content: WaSendMessageContent) => Promise<Proto.IMessage>
+    private readonly buildMessageContent: (
+        content: WaSendMessageContent
+    ) => Promise<WaMessageBuildResult>
     private readonly senderKeyManager: SenderKeyManager
     private readonly signalProtocol: SignalProtocol
     private readonly signalStore: WaSignalStore
@@ -121,6 +130,13 @@ export class WaMessageDispatchCoordinator {
         | undefined
     private readonly resolvePrivacyTokenNode: (recipientJid: string) => Promise<BinaryNode | null>
     private readonly onDirectMessageSent: (recipientJid: string) => void
+    private readonly sendNewsletterMessage:
+        | ((
+              newsletterJid: string,
+              content: WaSendMessageContent,
+              options: WaSendMessageOptions
+          ) => Promise<WaMessagePublishResult>)
+        | undefined
     private readonly getIcdcHashLength: (() => number) | undefined
     private readonly mobileMessageIdFormat: boolean
     private readonly icdcDedup = new PromiseDedup()
@@ -148,6 +164,7 @@ export class WaMessageDispatchCoordinator {
         this.getCurrentSignedIdentity = options.getCurrentSignedIdentity
         this.resolvePrivacyTokenNode = options.resolvePrivacyTokenNode
         this.onDirectMessageSent = options.onDirectMessageSent
+        this.sendNewsletterMessage = options.sendNewsletterMessage
         this.getIcdcHashLength = options.getIcdcHashLength
         this.mobileMessageIdFormat = options.mobileMessageIdFormat ?? false
     }
@@ -273,10 +290,19 @@ export class WaMessageDispatchCoordinator {
         options: WaSendMessageOptions = {}
     ): Promise<WaMessagePublishResult> {
         const recipientJid = normalizeRecipientJid(to)
-        const [message, sendOptions] = await Promise.all([
+        if (isNewsletterJid(recipientJid)) {
+            if (!this.sendNewsletterMessage) {
+                throw new Error('newsletter sendMessage requires sendNewsletterMessage dependency')
+            }
+            const sendOptions = await this.withResolvedMessageId(options)
+            return this.sendNewsletterMessage(recipientJid, content, sendOptions)
+        }
+        const [built, sendOptions] = await Promise.all([
             this.buildMessageContent(content),
             this.withResolvedMessageId(options)
         ])
+        const message = built.message
+        const upload = built.upload
         const messageWithSecret = await ensureMessageSecret(message)
         const rawSecret = messageWithSecret.messageContextInfo?.messageSecret
         if (
@@ -322,44 +348,41 @@ export class WaMessageDispatchCoordinator {
         const metaAttrs = resolveMetaAttrs(messageWithIcdc)
         const metaNode = metaAttrs ? buildMetaNode(metaAttrs as Record<string, string>) : undefined
 
-        if (isGroup) {
-            if (this.shouldUseGroupDirectPath(messageWithIcdc)) {
-                return this.publishGroupDirectMessage(
-                    recipientJid,
-                    messageWithIcdc,
-                    plaintext,
-                    type,
-                    sendOptions,
-                    {},
-                    edit,
-                    mediatype,
-                    metaNode
-                )
-            }
-            return this.publishGroupSenderKeyMessage(
-                recipientJid,
-                messageWithIcdc,
-                plaintext,
-                type,
-                sendOptions,
-                {},
-                edit,
-                mediatype,
-                metaNode
-            )
-        }
-
-        const directRecipientJid = toUserJid(recipientJid)
-        return this.publishDirectSignalMessageWithFanout(
-            directRecipientJid,
-            messageWithIcdc,
-            plaintext,
-            type,
-            sendOptions,
-            edit,
-            mediatype,
-            metaNode
-        )
+        const publishResult = isGroup
+            ? this.shouldUseGroupDirectPath(messageWithIcdc)
+                ? await this.publishGroupDirectMessage(
+                      recipientJid,
+                      messageWithIcdc,
+                      plaintext,
+                      type,
+                      sendOptions,
+                      {},
+                      edit,
+                      mediatype,
+                      metaNode
+                  )
+                : await this.publishGroupSenderKeyMessage(
+                      recipientJid,
+                      messageWithIcdc,
+                      plaintext,
+                      type,
+                      sendOptions,
+                      {},
+                      edit,
+                      mediatype,
+                      metaNode
+                  )
+            : await this.publishDirectSignalMessageWithFanout(
+                  toUserJid(recipientJid),
+                  messageWithIcdc,
+                  plaintext,
+                  type,
+                  sendOptions,
+                  edit,
+                  mediatype,
+                  metaNode
+              )
+        return upload ? { ...publishResult, upload } : publishResult
     }
 
     public async syncSignalSession(jid: string, reasonIdentity = false): Promise<void> {
@@ -1131,7 +1154,7 @@ export class WaMessageDispatchCoordinator {
         }
     }
 
-    private async generateOutgoingMessageId(): Promise<string> {
+    public async generateOutgoingMessageId(): Promise<string> {
         try {
             const meUserJid = toUserJid(this.requireCurrentMeJid('sendMessage'))
             const timestampBytes = new Uint8Array(8)

--- a/src/client/coordinators/WaNewsletterCoordinator.ts
+++ b/src/client/coordinators/WaNewsletterCoordinator.ts
@@ -1,0 +1,70 @@
+import { createAdminOps, type WaNewsletterAdminOps } from '@client/newsletter/admin'
+import { createDiscoveryOps, type WaNewsletterDiscoveryOps } from '@client/newsletter/discovery'
+import {
+    createMessagingOps,
+    type WaNewsletterMessagingDeps,
+    type WaNewsletterMessagingOps
+} from '@client/newsletter/messaging'
+import type { WaNewsletterMexDeps } from '@client/newsletter/mex'
+import {
+    type MexNewsletterEnvelope,
+    parseNewsletterMetadata as parseNewsletterMetadataImpl
+} from '@client/newsletter/parse'
+import type { WaNewsletterMetadata } from '@client/newsletter/types'
+
+export type {
+    WaNewsletterAdminInfo,
+    WaNewsletterAdminInviteInput,
+    WaNewsletterAdminInviteResult,
+    WaNewsletterAdminProfile,
+    WaNewsletterCapabilityExposure,
+    WaNewsletterCreateInput,
+    WaNewsletterDehydratedMetadata,
+    WaNewsletterDirectoryCategoriesPreviewOptions,
+    WaNewsletterDirectoryCategoryPreview,
+    WaNewsletterDirectoryListOptions,
+    WaNewsletterDirectoryResults,
+    WaNewsletterDirectorySearchOptions,
+    WaNewsletterDirectoryView,
+    WaNewsletterFetchOptions,
+    WaNewsletterFollower,
+    WaNewsletterFollowersOptions,
+    WaNewsletterFollowersPage,
+    WaNewsletterMetadata,
+    WaNewsletterMexEnvelope,
+    WaNewsletterMuteInput,
+    WaNewsletterPicture,
+    WaNewsletterPollVoter,
+    WaNewsletterReactInput,
+    WaNewsletterReactionSenders,
+    WaNewsletterRecommendedOptions,
+    WaNewsletterRevokeInput,
+    WaNewsletterSendOptions,
+    WaNewsletterSendResult,
+    WaNewsletterSimilarOptions,
+    WaNewsletterUpdateInput,
+    WaNewsletterViewReceiptInput,
+    WaNewsletterVotePollInput,
+    WaPageInfo
+} from '@client/newsletter/types'
+
+export type WaNewsletterCoordinator = WaNewsletterDiscoveryOps &
+    WaNewsletterAdminOps &
+    WaNewsletterMessagingOps
+
+export type WaNewsletterCoordinatorOptions = WaNewsletterMessagingDeps
+
+export function createNewsletterCoordinator(
+    options: WaNewsletterCoordinatorOptions
+): WaNewsletterCoordinator {
+    const mexDeps: WaNewsletterMexDeps = options
+    return {
+        ...createDiscoveryOps(mexDeps),
+        ...createAdminOps(mexDeps),
+        ...createMessagingOps(options)
+    }
+}
+
+export function parseNewsletterMetadata(envelope: MexNewsletterEnvelope): WaNewsletterMetadata {
+    return parseNewsletterMetadataImpl(envelope)
+}

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -120,7 +120,7 @@ function createMessageDispatchCoordinator(
         fanoutResolver: {} as never,
         participantsCache,
         appStateSyncKeyProtocol: {} as never,
-        buildMessageContent: async () => ({}),
+        buildMessageContent: async () => ({ message: {} }),
         senderKeyManager: {} as never,
         signalProtocol: {} as never,
         signalStore: {} as never,

--- a/src/client/coordinators/__tests__/newsletter-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/newsletter-coordinator.test.ts
@@ -1,0 +1,568 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    createNewsletterCoordinator,
+    parseNewsletterMetadata
+} from '@client/coordinators/WaNewsletterCoordinator'
+import { createNoopLogger } from '@infra/log/types'
+import { WA_NEWSLETTER_MUTE_TYPES, WA_NEWSLETTER_MUTE_VALUES } from '@protocol/constants'
+import type { BinaryNode } from '@transport/types'
+
+interface MexCall {
+    readonly node: BinaryNode
+    readonly timeoutMs: number
+}
+
+interface MexMockResponse {
+    readonly resultData: unknown
+}
+
+function createMexMockSocket(response: MexMockResponse): {
+    socket: { query: (node: BinaryNode, timeoutMs: number) => Promise<BinaryNode> }
+    calls: MexCall[]
+} {
+    const calls: MexCall[] = []
+    const json = JSON.stringify({ data: response.resultData })
+    const bytes = new TextEncoder().encode(json)
+    return {
+        calls,
+        socket: {
+            query: async (node, timeoutMs) => {
+                calls.push({ node, timeoutMs })
+                return Promise.resolve({
+                    tag: 'iq',
+                    attrs: { type: 'result', id: node.attrs.id ?? '1' },
+                    content: [
+                        {
+                            tag: 'result',
+                            attrs: {},
+                            content: bytes
+                        }
+                    ]
+                })
+            }
+        }
+    }
+}
+
+interface SendNodeCall {
+    readonly node: BinaryNode
+}
+
+function createSendNodeCollector(): {
+    sendNode: (node: BinaryNode) => Promise<void>
+    publishMessageNode: NonNullable<
+        Parameters<typeof createNewsletterCoordinator>[0]['publishMessageNode']
+    >
+    calls: SendNodeCall[]
+} {
+    const calls: SendNodeCall[] = []
+    return {
+        calls,
+        sendNode: (node) => {
+            calls.push({ node })
+            return Promise.resolve()
+        },
+        publishMessageNode: async (node) => {
+            calls.push({ node })
+            return {
+                id: node.attrs.id ?? '',
+                attempts: 1,
+                ackNode: { tag: 'ack', attrs: { id: node.attrs.id ?? '', class: 'message' } },
+                ack: { refreshLid: false }
+            }
+        }
+    }
+}
+
+const TEST_LOGGER = createNoopLogger()
+let stanzaCounter = 0
+const generateStanzaId = async (): Promise<string> => {
+    stanzaCounter += 1
+    return `STANZA-${stanzaCounter}`
+}
+
+interface CoordinatorTestEnv {
+    coordinator: ReturnType<typeof createNewsletterCoordinator>
+    mexCalls: MexCall[]
+    sendCalls: SendNodeCall[]
+}
+
+function createTestCoordinator(
+    response: MexMockResponse,
+    extra: Partial<Parameters<typeof createNewsletterCoordinator>[0]> = {}
+): CoordinatorTestEnv {
+    const mexMock = createMexMockSocket(response)
+    const sender = createSendNodeCollector()
+    const coordinator = createNewsletterCoordinator({
+        mexSocket: mexMock.socket,
+        sendNode: sender.sendNode,
+        publishMessageNode: sender.publishMessageNode,
+        generateStanzaId,
+        logger: TEST_LOGGER,
+        ...extra
+    })
+    return {
+        coordinator,
+        mexCalls: mexMock.calls,
+        sendCalls: sender.calls
+    }
+}
+
+test('parseNewsletterMetadata maps wa-web envelope into metadata', () => {
+    const meta = parseNewsletterMetadata({
+        id: '120363025343298869@newsletter',
+        state: { type: 'ACTIVE' },
+        thread_metadata: {
+            creation_time: '1700000000',
+            name: { text: 'Channel Name', update_time: '1700000010' },
+            description: { text: 'Channel desc', update_time: '1700000020' },
+            picture: { id: 'pic-id', direct_path: '/path' },
+            preview: { id: 'pv-id', direct_path: '/preview' },
+            invite: 'invite-code',
+            handle: 'handle',
+            subscribers_count: '1234',
+            verification: 'VERIFIED'
+        },
+        viewer_metadata: {
+            role: 'OWNER',
+            settings: [
+                {
+                    type: WA_NEWSLETTER_MUTE_TYPES.ADMIN_ACTIVITY,
+                    value: WA_NEWSLETTER_MUTE_VALUES.ON
+                },
+                {
+                    type: WA_NEWSLETTER_MUTE_TYPES.FOLLOWER_ACTIVITY,
+                    value: WA_NEWSLETTER_MUTE_VALUES.OFF
+                }
+            ]
+        }
+    })
+
+    assert.equal(meta.jid, '120363025343298869@newsletter')
+    assert.equal(meta.state, 'ACTIVE')
+    assert.equal(meta.creationTime, 1_700_000_000)
+    assert.equal(meta.name, 'Channel Name')
+    assert.equal(meta.subscribersCount, 1234)
+    assert.equal(meta.verification, 'VERIFIED')
+    assert.equal(meta.viewerRole, 'OWNER')
+    assert.equal(meta.mutedAdmin, true)
+    assert.equal(meta.mutedFollower, false)
+    assert.equal(meta.picture?.directPath, '/path')
+    assert.equal(meta.preview?.id, 'pv-id')
+})
+
+test('coordinator follow/unfollow sends mex with newsletter_id', async () => {
+    const env = createTestCoordinator({
+        resultData: { xwa2_newsletter_join_v2: { id: '1', state: { type: 'ACTIVE' } } }
+    })
+
+    await env.coordinator.follow('120363025343298869@newsletter')
+    assert.equal(env.mexCalls.length, 1)
+    const queryNode = env.mexCalls[0].node.content?.[0] as BinaryNode | undefined
+    assert.ok(queryNode)
+    assert.equal(queryNode.attrs.query_id, '24404358912487870')
+    const body = JSON.parse(queryNode.content as string)
+    assert.deepEqual(body.variables, {
+        newsletter_id: '120363025343298869@newsletter'
+    })
+
+    await env.coordinator.unfollow('120363025343298869@newsletter')
+    assert.equal(env.mexCalls.length, 2)
+    const leaveQuery = env.mexCalls[1].node.content?.[0] as BinaryNode | undefined
+    assert.equal(leaveQuery?.attrs.query_id, '9767147403369991')
+})
+
+test('coordinator mute toggles MUTE_FOLLOWER_ACTIVITY by default', async () => {
+    const env = createTestCoordinator({
+        resultData: {
+            xwa2_newsletter_update_user_setting: { id: '1', state: { type: 'ACTIVE' } }
+        }
+    })
+
+    await env.coordinator.mute({
+        newsletterJid: '120363025343298869@newsletter',
+        mute: true
+    })
+    const queryNode = env.mexCalls[0].node.content?.[0] as BinaryNode | undefined
+    const body = JSON.parse(queryNode!.content as string)
+    assert.deepEqual(body.variables.input, {
+        newsletter_id: '120363025343298869@newsletter',
+        type: WA_NEWSLETTER_MUTE_TYPES.FOLLOWER_ACTIVITY,
+        value: WA_NEWSLETTER_MUTE_VALUES.ON
+    })
+
+    await env.coordinator.mute({
+        newsletterJid: '120363025343298869@newsletter',
+        mute: false,
+        type: 'admin'
+    })
+    const adminQuery = env.mexCalls[1].node.content?.[0] as BinaryNode | undefined
+    const adminBody = JSON.parse(adminQuery?.content as string)
+    assert.equal(adminBody.variables.input.type, WA_NEWSLETTER_MUTE_TYPES.ADMIN_ACTIVITY)
+    assert.equal(adminBody.variables.input.value, WA_NEWSLETTER_MUTE_VALUES.OFF)
+})
+
+test('coordinator sendMessage(jid, "text") wraps as conversation proto', async () => {
+    const env = createTestCoordinator({ resultData: null })
+    const result = await env.coordinator.sendMessage(
+        '120363025343298869@newsletter',
+        'hello channel'
+    )
+    assert.ok(result.id.startsWith('STANZA-'))
+    assert.equal(result.upload, undefined)
+    assert.equal(env.sendCalls.length, 1)
+    const stanza = env.sendCalls[0].node
+    assert.equal(stanza.attrs.type, 'text')
+    assert.equal(stanza.attrs.id, result.id)
+    assert.ok(Array.isArray(stanza.content))
+    assert.equal(stanza.content[0].tag, 'plaintext')
+    assert.ok(stanza.content[0].content instanceof Uint8Array)
+})
+
+test('coordinator sendMessage with explicit stanzaId honors caller id', async () => {
+    const env = createTestCoordinator({ resultData: null })
+    const result = await env.coordinator.sendMessage('120363025343298869@newsletter', 'hello', {
+        stanzaId: 'CUSTOM'
+    })
+    assert.equal(result.id, 'CUSTOM')
+    assert.equal(env.sendCalls[0].node.attrs.id, 'CUSTOM')
+})
+
+test('coordinator listSubscribed parses metadata array', async () => {
+    const env = createTestCoordinator({
+        resultData: {
+            xwa2_newsletter_subscribed: [
+                {
+                    id: 'a@newsletter',
+                    state: { type: 'ACTIVE' },
+                    thread_metadata: { name: { text: 'A' } },
+                    viewer_metadata: { role: 'SUBSCRIBER' }
+                },
+                {
+                    id: 'b@newsletter',
+                    state: { type: 'GEOSUSPENDED' },
+                    thread_metadata: { name: { text: 'B' } },
+                    viewer_metadata: { role: 'OWNER' }
+                }
+            ]
+        }
+    })
+
+    const list = await env.coordinator.listSubscribed()
+    assert.equal(list.length, 2)
+    assert.equal(list[0].name, 'A')
+    assert.equal(list[1].state, 'GEOSUSPENDED')
+    assert.equal(list[1].viewerRole, 'OWNER')
+})
+
+test('coordinator sendMessage with media uploads plaintext blob and emits media stanza', async () => {
+    const responseBody = new TextEncoder().encode(
+        JSON.stringify({
+            url: 'https://media.example/blob',
+            direct_path: '/v/abc',
+            handle: 'H1'
+        })
+    )
+    const captured: { url?: string; method?: string; body?: Uint8Array } = {}
+    const mediaTransfer = {
+        uploadStream: async (request: { url: string; method?: string; body: Uint8Array }) => {
+            captured.url = request.url
+            captured.method = request.method
+            captured.body = request.body
+            return { url: request.url, status: 200, ok: true, headers: {}, body: null }
+        },
+        readResponseBytes: async () => responseBody
+    }
+    const env = createTestCoordinator(
+        { resultData: null },
+        {
+            mediaTransfer: mediaTransfer as unknown as Parameters<
+                typeof createNewsletterCoordinator
+            >[0]['mediaTransfer'],
+            getMediaConn: async () => ({
+                auth: 'AUTH',
+                expiresAtMs: Date.now() + 60_000,
+                hosts: [{ hostname: 'mmg.whatsapp.net', isFallback: false }]
+            })
+        }
+    )
+
+    const result = await env.coordinator.sendMessage('120363025343298869@newsletter', {
+        type: 'image',
+        media: new Uint8Array([7, 8, 9]),
+        mimetype: 'image/jpeg',
+        caption: 'hi'
+    })
+    assert.match(captured.url ?? '', /\/newsletter\/newsletter-image\//)
+    assert.equal(captured.method, 'POST')
+    assert.ok(result.upload)
+    assert.equal(result.upload.url, 'https://media.example/blob')
+    assert.equal(env.sendCalls.length, 1)
+    const stanza = env.sendCalls[0].node
+    assert.equal(stanza.attrs.type, 'media')
+    assert.ok(Array.isArray(stanza.content))
+    assert.equal(stanza.content[0].tag, 'plaintext')
+    assert.equal(stanza.content[0].attrs.mediatype, 'image')
+})
+
+test('coordinator editMessage emits stanza with edit=3 and parent id', async () => {
+    const env = createTestCoordinator({ resultData: null })
+
+    const result = await env.coordinator.editMessage(
+        '120363025343298869@newsletter',
+        'PARENT',
+        'edited text'
+    )
+    assert.equal(result.id, 'PARENT')
+    assert.equal(env.sendCalls.length, 1)
+    const stanza = env.sendCalls[0].node
+    assert.equal(stanza.attrs.id, 'PARENT')
+    assert.equal(stanza.attrs.edit, '3')
+    assert.equal(stanza.attrs.type, 'text')
+})
+
+test('coordinator react/revoke/votePoll produce stanzas with parent server_id', async () => {
+    const env = createTestCoordinator({ resultData: null })
+    const newsletterJid = '120363025343298869@newsletter'
+
+    const reactResult = await env.coordinator.react({
+        newsletterJid,
+        parentMessageServerId: 42,
+        reactionCode: '1f44d'
+    })
+    assert.ok(reactResult.stanzaId)
+    assert.equal(env.sendCalls[0].node.attrs.type, 'reaction')
+    assert.equal(env.sendCalls[0].node.attrs.server_id, '42')
+
+    const revokeResult = await env.coordinator.revoke({
+        newsletterJid,
+        originalMessageId: 'MSG-TO-REVOKE'
+    })
+    assert.equal(revokeResult.stanzaId, 'MSG-TO-REVOKE')
+    assert.equal(env.sendCalls[1].node.attrs.id, 'MSG-TO-REVOKE')
+    assert.equal(env.sendCalls[1].node.attrs.type, 'text')
+    assert.equal(env.sendCalls[1].node.attrs.edit, '8')
+    assert.equal(env.sendCalls[1].node.attrs.server_id, undefined)
+
+    const voteResult = await env.coordinator.votePoll({
+        newsletterJid,
+        parentMessageServerId: 77,
+        votes: [new Uint8Array([1])]
+    })
+    assert.ok(voteResult.stanzaId)
+    assert.equal(env.sendCalls[2].node.attrs.type, 'poll')
+    assert.equal(env.sendCalls[2].node.attrs.server_id, '77')
+})
+
+test('coordinator create auto-accepts creation tos when notice not yet accepted', async () => {
+    const sentNodes: BinaryNode[] = []
+    const env = createTestCoordinator(
+        {
+            resultData: {
+                xwa2_newsletter_create: {
+                    id: '120363025343298869@newsletter',
+                    state: { type: 'ACTIVE' },
+                    thread_metadata: { name: { text: 'New' } }
+                }
+            }
+        },
+        {
+            getAbPropString: (name) =>
+                name === 'newsletter_creation_tos_id' ? 'CREATE_TOS_ID' : '',
+            queryWithContext: async (_ctx, node) => {
+                sentNodes.push(node)
+                if (node.attrs.type === 'get') {
+                    return {
+                        tag: 'iq',
+                        attrs: { type: 'result' },
+                        content: [
+                            {
+                                tag: 'tos',
+                                attrs: { refresh: '86400' },
+                                content: [
+                                    {
+                                        tag: 'notice',
+                                        attrs: { id: 'CREATE_TOS_ID', state: 'false' }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+                return { tag: 'iq', attrs: { type: 'result' } }
+            }
+        }
+    )
+
+    await env.coordinator.create({ name: 'New' })
+    assert.equal(sentNodes.length, 2)
+    assert.equal(sentNodes[0].attrs.type, 'get')
+    assert.equal(sentNodes[0].attrs.xmlns, 'tos')
+    assert.equal(sentNodes[1].attrs.type, 'set')
+    assert.equal(sentNodes[1].attrs.xmlns, 'tos')
+})
+
+test('coordinator create skips tos accept when already accepted', async () => {
+    const sentNodes: BinaryNode[] = []
+    const env = createTestCoordinator(
+        {
+            resultData: {
+                xwa2_newsletter_create: {
+                    id: 'a@newsletter',
+                    state: { type: 'ACTIVE' },
+                    thread_metadata: { name: { text: 'A' } }
+                }
+            }
+        },
+        {
+            getAbPropString: (name) =>
+                name === 'newsletter_creation_tos_id' ? 'CREATE_TOS_ID' : '',
+            queryWithContext: async (_ctx, node) => {
+                sentNodes.push(node)
+                return {
+                    tag: 'iq',
+                    attrs: { type: 'result' },
+                    content: [
+                        {
+                            tag: 'tos',
+                            attrs: { refresh: '86400' },
+                            content: [
+                                { tag: 'notice', attrs: { id: 'CREATE_TOS_ID', state: 'true' } }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    await env.coordinator.create({ name: 'A' })
+    assert.equal(sentNodes.length, 1)
+    assert.equal(sentNodes[0].attrs.type, 'get')
+})
+
+test('coordinator queryTosState/acceptTos send tos IQs with notice ids', async () => {
+    const sentNodes: BinaryNode[] = []
+    const env = createTestCoordinator(
+        { resultData: null },
+        {
+            queryWithContext: async (_ctx, node) => {
+                sentNodes.push(node)
+                if (node.attrs.type === 'get') {
+                    return {
+                        tag: 'iq',
+                        attrs: { type: 'result' },
+                        content: [
+                            {
+                                tag: 'tos',
+                                attrs: { refresh: '86400' },
+                                content: [
+                                    { tag: 'notice', attrs: { id: 'CREATE_TOS', state: 'true' } },
+                                    { tag: 'notice', attrs: { id: 'INVITE_TOS', state: 'false' } }
+                                ]
+                            }
+                        ]
+                    }
+                }
+                return { tag: 'iq', attrs: { type: 'result' } }
+            }
+        }
+    )
+
+    const state = await env.coordinator.queryTosState(['CREATE_TOS', 'INVITE_TOS'])
+    assert.equal(state.refreshSeconds, 86400)
+    assert.deepEqual(state.notices, [
+        { id: 'CREATE_TOS', accepted: true },
+        { id: 'INVITE_TOS', accepted: false }
+    ])
+    assert.equal(sentNodes[0].attrs.xmlns, 'tos')
+    assert.equal(sentNodes[0].attrs.type, 'get')
+
+    await env.coordinator.acceptTos(['CREATE_TOS'])
+    assert.equal(sentNodes[1].attrs.type, 'set')
+    assert.ok(Array.isArray(sentNodes[1].content))
+    const setRequest = (sentNodes[1].content as readonly BinaryNode[])[0]
+    assert.equal(setRequest.tag, 'request')
+    assert.equal(setRequest.attrs.type, 'session_update')
+    assert.ok(Array.isArray(setRequest.content))
+    assert.equal((setRequest.content as readonly BinaryNode[])[0].attrs.id, 'CREATE_TOS')
+})
+
+test('coordinator subscribeLiveUpdates sends set IQ to newsletter and parses duration', async () => {
+    let receivedNode: BinaryNode | null = null
+    const env = createTestCoordinator(
+        { resultData: null },
+        {
+            queryWithContext: async (_ctx, node) => {
+                receivedNode = node
+                return {
+                    tag: 'iq',
+                    attrs: { type: 'result', id: '1' },
+                    content: [
+                        {
+                            tag: 'live_updates',
+                            attrs: { duration: '120' }
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    const result = await env.coordinator.subscribeLiveUpdates('120363025343298869@newsletter')
+    assert.equal(result.durationSeconds, 120)
+    const sentNode = receivedNode as unknown as BinaryNode
+    assert.equal(sentNode.attrs.type, 'set')
+    assert.equal(sentNode.attrs.to, '120363025343298869@newsletter')
+    assert.equal(sentNode.attrs.xmlns, 'newsletter')
+    assert.ok(Array.isArray(sentNode.content))
+    assert.equal((sentNode.content as readonly BinaryNode[])[0].tag, 'live_updates')
+})
+
+test('coordinator subscribeLiveUpdates rejects invalid duration', async () => {
+    const env = createTestCoordinator(
+        { resultData: null },
+        {
+            queryWithContext: async () => ({
+                tag: 'iq',
+                attrs: { type: 'result' },
+                content: [{ tag: 'live_updates', attrs: { duration: '5' } }]
+            })
+        }
+    )
+    await assert.rejects(
+        () => env.coordinator.subscribeLiveUpdates('120363025343298869@newsletter'),
+        /invalid duration/
+    )
+})
+
+test('coordinator fetchMessages requires queryWithContext and forwards stanza', async () => {
+    let receivedNode: BinaryNode | null = null
+    const env = createTestCoordinator(
+        { resultData: null },
+        {
+            queryWithContext: async (_ctx, node) => {
+                receivedNode = node
+                return {
+                    tag: 'iq',
+                    attrs: { type: 'result' }
+                }
+            }
+        }
+    )
+
+    await env.coordinator.fetchMessages({
+        newsletterJid: '120363025343298869@newsletter',
+        count: 25,
+        before: 1234
+    })
+    assert.ok(receivedNode)
+    const node = receivedNode as unknown as BinaryNode
+    assert.equal(node.attrs.xmlns, 'newsletter')
+    assert.ok(Array.isArray(node.content))
+    const messagesNode = (node.content as readonly BinaryNode[])[0]
+    assert.equal(messagesNode.tag, 'messages')
+    assert.equal(messagesNode.attrs.before, '1234')
+})

--- a/src/client/dirty.ts
+++ b/src/client/dirty.ts
@@ -41,6 +41,7 @@ interface WaDirtySyncRuntime {
     readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly syncAppState: () => Promise<void>
     readonly generateUsyncSid: () => Promise<string>
+    readonly newsletterListSubscribed?: () => Promise<unknown>
 }
 
 const SUPPORTED_DIRTY_TYPES = new Set<string>(WA_SUPPORTED_DIRTY_TYPES)
@@ -320,14 +321,21 @@ async function syncGroupsDirtyBit(runtime: WaDirtySyncRuntime): Promise<void> {
 }
 
 async function syncNewsletterMetadataDirtyBit(runtime: WaDirtySyncRuntime): Promise<void> {
-    runtime.logger.info(
-        'newsletter_metadata dirty bit received (GraphQL/MEX sync intentionally disabled)'
-    )
     await runtime.queryWithContext(
         'dirty.newsletter_metadata',
         buildNewsletterMetadataSyncIq(),
         WA_DEFAULTS.IQ_TIMEOUT_MS
     )
+    if (runtime.newsletterListSubscribed) {
+        try {
+            await runtime.newsletterListSubscribed()
+        } catch (error) {
+            runtime.logger.warn('newsletter_metadata MEX sync failed', {
+                message: toError(error).message
+            })
+            throw error
+        }
+    }
 }
 
 function resolveAccountSyncDeviceTargets(credentials: WaAuthCredentials | null): readonly string[] {

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -1,14 +1,15 @@
+import { createHash } from 'node:crypto'
 import { createReadStream, createWriteStream } from 'node:fs'
 import { open, unlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import type { Readable } from 'node:stream'
+import { type Readable, Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 
 import type { WaMediaOptions } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import type { WaSendMediaMessage } from '@message/types'
-import { toBytesView } from '@util/bytes'
+import { toBytesView, toChunkBytes } from '@util/bytes'
 import { toError } from '@util/primitives'
 
 export interface ProcessedMediaFields {
@@ -129,6 +130,58 @@ async function streamToTempFile(source: Readable): Promise<string> {
 
 export async function cleanupTempFile(filePath: string): Promise<void> {
     await unlink(filePath).catch(() => undefined)
+}
+
+export interface StreamFileMetrics {
+    readonly fileSha256: Uint8Array
+    readonly byteLength: number
+}
+
+function createSha256SizeMeter(): {
+    readonly transform: Transform
+    readonly finalize: () => StreamFileMetrics
+} {
+    const hash = createHash('sha256')
+    let byteLength = 0
+    const transform = new Transform({
+        transform(chunk, _enc, cb) {
+            const bytes = chunk instanceof Uint8Array ? chunk : toChunkBytes(chunk)
+            hash.update(bytes)
+            byteLength += bytes.byteLength
+            cb(null, bytes)
+        }
+    })
+    return {
+        transform,
+        finalize: () => ({ fileSha256: toBytesView(hash.digest()), byteLength })
+    }
+}
+
+export async function streamToTempFileWithSha256(
+    source: Readable
+): Promise<StreamFileMetrics & { readonly filePath: string }> {
+    const filePath = join(
+        tmpdir(),
+        `zapo-media-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    )
+    const meter = createSha256SizeMeter()
+    try {
+        await pipeline(source, meter.transform, createWriteStream(filePath))
+    } catch (error) {
+        await unlink(filePath).catch(() => undefined)
+        throw error
+    }
+    return { filePath, ...meter.finalize() }
+}
+
+export async function hashFileWithSha256(filePath: string): Promise<StreamFileMetrics> {
+    const meter = createSha256SizeMeter()
+    await pipeline(createReadStream(filePath), meter.transform, async (chunks) => {
+        for await (const chunk of chunks) {
+            void chunk
+        }
+    })
+    return meter.finalize()
 }
 
 export interface ResolvedMediaInputs {

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -18,8 +18,12 @@ import type { MediaCryptoType, WaMediaConn } from '@media/types'
 import { WaMediaCrypto } from '@media/WaMediaCrypto'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
 import { isSendMediaMessage } from '@message/content'
-import type { WaSendMediaMessage, WaSendMessageContent } from '@message/types'
-import type { Proto } from '@proto'
+import type {
+    WaMessageBuildResult,
+    WaMessageUploadInfo,
+    WaSendMediaMessage,
+    WaSendMessageContent
+} from '@message/types'
 import { WA_DEFAULTS } from '@protocol/constants'
 import { buildMediaConnIq } from '@transport/node/builders/media'
 import type { BinaryNode } from '@transport/types'
@@ -44,11 +48,9 @@ export interface WaMediaMessageOptions {
 export async function buildMediaMessageContent(
     options: WaMediaMessageOptions,
     content: WaSendMessageContent
-): Promise<Proto.IMessage> {
+): Promise<WaMessageBuildResult> {
     if (typeof content === 'string') {
-        return {
-            conversation: content
-        }
+        return { message: { conversation: content } }
     }
     if (isSendMediaMessage(content)) {
         return buildMediaMessage(options, content)
@@ -56,7 +58,7 @@ export async function buildMediaMessageContent(
     if (!content || typeof content !== 'object') {
         throw new Error('invalid message content')
     }
-    return content
+    return { message: content }
 }
 
 export async function getMediaConn(
@@ -97,7 +99,7 @@ function resolveMimetype(content: WaSendMediaMessage): string {
 async function buildMediaMessage(
     options: WaMediaMessageOptions,
     content: WaSendMediaMessage
-): Promise<Proto.IMessage> {
+): Promise<WaMessageBuildResult> {
     const needsTempFile =
         hasMediaProcessingTasks(options.media, content) ||
         (content.type === 'sticker' && content.firstFrameLength === undefined)
@@ -148,6 +150,13 @@ async function buildMediaMessage(
             mediaKeyTimestamp,
             mimetype: resolveMimetype(content)
         }
+        const uploadSummary: WaMessageUploadInfo = {
+            url: uploaded.url,
+            directPath: uploaded.directPath,
+            fileSha256: uploaded.fileSha256,
+            fileLength: uploaded.fileLength,
+            metadataUrl: uploaded.metadataUrl
+        }
 
         function spread(c: WaSendMediaMessage): Record<string, unknown> {
             const result: Record<string, unknown> = {}
@@ -167,74 +176,93 @@ async function buildMediaMessage(
         switch (content.type) {
             case 'image':
                 return {
-                    imageMessage: {
-                        ...spread(content),
-                        ...uploadedFields,
-                        width: content.width ?? processed.width,
-                        height: content.height ?? processed.height,
-                        jpegThumbnail: content.jpegThumbnail ?? processed.jpegThumbnail
+                    upload: uploadSummary,
+                    message: {
+                        imageMessage: {
+                            ...spread(content),
+                            ...uploadedFields,
+                            width: content.width ?? processed.width,
+                            height: content.height ?? processed.height,
+                            jpegThumbnail: content.jpegThumbnail ?? processed.jpegThumbnail
+                        }
                     }
                 }
             case 'video':
                 return {
-                    videoMessage: {
-                        ...spread(content),
-                        ...uploadedFields,
-                        seconds: content.seconds ?? processed.seconds,
-                        width: content.width ?? processed.width,
-                        height: content.height ?? processed.height,
-                        jpegThumbnail: content.jpegThumbnail ?? processed.jpegThumbnail,
-                        streamingSidecar: uploaded.streamingSidecar,
-                        metadataUrl: uploaded.metadataUrl
+                    upload: uploadSummary,
+                    message: {
+                        videoMessage: {
+                            ...spread(content),
+                            ...uploadedFields,
+                            seconds: content.seconds ?? processed.seconds,
+                            width: content.width ?? processed.width,
+                            height: content.height ?? processed.height,
+                            jpegThumbnail: content.jpegThumbnail ?? processed.jpegThumbnail,
+                            streamingSidecar: uploaded.streamingSidecar,
+                            metadataUrl: uploaded.metadataUrl
+                        }
                     }
                 }
             case 'ptv':
                 return {
-                    ptvMessage: {
-                        ...spread(content),
-                        ...uploadedFields,
-                        seconds: content.seconds ?? processed.seconds,
-                        width: content.width ?? processed.width,
-                        height: content.height ?? processed.height,
-                        jpegThumbnail: content.jpegThumbnail ?? processed.jpegThumbnail,
-                        streamingSidecar: uploaded.streamingSidecar
+                    upload: uploadSummary,
+                    message: {
+                        ptvMessage: {
+                            ...spread(content),
+                            ...uploadedFields,
+                            seconds: content.seconds ?? processed.seconds,
+                            width: content.width ?? processed.width,
+                            height: content.height ?? processed.height,
+                            jpegThumbnail: content.jpegThumbnail ?? processed.jpegThumbnail,
+                            streamingSidecar: uploaded.streamingSidecar
+                        }
                     }
                 }
             case 'audio':
                 return {
-                    audioMessage: {
-                        ...spread(content),
-                        ...uploadedFields,
-                        seconds: content.seconds ?? processed.seconds,
-                        streamingSidecar: uploaded.streamingSidecar,
-                        waveform: content.waveform ?? processed.waveform
+                    upload: uploadSummary,
+                    message: {
+                        audioMessage: {
+                            ...spread(content),
+                            ...uploadedFields,
+                            seconds: content.seconds ?? processed.seconds,
+                            streamingSidecar: uploaded.streamingSidecar,
+                            waveform: content.waveform ?? processed.waveform
+                        }
                     }
                 }
             case 'document':
                 return {
-                    documentMessage: {
-                        ...spread(content),
-                        ...uploadedFields,
-                        fileName: content.fileName ?? 'file',
-                        title: content.title ?? content.fileName ?? undefined,
-                        jpegThumbnail: content.jpegThumbnail ?? processed.jpegThumbnail
+                    upload: uploadSummary,
+                    message: {
+                        documentMessage: {
+                            ...spread(content),
+                            ...uploadedFields,
+                            fileName: content.fileName ?? 'file',
+                            title: content.title ?? content.fileName ?? undefined,
+                            jpegThumbnail: content.jpegThumbnail ?? processed.jpegThumbnail
+                        }
                     }
                 }
             case 'sticker':
                 return {
-                    stickerMessage: {
-                        ...spread(content),
-                        ...uploadedFields,
-                        width: content.width ?? processed.width,
-                        height: content.height ?? processed.height,
-                        pngThumbnail: content.pngThumbnail ?? processed.pngThumbnail,
-                        isAnimated:
-                            content.isAnimated ??
-                            processed.isAnimated ??
-                            firstFrameLength !== undefined,
-                        firstFrameLength: content.firstFrameLength ?? uploaded.firstFrameLength,
-                        firstFrameSidecar: content.firstFrameSidecar ?? uploaded.firstFrameSidecar,
-                        stickerSentTs: content.stickerSentTs ?? Date.now()
+                    upload: uploadSummary,
+                    message: {
+                        stickerMessage: {
+                            ...spread(content),
+                            ...uploadedFields,
+                            width: content.width ?? processed.width,
+                            height: content.height ?? processed.height,
+                            pngThumbnail: content.pngThumbnail ?? processed.pngThumbnail,
+                            isAnimated:
+                                content.isAnimated ??
+                                processed.isAnimated ??
+                                firstFrameLength !== undefined,
+                            firstFrameLength: content.firstFrameLength ?? uploaded.firstFrameLength,
+                            firstFrameSidecar:
+                                content.firstFrameSidecar ?? uploaded.firstFrameSidecar,
+                            stickerSentTs: content.stickerSentTs ?? Date.now()
+                        }
                     }
                 }
             default:

--- a/src/client/newsletter/__tests__/parse.test.ts
+++ b/src/client/newsletter/__tests__/parse.test.ts
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    parseAdminCapabilities,
+    parseAdminInfo,
+    parseDirectorySearch,
+    parseDomainsPreviewable,
+    parseFollowers,
+    parsePendingInvites,
+    parsePollVoters,
+    parseReactionSenders,
+    parseRecommended,
+    parseSimilar
+} from '@client/newsletter/parse'
+
+test('parseAdminInfo extracts admin count and profile', () => {
+    const info = parseAdminInfo({
+        xwa2_newsletter_admin: {
+            admin_count: 3,
+            admin_profile: {
+                id: 'admin-1',
+                name: 'Admin Name',
+                picture: { id: 'pic', direct_path: '/p' }
+            }
+        }
+    })
+    assert.equal(info.adminCount, 3)
+    assert.deepEqual(info.adminProfile, {
+        id: 'admin-1',
+        name: 'Admin Name',
+        pictureId: 'pic',
+        pictureDirectPath: '/p'
+    })
+
+    const empty = parseAdminInfo({})
+    assert.equal(empty.adminProfile, null)
+})
+
+test('parseAdminCapabilities returns set of capability strings', () => {
+    const caps = parseAdminCapabilities({
+        xwa2_newsletter_admin: { capabilities: ['SEND', 'EDIT', 'DELETE'] }
+    })
+    assert.equal(caps.size, 3)
+    assert.ok(caps.has('SEND'))
+    assert.equal(parseAdminCapabilities({}).size, 0)
+})
+
+test('parsePendingInvites extracts user jids preferring pn over id', () => {
+    const invites = parsePendingInvites({
+        xwa2_newsletter_admin: {
+            pending_admin_invites: [
+                { user: { id: '1@lid', pn: '111@s.whatsapp.net' } },
+                { user: { id: '2@lid' } },
+                { user: undefined }
+            ]
+        }
+    })
+    assert.deepEqual(invites, ['111@s.whatsapp.net', '2@lid'])
+})
+
+test('parseFollowers maps edges into typed followers', () => {
+    const page = parseFollowers({
+        xwa2_newsletter_followers: {
+            followers: {
+                edges: [
+                    {
+                        role: 'OWNER',
+                        follow_time: '1700000000',
+                        node: {
+                            id: 'a@lid',
+                            display_name: 'A',
+                            pn: '111@s.whatsapp.net',
+                            username_info: { username: 'aaa' }
+                        },
+                        admin_profile: {
+                            id: 'a',
+                            name: 'A profile',
+                            picture: { direct_path: '/a' }
+                        }
+                    },
+                    {
+                        role: 'SUBSCRIBER',
+                        node: { id: 'b@lid' }
+                    }
+                ],
+                page_info: { hasNextPage: true, endCursor: 'CURSOR' }
+            }
+        }
+    })
+    assert.equal(page.followers.length, 2)
+    assert.equal(page.followers[0].id, 'a@lid')
+    assert.equal(page.followers[0].role, 'OWNER')
+    assert.equal(page.followers[0].username, 'aaa')
+    assert.equal(page.followers[0].adminProfile?.name, 'A profile')
+    assert.equal(page.followers[1].adminProfile, null)
+    assert.equal(page.pageInfo?.hasNextPage, true)
+    assert.equal(page.pageInfo?.endCursor, 'CURSOR')
+})
+
+test('parseDirectorySearch and related parsers map results to metadata', () => {
+    const envelope = {
+        xwa2_newsletters_directory_search: {
+            result: [
+                {
+                    id: 'a@newsletter',
+                    state: { type: 'ACTIVE' },
+                    thread_metadata: { name: { text: 'A' }, subscribers_count: '100' }
+                },
+                {
+                    id: 'b@newsletter',
+                    state: { type: 'GEOSUSPENDED' },
+                    thread_metadata: { name: { text: 'B' } }
+                }
+            ],
+            page_info: { hasNextPage: false }
+        }
+    }
+    const search = parseDirectorySearch(envelope)
+    assert.equal(search.results.length, 2)
+    assert.equal(search.results[0].name, 'A')
+    assert.equal(search.results[0].subscribersCount, 100)
+    assert.equal(search.results[1].state, 'GEOSUSPENDED')
+    assert.equal(search.pageInfo?.hasNextPage, false)
+
+    const recommended = parseRecommended({
+        xwa2_recommended_newsletters: {
+            result: [{ id: 'r@newsletter', state: { type: 'ACTIVE' } }]
+        }
+    })
+    assert.equal(recommended.length, 1)
+    assert.equal(recommended[0].jid, 'r@newsletter')
+
+    const similar = parseSimilar({
+        xwa2_newsletters_similar: { result: [{ id: 's@newsletter', state: { type: 'ACTIVE' } }] }
+    })
+    assert.equal(similar.length, 1)
+})
+
+test('parseDomainsPreviewable builds map of domain to flag', () => {
+    const map = parseDomainsPreviewable({
+        xwa2_newsletter_message_integrity: {
+            url_previews: [
+                { url_domain: 'foo.com', is_previewable: true },
+                { url_domain: 'bar.com', is_previewable: false }
+            ]
+        }
+    })
+    assert.equal(map.size, 2)
+    assert.equal(map.get('foo.com'), true)
+    assert.equal(map.get('bar.com'), false)
+})
+
+test('parseReactionSenders maps reaction code groups', () => {
+    const reactions = parseReactionSenders({
+        xwa2_newsletters_reaction_sender_list: {
+            reactions: [
+                {
+                    reaction_code: '1f44d',
+                    sender_list: {
+                        edges: [
+                            { node: { id: 'u1@lid', profile_pic_direct_path: '/p1' } },
+                            { node: { id: 'u2@lid' } },
+                            { node: {} }
+                        ]
+                    }
+                }
+            ]
+        }
+    })
+    assert.equal(reactions.length, 1)
+    assert.equal(reactions[0].reactionCode, '1f44d')
+    assert.equal(reactions[0].senders.length, 2)
+})
+
+test('parsePollVoters returns map keyed by vote hash with seconds time', () => {
+    const map = parsePollVoters({
+        voter_list: {
+            votes: [
+                {
+                    vote_hash: 'AAAA',
+                    voter_list: {
+                        edges: [{ node: { id: 'u1@lid' }, action_time: '1700000000000000' }]
+                    }
+                }
+            ]
+        }
+    })
+    assert.equal(map.size, 1)
+    const voters = map.get('AAAA')
+    assert.ok(voters)
+    assert.equal(voters[0].id, 'u1@lid')
+    assert.equal(voters[0].time, 1_700_000_000)
+})

--- a/src/client/newsletter/admin.ts
+++ b/src/client/newsletter/admin.ts
@@ -1,0 +1,310 @@
+import {
+    ensureTosAccepted,
+    runMex,
+    runMexEnvelope,
+    type WaNewsletterMexDeps
+} from '@client/newsletter/mex'
+import {
+    type MexNewsletterEnvelope,
+    parseAdminCapabilities,
+    parseAdminInfo,
+    parseAdminInviteResult,
+    parseFollowers,
+    parseNewsletterMetadata,
+    parsePendingInvites,
+    parsePollVoters,
+    parseReactionSenders
+} from '@client/newsletter/parse'
+import type {
+    WaNewsletterAdminInfo,
+    WaNewsletterAdminInviteInput,
+    WaNewsletterAdminInviteResult,
+    WaNewsletterCapabilityExposure,
+    WaNewsletterCreateInput,
+    WaNewsletterFollowersOptions,
+    WaNewsletterFollowersPage,
+    WaNewsletterMetadata,
+    WaNewsletterMexEnvelope,
+    WaNewsletterPollVoter,
+    WaNewsletterReactionSenders,
+    WaNewsletterUpdateInput
+} from '@client/newsletter/types'
+import {
+    buildTosQueryIq,
+    buildTosUpdateIq,
+    parseTosQueryResponse,
+    type WaTosQueryResult
+} from '@transport/node/builders/tos'
+import { WA_MEX_PERSIST_IDS } from '@transport/node/mex/persist-ids'
+import { bytesToBase64 } from '@util/bytes'
+
+export interface WaNewsletterAdminOps {
+    readonly create: (input: WaNewsletterCreateInput) => Promise<WaNewsletterMetadata>
+    readonly update: (
+        newsletterJid: string,
+        input: WaNewsletterUpdateInput
+    ) => Promise<WaNewsletterMetadata>
+    readonly delete: (newsletterJid: string) => Promise<void>
+    readonly fetchAdminInfo: (newsletterJid: string) => Promise<WaNewsletterAdminInfo>
+    readonly fetchAdminCapabilities: (newsletterJid: string) => Promise<ReadonlySet<string>>
+    readonly fetchFollowers: (
+        newsletterJid: string,
+        options?: WaNewsletterFollowersOptions
+    ) => Promise<WaNewsletterFollowersPage>
+    readonly fetchInsights: (
+        newsletterJid: string,
+        metrics?: readonly string[]
+    ) => Promise<WaNewsletterMexEnvelope>
+    readonly fetchReports: () => Promise<WaNewsletterMexEnvelope>
+    readonly fetchPendingInvites: (newsletterJid: string) => Promise<readonly string[]>
+    readonly fetchEnforcements: (newsletterJid: string) => Promise<WaNewsletterMexEnvelope>
+    readonly fetchPollVoters: (input: {
+        readonly newsletterJid: string
+        readonly messageServerId: number
+        readonly voteHash: string
+        readonly limit?: number
+    }) => Promise<ReadonlyMap<string, readonly WaNewsletterPollVoter[]>>
+    readonly fetchMessageReactionSenders: (input: {
+        readonly newsletterJid: string
+        readonly messageServerId: number
+    }) => Promise<readonly WaNewsletterReactionSenders[]>
+    readonly logExposures: (exposures: readonly WaNewsletterCapabilityExposure[]) => Promise<void>
+    readonly changeOwner: (input: WaNewsletterAdminInviteInput) => Promise<void>
+    readonly demoteAdmin: (input: WaNewsletterAdminInviteInput) => Promise<void>
+    readonly createAdminInvite: (
+        input: WaNewsletterAdminInviteInput
+    ) => Promise<WaNewsletterAdminInviteResult>
+    readonly acceptAdminInvite: (newsletterJid: string) => Promise<void>
+    readonly revokeAdminInvite: (input: WaNewsletterAdminInviteInput) => Promise<void>
+    readonly queryTosState: (noticeIds: readonly string[]) => Promise<WaTosQueryResult>
+    readonly acceptTos: (noticeIds: readonly string[]) => Promise<void>
+}
+
+export function createAdminOps(deps: WaNewsletterMexDeps): WaNewsletterAdminOps {
+    return {
+        create: async (input) => {
+            await ensureTosAccepted(deps, 'creation')
+            const data = await runMex<{
+                readonly xwa2_newsletter_create?: MexNewsletterEnvelope
+            } | null>(deps, WA_MEX_PERSIST_IDS.NewsletterCreate, 'NewsletterCreate', {
+                input: {
+                    name: input.name,
+                    description: input.description,
+                    picture: input.picture ? bytesToBase64(input.picture) : undefined
+                }
+            })
+            if (!data?.xwa2_newsletter_create) {
+                throw new Error('newsletter create returned no envelope')
+            }
+            return parseNewsletterMetadata(data.xwa2_newsletter_create)
+        },
+        update: async (newsletterJid, input) => {
+            const updates: Record<string, unknown> = {}
+            if (input.name !== undefined) updates.name = input.name
+            if (input.description !== undefined) updates.description = input.description
+            if (input.picture !== undefined) {
+                updates.picture = input.picture === null ? null : bytesToBase64(input.picture)
+            }
+            if (input.reactionCodesSetting !== undefined) {
+                updates.reaction_codes = { value: input.reactionCodesSetting }
+            }
+            const data = await runMex<{
+                readonly xwa2_newsletter_update?: MexNewsletterEnvelope
+            } | null>(deps, WA_MEX_PERSIST_IDS.NewsletterUpdate, 'NewsletterUpdate', {
+                newsletter_id: newsletterJid,
+                updates
+            })
+            if (!data?.xwa2_newsletter_update) {
+                throw new Error('newsletter update returned no envelope')
+            }
+            return parseNewsletterMetadata(data.xwa2_newsletter_update)
+        },
+        delete: async (newsletterJid) => {
+            await runMex<unknown>(deps, WA_MEX_PERSIST_IDS.NewsletterDelete, 'NewsletterDelete', {
+                newsletter_id: newsletterJid
+            })
+        },
+        fetchAdminInfo: async (newsletterJid) => {
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterAdminInfo,
+                'NewsletterAdminInfo',
+                { newsletter_id: newsletterJid }
+            )
+            return parseAdminInfo(envelope)
+        },
+        fetchAdminCapabilities: async (newsletterJid) => {
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFetchAdminCapabilities,
+                'NewsletterFetchAdminCapabilities',
+                { newsletter_id: newsletterJid }
+            )
+            return parseAdminCapabilities(envelope)
+        },
+        fetchFollowers: async (newsletterJid, opts) => {
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFollowers,
+                'NewsletterFollowers',
+                {
+                    input: {
+                        newsletter_id: newsletterJid,
+                        count: opts?.count ?? 50
+                    }
+                }
+            )
+            return parseFollowers(envelope)
+        },
+        fetchInsights: (newsletterJid, metrics) =>
+            runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFetchInsights,
+                'NewsletterFetchInsights',
+                {
+                    input: {
+                        newsletter_id: newsletterJid,
+                        metrics: metrics ?? []
+                    }
+                }
+            ),
+        fetchReports: () =>
+            runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFetchReports,
+                'NewsletterFetchReports',
+                {}
+            ),
+        fetchPendingInvites: async (newsletterJid) => {
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFetchPendingInvites,
+                'NewsletterFetchPendingInvites',
+                { newsletter_id: newsletterJid }
+            )
+            return parsePendingInvites(envelope)
+        },
+        fetchEnforcements: (newsletterJid) =>
+            runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFetchEnforcements,
+                'NewsletterFetchEnforcements',
+                { newsletter_id: newsletterJid }
+            ),
+        fetchPollVoters: async (input) => {
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFetchPollVoters,
+                'NewsletterFetchPollVoters',
+                {
+                    input: {
+                        newsletter_id: input.newsletterJid,
+                        server_id: String(input.messageServerId),
+                        vote_hash: input.voteHash,
+                        limit: input.limit ?? 50
+                    }
+                }
+            )
+            return parsePollVoters(envelope)
+        },
+        fetchMessageReactionSenders: async (input) => {
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFetchMessageReactionSenders,
+                'NewsletterFetchMessageReactionSenders',
+                {
+                    input: {
+                        id: input.newsletterJid,
+                        server_id: input.messageServerId
+                    }
+                }
+            )
+            return parseReactionSenders(envelope)
+        },
+        logExposures: async (exposures) => {
+            await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterLogExposures,
+                'NewsletterLogExposures',
+                {
+                    input: {
+                        exposures: exposures.map((e) => ({
+                            newsletter_id: e.newsletterJid,
+                            capability: e.capability
+                        }))
+                    }
+                }
+            )
+        },
+        changeOwner: async (input) => {
+            await runMex<unknown>(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterChangeOwner,
+                'NewsletterChangeOwner',
+                {
+                    newsletter_id: input.newsletterJid,
+                    user_id: input.userJid
+                }
+            )
+        },
+        demoteAdmin: async (input) => {
+            await runMex<unknown>(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterDemoteAdmin,
+                'NewsletterDemoteAdmin',
+                {
+                    newsletter_id: input.newsletterJid,
+                    user_id: input.userJid
+                }
+            )
+        },
+        createAdminInvite: async (input) => {
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterCreateAdminInvite,
+                'NewsletterCreateAdminInvite',
+                {
+                    newsletter_id: input.newsletterJid,
+                    user_id: input.userJid
+                }
+            )
+            return parseAdminInviteResult(envelope)
+        },
+        acceptAdminInvite: async (newsletterJid) => {
+            await ensureTosAccepted(deps, 'admin_invite')
+            await runMex<unknown>(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterAcceptAdminInvite,
+                'NewsletterAcceptAdminInvite',
+                { newsletter_id: newsletterJid }
+            )
+        },
+        revokeAdminInvite: async (input) => {
+            await runMex<unknown>(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterRevokeAdminInvite,
+                'NewsletterRevokeAdminInvite',
+                {
+                    newsletter_id: input.newsletterJid,
+                    user_id: input.userJid
+                }
+            )
+        },
+        queryTosState: async (noticeIds) => {
+            if (!deps.queryWithContext) {
+                throw new Error('newsletter queryTosState requires queryWithContext')
+            }
+            const response = await deps.queryWithContext(
+                'newsletter.query_tos',
+                buildTosQueryIq(noticeIds)
+            )
+            return parseTosQueryResponse(response)
+        },
+        acceptTos: async (noticeIds) => {
+            if (!deps.queryWithContext) {
+                throw new Error('newsletter acceptTos requires queryWithContext')
+            }
+            await deps.queryWithContext('newsletter.accept_tos', buildTosUpdateIq(noticeIds))
+        }
+    }
+}

--- a/src/client/newsletter/content.ts
+++ b/src/client/newsletter/content.ts
@@ -1,0 +1,179 @@
+import type { Readable } from 'node:stream'
+
+import {
+    uploadNewsletterMedia,
+    type WaNewsletterUploadResult
+} from '@client/newsletter/media-upload'
+import type { Logger } from '@infra/log/types'
+import type { NewsletterMediaKind } from '@media/constants'
+import type { WaMediaConn } from '@media/types'
+import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
+import { isSendMediaMessage, resolveMessageTypeAttr } from '@message/content'
+import type { WaSendMediaMessage, WaSendMessageContent } from '@message/types'
+import { proto, type Proto } from '@proto'
+
+export type WaNewsletterContentKind = 'text' | 'media' | 'poll-creation'
+
+export interface WaNewsletterBuiltContent {
+    readonly kind: WaNewsletterContentKind
+    readonly plaintext: Uint8Array
+    readonly mediaType: string | null
+    readonly upload: WaNewsletterUploadResult | null
+}
+
+export interface BuildNewsletterContentOptions {
+    readonly logger: Logger
+    readonly mediaTransfer?: WaMediaTransferClient
+    readonly getMediaConn?: () => Promise<WaMediaConn>
+}
+
+function resolveSendMediaKind(content: WaSendMediaMessage): NewsletterMediaKind {
+    if (content.type === 'video' && content.gifPlayback) return 'gif'
+    if (content.type === 'audio' && content.ptt) return 'ptt'
+    return content.type
+}
+
+function pickMediaTypeFromMessage(message: Proto.IMessage): string | null {
+    if (message.imageMessage) return 'image'
+    if (message.videoMessage) return message.videoMessage.gifPlayback ? 'gif' : 'video'
+    if (message.audioMessage) return message.audioMessage.ptt ? 'ptt' : 'audio'
+    if (message.documentMessage) return 'document'
+    if (message.stickerMessage) return 'sticker'
+    if (message.ptvMessage) return 'ptv'
+    return null
+}
+
+function buildMediaProtoMessage(
+    content: WaSendMediaMessage,
+    upload: WaNewsletterUploadResult
+): Proto.IMessage {
+    const common = {
+        url: upload.url,
+        directPath: upload.directPath,
+        mimetype: 'mimetype' in content ? content.mimetype : undefined,
+        fileSha256: upload.fileSha256,
+        fileLength: upload.fileLength
+    }
+    switch (content.type) {
+        case 'image':
+            return {
+                imageMessage: {
+                    ...content,
+                    ...common,
+                    type: undefined,
+                    media: undefined
+                } as Proto.Message.IImageMessage
+            }
+        case 'video':
+            return {
+                videoMessage: {
+                    ...content,
+                    ...common,
+                    type: undefined,
+                    media: undefined
+                } as Proto.Message.IVideoMessage
+            }
+        case 'ptv':
+            return {
+                ptvMessage: {
+                    ...content,
+                    ...common,
+                    type: undefined,
+                    media: undefined
+                } as Proto.Message.IVideoMessage
+            }
+        case 'audio':
+            return {
+                audioMessage: {
+                    ...content,
+                    ...common,
+                    type: undefined,
+                    media: undefined
+                } as Proto.Message.IAudioMessage
+            }
+        case 'document':
+            return {
+                documentMessage: {
+                    ...content,
+                    ...common,
+                    type: undefined,
+                    media: undefined
+                } as Proto.Message.IDocumentMessage
+            }
+        case 'sticker':
+            return {
+                stickerMessage: {
+                    ...content,
+                    ...common,
+                    mimetype: common.mimetype ?? 'image/webp',
+                    type: undefined,
+                    media: undefined
+                } as Proto.Message.IStickerMessage
+            }
+    }
+}
+
+function toUploadMedia(media: WaSendMediaMessage['media']): Uint8Array | string | Readable {
+    if (media instanceof Uint8Array) return media
+    if (media instanceof ArrayBuffer) return new Uint8Array(media)
+    return media
+}
+
+export async function buildNewsletterMessageContent(
+    options: BuildNewsletterContentOptions,
+    content: WaSendMessageContent
+): Promise<WaNewsletterBuiltContent> {
+    if (typeof content === 'string') {
+        const message: Proto.IMessage = { conversation: content }
+        return {
+            kind: 'text',
+            plaintext: proto.Message.encode(message).finish(),
+            mediaType: null,
+            upload: null
+        }
+    }
+
+    if (isSendMediaMessage(content)) {
+        if (!options.mediaTransfer || !options.getMediaConn) {
+            throw new Error(
+                'newsletter media send requires mediaTransfer and getMediaConn dependencies'
+            )
+        }
+        const mediaConn = await options.getMediaConn()
+        const explicitMimetype = 'mimetype' in content && content.mimetype ? content.mimetype : null
+        const resolvedMimetype =
+            explicitMimetype ?? (content.type === 'sticker' ? 'image/webp' : null)
+        if (!resolvedMimetype) {
+            throw new Error(
+                `newsletter media send requires explicit mimetype for ${content.type} content`
+            )
+        }
+        const upload = await uploadNewsletterMedia(
+            { mediaTransfer: options.mediaTransfer, logger: options.logger },
+            {
+                mediaKind: resolveSendMediaKind(content),
+                media: toUploadMedia(content.media),
+                mimetype: resolvedMimetype,
+                mediaConn
+            }
+        )
+        const message = buildMediaProtoMessage(content, upload)
+        return {
+            kind: 'media',
+            plaintext: proto.Message.encode(message).finish(),
+            mediaType: resolveSendMediaKind(content),
+            upload
+        }
+    }
+
+    const protoMessage = content
+    const messageTypeAttr = resolveMessageTypeAttr(protoMessage)
+    const isPollCreation = messageTypeAttr === 'poll' && Boolean(protoMessage.pollCreationMessage)
+    const mediaTypeAttr = pickMediaTypeFromMessage(protoMessage)
+    return {
+        kind: isPollCreation ? 'poll-creation' : mediaTypeAttr ? 'media' : 'text',
+        plaintext: proto.Message.encode(protoMessage).finish(),
+        mediaType: mediaTypeAttr,
+        upload: null
+    }
+}

--- a/src/client/newsletter/discovery.ts
+++ b/src/client/newsletter/discovery.ts
@@ -1,0 +1,214 @@
+import { runMex, runMexEnvelope, type WaNewsletterMexDeps } from '@client/newsletter/mex'
+import {
+    type MexNewsletterEnvelope,
+    parseDehydratedMetadata,
+    parseDirectoryCategoriesPreview,
+    parseDirectoryList,
+    parseDirectorySearch,
+    parseDomainsPreviewable,
+    parseNewsletterMetadata,
+    parseRecommended,
+    parseSimilar
+} from '@client/newsletter/parse'
+import type {
+    WaNewsletterDehydratedMetadata,
+    WaNewsletterDirectoryCategoriesPreviewOptions,
+    WaNewsletterDirectoryCategoryPreview,
+    WaNewsletterDirectoryListOptions,
+    WaNewsletterDirectoryResults,
+    WaNewsletterDirectorySearchOptions,
+    WaNewsletterFetchOptions,
+    WaNewsletterMetadata,
+    WaNewsletterRecommendedOptions,
+    WaNewsletterSimilarOptions
+} from '@client/newsletter/types'
+import { WA_NEWSLETTER_FETCH_KEY_TYPES, WA_NEWSLETTER_VIEW_ROLES } from '@protocol/newsletter'
+import { WA_MEX_PERSIST_IDS } from '@transport/node/mex/persist-ids'
+
+export interface WaNewsletterDiscoveryOps {
+    readonly fetch: (
+        newsletterJid: string,
+        options?: WaNewsletterFetchOptions
+    ) => Promise<WaNewsletterMetadata>
+    readonly fetchByInvite: (
+        inviteCode: string,
+        options?: WaNewsletterFetchOptions
+    ) => Promise<WaNewsletterMetadata>
+    readonly listSubscribed: (options?: {
+        readonly fetchWamoSub?: boolean
+    }) => Promise<readonly WaNewsletterMetadata[]>
+    readonly searchDirectory: (
+        options?: WaNewsletterDirectorySearchOptions
+    ) => Promise<WaNewsletterDirectoryResults>
+    readonly fetchRecommended: (
+        options?: WaNewsletterRecommendedOptions
+    ) => Promise<readonly WaNewsletterMetadata[]>
+    readonly fetchSimilar: (
+        newsletterJid: string,
+        options?: WaNewsletterSimilarOptions
+    ) => Promise<readonly WaNewsletterMetadata[]>
+    readonly fetchDirectoryList: (
+        options: WaNewsletterDirectoryListOptions
+    ) => Promise<WaNewsletterDirectoryResults>
+    readonly fetchDirectoryCategoriesPreview: (
+        options: WaNewsletterDirectoryCategoriesPreviewOptions
+    ) => Promise<readonly WaNewsletterDirectoryCategoryPreview[]>
+    readonly fetchIsDomainPreviewable: (
+        domains: readonly string[]
+    ) => Promise<ReadonlyMap<string, boolean>>
+    readonly fetchDehydrated: (
+        keyOrInvite: string,
+        options?: { readonly viewRole?: string; readonly fetchWamoSub?: boolean }
+    ) => Promise<WaNewsletterDehydratedMetadata>
+}
+
+export function createDiscoveryOps(deps: WaNewsletterMexDeps): WaNewsletterDiscoveryOps {
+    async function fetchMetadata(
+        key: string,
+        keyType: 'JID' | 'INVITE',
+        opts: WaNewsletterFetchOptions | undefined
+    ): Promise<WaNewsletterMetadata> {
+        const data = await runMex<{ readonly xwa2_newsletter?: MexNewsletterEnvelope } | null>(
+            deps,
+            WA_MEX_PERSIST_IDS.NewsletterFetch,
+            'NewsletterFetch',
+            {
+                input: {
+                    key,
+                    type: keyType,
+                    view_role: opts?.viewRole ?? WA_NEWSLETTER_VIEW_ROLES.SUBSCRIBER
+                },
+                fetch_viewer_metadata: opts?.fetchViewerMetadata ?? true,
+                fetch_full_image: opts?.fetchFullImage ?? keyType !== 'INVITE',
+                fetch_creation_time: opts?.fetchCreationTime ?? true,
+                fetch_wamo_sub: opts?.fetchWamoSub ?? false
+            }
+        )
+        if (!data?.xwa2_newsletter) {
+            throw new Error('newsletter fetch returned no envelope')
+        }
+        return parseNewsletterMetadata(data.xwa2_newsletter)
+    }
+
+    return {
+        fetch: (jid, opts) => fetchMetadata(jid, WA_NEWSLETTER_FETCH_KEY_TYPES.JID, opts),
+        fetchByInvite: (invite, opts) =>
+            fetchMetadata(invite, WA_NEWSLETTER_FETCH_KEY_TYPES.INVITE, opts),
+        listSubscribed: async (opts) => {
+            const data = await runMex<{
+                readonly xwa2_newsletter_subscribed?: readonly MexNewsletterEnvelope[]
+            } | null>(deps, WA_MEX_PERSIST_IDS.NewsletterFetchAll, 'NewsletterFetchAll', {
+                fetch_wamo_sub: opts?.fetchWamoSub ?? false
+            })
+            const list = data?.xwa2_newsletter_subscribed ?? []
+            return list.map(parseNewsletterMetadata)
+        },
+        searchDirectory: async (opts) => {
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterDirectorySearch,
+                'NewsletterDirectorySearch',
+                {
+                    input: {
+                        search_text: opts?.searchText ?? '',
+                        categories: opts?.categories ?? [],
+                        limit: opts?.limit ?? 100,
+                        start_cursor: opts?.startCursor
+                    }
+                }
+            )
+            return parseDirectorySearch(envelope)
+        },
+        fetchRecommended: async (opts) => {
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFetchRecommended,
+                'NewsletterFetchRecommended',
+                {
+                    input: {
+                        limit: opts?.limit ?? 25,
+                        country_codes: opts?.countryCodes ?? []
+                    }
+                }
+            )
+            return parseRecommended(envelope)
+        },
+        fetchSimilar: async (newsletterJid, opts) => {
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFetchSimilar,
+                'NewsletterFetchSimilar',
+                {
+                    input: {
+                        newsletter_id: newsletterJid,
+                        limit: opts?.limit ?? 10,
+                        country_codes: opts?.countryCodes ?? []
+                    }
+                }
+            )
+            return parseSimilar(envelope)
+        },
+        fetchDirectoryList: async (opts) => {
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFetchDirectoryList,
+                'NewsletterFetchDirectoryList',
+                {
+                    input: {
+                        view: opts.view,
+                        filters: {
+                            country_codes: opts.countryCodes ?? [],
+                            categories: opts.categories ?? []
+                        },
+                        limit: opts.limit ?? 25,
+                        start_cursor: opts.startCursor
+                    }
+                }
+            )
+            return parseDirectoryList(envelope)
+        },
+        fetchDirectoryCategoriesPreview: async (opts) => {
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFetchDirectoryCategoriesPreview,
+                'NewsletterFetchDirectoryCategoriesPreview',
+                {
+                    input: {
+                        categories: opts.categories,
+                        country_code: opts.countryCode || undefined,
+                        per_category_limit: opts.perCategoryLimit ?? 10
+                    }
+                }
+            )
+            return parseDirectoryCategoriesPreview(envelope)
+        },
+        fetchIsDomainPreviewable: async (domains) => {
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFetchIsDomainPreviewable,
+                'NewsletterFetchIsDomainPreviewable',
+                {
+                    url_domains: domains
+                }
+            )
+            return parseDomainsPreviewable(envelope)
+        },
+        fetchDehydrated: async (keyOrInvite, opts) => {
+            const isJid = keyOrInvite.endsWith('@newsletter')
+            const envelope = await runMexEnvelope(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterFetchDehydrated,
+                'NewsletterFetchDehydrated',
+                {
+                    input: {
+                        key: keyOrInvite,
+                        type: isJid ? 'JID' : 'INVITE',
+                        view_role: opts?.viewRole ?? WA_NEWSLETTER_VIEW_ROLES.SUBSCRIBER
+                    },
+                    fetch_wamo_sub: opts?.fetchWamoSub ?? false
+                }
+            )
+            return parseDehydratedMetadata(envelope)
+        }
+    }
+}

--- a/src/client/newsletter/media-upload.ts
+++ b/src/client/newsletter/media-upload.ts
@@ -1,0 +1,182 @@
+import { createReadStream } from 'node:fs'
+import type { Readable } from 'node:stream'
+
+import {
+    cleanupTempFile,
+    hashFileWithSha256,
+    isReadableStream,
+    streamToTempFileWithSha256
+} from '@client/media'
+import { randomIntAsync, sha256 } from '@crypto/core'
+import type { Logger } from '@infra/log/types'
+import { NEWSLETTER_MEDIA_UPLOAD_PATHS, type NewsletterMediaKind } from '@media/constants'
+import type { WaMediaConn } from '@media/types'
+import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
+import { base64ToBytes, bytesToBase64UrlSafe, TEXT_DECODER } from '@util/bytes'
+import { toError } from '@util/primitives'
+
+// node:crypto randomInt caps max at 2**48 - 1; well within JS safe integer range.
+const MEDIA_ID_MAX = 281_474_976_710_655
+
+export type WaNewsletterUploadMedia = Uint8Array | string | Readable
+
+export interface WaNewsletterUploadInput {
+    readonly mediaKind: NewsletterMediaKind
+    readonly media: WaNewsletterUploadMedia
+    readonly mimetype: string
+    readonly mediaConn: WaMediaConn
+}
+
+export interface WaNewsletterUploadResult {
+    readonly url: string
+    readonly directPath: string
+    readonly handle?: string
+    readonly metadataUrl?: string
+    readonly thumbnailDirectPath?: string
+    readonly thumbnailSha256?: Uint8Array
+    readonly fileSha256: Uint8Array
+    readonly fileLength: number
+    readonly mediaId: string
+}
+
+interface NewsletterUploadResponseJson {
+    readonly url?: string
+    readonly direct_path?: string
+    readonly handle?: string
+    readonly metadata_url?: string
+    readonly thumbnail_info?: {
+        readonly thumbnail_direct_path?: string
+        readonly thumbnail_sha256?: string
+    }
+}
+
+interface PreparedUpload {
+    readonly fileSha256: Uint8Array
+    readonly byteLength: number
+    readonly body: Uint8Array | Readable
+    readonly cleanup?: () => Promise<void>
+}
+
+async function prepareUpload(media: WaNewsletterUploadMedia): Promise<PreparedUpload> {
+    if (media instanceof Uint8Array) {
+        return {
+            fileSha256: sha256(media),
+            byteLength: media.byteLength,
+            body: media
+        }
+    }
+    if (typeof media === 'string') {
+        const metrics = await hashFileWithSha256(media)
+        return {
+            fileSha256: metrics.fileSha256,
+            byteLength: metrics.byteLength,
+            body: createReadStream(media)
+        }
+    }
+    if (isReadableStream(media)) {
+        const result = await streamToTempFileWithSha256(media)
+        return {
+            fileSha256: result.fileSha256,
+            byteLength: result.byteLength,
+            body: createReadStream(result.filePath),
+            cleanup: () => cleanupTempFile(result.filePath)
+        }
+    }
+    throw new Error('newsletter media upload received unsupported media type')
+}
+
+async function generateMediaId(): Promise<string> {
+    const value = await randomIntAsync(0, MEDIA_ID_MAX)
+    return value.toString(10)
+}
+
+function buildNewsletterUploadUrl(
+    host: string,
+    mediaKind: NewsletterMediaKind,
+    auth: string,
+    fileSha256: Uint8Array,
+    mediaId: string
+): string {
+    const path = NEWSLETTER_MEDIA_UPLOAD_PATHS[mediaKind]
+    const hashToken = bytesToBase64UrlSafe(fileSha256)
+    return (
+        `https://${host}${path}/${hashToken}` +
+        `?auth=${encodeURIComponent(auth)}&token=${encodeURIComponent(hashToken)}&media_id=${mediaId}`
+    )
+}
+
+type ParsedUploadResponse = Omit<WaNewsletterUploadResult, 'fileSha256' | 'fileLength' | 'mediaId'>
+
+function parseNewsletterUploadResponse(body: Uint8Array, status: number): ParsedUploadResponse {
+    if (status < 200 || status >= 300) {
+        throw new Error(`newsletter media upload failed with status ${status}`)
+    }
+    let parsed: NewsletterUploadResponseJson
+    try {
+        parsed = JSON.parse(TEXT_DECODER.decode(body)) as NewsletterUploadResponseJson
+    } catch (error) {
+        throw new Error(`newsletter media upload returned invalid json: ${toError(error).message}`)
+    }
+    if (!parsed.url || !parsed.direct_path) {
+        throw new Error('newsletter media upload response missing url/direct_path')
+    }
+    return {
+        url: parsed.url,
+        directPath: parsed.direct_path,
+        handle: parsed.handle,
+        metadataUrl: parsed.metadata_url,
+        thumbnailDirectPath: parsed.thumbnail_info?.thumbnail_direct_path,
+        thumbnailSha256: parsed.thumbnail_info?.thumbnail_sha256
+            ? base64ToBytes(parsed.thumbnail_info.thumbnail_sha256)
+            : undefined
+    }
+}
+
+export async function uploadNewsletterMedia(
+    options: {
+        readonly mediaTransfer: WaMediaTransferClient
+        readonly logger: Logger
+    },
+    input: WaNewsletterUploadInput
+): Promise<WaNewsletterUploadResult> {
+    const prepared = await prepareUpload(input.media)
+    try {
+        const mediaConn = input.mediaConn
+        const selectedHost =
+            mediaConn.hosts.find((host) => !host.isFallback)?.hostname ??
+            mediaConn.hosts[0].hostname
+        const mediaId = await generateMediaId()
+        const uploadUrl = buildNewsletterUploadUrl(
+            selectedHost,
+            input.mediaKind,
+            mediaConn.auth,
+            prepared.fileSha256,
+            mediaId
+        )
+
+        options.logger.debug('sending newsletter media upload', {
+            mediaKind: input.mediaKind,
+            host: selectedHost,
+            size: prepared.byteLength
+        })
+
+        const response = await options.mediaTransfer.uploadStream({
+            url: uploadUrl,
+            method: 'POST',
+            body: prepared.body,
+            contentLength: prepared.byteLength,
+            contentType: input.mimetype
+        })
+        const responseBytes = await options.mediaTransfer.readResponseBytes(response)
+        const parsed = parseNewsletterUploadResponse(responseBytes, response.status)
+
+        return {
+            ...parsed,
+            fileSha256: prepared.fileSha256,
+            fileLength: prepared.byteLength,
+            mediaId
+        }
+    } finally {
+        await prepared.cleanup?.()
+    }
+}

--- a/src/client/newsletter/messaging.ts
+++ b/src/client/newsletter/messaging.ts
@@ -1,0 +1,318 @@
+import {
+    buildNewsletterMessageContent,
+    type WaNewsletterBuiltContent
+} from '@client/newsletter/content'
+import { ensureTosAccepted, runMex, type WaNewsletterMexDeps } from '@client/newsletter/mex'
+import type {
+    WaNewsletterMuteInput,
+    WaNewsletterReactInput,
+    WaNewsletterRevokeInput,
+    WaNewsletterSendOptions,
+    WaNewsletterSendResult,
+    WaNewsletterViewReceiptInput,
+    WaNewsletterVotePollInput
+} from '@client/newsletter/types'
+import type { WaMediaConn } from '@media/types'
+import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
+import type {
+    WaMessagePublishOptions,
+    WaMessagePublishResult,
+    WaMessageUploadInfo,
+    WaSendMessageContent
+} from '@message/types'
+import { WA_NEWSLETTER_MUTE_TYPES, WA_NEWSLETTER_MUTE_VALUES } from '@protocol/newsletter'
+import {
+    buildNewsletterMessageNode,
+    buildNewsletterMessagesIq,
+    buildNewsletterMessageUpdatesIq,
+    buildNewsletterSubscribeLiveUpdatesIq,
+    buildNewsletterViewReceiptNode
+} from '@transport/node/builders/newsletter'
+import { findNodeChild } from '@transport/node/helpers'
+import { WA_MEX_PERSIST_IDS } from '@transport/node/mex/persist-ids'
+import type { BinaryNode } from '@transport/types'
+
+export interface WaNewsletterMessagingDeps extends WaNewsletterMexDeps {
+    readonly sendNode: (node: BinaryNode) => Promise<void>
+    readonly publishMessageNode: (
+        node: BinaryNode,
+        options?: WaMessagePublishOptions
+    ) => Promise<WaMessagePublishResult>
+    readonly generateStanzaId: () => Promise<string>
+    readonly mediaTransfer?: WaMediaTransferClient
+    readonly getMediaConn?: () => Promise<WaMediaConn>
+}
+
+export interface WaNewsletterMessagingOps {
+    readonly sendMessage: (
+        newsletterJid: string,
+        content: WaSendMessageContent,
+        options?: WaNewsletterSendOptions
+    ) => Promise<WaNewsletterSendResult>
+    readonly editMessage: (
+        newsletterJid: string,
+        parentMessageId: string,
+        content: WaSendMessageContent
+    ) => Promise<WaNewsletterSendResult>
+    readonly react: (input: WaNewsletterReactInput) => Promise<{ readonly stanzaId: string }>
+    readonly revoke: (input: WaNewsletterRevokeInput) => Promise<{ readonly stanzaId: string }>
+    readonly votePoll: (input: WaNewsletterVotePollInput) => Promise<{ readonly stanzaId: string }>
+    readonly sendViewReceipt: (
+        input: WaNewsletterViewReceiptInput
+    ) => Promise<{ readonly stanzaId: string }>
+    readonly fetchMessages: (input: {
+        readonly newsletterJid: string
+        readonly count: number
+        readonly before?: number
+        readonly after?: number
+        readonly viewRole?: string
+    }) => Promise<BinaryNode>
+    readonly fetchMessageUpdates: (input: {
+        readonly newsletterJid: string
+        readonly count: number
+        readonly since?: number
+        readonly before?: number
+        readonly after?: number
+    }) => Promise<BinaryNode>
+    readonly subscribeLiveUpdates: (
+        newsletterJid: string
+    ) => Promise<{ readonly durationSeconds: number }>
+    readonly follow: (newsletterJid: string) => Promise<void>
+    readonly unfollow: (newsletterJid: string) => Promise<void>
+    readonly mute: (input: WaNewsletterMuteInput) => Promise<void>
+}
+
+async function buildContent(
+    deps: WaNewsletterMessagingDeps,
+    content: WaSendMessageContent
+): Promise<WaNewsletterBuiltContent> {
+    return buildNewsletterMessageContent(
+        {
+            logger: deps.logger,
+            mediaTransfer: deps.mediaTransfer,
+            getMediaConn: deps.getMediaConn
+        },
+        content
+    )
+}
+
+function toUploadSummary(built: WaNewsletterBuiltContent): WaMessageUploadInfo | undefined {
+    if (!built.upload) return undefined
+    return {
+        url: built.upload.url,
+        directPath: built.upload.directPath,
+        fileSha256: built.upload.fileSha256,
+        fileLength: built.upload.fileLength,
+        metadataUrl: built.upload.metadataUrl
+    }
+}
+
+function buildDispatchNode(
+    newsletterJid: string,
+    stanzaId: string,
+    built: WaNewsletterBuiltContent,
+    edit: { readonly parentMessageId: string } | null
+): BinaryNode {
+    if (built.kind === 'poll-creation') {
+        if (edit) {
+            throw new Error('newsletter poll creation cannot be sent as an edit')
+        }
+        return buildNewsletterMessageNode({
+            kind: 'poll-creation',
+            to: newsletterJid,
+            id: stanzaId,
+            plaintext: built.plaintext
+        })
+    }
+    if (built.kind === 'media') {
+        if (built.mediaType === null) {
+            throw new Error('newsletter media content missing mediaType attribute')
+        }
+        return buildNewsletterMessageNode(
+            edit
+                ? {
+                      kind: 'edit-media',
+                      to: newsletterJid,
+                      parentMessageId: edit.parentMessageId,
+                      plaintext: built.plaintext,
+                      mediaType: built.mediaType
+                  }
+                : {
+                      kind: 'media',
+                      to: newsletterJid,
+                      id: stanzaId,
+                      plaintext: built.plaintext,
+                      mediaType: built.mediaType,
+                      mediaHandle: built.upload?.handle
+                  }
+        )
+    }
+    return buildNewsletterMessageNode(
+        edit
+            ? {
+                  kind: 'edit-text',
+                  to: newsletterJid,
+                  parentMessageId: edit.parentMessageId,
+                  plaintext: built.plaintext
+              }
+            : {
+                  kind: 'text',
+                  to: newsletterJid,
+                  id: stanzaId,
+                  plaintext: built.plaintext
+              }
+    )
+}
+
+export function createMessagingOps(deps: WaNewsletterMessagingDeps): WaNewsletterMessagingOps {
+    async function resolveStanzaId(provided: string | undefined): Promise<string> {
+        return provided ?? deps.generateStanzaId()
+    }
+
+    return {
+        sendMessage: async (
+            newsletterJid,
+            content,
+            sendOptions
+        ): Promise<WaNewsletterSendResult> => {
+            const stanzaId = await resolveStanzaId(sendOptions?.stanzaId)
+            const built = await buildContent(deps, content)
+            const node = buildDispatchNode(newsletterJid, stanzaId, built, null)
+            const result = await deps.publishMessageNode(node)
+            return { ...result, upload: toUploadSummary(built) }
+        },
+        editMessage: async (newsletterJid, parentMessageId, content) => {
+            const built = await buildContent(deps, content)
+            if (built.kind === 'poll-creation') {
+                throw new Error('newsletter poll creations cannot be edited')
+            }
+            const node = buildDispatchNode(newsletterJid, parentMessageId, built, {
+                parentMessageId
+            })
+            const result = await deps.publishMessageNode(node)
+            return { ...result, upload: toUploadSummary(built) }
+        },
+        react: async (input) => {
+            const stanzaId = await resolveStanzaId(input.stanzaId)
+            await deps.sendNode(
+                buildNewsletterMessageNode(
+                    input.revoke
+                        ? {
+                              kind: 'reaction-revoke',
+                              to: input.newsletterJid,
+                              id: stanzaId,
+                              parentMessageServerId: input.parentMessageServerId
+                          }
+                        : {
+                              kind: 'reaction',
+                              to: input.newsletterJid,
+                              id: stanzaId,
+                              parentMessageServerId: input.parentMessageServerId,
+                              reactionCode: input.reactionCode
+                          }
+                )
+            )
+            return { stanzaId }
+        },
+        revoke: async (input) => {
+            const node = buildNewsletterMessageNode({
+                kind: 'revoke',
+                to: input.newsletterJid,
+                originalMessageId: input.originalMessageId
+            })
+            const result = await deps.publishMessageNode(node)
+            return { stanzaId: result.id }
+        },
+        votePoll: async (input) => {
+            const stanzaId = await resolveStanzaId(input.stanzaId)
+            await deps.sendNode(
+                buildNewsletterMessageNode({
+                    kind: 'poll-vote',
+                    to: input.newsletterJid,
+                    id: stanzaId,
+                    parentMessageServerId: input.parentMessageServerId,
+                    votes: input.votes,
+                    contentType: input.contentType
+                })
+            )
+            return { stanzaId }
+        },
+        sendViewReceipt: async (input) => {
+            const stanzaId = await resolveStanzaId(input.stanzaId)
+            await deps.sendNode(
+                buildNewsletterViewReceiptNode({
+                    to: input.newsletterJid,
+                    id: stanzaId,
+                    itemServerIds: input.itemServerIds
+                })
+            )
+            return { stanzaId }
+        },
+        fetchMessages: async (input) => {
+            if (!deps.queryWithContext) {
+                throw new Error('newsletter fetchMessages requires queryWithContext')
+            }
+            return deps.queryWithContext(
+                'newsletter.fetch_messages',
+                buildNewsletterMessagesIq(input)
+            )
+        },
+        fetchMessageUpdates: async (input) => {
+            if (!deps.queryWithContext) {
+                throw new Error('newsletter fetchMessageUpdates requires queryWithContext')
+            }
+            return deps.queryWithContext(
+                'newsletter.fetch_message_updates',
+                buildNewsletterMessageUpdatesIq(input)
+            )
+        },
+        subscribeLiveUpdates: async (newsletterJid) => {
+            if (!deps.queryWithContext) {
+                throw new Error('newsletter subscribeLiveUpdates requires queryWithContext')
+            }
+            const response = await deps.queryWithContext(
+                'newsletter.subscribe_live_updates',
+                buildNewsletterSubscribeLiveUpdatesIq(newsletterJid)
+            )
+            const liveUpdates = findNodeChild(response, 'live_updates')
+            const durationAttr = liveUpdates?.attrs.duration
+            const parsed = durationAttr ? Number.parseInt(durationAttr, 10) : NaN
+            if (!Number.isFinite(parsed) || parsed < 30 || parsed > 600) {
+                throw new Error(
+                    `newsletter subscribeLiveUpdates returned invalid duration: ${durationAttr}`
+                )
+            }
+            return { durationSeconds: parsed }
+        },
+        follow: async (newsletterJid) => {
+            await ensureTosAccepted(deps, 'consumer')
+            await runMex<unknown>(deps, WA_MEX_PERSIST_IDS.NewsletterJoin, 'NewsletterJoin', {
+                newsletter_id: newsletterJid
+            })
+        },
+        unfollow: async (newsletterJid) => {
+            await runMex<unknown>(deps, WA_MEX_PERSIST_IDS.NewsletterLeave, 'NewsletterLeave', {
+                newsletter_id: newsletterJid
+            })
+        },
+        mute: async (input) => {
+            const muteType =
+                input.type === 'admin'
+                    ? WA_NEWSLETTER_MUTE_TYPES.ADMIN_ACTIVITY
+                    : WA_NEWSLETTER_MUTE_TYPES.FOLLOWER_ACTIVITY
+            const value = input.mute ? WA_NEWSLETTER_MUTE_VALUES.ON : WA_NEWSLETTER_MUTE_VALUES.OFF
+            await runMex<unknown>(
+                deps,
+                WA_MEX_PERSIST_IDS.NewsletterUpdateUserSetting,
+                'NewsletterUpdateUserSetting',
+                {
+                    input: {
+                        newsletter_id: input.newsletterJid,
+                        type: muteType,
+                        value
+                    }
+                }
+            )
+        }
+    }
+}

--- a/src/client/newsletter/mex.ts
+++ b/src/client/newsletter/mex.ts
@@ -1,0 +1,86 @@
+import type { WaNewsletterMexEnvelope } from '@client/newsletter/types'
+import type { Logger } from '@infra/log/types'
+import type { AbPropName } from '@protocol/abprops'
+import {
+    buildTosQueryIq,
+    buildTosUpdateIq,
+    parseTosQueryResponse
+} from '@transport/node/builders/tos'
+import { dispatchMexQuery, type WaMexQuerySocket } from '@transport/node/mex/client'
+import type { WaMexPersistId } from '@transport/node/mex/persist-ids'
+import type { BinaryNode } from '@transport/types'
+import { toError } from '@util/primitives'
+
+export type WaNewsletterTosKind = 'creation' | 'consumer' | 'admin_invite'
+
+export interface WaNewsletterMexDeps {
+    readonly mexSocket: WaMexQuerySocket
+    readonly queryWithContext?: (
+        context: string,
+        node: BinaryNode,
+        timeoutMs?: number
+    ) => Promise<BinaryNode>
+    readonly getAbPropString?: (name: AbPropName) => string
+    readonly logger: Logger
+}
+
+export async function runMex<T>(
+    deps: WaNewsletterMexDeps,
+    persist: WaMexPersistId,
+    opName: string,
+    variables: Readonly<Record<string, unknown>>
+): Promise<T> {
+    const { data } = await dispatchMexQuery(deps.mexSocket, {
+        docId: persist.docId,
+        clientDocId: persist.clientDocId,
+        opName,
+        variables
+    })
+    return data as T
+}
+
+export async function runMexEnvelope(
+    deps: WaNewsletterMexDeps,
+    persist: WaMexPersistId,
+    opName: string,
+    variables: Readonly<Record<string, unknown>>
+): Promise<WaNewsletterMexEnvelope> {
+    const data = await runMex<Record<string, unknown> | null>(deps, persist, opName, variables)
+    return data ?? {}
+}
+
+function resolveTosId(deps: WaNewsletterMexDeps, kind: WaNewsletterTosKind): string | null {
+    if (!deps.getAbPropString) return null
+    const propName: AbPropName =
+        kind === 'creation'
+            ? 'newsletter_creation_tos_id'
+            : kind === 'consumer'
+              ? 'newsletter_tos_notice_id'
+              : 'newsletter_admin_invite_tos_id'
+    const id = deps.getAbPropString(propName)
+    return id.length > 0 ? id : null
+}
+
+export async function ensureTosAccepted(
+    deps: WaNewsletterMexDeps,
+    kind: WaNewsletterTosKind
+): Promise<void> {
+    const noticeId = resolveTosId(deps, kind)
+    if (!noticeId || !deps.queryWithContext) return
+    try {
+        const response = await deps.queryWithContext(
+            'newsletter.query_tos',
+            buildTosQueryIq([noticeId])
+        )
+        const parsed = parseTosQueryResponse(response)
+        const existing = parsed.notices.find((entry) => entry.id === noticeId)
+        if (existing?.accepted) return
+        await deps.queryWithContext('newsletter.accept_tos', buildTosUpdateIq([noticeId]))
+    } catch (error) {
+        deps.logger.warn('newsletter tos auto-accept failed', {
+            kind,
+            noticeId,
+            message: toError(error).message
+        })
+    }
+}

--- a/src/client/newsletter/parse.ts
+++ b/src/client/newsletter/parse.ts
@@ -1,0 +1,426 @@
+import type {
+    WaNewsletterAdminInfo,
+    WaNewsletterAdminInviteResult,
+    WaNewsletterAdminProfile,
+    WaNewsletterDehydratedMetadata,
+    WaNewsletterDirectoryCategoryPreview,
+    WaNewsletterDirectoryResults,
+    WaNewsletterFollower,
+    WaNewsletterFollowersPage,
+    WaNewsletterMetadata,
+    WaNewsletterMexEnvelope,
+    WaNewsletterPicture,
+    WaNewsletterPollVoter,
+    WaNewsletterReactionSenders,
+    WaPageInfo
+} from '@client/newsletter/types'
+import {
+    WA_NEWSLETTER_MUTE_TYPES,
+    WA_NEWSLETTER_MUTE_VALUES,
+    type WaNewsletterRole,
+    type WaNewsletterStateType
+} from '@protocol/newsletter'
+
+interface RawPicture {
+    readonly id?: string
+    readonly direct_path?: string
+}
+
+export interface MexNewsletterEnvelope {
+    readonly id?: string
+    readonly state?: { readonly type?: WaNewsletterStateType }
+    readonly thread_metadata?: {
+        readonly creation_time?: string | number
+        readonly name?: { readonly text?: string; readonly update_time?: string | number }
+        readonly description?: {
+            readonly text?: string
+            readonly update_time?: string | number
+        }
+        readonly picture?: RawPicture
+        readonly preview?: RawPicture
+        readonly invite?: string
+        readonly handle?: string
+        readonly subscribers_count?: string | number
+        readonly verification?: string
+    }
+    readonly viewer_metadata?: {
+        readonly role?: WaNewsletterRole
+        readonly settings?: readonly { readonly type?: string; readonly value?: string }[]
+    }
+}
+
+interface RawAdminProfile {
+    readonly id?: string
+    readonly name?: string
+    readonly picture?: RawPicture
+}
+
+interface RawFollowerEdge {
+    readonly admin_profile?: RawAdminProfile
+    readonly follow_time?: string | number
+    readonly role?: string
+    readonly node?: {
+        readonly id?: string
+        readonly pn?: string
+        readonly display_name?: string
+        readonly username_info?: { readonly username?: string }
+    }
+}
+
+interface RawPageInfo {
+    readonly hasNextPage?: boolean
+    readonly hasPreviousPage?: boolean
+    readonly startCursor?: string
+    readonly endCursor?: string
+}
+
+export function toNumber(value: string | number | null | undefined): number | undefined {
+    if (value === null || value === undefined) return undefined
+    if (typeof value === 'number') return value
+    const parsed = Number.parseInt(value, 10)
+    return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function parsePicture(raw: RawPicture | undefined): WaNewsletterPicture | undefined {
+    if (!raw) return undefined
+    if (!raw.id && !raw.direct_path) return undefined
+    return {
+        id: raw.id,
+        directPath: raw.direct_path
+    }
+}
+
+function parseAdminProfile(raw: RawAdminProfile | undefined): WaNewsletterAdminProfile | null {
+    if (!raw || !raw.name) return null
+    return {
+        id: raw.id,
+        name: raw.name,
+        pictureId: raw.picture?.id,
+        pictureDirectPath: raw.picture?.direct_path
+    }
+}
+
+function parsePageInfo(raw: RawPageInfo | undefined): WaPageInfo | undefined {
+    if (!raw) return undefined
+    return {
+        hasNextPage: raw.hasNextPage,
+        hasPreviousPage: raw.hasPreviousPage,
+        startCursor: raw.startCursor,
+        endCursor: raw.endCursor
+    }
+}
+
+export function parseNewsletterMetadata(envelope: MexNewsletterEnvelope): WaNewsletterMetadata {
+    const meta = envelope.thread_metadata
+    const viewer = envelope.viewer_metadata
+    const settings = viewer?.settings ?? []
+
+    let mutedAdmin: boolean | undefined
+    let mutedFollower: boolean | undefined
+    for (const setting of settings) {
+        if (setting.type === WA_NEWSLETTER_MUTE_TYPES.ADMIN_ACTIVITY) {
+            mutedAdmin = setting.value === WA_NEWSLETTER_MUTE_VALUES.ON
+        } else if (setting.type === WA_NEWSLETTER_MUTE_TYPES.FOLLOWER_ACTIVITY) {
+            mutedFollower = setting.value === WA_NEWSLETTER_MUTE_VALUES.ON
+        }
+    }
+
+    return {
+        jid: envelope.id ?? '',
+        state: envelope.state?.type ?? 'ACTIVE',
+        creationTime: toNumber(meta?.creation_time),
+        name: meta?.name?.text,
+        nameUpdateTime: toNumber(meta?.name?.update_time),
+        description: meta?.description?.text,
+        descriptionUpdateTime: toNumber(meta?.description?.update_time),
+        picture: parsePicture(meta?.picture),
+        preview: parsePicture(meta?.preview),
+        invite: meta?.invite,
+        handle: meta?.handle,
+        subscribersCount: toNumber(meta?.subscribers_count),
+        verification: meta?.verification,
+        viewerRole: viewer?.role,
+        mutedAdmin,
+        mutedFollower
+    }
+}
+
+export function parseAdminInfo(envelope: WaNewsletterMexEnvelope): WaNewsletterAdminInfo {
+    const admin = (envelope as { readonly xwa2_newsletter_admin?: unknown }).xwa2_newsletter_admin
+    if (!admin || typeof admin !== 'object') {
+        return { adminProfile: null }
+    }
+    const node = admin as {
+        readonly admin_count?: number
+        readonly admin_profile?: RawAdminProfile
+    }
+    return {
+        adminCount: node.admin_count,
+        adminProfile: parseAdminProfile(node.admin_profile)
+    }
+}
+
+export function parseAdminCapabilities(envelope: WaNewsletterMexEnvelope): ReadonlySet<string> {
+    const admin = (envelope as { readonly xwa2_newsletter_admin?: unknown }).xwa2_newsletter_admin
+    if (!admin || typeof admin !== 'object') return new Set()
+    const capabilities = (admin as { readonly capabilities?: readonly string[] }).capabilities
+    return new Set(Array.isArray(capabilities) ? capabilities : [])
+}
+
+export function parsePendingInvites(envelope: WaNewsletterMexEnvelope): readonly string[] {
+    const admin = (envelope as { readonly xwa2_newsletter_admin?: unknown }).xwa2_newsletter_admin
+    if (!admin || typeof admin !== 'object') return []
+    const invites = (
+        admin as {
+            readonly pending_admin_invites?: readonly {
+                readonly user?: { readonly id?: string; readonly pn?: string }
+            }[]
+        }
+    ).pending_admin_invites
+    if (!Array.isArray(invites)) return []
+    const result: string[] = []
+    for (const invite of invites) {
+        const user = invite?.user
+        const id = user?.pn ?? user?.id
+        if (id) result.push(id)
+    }
+    return result
+}
+
+export function parseFollowers(envelope: WaNewsletterMexEnvelope): WaNewsletterFollowersPage {
+    const root = (envelope as { readonly xwa2_newsletter_followers?: unknown })
+        .xwa2_newsletter_followers
+    if (!root || typeof root !== 'object') {
+        return { followers: [] }
+    }
+    const followersWrap = (
+        root as {
+            readonly followers?: {
+                readonly edges?: readonly RawFollowerEdge[]
+                readonly page_info?: RawPageInfo
+            }
+        }
+    ).followers
+    const edges = followersWrap?.edges ?? []
+    const followers: WaNewsletterFollower[] = []
+    for (const edge of edges) {
+        const id = edge.node?.id
+        if (!id) continue
+        followers.push({
+            id,
+            displayName: edge.node?.display_name,
+            role: edge.role as WaNewsletterRole | undefined,
+            phoneJid: edge.node?.pn,
+            username: edge.node?.username_info?.username,
+            followTime: toNumber(edge.follow_time),
+            adminProfile: parseAdminProfile(edge.admin_profile)
+        })
+    }
+    return { followers, pageInfo: parsePageInfo(followersWrap?.page_info) }
+}
+
+interface RawDirectoryResponse {
+    readonly result?: readonly MexNewsletterEnvelope[]
+    readonly page_info?: RawPageInfo
+}
+
+export function parseDirectorySearch(
+    envelope: WaNewsletterMexEnvelope
+): WaNewsletterDirectoryResults {
+    const root = (envelope as { readonly xwa2_newsletters_directory_search?: RawDirectoryResponse })
+        .xwa2_newsletters_directory_search
+    return {
+        results: (root?.result ?? []).map(parseNewsletterMetadata),
+        pageInfo: parsePageInfo(root?.page_info)
+    }
+}
+
+export function parseDirectoryList(
+    envelope: WaNewsletterMexEnvelope
+): WaNewsletterDirectoryResults {
+    const root = (
+        envelope as { readonly xwa2_newsletters_directory_list_v2?: RawDirectoryResponse }
+    ).xwa2_newsletters_directory_list_v2
+    return {
+        results: (root?.result ?? []).map(parseNewsletterMetadata),
+        pageInfo: parsePageInfo(root?.page_info)
+    }
+}
+
+export function parseRecommended(
+    envelope: WaNewsletterMexEnvelope
+): readonly WaNewsletterMetadata[] {
+    const root = (envelope as { readonly xwa2_recommended_newsletters?: RawDirectoryResponse })
+        .xwa2_recommended_newsletters
+    return (root?.result ?? []).map(parseNewsletterMetadata)
+}
+
+export function parseSimilar(envelope: WaNewsletterMexEnvelope): readonly WaNewsletterMetadata[] {
+    const root = (envelope as { readonly xwa2_newsletters_similar?: RawDirectoryResponse })
+        .xwa2_newsletters_similar
+    return (root?.result ?? []).map(parseNewsletterMetadata)
+}
+
+export function parseDomainsPreviewable(
+    envelope: WaNewsletterMexEnvelope
+): ReadonlyMap<string, boolean> {
+    const root = (
+        envelope as {
+            readonly xwa2_newsletter_message_integrity?: {
+                readonly url_previews?: readonly {
+                    readonly url_domain?: string
+                    readonly is_previewable?: boolean
+                }[]
+            }
+        }
+    ).xwa2_newsletter_message_integrity
+    const previews = root?.url_previews ?? []
+    const map = new Map<string, boolean>()
+    for (const preview of previews) {
+        if (preview.url_domain) {
+            map.set(preview.url_domain, preview.is_previewable === true)
+        }
+    }
+    return map
+}
+
+interface RawDirectoryCategoryPreviewEntry {
+    readonly category?: string
+    readonly category_title?: string
+    readonly newsletters?: readonly MexNewsletterEnvelope[]
+}
+
+export function parseDirectoryCategoriesPreview(
+    envelope: WaNewsletterMexEnvelope
+): readonly WaNewsletterDirectoryCategoryPreview[] {
+    const root = (
+        envelope as {
+            readonly xwa2_newsletters_directory_category_preview?: {
+                readonly result?: readonly RawDirectoryCategoryPreviewEntry[]
+            }
+        }
+    ).xwa2_newsletters_directory_category_preview
+    const entries = root?.result ?? []
+    const result: WaNewsletterDirectoryCategoryPreview[] = []
+    for (const entry of entries) {
+        if (!entry.category) continue
+        result.push({
+            category: entry.category,
+            categoryTitle: entry.category_title,
+            newsletters: (entry.newsletters ?? []).map(parseNewsletterMetadata)
+        })
+    }
+    return result
+}
+
+interface RawDehydratedNewsletter {
+    readonly id?: string
+    readonly thread_metadata?: {
+        readonly subscribers_count?: string | number
+        readonly verification?: string
+        readonly settings?: { readonly reaction_codes?: { readonly value?: string } }
+        readonly wamo_sub?: { readonly plan_id?: string }
+    }
+    readonly viewer_metadata?: { readonly wamo_sub_status?: string }
+}
+
+export function parseDehydratedMetadata(
+    envelope: WaNewsletterMexEnvelope
+): WaNewsletterDehydratedMetadata {
+    const node = (envelope as { readonly xwa2_newsletter?: RawDehydratedNewsletter })
+        .xwa2_newsletter
+    const meta = node?.thread_metadata
+    return {
+        jid: node?.id ?? '',
+        subscribersCount: toNumber(meta?.subscribers_count),
+        verification: meta?.verification,
+        reactionCodesSetting: meta?.settings?.reaction_codes?.value,
+        wamoSubPlanId: meta?.wamo_sub?.plan_id,
+        wamoSubStatus: node?.viewer_metadata?.wamo_sub_status
+    }
+}
+
+export function parseAdminInviteResult(
+    envelope: WaNewsletterMexEnvelope
+): WaNewsletterAdminInviteResult {
+    const root = (
+        envelope as {
+            readonly xwa2_newsletter_admin_invite_create?: {
+                readonly id?: string
+                readonly invite_expiration_time?: string | number
+            }
+        }
+    ).xwa2_newsletter_admin_invite_create
+    return {
+        inviteId: root?.id,
+        expirationTime: toNumber(root?.invite_expiration_time)
+    }
+}
+
+interface RawReactionEntry {
+    readonly reaction_code?: string
+    readonly sender_list?: {
+        readonly edges?: readonly {
+            readonly node?: { readonly id?: string; readonly profile_pic_direct_path?: string }
+        }[]
+    }
+}
+
+export function parseReactionSenders(
+    envelope: WaNewsletterMexEnvelope
+): readonly WaNewsletterReactionSenders[] {
+    const root = (
+        envelope as {
+            readonly xwa2_newsletters_reaction_sender_list?: {
+                readonly reactions?: readonly RawReactionEntry[]
+            }
+        }
+    ).xwa2_newsletters_reaction_sender_list
+    const reactions = root?.reactions ?? []
+    return reactions.map((entry) => ({
+        reactionCode: entry.reaction_code ?? '',
+        senders: (entry.sender_list?.edges ?? [])
+            .map((edge) => ({
+                id: edge.node?.id ?? '',
+                profileUrl: edge.node?.profile_pic_direct_path
+            }))
+            .filter((sender) => sender.id.length > 0)
+    }))
+}
+
+interface RawVotesGroup {
+    readonly vote_hash?: string
+    readonly voter_list?: {
+        readonly edges?: readonly {
+            readonly node?: { readonly id?: string }
+            readonly action_time?: string | number
+        }[]
+    }
+}
+
+export function parsePollVoters(
+    envelope: WaNewsletterMexEnvelope
+): ReadonlyMap<string, readonly WaNewsletterPollVoter[]> {
+    const root = (
+        envelope as {
+            readonly voter_list?: { readonly votes?: readonly RawVotesGroup[] }
+        }
+    ).voter_list
+    const votes = root?.votes ?? []
+    const map = new Map<string, readonly WaNewsletterPollVoter[]>()
+    for (const group of votes) {
+        if (!group.vote_hash) continue
+        const voters: WaNewsletterPollVoter[] = []
+        for (const edge of group.voter_list?.edges ?? []) {
+            const id = edge.node?.id
+            if (!id) continue
+            const time = toNumber(edge.action_time)
+            voters.push({
+                id,
+                time: time !== undefined ? Math.floor(time / 1_000_000) : undefined
+            })
+        }
+        map.set(group.vote_hash, voters)
+    }
+    return map
+}

--- a/src/client/newsletter/types.ts
+++ b/src/client/newsletter/types.ts
@@ -1,0 +1,209 @@
+import type { WaMessagePublishResult } from '@message/types'
+import type {
+    WA_NEWSLETTER_VIEW_ROLES,
+    WaNewsletterRole,
+    WaNewsletterStateType
+} from '@protocol/newsletter'
+
+export interface WaNewsletterPicture {
+    readonly url?: string
+    readonly directPath?: string
+    readonly id?: string
+}
+
+export interface WaNewsletterMetadata {
+    readonly jid: string
+    readonly state: WaNewsletterStateType
+    readonly creationTime?: number
+    readonly name?: string
+    readonly nameUpdateTime?: number
+    readonly description?: string
+    readonly descriptionUpdateTime?: number
+    readonly picture?: WaNewsletterPicture
+    readonly preview?: WaNewsletterPicture
+    readonly invite?: string
+    readonly handle?: string
+    readonly subscribersCount?: number
+    readonly verification?: string
+    readonly viewerRole?: WaNewsletterRole
+    readonly mutedAdmin?: boolean
+    readonly mutedFollower?: boolean
+}
+
+export interface WaNewsletterFetchOptions {
+    readonly fetchViewerMetadata?: boolean
+    readonly fetchCreationTime?: boolean
+    readonly fetchFullImage?: boolean
+    readonly fetchWamoSub?: boolean
+    readonly viewRole?: keyof typeof WA_NEWSLETTER_VIEW_ROLES
+}
+
+export interface WaNewsletterDirectorySearchOptions {
+    readonly searchText?: string
+    readonly startCursor?: string
+    readonly limit?: number
+    readonly categories?: readonly string[]
+}
+
+export type WaNewsletterDirectoryView = 'RECOMMENDED' | 'NEW' | 'POPULAR' | 'FEATURED' | 'TRENDING'
+
+export interface WaNewsletterDirectoryListOptions {
+    readonly view: WaNewsletterDirectoryView
+    readonly countryCodes?: readonly string[]
+    readonly categories?: readonly string[]
+    readonly startCursor?: string
+    readonly limit?: number
+}
+
+export interface WaNewsletterRecommendedOptions {
+    readonly limit?: number
+    readonly countryCodes?: readonly string[]
+}
+
+export interface WaNewsletterSimilarOptions {
+    readonly limit?: number
+    readonly countryCodes?: readonly string[]
+}
+
+export interface WaNewsletterFollowersOptions {
+    readonly count?: number
+}
+
+export interface WaNewsletterDirectoryCategoriesPreviewOptions {
+    readonly categories: readonly string[]
+    readonly countryCode?: string
+    readonly perCategoryLimit?: number
+}
+
+export interface WaNewsletterCapabilityExposure {
+    readonly newsletterJid: string
+    readonly capability: string
+}
+
+export interface WaNewsletterCreateInput {
+    readonly name: string
+    readonly description?: string
+    readonly picture?: Uint8Array
+}
+
+export interface WaNewsletterUpdateInput {
+    readonly name?: string
+    readonly description?: string
+    readonly picture?: Uint8Array | null
+    readonly reactionCodesSetting?: string
+}
+
+export interface WaNewsletterMuteInput {
+    readonly newsletterJid: string
+    readonly mute: boolean
+    readonly type?: 'admin' | 'follower'
+}
+
+export interface WaNewsletterAdminInviteInput {
+    readonly newsletterJid: string
+    readonly userJid: string
+}
+
+export interface WaNewsletterAdminInviteResult {
+    readonly inviteId?: string
+    readonly expirationTime?: number
+}
+
+export interface WaNewsletterSendOptions {
+    readonly stanzaId?: string
+}
+
+export type WaNewsletterSendResult = WaMessagePublishResult
+
+export interface WaNewsletterReactInput {
+    readonly newsletterJid: string
+    readonly parentMessageServerId: number
+    readonly reactionCode: string
+    readonly stanzaId?: string
+    readonly revoke?: boolean
+}
+
+export interface WaNewsletterRevokeInput {
+    readonly newsletterJid: string
+    readonly originalMessageId: string
+}
+
+export interface WaNewsletterVotePollInput {
+    readonly newsletterJid: string
+    readonly parentMessageServerId: number
+    readonly votes: readonly Uint8Array[]
+    readonly stanzaId?: string
+    readonly contentType?: string
+}
+
+export interface WaNewsletterViewReceiptInput {
+    readonly newsletterJid: string
+    readonly itemServerIds: readonly number[]
+    readonly stanzaId?: string
+}
+
+export type WaNewsletterMexEnvelope = Readonly<Record<string, unknown>>
+
+export interface WaNewsletterAdminInfo {
+    readonly adminCount?: number
+    readonly adminProfile: WaNewsletterAdminProfile | null
+}
+
+export interface WaNewsletterAdminProfile {
+    readonly id?: string
+    readonly name?: string
+    readonly pictureId?: string
+    readonly pictureDirectPath?: string
+}
+
+export interface WaNewsletterFollower {
+    readonly id: string
+    readonly displayName?: string
+    readonly role?: WaNewsletterRole
+    readonly phoneJid?: string
+    readonly username?: string
+    readonly followTime?: number
+    readonly adminProfile: WaNewsletterAdminProfile | null
+}
+
+export interface WaPageInfo {
+    readonly hasNextPage?: boolean
+    readonly hasPreviousPage?: boolean
+    readonly startCursor?: string
+    readonly endCursor?: string
+}
+
+export interface WaNewsletterFollowersPage {
+    readonly followers: readonly WaNewsletterFollower[]
+    readonly pageInfo?: WaPageInfo
+}
+
+export interface WaNewsletterDirectoryResults {
+    readonly results: readonly WaNewsletterMetadata[]
+    readonly pageInfo?: WaPageInfo
+}
+
+export interface WaNewsletterDirectoryCategoryPreview {
+    readonly category: string
+    readonly categoryTitle?: string
+    readonly newsletters: readonly WaNewsletterMetadata[]
+}
+
+export interface WaNewsletterDehydratedMetadata {
+    readonly jid: string
+    readonly subscribersCount?: number
+    readonly verification?: string
+    readonly reactionCodesSetting?: string
+    readonly wamoSubPlanId?: string
+    readonly wamoSubStatus?: string
+}
+
+export interface WaNewsletterReactionSenders {
+    readonly reactionCode: string
+    readonly senders: readonly { readonly id: string; readonly profileUrl?: string }[]
+}
+
+export interface WaNewsletterPollVoter {
+    readonly id: string
+    readonly time?: number
+}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -209,6 +209,9 @@ export interface WaIncomingMessageEvent extends WaIncomingBaseEvent {
     readonly encryptionType?: string
     readonly isGroupChat: boolean
     readonly isBroadcastChat: boolean
+    readonly isNewsletterChat?: boolean
+    readonly serverId?: number
+    readonly isSender?: boolean
     readonly plaintext?: Uint8Array
     readonly message?: Proto.IMessage
 }
@@ -269,6 +272,27 @@ export interface WaIncomingFailureEvent extends WaIncomingBaseEvent {
 
 export interface WaIncomingUnhandledStanzaEvent extends WaIncomingBaseEvent {
     readonly reason: string
+}
+
+export interface WaIncomingNewsletterReactionEvent extends WaIncomingBaseEvent {
+    readonly timestampSeconds?: number
+    readonly parentMessageServerId?: number
+    readonly reactionCode?: string
+    readonly revoked: boolean
+}
+
+export type WaNewsletterEventAction =
+    | 'subscribers_count_change'
+    | 'live_updates'
+    | 'membership_revoke'
+    | 'admin_metadata_update'
+    | 'unknown'
+
+export interface WaIncomingNewsletterEvent extends WaIncomingBaseEvent {
+    readonly newsletterJid: string
+    readonly action: WaNewsletterEventAction
+    readonly subType?: string
+    readonly details?: Readonly<Record<string, unknown>>
 }
 
 export type WaGroupEventAction =
@@ -456,6 +480,8 @@ export interface WaClientEventMap {
     readonly message_addon: (event: WaIncomingAddonEvent) => void
     readonly message_protocol: (event: WaIncomingProtocolMessageEvent) => void
     readonly message_receipt: (event: WaIncomingReceiptEvent) => void
+    readonly newsletter_reaction: (event: WaIncomingNewsletterReactionEvent) => void
+    readonly newsletter_event: (event: WaIncomingNewsletterEvent) => void
     readonly presence: (event: WaIncomingPresenceEvent) => void
     readonly chatstate: (event: WaIncomingChatstateEvent) => void
     readonly call: (event: WaIncomingCallEvent) => void

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,42 @@ export type {
     WaPrivacyDisallowedListResult,
     WaPrivacySettings
 } from '@client/coordinators/WaPrivacyCoordinator'
+export type {
+    WaNewsletterAdminInfo,
+    WaNewsletterAdminInviteInput,
+    WaNewsletterAdminInviteResult,
+    WaNewsletterAdminProfile,
+    WaNewsletterCapabilityExposure,
+    WaNewsletterCoordinator,
+    WaNewsletterCreateInput,
+    WaNewsletterDehydratedMetadata,
+    WaNewsletterDirectoryCategoriesPreviewOptions,
+    WaNewsletterDirectoryCategoryPreview,
+    WaNewsletterDirectoryListOptions,
+    WaNewsletterDirectoryResults,
+    WaNewsletterDirectorySearchOptions,
+    WaNewsletterDirectoryView,
+    WaNewsletterFetchOptions,
+    WaNewsletterFollower,
+    WaNewsletterFollowersOptions,
+    WaNewsletterFollowersPage,
+    WaNewsletterMetadata,
+    WaNewsletterMexEnvelope,
+    WaNewsletterMuteInput,
+    WaNewsletterPicture,
+    WaNewsletterPollVoter,
+    WaNewsletterReactInput,
+    WaNewsletterReactionSenders,
+    WaNewsletterRecommendedOptions,
+    WaNewsletterRevokeInput,
+    WaNewsletterSendOptions,
+    WaNewsletterSendResult,
+    WaNewsletterSimilarOptions,
+    WaNewsletterUpdateInput,
+    WaNewsletterViewReceiptInput,
+    WaNewsletterVotePollInput,
+    WaPageInfo
+} from '@client/coordinators/WaNewsletterCoordinator'
 export type { WaAuthCredentials } from '@auth/types'
 export { ConsoleLogger } from '@infra/log/ConsoleLogger'
 export { PinoLogger, createPinoLogger } from '@infra/log/PinoLogger'

--- a/src/media/__tests__/media.test.ts
+++ b/src/media/__tests__/media.test.ts
@@ -447,7 +447,7 @@ test('media message builder supports text passthrough and conn caching', async (
         },
         'hello'
     )
-    assert.equal(asMessage.conversation, 'hello')
+    assert.equal(asMessage.message.conversation, 'hello')
 
     const fetched = await getMediaConn(
         {
@@ -504,7 +504,7 @@ test('media message builder uploads ptv bytes and maps upload response fields', 
         readonly contentLength?: number
     }[] = []
 
-    const message = await buildMediaMessageContent(
+    const { message } = await buildMediaMessageContent(
         {
             logger,
             mediaTransfer: {
@@ -559,7 +559,7 @@ test('media message builder continues probe extraction when thumbnail generation
     }
     const encoder = new TextEncoder()
 
-    const message = await buildMediaMessageContent(
+    const { message } = await buildMediaMessageContent(
         {
             logger,
             mediaTransfer: {
@@ -606,7 +606,7 @@ test('media message builder fills only missing probe fields', async () => {
     const logger = createLogger()
     const encoder = new TextEncoder()
 
-    const message = await buildMediaMessageContent(
+    const { message } = await buildMediaMessageContent(
         {
             logger,
             mediaTransfer: {
@@ -650,7 +650,7 @@ test('media message builder reuses streamed media across processor steps', async
     const encoder = new TextEncoder()
     const calls: Array<{ readonly step: string; readonly isStream: boolean }> = []
 
-    const message = await buildMediaMessageContent(
+    const { message } = await buildMediaMessageContent(
         {
             logger,
             mediaTransfer: {
@@ -713,7 +713,7 @@ test('media message builder supports file path input for upload and processing',
     await writeFile(filePath, new Uint8Array([1, 2, 3, 4]))
 
     try {
-        const message = await buildMediaMessageContent(
+        const { message } = await buildMediaMessageContent(
             {
                 logger,
                 mediaTransfer: {

--- a/src/media/constants.ts
+++ b/src/media/constants.ts
@@ -26,3 +26,29 @@ export const MEDIA_UPLOAD_PATHS: Readonly<
     ptt: '/mms/ptt',
     ptv: '/mms/video'
 })
+
+export type NewsletterMediaKind =
+    | 'image'
+    | 'video'
+    | 'audio'
+    | 'document'
+    | 'sticker'
+    | 'sticker-pack'
+    | 'gif'
+    | 'ptt'
+    | 'ptv'
+    | 'thumbnail-link'
+
+export const NEWSLETTER_MEDIA_UPLOAD_PATHS: Readonly<Record<NewsletterMediaKind, string>> =
+    Object.freeze({
+        image: '/newsletter/newsletter-image',
+        video: '/newsletter/newsletter-video',
+        audio: '/newsletter/newsletter-audio',
+        document: '/newsletter/newsletter-document',
+        sticker: '/newsletter/newsletter-sticker',
+        'sticker-pack': '/newsletter/newsletter-sticker-pack',
+        gif: '/newsletter/newsletter-gif',
+        ptt: '/newsletter/newsletter-ptt',
+        ptv: '/newsletter/newsletter-ptv',
+        'thumbnail-link': '/newsletter/newsletter-thumbnail-link'
+    })

--- a/src/message/__tests__/message.test.ts
+++ b/src/message/__tests__/message.test.ts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
+import type {
+    WaIncomingMessageEvent,
+    WaIncomingNewsletterReactionEvent,
+    WaIncomingUnhandledStanzaEvent
+} from '@client/types'
+import { createNoopLogger } from '@infra/log/types'
 import {
     describeAckNode,
     isAckOrReceiptNode,
@@ -17,6 +23,7 @@ import {
 } from '@message/content'
 import { unwrapDeviceSentMessage, wrapDeviceSentMessage } from '@message/device-sent'
 import { computeDeviceKeyHash, injectDeviceListMetadata } from '@message/icdc'
+import { processIncomingNewsletterMessage } from '@message/newsletter'
 import { unpadPkcs7, writeRandomPadMax16 } from '@message/padding'
 import { computePhashV2 } from '@message/phash'
 import { buildReportingTokenArtifacts } from '@message/reporting-token'
@@ -26,6 +33,7 @@ import {
     ensureMessageSecret,
     WA_USE_CASE_SECRET_MODIFICATION_TYPES
 } from '@message/use-case-secret'
+import { proto } from '@proto'
 
 test('ack helpers classify receipt and retryability correctly', () => {
     const ackNode = { tag: 'ack', attrs: { id: '1', type: 'error', code: '500' } }
@@ -386,4 +394,185 @@ test('injectDeviceListMetadata sets sender and recipient fields', () => {
 
     const unchanged = injectDeviceListMetadata(msg, null, null)
     assert.equal(unchanged, msg)
+})
+
+const NEWSLETTER_LOGGER = createNoopLogger()
+
+test('processIncomingNewsletterMessage decodes plaintext message and emits event', () => {
+    const plaintextBytes = proto.Message.encode({ conversation: 'hello channel' }).finish()
+    const node = {
+        tag: 'message',
+        attrs: {
+            id: 'STANZA1',
+            from: '120363025343298869@newsletter',
+            type: 'text',
+            t: '1700000000',
+            server_id: '12345',
+            is_sender: 'true'
+        },
+        content: [
+            {
+                tag: 'plaintext',
+                attrs: {},
+                content: plaintextBytes
+            }
+        ]
+    }
+
+    let emitted: WaIncomingMessageEvent | null = null
+    let unhandled: WaIncomingUnhandledStanzaEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitIncomingMessage: (event) => {
+            emitted = event
+        },
+        emitUnhandledStanza: (event) => {
+            unhandled = event
+        }
+    })
+
+    assert.equal(unhandled, null)
+    assert.ok(emitted)
+    const event = emitted as unknown as WaIncomingMessageEvent
+    assert.equal(event.chatJid, '120363025343298869@newsletter')
+    assert.equal(event.senderJid, '120363025343298869@newsletter')
+    assert.equal(event.encryptionType, 'plaintext')
+    assert.equal(event.isNewsletterChat, true)
+    assert.equal(event.isGroupChat, false)
+    assert.equal(event.isBroadcastChat, false)
+    assert.equal(event.timestampSeconds, 1700000000)
+    assert.equal(event.serverId, 12345)
+    assert.equal(event.isSender, true)
+    assert.equal(event.message?.conversation, 'hello channel')
+})
+
+test('processIncomingNewsletterMessage emits unhandled when plaintext is missing', () => {
+    const node = {
+        tag: 'message',
+        attrs: {
+            id: 'STANZA2',
+            from: '120363025343298869@newsletter',
+            type: 'text'
+        },
+        content: []
+    }
+
+    let emitted = 0
+    let unhandled: WaIncomingUnhandledStanzaEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitIncomingMessage: () => {
+            emitted += 1
+        },
+        emitUnhandledStanza: (event) => {
+            unhandled = event
+        }
+    })
+
+    assert.equal(emitted, 0)
+    assert.ok(unhandled)
+    assert.equal(
+        (unhandled as unknown as WaIncomingUnhandledStanzaEvent).reason,
+        'newsletter.missing_plaintext'
+    )
+})
+
+test('processIncomingNewsletterMessage emits reaction event with parent server_id', () => {
+    const node = {
+        tag: 'message',
+        attrs: {
+            id: 'REACT1',
+            from: '120363025343298869@newsletter',
+            type: 'reaction',
+            server_id: '42',
+            t: '1700000000'
+        },
+        content: [
+            {
+                tag: 'reaction',
+                attrs: { code: '1f44d' }
+            }
+        ]
+    }
+
+    let reactionEvent: WaIncomingNewsletterReactionEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterReaction: (event) => {
+            reactionEvent = event
+        }
+    })
+
+    assert.ok(reactionEvent)
+    const event = reactionEvent as unknown as WaIncomingNewsletterReactionEvent
+    assert.equal(event.parentMessageServerId, 42)
+    assert.equal(event.reactionCode, '1f44d')
+    assert.equal(event.revoked, false)
+    assert.equal(event.timestampSeconds, 1700000000)
+})
+
+test('processIncomingNewsletterMessage emits reaction_revoke with revoked flag', () => {
+    const node = {
+        tag: 'message',
+        attrs: {
+            id: 'REACT2',
+            from: '120363025343298869@newsletter',
+            type: 'reaction_revoke',
+            server_id: '42'
+        },
+        content: [
+            {
+                tag: 'reaction',
+                attrs: { code: '' }
+            }
+        ]
+    }
+
+    let reactionEvent: WaIncomingNewsletterReactionEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterReaction: (event) => {
+            reactionEvent = event
+        }
+    })
+
+    assert.ok(reactionEvent)
+    assert.equal((reactionEvent as unknown as WaIncomingNewsletterReactionEvent).revoked, true)
+})
+
+test('processIncomingNewsletterMessage emits unhandled on decode failure', () => {
+    const node = {
+        tag: 'message',
+        attrs: {
+            id: 'STANZA3',
+            from: '120363025343298869@newsletter',
+            type: 'text'
+        },
+        content: [
+            {
+                tag: 'plaintext',
+                attrs: {},
+                content: new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff])
+            }
+        ]
+    }
+
+    let emitted = 0
+    let unhandled: WaIncomingUnhandledStanzaEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitIncomingMessage: () => {
+            emitted += 1
+        },
+        emitUnhandledStanza: (event) => {
+            unhandled = event
+        }
+    })
+
+    assert.equal(emitted, 0)
+    assert.ok(unhandled)
+    assert.equal(
+        (unhandled as unknown as WaIncomingUnhandledStanzaEvent).reason,
+        'newsletter.decode_failed'
+    )
 })

--- a/src/message/incoming.ts
+++ b/src/message/incoming.ts
@@ -1,10 +1,20 @@
-import type { WaIncomingMessageEvent, WaIncomingUnhandledStanzaEvent } from '@client/types'
+import type {
+    WaIncomingMessageEvent,
+    WaIncomingNewsletterReactionEvent,
+    WaIncomingUnhandledStanzaEvent
+} from '@client/types'
 import type { Logger } from '@infra/log/types'
 import { unwrapDeviceSentMessage } from '@message/device-sent'
+import { processIncomingNewsletterMessage } from '@message/newsletter'
 import { unpadPkcs7 } from '@message/padding'
 import { proto } from '@proto'
 import { WA_MESSAGE_TAGS, WA_MESSAGE_TYPES } from '@protocol/constants'
-import { isBroadcastJid, isGroupJid, parseSignalAddressFromJid } from '@protocol/jid'
+import {
+    isBroadcastJid,
+    isGroupJid,
+    isNewsletterJid,
+    parseSignalAddressFromJid
+} from '@protocol/jid'
 import type { WaRetryDecryptFailureContext } from '@retry/types'
 import type { SenderKeyManager } from '@signal/group/SenderKeyManager'
 import type { SignalProtocol } from '@signal/session/SignalProtocol'
@@ -25,6 +35,7 @@ interface WaIncomingMessageAckHandlerOptions {
         error: unknown
     ) => Promise<boolean>
     readonly emitIncomingMessage?: (event: WaIncomingMessageEvent) => void
+    readonly emitNewsletterReaction?: (event: WaIncomingNewsletterReactionEvent) => void
     readonly emitUnhandledStanza?: (event: WaIncomingUnhandledStanzaEvent) => void
 }
 
@@ -284,6 +295,11 @@ export async function handleIncomingMessageAck(
         return false
     }
 
+    const from = node.attrs.from
+    if (from && isNewsletterJid(from)) {
+        return handleIncomingNewsletterMessage(node, options)
+    }
+
     let shouldSendStandardReceipt = true
     const nodeContent = node.content
     if (Array.isArray(nodeContent) && nodeContent.length > 0) {
@@ -377,7 +393,6 @@ export async function handleIncomingMessageAck(
     }
 
     const id = node.attrs.id
-    const from = node.attrs.from
     if (!id || !from) {
         options.logger.warn('incoming message missing required attrs for ack/receipt', {
             hasId: Boolean(id),
@@ -422,5 +437,42 @@ export async function handleIncomingMessageAck(
         participant: receiptNode.attrs.participant
     })
     await options.sendNode(receiptNode)
+    return true
+}
+
+async function handleIncomingNewsletterMessage(
+    node: BinaryNode,
+    options: WaIncomingMessageAckHandlerOptions
+): Promise<boolean> {
+    processIncomingNewsletterMessage(node, {
+        logger: options.logger,
+        emitIncomingMessage: options.emitIncomingMessage,
+        emitNewsletterReaction: options.emitNewsletterReaction,
+        emitUnhandledStanza: options.emitUnhandledStanza
+    })
+
+    const id = node.attrs.id
+    const from = node.attrs.from
+    if (!id || !from) {
+        options.logger.warn('incoming newsletter message missing required attrs for ack', {
+            hasId: Boolean(id),
+            hasFrom: Boolean(from),
+            type: node.attrs.type
+        })
+        return true
+    }
+
+    const ackNode = buildAckNode({
+        kind: 'message',
+        node,
+        id,
+        to: from
+    })
+    options.logger.debug('sending inbound newsletter message ack', {
+        id,
+        to: from,
+        type: ackNode.attrs.type
+    })
+    await options.sendNode(ackNode)
     return true
 }

--- a/src/message/newsletter.ts
+++ b/src/message/newsletter.ts
@@ -1,0 +1,115 @@
+import type {
+    WaIncomingMessageEvent,
+    WaIncomingNewsletterReactionEvent,
+    WaIncomingUnhandledStanzaEvent
+} from '@client/types'
+import type { Logger } from '@infra/log/types'
+import { proto } from '@proto'
+import { WA_NODE_TAGS } from '@protocol/constants'
+import { decodeNodeContentBase64OrBytes, findNodeChild } from '@transport/node/helpers'
+import type { BinaryNode } from '@transport/types'
+import { parseOptionalInt, toError } from '@util/primitives'
+
+interface ProcessNewsletterMessageOptions {
+    readonly logger: Logger
+    readonly emitIncomingMessage?: (event: WaIncomingMessageEvent) => void
+    readonly emitNewsletterReaction?: (event: WaIncomingNewsletterReactionEvent) => void
+    readonly emitUnhandledStanza?: (event: WaIncomingUnhandledStanzaEvent) => void
+}
+
+export function processIncomingNewsletterMessage(
+    node: BinaryNode,
+    options: ProcessNewsletterMessageOptions
+): void {
+    const chatJid = node.attrs.from
+    const messageType = node.attrs.type
+
+    if (messageType === 'reaction') {
+        emitReactionEvent(node, options, false)
+        return
+    }
+    if (messageType === 'reaction_revoke') {
+        emitReactionEvent(node, options, true)
+        return
+    }
+
+    const plaintextNode = findNodeChild(node, WA_NODE_TAGS.PLAINTEXT)
+    if (!plaintextNode) {
+        options.emitUnhandledStanza?.({
+            rawNode: node,
+            stanzaId: node.attrs.id,
+            chatJid,
+            stanzaType: messageType,
+            reason: 'newsletter.missing_plaintext'
+        })
+        return
+    }
+
+    let plaintext: Uint8Array
+    let message: proto.IMessage
+    try {
+        plaintext = decodeNodeContentBase64OrBytes(plaintextNode.content, 'newsletter.plaintext')
+        message = proto.Message.decode(plaintext)
+    } catch (error) {
+        options.logger.warn('failed to decode newsletter plaintext message', {
+            id: node.attrs.id,
+            from: chatJid,
+            type: messageType,
+            message: toError(error).message
+        })
+        options.emitUnhandledStanza?.({
+            rawNode: node,
+            stanzaId: node.attrs.id,
+            chatJid,
+            stanzaType: messageType,
+            reason: 'newsletter.decode_failed'
+        })
+        return
+    }
+
+    options.emitIncomingMessage?.({
+        rawNode: node,
+        stanzaId: node.attrs.id,
+        chatJid,
+        stanzaType: messageType,
+        timestampSeconds: parseOptionalInt(node.attrs.t),
+        senderJid: chatJid,
+        encryptionType: 'plaintext',
+        isGroupChat: false,
+        isBroadcastChat: false,
+        isNewsletterChat: true,
+        serverId: parseOptionalInt(node.attrs.server_id),
+        isSender: node.attrs.is_sender === 'true',
+        plaintext,
+        message
+    })
+}
+
+function emitReactionEvent(
+    node: BinaryNode,
+    options: ProcessNewsletterMessageOptions,
+    revoked: boolean
+): void {
+    const chatJid = node.attrs.from
+    const reactionNode = findNodeChild(node, 'reaction')
+    if (!reactionNode) {
+        options.emitUnhandledStanza?.({
+            rawNode: node,
+            stanzaId: node.attrs.id,
+            chatJid,
+            stanzaType: node.attrs.type,
+            reason: 'newsletter.missing_reaction'
+        })
+        return
+    }
+    options.emitNewsletterReaction?.({
+        rawNode: node,
+        stanzaId: node.attrs.id,
+        chatJid,
+        stanzaType: node.attrs.type,
+        timestampSeconds: parseOptionalInt(node.attrs.t),
+        parentMessageServerId: parseOptionalInt(node.attrs.server_id),
+        reactionCode: reactionNode.attrs.code,
+        revoked
+    })
+}

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -24,6 +24,20 @@ export interface WaMessagePublishResult {
     readonly attempts: number
     readonly ackNode: BinaryNode
     readonly ack: WaMessageAckMetadata
+    readonly upload?: WaMessageUploadInfo
+}
+
+export interface WaMessageUploadInfo {
+    readonly url: string
+    readonly directPath: string
+    readonly fileSha256: Uint8Array
+    readonly fileLength: number
+    readonly metadataUrl?: string
+}
+
+export interface WaMessageBuildResult {
+    readonly message: Proto.IMessage
+    readonly upload?: WaMessageUploadInfo
 }
 
 type MediaInput = Uint8Array | ArrayBuffer | Readable | string

--- a/src/protocol/__tests__/protocol.test.ts
+++ b/src/protocol/__tests__/protocol.test.ts
@@ -26,6 +26,7 @@ import {
     isHostedDeviceId,
     isHostedDeviceJid,
     isHostedServer,
+    isNewsletterJid,
     normalizeDeviceJid,
     normalizeRecipientJid,
     parsePhoneJid,
@@ -58,6 +59,9 @@ test('jid type detection and device handling', () => {
     assert.equal(isGroupJid('123@g.us'), true)
     assert.equal(isBroadcastJid('abc@broadcast'), true)
     assert.equal(isGroupOrBroadcastJid('abc@broadcast'), true)
+    assert.equal(isNewsletterJid('120363025343298869@newsletter'), true)
+    assert.equal(isNewsletterJid('120363025343298869@s.whatsapp.net'), false)
+    assert.equal(isNewsletterJid('@newsletter'), false)
 
     assert.deepEqual(parseSignalAddressFromJid('5511:3@s.whatsapp.net'), {
         user: '5511',

--- a/src/protocol/abprops.ts
+++ b/src/protocol/abprops.ts
@@ -40,6 +40,17 @@ export const AB_PROP_CONFIGS = Object.freeze({
     enable_mention_everyone_syncd_sender: prop(24244, 'bool', false),
     username_contact_syncd_support_enable: prop(17614, 'bool', false),
 
+    // --- newsletter ToS / NUX notice ids ---
+    newsletter_tos_notice_id: prop(3810, 'string', '20601216'),
+    newsletter_tos_notice_id_smb_web: prop(5597, 'string', '20601216'),
+    newsletter_creation_tos_id: prop(3834, 'string', '20601217'),
+    newsletter_creation_tos_id_smb_web: prop(5598, 'string', '20601217'),
+    newsletter_admin_invite_tos_id: prop(6498, 'string', '20610101'),
+    newsletter_admin_invite_tos_id_smb_web: prop(6536, 'string', '20610104'),
+    newsletter_creation_nux_id: prop(3835, 'string', '20601218'),
+    newsletter_nux_notice_id: prop(15255, 'string', '20610210'),
+    newsletter_admin_invite_nux_id: prop(15256, 'string', '20610220'),
+
     // --- message sending / encryption ---
     after_read_sending_enabled: prop(7293, 'bool', false),
     after_read_fallback_duration: prop(7294, 'int', 86_400),

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -44,6 +44,7 @@ export {
 } from '@protocol/dirty'
 export {
     WA_GROUP_NOTIFICATION_TAGS,
+    WA_NEWSLETTER_NOTIFICATION_TAGS,
     WA_NOTIFICATION_TYPES,
     WA_REGISTRATION_NOTIFICATION_TAGS
 } from '@protocol/notification'
@@ -80,3 +81,21 @@ export {
 export type { AbPropConfigEntry, AbPropName, AbPropType, AbPropValue } from '@protocol/abprops'
 export { WA_GROUP_PARTICIPANT_TYPES, type WaGroupSetting } from '@protocol/group'
 export { WA_USYNC_CONTEXTS, WA_USYNC_DEFAULTS, WA_USYNC_MODES } from '@protocol/usync'
+export {
+    WA_NEWSLETTER_FETCH_KEY_TYPES,
+    WA_NEWSLETTER_MUTE_TYPES,
+    WA_NEWSLETTER_MUTE_VALUES,
+    WA_NEWSLETTER_PICTURE_TYPES,
+    WA_NEWSLETTER_RECEIVE_TYPES,
+    WA_NEWSLETTER_ROLES,
+    WA_NEWSLETTER_SEND_TYPES,
+    WA_NEWSLETTER_STATE_TYPES,
+    WA_NEWSLETTER_VERIFICATION_STATES,
+    WA_NEWSLETTER_VIEW_ROLES
+} from '@protocol/newsletter'
+export type {
+    WaNewsletterReceiveType,
+    WaNewsletterRole,
+    WaNewsletterSendType,
+    WaNewsletterStateType
+} from '@protocol/newsletter'

--- a/src/protocol/defaults.ts
+++ b/src/protocol/defaults.ts
@@ -10,6 +10,7 @@ export const WA_DEFAULTS = Object.freeze({
     HOSTED_DEVICE_ID: 99,
     MSGR_SERVER: 'msgr',
     INTEROP_SERVER: 'interop',
+    NEWSLETTER_SERVER: 'newsletter',
     DEVICE_BROWSER: WA_BROWSERS.FIREFOX,
     DEVICE_PLATFORM: getWaCompanionPlatformId(WA_BROWSERS.FIREFOX),
     CHAT_SOCKET_URLS: ['wss://web.whatsapp.com/ws/chat', 'wss://web.whatsapp.com:5222/ws/chat'],

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -8,6 +8,7 @@ export {
     isHostedDeviceJid,
     isHostedServer,
     isGroupJid,
+    isNewsletterJid,
     normalizeDeviceJid,
     normalizeRecipientJid,
     parsePhoneJid,

--- a/src/protocol/jid.ts
+++ b/src/protocol/jid.ts
@@ -9,7 +9,8 @@ const KNOWN_SERVERS: Record<string, string> = {
     [WA_DEFAULTS.HOSTED_SERVER]: WA_DEFAULTS.HOSTED_SERVER,
     [WA_DEFAULTS.HOSTED_LID_SERVER]: WA_DEFAULTS.HOSTED_LID_SERVER,
     [WA_DEFAULTS.MSGR_SERVER]: WA_DEFAULTS.MSGR_SERVER,
-    [WA_DEFAULTS.INTEROP_SERVER]: WA_DEFAULTS.INTEROP_SERVER
+    [WA_DEFAULTS.INTEROP_SERVER]: WA_DEFAULTS.INTEROP_SERVER,
+    [WA_DEFAULTS.NEWSLETTER_SERVER]: WA_DEFAULTS.NEWSLETTER_SERVER
 }
 
 /**
@@ -78,6 +79,10 @@ export function isGroupJid(jid: string): boolean {
 
 export function isBroadcastJid(jid: string): boolean {
     return isJidType(jid, WA_DEFAULTS.BROADCAST_SERVER)
+}
+
+export function isNewsletterJid(jid: string): boolean {
+    return isJidType(jid, WA_DEFAULTS.NEWSLETTER_SERVER)
 }
 
 export function isGroupOrBroadcastJid(jid: string): boolean {

--- a/src/protocol/message.ts
+++ b/src/protocol/message.ts
@@ -40,6 +40,7 @@ export const WA_STANZA_MSG_TYPES = Object.freeze({
 export const WA_EDIT_ATTRS = Object.freeze({
     MESSAGE_EDIT: '1',
     PIN_IN_CHAT: '2',
+    NEWSLETTER_EDIT: '3',
     SENDER_REVOKE: '7',
     ADMIN_REVOKE: '8'
 } as const)

--- a/src/protocol/newsletter.ts
+++ b/src/protocol/newsletter.ts
@@ -1,0 +1,79 @@
+export const WA_NEWSLETTER_ROLES = Object.freeze({
+    SUBSCRIBER: 'SUBSCRIBER',
+    GUEST: 'GUEST',
+    ADMIN: 'ADMIN',
+    OWNER: 'OWNER'
+} as const)
+
+export type WaNewsletterRole = (typeof WA_NEWSLETTER_ROLES)[keyof typeof WA_NEWSLETTER_ROLES]
+
+export const WA_NEWSLETTER_STATE_TYPES = Object.freeze({
+    ACTIVE: 'ACTIVE',
+    SUSPENDED: 'SUSPENDED',
+    GEOSUSPENDED: 'GEOSUSPENDED'
+} as const)
+
+export type WaNewsletterStateType =
+    (typeof WA_NEWSLETTER_STATE_TYPES)[keyof typeof WA_NEWSLETTER_STATE_TYPES]
+
+export const WA_NEWSLETTER_PICTURE_TYPES = Object.freeze({
+    IMAGE: 'IMAGE',
+    PREVIEW: 'PREVIEW'
+} as const)
+
+export const WA_NEWSLETTER_FETCH_KEY_TYPES = Object.freeze({
+    JID: 'JID',
+    INVITE: 'INVITE'
+} as const)
+
+export const WA_NEWSLETTER_VIEW_ROLES = Object.freeze({
+    GUEST: 'GUEST',
+    SUBSCRIBER: 'SUBSCRIBER',
+    ADMIN: 'ADMIN',
+    OWNER: 'OWNER'
+} as const)
+
+export const WA_NEWSLETTER_MUTE_TYPES = Object.freeze({
+    ADMIN_ACTIVITY: 'MUTE_ADMIN_ACTIVITY',
+    FOLLOWER_ACTIVITY: 'MUTE_FOLLOWER_ACTIVITY'
+} as const)
+
+export const WA_NEWSLETTER_MUTE_VALUES = Object.freeze({
+    ON: 'ON',
+    OFF: 'OFF'
+} as const)
+
+export const WA_NEWSLETTER_SEND_TYPES = Object.freeze({
+    TEXT: 'text',
+    MEDIA: 'media',
+    REACTION: 'reaction',
+    REVOKE: 'revoke'
+} as const)
+
+export type WaNewsletterSendType =
+    (typeof WA_NEWSLETTER_SEND_TYPES)[keyof typeof WA_NEWSLETTER_SEND_TYPES]
+
+export const WA_NEWSLETTER_RECEIVE_TYPES = Object.freeze({
+    TEXT: 'NewsletterText',
+    MEDIA: 'NewsletterMedia',
+    REACTION: 'NewsletterReaction',
+    REACTION_REVOKE: 'NewsletterReactionRevoke',
+    REVOKE: 'NewsletterRevoke',
+    EDIT: 'NewsletterEdit',
+    POLL_CREATION: 'NewsletterPollCreation',
+    POLL_VOTE: 'NewsletterPollVote',
+    POLL_RESULT_SNAPSHOT: 'NewsletterPollResultSnapshot',
+    QUIZ_CREATION: 'NewsletterQuizCreation',
+    QUESTION: 'NewsletterQuestion',
+    QUESTION_REPLY: 'NewsletterQuestionReply',
+    QUESTION_RESPONSE: 'NewsletterQuestionResponse',
+    WAMO_EMPTY: 'NewsletterWAMOEmpty'
+} as const)
+
+export type WaNewsletterReceiveType =
+    (typeof WA_NEWSLETTER_RECEIVE_TYPES)[keyof typeof WA_NEWSLETTER_RECEIVE_TYPES]
+
+export const WA_NEWSLETTER_VERIFICATION_STATES = Object.freeze({
+    VERIFIED: 'VERIFIED',
+    UNVERIFIED: 'UNVERIFIED'
+} as const)

--- a/src/protocol/nodes.ts
+++ b/src/protocol/nodes.ts
@@ -62,7 +62,8 @@ export const WA_NODE_TAGS = Object.freeze({
     EPHEMERAL: 'ephemeral',
     MEMBERSHIP_APPROVAL_MODE: 'membership_approval_mode',
     GROUP_JOIN: 'group_join',
-    ABPROPS: 'abprops'
+    ABPROPS: 'abprops',
+    PLAINTEXT: 'plaintext'
 } as const)
 
 export const WA_IQ_TYPES = Object.freeze({
@@ -86,6 +87,7 @@ export const WA_XMLNS = Object.freeze({
     STATUS: 'status',
     GROUPS: 'w:g2',
     NEWSLETTER: 'newsletter',
+    TOS: 'tos',
     XMPP_PING: 'urn:xmpp:ping',
     WHATSAPP_PING: 'w:p',
     ABPROPS: 'abt',

--- a/src/protocol/notification.ts
+++ b/src/protocol/notification.ts
@@ -3,7 +3,12 @@ export const WA_NOTIFICATION_TYPES = Object.freeze({
     ENCRYPT: 'encrypt',
     DEVICES: 'devices',
     SERVER: 'server',
-    REGISTRATION: 'registration'
+    REGISTRATION: 'registration',
+    NEWSLETTER: 'newsletter'
+} as const)
+
+export const WA_NEWSLETTER_NOTIFICATION_TAGS = Object.freeze({
+    LIVE_UPDATES: 'live_updates'
 } as const)
 
 export const WA_REGISTRATION_NOTIFICATION_TAGS = Object.freeze({

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -1140,3 +1140,164 @@ test('email builders produce account namespace iq stanzas', () => {
     assert.equal(confirmWithCtx.content[0].content[0].tag, WA_EMAIL_TAGS.CONTEXT)
     assert.equal(confirmWithCtx.content[0].content[0].content, 'settings')
 })
+
+test('buildNewsletterMessageNode covers every message kind variant', async () => {
+    const { buildNewsletterMessageNode, buildNewsletterViewReceiptNode } =
+        await import('@transport/node/builders/newsletter')
+    const to = '120363025343298869@newsletter'
+
+    const text = buildNewsletterMessageNode({
+        kind: 'text',
+        to,
+        id: 'S1',
+        plaintext: new Uint8Array([1, 2, 3])
+    })
+    assert.equal(text.attrs.type, 'text')
+    assert.equal(text.attrs.id, 'S1')
+    assert.ok(Array.isArray(text.content))
+    assert.equal(text.content[0].tag, WA_NODE_TAGS.PLAINTEXT)
+    assert.deepEqual(text.content[0].content, new Uint8Array([1, 2, 3]))
+
+    const media = buildNewsletterMessageNode({
+        kind: 'media',
+        to,
+        id: 'S2',
+        plaintext: new Uint8Array([9]),
+        mediaType: 'image'
+    })
+    assert.equal(media.attrs.type, 'media')
+    assert.ok(Array.isArray(media.content))
+    assert.equal(media.content[0].attrs.mediatype, 'image')
+
+    const editText = buildNewsletterMessageNode({
+        kind: 'edit-text',
+        to,
+        parentMessageId: 'PARENT1',
+        plaintext: new Uint8Array([1])
+    })
+    assert.equal(editText.attrs.id, 'PARENT1')
+    assert.equal(editText.attrs.edit, '3')
+    assert.equal(editText.attrs.type, 'text')
+
+    const editMedia = buildNewsletterMessageNode({
+        kind: 'edit-media',
+        to,
+        parentMessageId: 'PARENT2',
+        plaintext: new Uint8Array([2]),
+        mediaType: 'image'
+    })
+    assert.equal(editMedia.attrs.edit, '3')
+    assert.equal(editMedia.attrs.type, 'media')
+
+    const reaction = buildNewsletterMessageNode({
+        kind: 'reaction',
+        to,
+        id: 'S3',
+        parentMessageServerId: 99,
+        reactionCode: '1f44d'
+    })
+    assert.equal(reaction.attrs.type, 'reaction')
+    assert.equal(reaction.attrs.server_id, '99')
+    assert.ok(Array.isArray(reaction.content))
+    assert.equal(reaction.content[0].tag, 'reaction')
+    assert.equal(reaction.content[0].attrs.code, '1f44d')
+
+    const revoke = buildNewsletterMessageNode({
+        kind: 'revoke',
+        to,
+        originalMessageId: 'ORIG-MSG-1'
+    })
+    assert.equal(revoke.attrs.id, 'ORIG-MSG-1')
+    assert.equal(revoke.attrs.type, 'text')
+    assert.equal(revoke.attrs.edit, '8')
+    assert.equal(revoke.attrs.server_id, undefined)
+    assert.ok(Array.isArray(revoke.content))
+    assert.equal(revoke.content[0].tag, 'plaintext')
+    assert.equal(revoke.content[0].content, undefined)
+
+    const pollCreate = buildNewsletterMessageNode({
+        kind: 'poll-creation',
+        to,
+        id: 'PC1',
+        plaintext: new Uint8Array([3])
+    })
+    assert.equal(pollCreate.attrs.type, 'poll')
+    assert.ok(Array.isArray(pollCreate.content))
+    assert.equal(pollCreate.content[0].tag, 'plaintext')
+    assert.equal(pollCreate.content[1].attrs.polltype, 'creation')
+
+    const pollVote = buildNewsletterMessageNode({
+        kind: 'poll-vote',
+        to,
+        id: 'PV1',
+        parentMessageServerId: 99,
+        votes: [new Uint8Array([1, 1]), new Uint8Array([2, 2])]
+    })
+    assert.equal(pollVote.attrs.server_id, '99')
+    assert.ok(Array.isArray(pollVote.content))
+    assert.equal(pollVote.content[0].tag, 'votes')
+    assert.ok(Array.isArray(pollVote.content[0].content))
+    assert.equal(pollVote.content[0].content.length, 2)
+    assert.equal(pollVote.content[1].tag, 'meta')
+    assert.equal(pollVote.content[1].attrs.polltype, 'vote')
+
+    assert.throws(
+        () =>
+            buildNewsletterMessageNode({
+                kind: 'poll-vote',
+                to,
+                id: 'PVERR',
+                parentMessageServerId: 1,
+                votes: []
+            }),
+        /at least one vote/
+    )
+
+    const receipt = buildNewsletterViewReceiptNode({
+        to,
+        id: 'R1',
+        itemServerIds: [10, 20]
+    })
+    assert.equal(receipt.attrs.type, 'view')
+    assert.ok(Array.isArray(receipt.content))
+    assert.equal(receipt.content[0].tag, 'list')
+    assert.ok(Array.isArray(receipt.content[0].content))
+    assert.equal(receipt.content[0].content.length, 2)
+    assert.equal(receipt.content[0].content[0].attrs.server_id, '10')
+    assert.throws(
+        () =>
+            buildNewsletterViewReceiptNode({
+                to,
+                id: 'R2',
+                itemServerIds: []
+            }),
+        /at least one item/
+    )
+})
+
+test('newsletter fetch IQs build the right history/update stanzas', async () => {
+    const { buildNewsletterMessagesIq, buildNewsletterMessageUpdatesIq } =
+        await import('@transport/node/builders/newsletter')
+
+    const fetchMessages = buildNewsletterMessagesIq({
+        newsletterJid: '120363025343298869@newsletter',
+        count: 50,
+        before: 1234
+    })
+    assert.equal(fetchMessages.attrs.type, 'get')
+    assert.equal(fetchMessages.attrs.xmlns, 'newsletter')
+    assert.ok(Array.isArray(fetchMessages.content))
+    assert.equal(fetchMessages.content[0].tag, 'messages')
+    assert.equal(fetchMessages.content[0].attrs.jid, '120363025343298869@newsletter')
+    assert.equal(fetchMessages.content[0].attrs.count, '50')
+    assert.equal(fetchMessages.content[0].attrs.before, '1234')
+
+    const fetchUpdates = buildNewsletterMessageUpdatesIq({
+        newsletterJid: '120363025343298869@newsletter',
+        count: 100,
+        since: 1700000000
+    })
+    assert.ok(Array.isArray(fetchUpdates.content))
+    assert.equal(fetchUpdates.content[0].tag, 'message_updates')
+    assert.equal(fetchUpdates.content[0].attrs.since, '1700000000')
+})

--- a/src/transport/node/builders/newsletter.ts
+++ b/src/transport/node/builders/newsletter.ts
@@ -1,0 +1,267 @@
+import { WA_DEFAULTS } from '@protocol/defaults'
+import { WA_EDIT_ATTRS } from '@protocol/message'
+import { WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
+import { buildIqNode } from '@transport/node/query'
+import type { BinaryNode } from '@transport/types'
+
+interface NewsletterMessageBaseInput {
+    readonly to: string
+}
+
+interface NewsletterMessageNewInput extends NewsletterMessageBaseInput {
+    readonly id: string
+}
+
+interface NewsletterMessageEditInput extends NewsletterMessageBaseInput {
+    readonly parentMessageId: string
+}
+
+interface NewsletterMessageReplyInput extends NewsletterMessageNewInput {
+    readonly parentMessageServerId: number
+}
+
+interface NewsletterMessageRevokeInput extends NewsletterMessageBaseInput {
+    readonly originalMessageId: string
+}
+
+export type BuildNewsletterMessageInput =
+    | (NewsletterMessageNewInput & { readonly kind: 'text'; readonly plaintext: Uint8Array })
+    | (NewsletterMessageNewInput & {
+          readonly kind: 'media'
+          readonly plaintext: Uint8Array
+          readonly mediaType: string
+          readonly mediaHandle?: string
+      })
+    | (NewsletterMessageEditInput & {
+          readonly kind: 'edit-text'
+          readonly plaintext: Uint8Array
+      })
+    | (NewsletterMessageEditInput & {
+          readonly kind: 'edit-media'
+          readonly plaintext: Uint8Array
+          readonly mediaType: string
+      })
+    | (NewsletterMessageReplyInput & {
+          readonly kind: 'reaction'
+          readonly reactionCode: string
+      })
+    | (NewsletterMessageReplyInput & { readonly kind: 'reaction-revoke' })
+    | (NewsletterMessageRevokeInput & { readonly kind: 'revoke' })
+    | (NewsletterMessageNewInput & {
+          readonly kind: 'poll-creation'
+          readonly plaintext: Uint8Array
+          readonly contentType?: string
+      })
+    | (NewsletterMessageReplyInput & {
+          readonly kind: 'poll-vote'
+          readonly votes: readonly Uint8Array[]
+          readonly contentType?: string
+      })
+
+function plaintextChild(plaintext: Uint8Array, mediaType?: string): BinaryNode {
+    return {
+        tag: WA_NODE_TAGS.PLAINTEXT,
+        attrs: mediaType ? { mediatype: mediaType } : {},
+        content: plaintext
+    }
+}
+
+function pollMetaChild(polltype: 'creation' | 'vote', contentType?: string): BinaryNode {
+    const attrs: Record<string, string> = { polltype }
+    if (contentType) {
+        attrs.contenttype = contentType
+    }
+    return { tag: 'meta', attrs }
+}
+
+export function buildNewsletterMessageNode(input: BuildNewsletterMessageInput): BinaryNode {
+    const attrs: Record<string, string> = { to: input.to }
+    let content: BinaryNode[] | undefined
+
+    switch (input.kind) {
+        case 'text':
+            attrs.id = input.id
+            attrs.type = 'text'
+            content = [plaintextChild(input.plaintext)]
+            break
+        case 'media':
+            attrs.id = input.id
+            attrs.type = 'media'
+            if (input.mediaHandle) {
+                attrs.media_id = input.mediaHandle
+            }
+            content = [plaintextChild(input.plaintext, input.mediaType)]
+            break
+        case 'edit-text':
+            attrs.id = input.parentMessageId
+            attrs.type = 'text'
+            attrs.edit = WA_EDIT_ATTRS.NEWSLETTER_EDIT
+            content = [plaintextChild(input.plaintext)]
+            break
+        case 'edit-media':
+            attrs.id = input.parentMessageId
+            attrs.type = 'media'
+            attrs.edit = WA_EDIT_ATTRS.NEWSLETTER_EDIT
+            content = [plaintextChild(input.plaintext, input.mediaType)]
+            break
+        case 'reaction':
+            attrs.id = input.id
+            attrs.server_id = String(input.parentMessageServerId)
+            attrs.type = 'reaction'
+            content = [{ tag: 'reaction', attrs: { code: input.reactionCode } }]
+            break
+        case 'reaction-revoke':
+            attrs.id = input.id
+            attrs.server_id = String(input.parentMessageServerId)
+            attrs.type = 'reaction'
+            attrs.edit = WA_EDIT_ATTRS.SENDER_REVOKE
+            content = [{ tag: 'reaction', attrs: {} }]
+            break
+        case 'revoke':
+            attrs.id = input.originalMessageId
+            attrs.type = 'text'
+            attrs.edit = WA_EDIT_ATTRS.ADMIN_REVOKE
+            content = [{ tag: WA_NODE_TAGS.PLAINTEXT, attrs: {} }]
+            break
+        case 'poll-creation':
+            attrs.id = input.id
+            attrs.type = 'poll'
+            content = [
+                plaintextChild(input.plaintext),
+                pollMetaChild('creation', input.contentType)
+            ]
+            break
+        case 'poll-vote':
+            if (input.votes.length === 0) {
+                throw new Error('newsletter poll vote requires at least one vote payload')
+            }
+            attrs.id = input.id
+            attrs.server_id = String(input.parentMessageServerId)
+            attrs.type = 'poll'
+            content = [
+                {
+                    tag: 'votes',
+                    attrs: {},
+                    content: input.votes.map((vote) => ({
+                        tag: 'vote',
+                        attrs: {},
+                        content: vote
+                    }))
+                },
+                pollMetaChild('vote', input.contentType)
+            ]
+            break
+    }
+
+    return content === undefined ? { tag: 'message', attrs } : { tag: 'message', attrs, content }
+}
+
+export interface BuildNewsletterViewReceiptInput {
+    readonly to: string
+    readonly id: string
+    readonly itemServerIds: readonly number[]
+}
+
+export function buildNewsletterViewReceiptNode(input: BuildNewsletterViewReceiptInput): BinaryNode {
+    if (input.itemServerIds.length === 0) {
+        throw new Error('newsletter view receipt requires at least one item')
+    }
+    return {
+        tag: 'receipt',
+        attrs: {
+            to: input.to,
+            id: input.id,
+            type: 'view'
+        },
+        content: [
+            {
+                tag: 'list',
+                attrs: {},
+                content: input.itemServerIds.map((serverId) => ({
+                    tag: 'item',
+                    attrs: { server_id: String(serverId) }
+                }))
+            }
+        ]
+    }
+}
+
+export function buildNewsletterMetadataIq(): BinaryNode {
+    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.NEWSLETTER, [
+        {
+            tag: WA_NODE_TAGS.MY_ADDONS,
+            attrs: {
+                limit: '1'
+            }
+        }
+    ])
+}
+
+export function buildNewsletterSubscribeLiveUpdatesIq(newsletterJid: string): BinaryNode {
+    return buildIqNode('set', newsletterJid, WA_XMLNS.NEWSLETTER, [
+        {
+            tag: 'live_updates',
+            attrs: {}
+        }
+    ])
+}
+
+export interface BuildNewsletterMessagesIqInput {
+    readonly newsletterJid: string
+    readonly count: number
+    readonly before?: number
+    readonly after?: number
+    readonly viewRole?: string
+}
+
+export function buildNewsletterMessagesIq(input: BuildNewsletterMessagesIqInput): BinaryNode {
+    const attrs: Record<string, string> = {
+        type: 'jid',
+        jid: input.newsletterJid,
+        count: String(input.count)
+    }
+    if (input.before !== undefined) {
+        attrs.before = String(input.before)
+    } else if (input.after !== undefined) {
+        attrs.after = String(input.after)
+    }
+    if (input.viewRole) {
+        attrs.view_role = input.viewRole
+    }
+    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.NEWSLETTER, [
+        {
+            tag: 'messages',
+            attrs
+        }
+    ])
+}
+
+export interface BuildNewsletterMessageUpdatesIqInput {
+    readonly newsletterJid: string
+    readonly count: number
+    readonly since?: number
+    readonly before?: number
+    readonly after?: number
+}
+
+export function buildNewsletterMessageUpdatesIq(
+    input: BuildNewsletterMessageUpdatesIqInput
+): BinaryNode {
+    const attrs: Record<string, string> = {
+        count: String(input.count)
+    }
+    if (input.since !== undefined) {
+        attrs.since = String(input.since)
+    }
+    if (input.before !== undefined) {
+        attrs.before = String(input.before)
+    } else if (input.after !== undefined) {
+        attrs.after = String(input.after)
+    }
+    return buildIqNode('get', input.newsletterJid, WA_XMLNS.NEWSLETTER, [
+        {
+            tag: 'message_updates',
+            attrs
+        }
+    ])
+}

--- a/src/transport/node/builders/tos.ts
+++ b/src/transport/node/builders/tos.ts
@@ -1,0 +1,71 @@
+import { WA_DEFAULTS } from '@protocol/defaults'
+import { WA_XMLNS } from '@protocol/nodes'
+import { buildIqNode } from '@transport/node/query'
+import type { BinaryNode } from '@transport/types'
+
+function noticeNodes(noticeIds: readonly string[]): BinaryNode[] {
+    return noticeIds.map((id) => ({
+        tag: 'notice',
+        attrs: { id }
+    }))
+}
+
+export function buildTosQueryIq(noticeIds: readonly string[]): BinaryNode {
+    if (noticeIds.length === 0) {
+        throw new Error('tos query requires at least one notice id')
+    }
+    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.TOS, [
+        {
+            tag: 'request',
+            attrs: {},
+            content: noticeNodes(noticeIds)
+        }
+    ])
+}
+
+export function buildTosUpdateIq(noticeIds: readonly string[]): BinaryNode {
+    if (noticeIds.length === 0) {
+        throw new Error('tos update requires at least one notice id')
+    }
+    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.TOS, [
+        {
+            tag: 'request',
+            attrs: { type: 'session_update' },
+            content: noticeNodes(noticeIds)
+        }
+    ])
+}
+
+export interface WaTosNoticeState {
+    readonly id: string
+    readonly accepted: boolean
+}
+
+export interface WaTosQueryResult {
+    readonly refreshSeconds: number
+    readonly notices: readonly WaTosNoticeState[]
+}
+
+export function parseTosQueryResponse(node: BinaryNode): WaTosQueryResult {
+    const tosNode = Array.isArray(node.content)
+        ? node.content.find((child) => child.tag === 'tos')
+        : undefined
+    if (!tosNode) {
+        throw new Error('tos response missing <tos> node')
+    }
+    const refreshAttr = tosNode.attrs.refresh
+    const refreshSeconds = refreshAttr ? Number.parseInt(refreshAttr, 10) : 0
+    const notices: WaTosNoticeState[] = []
+    if (Array.isArray(tosNode.content)) {
+        for (const child of tosNode.content) {
+            if (child.tag !== 'notice') continue
+            const id = child.attrs.id
+            if (!id) continue
+            notices.push({
+                id,
+                accepted: child.attrs.state !== 'false'
+            })
+        }
+    }
+    return { refreshSeconds, notices }
+}

--- a/src/transport/node/mex/persist-ids.ts
+++ b/src/transport/node/mex/persist-ids.ts
@@ -11,5 +11,125 @@ export const WA_MEX_PERSIST_IDS = Object.freeze({
     WWWCreateUser: Object.freeze({
         docId: '8548056818544135',
         clientDocId: '25777518041400352865446016972'
+    }),
+    NewsletterFetch: Object.freeze({
+        docId: '35452404184358876',
+        clientDocId: '35452404184358876'
+    }),
+    NewsletterFetchAll: Object.freeze({
+        docId: '25399611239711790',
+        clientDocId: '25399611239711790'
+    }),
+    NewsletterDirectorySearch: Object.freeze({
+        docId: '26301059626252132',
+        clientDocId: '26301059626252132'
+    }),
+    NewsletterFollowers: Object.freeze({
+        docId: '27472091235714801',
+        clientDocId: '27472091235714801'
+    }),
+    NewsletterAdminInfo: Object.freeze({
+        docId: '34983385154639574',
+        clientDocId: '34983385154639574'
+    }),
+    NewsletterCreate: Object.freeze({
+        docId: '25149874324715067',
+        clientDocId: '25149874324715067'
+    }),
+    NewsletterUpdate: Object.freeze({
+        docId: '24250201037901610',
+        clientDocId: '24250201037901610'
+    }),
+    NewsletterDelete: Object.freeze({
+        docId: '30062808666639665',
+        clientDocId: '30062808666639665'
+    }),
+    NewsletterJoin: Object.freeze({
+        docId: '24404358912487870',
+        clientDocId: '24404358912487870'
+    }),
+    NewsletterLeave: Object.freeze({
+        docId: '9767147403369991',
+        clientDocId: '9767147403369991'
+    }),
+    NewsletterUpdateUserSetting: Object.freeze({
+        docId: '31938993655691868',
+        clientDocId: '31938993655691868'
+    }),
+    NewsletterChangeOwner: Object.freeze({
+        docId: '9546742745432473',
+        clientDocId: '9546742745432473'
+    }),
+    NewsletterDemoteAdmin: Object.freeze({
+        docId: '9880997548630971',
+        clientDocId: '9880997548630971'
+    }),
+    NewsletterCreateAdminInvite: Object.freeze({
+        docId: '9387141988078609',
+        clientDocId: '9387141988078609'
+    }),
+    NewsletterAcceptAdminInvite: Object.freeze({
+        docId: '9580828702035549',
+        clientDocId: '9580828702035549'
+    }),
+    NewsletterRevokeAdminInvite: Object.freeze({
+        docId: '9656078347839416',
+        clientDocId: '9656078347839416'
+    }),
+    NewsletterFetchInsights: Object.freeze({
+        docId: '9853618868050977',
+        clientDocId: '9853618868050977'
+    }),
+    NewsletterFetchReports: Object.freeze({
+        docId: '24241374008893508',
+        clientDocId: '24241374008893508'
+    }),
+    NewsletterFetchPendingInvites: Object.freeze({
+        docId: '9783111038412085',
+        clientDocId: '9783111038412085'
+    }),
+    NewsletterFetchRecommended: Object.freeze({
+        docId: '25806748772361516',
+        clientDocId: '25806748772361516'
+    }),
+    NewsletterFetchSimilar: Object.freeze({
+        docId: '26217043484590756',
+        clientDocId: '26217043484590756'
+    }),
+    NewsletterFetchEnforcements: Object.freeze({
+        docId: '25987882310910935',
+        clientDocId: '25987882310910935'
+    }),
+    NewsletterFetchPollVoters: Object.freeze({
+        docId: '9407762219322536',
+        clientDocId: '9407762219322536'
+    }),
+    NewsletterFetchMessageReactionSenders: Object.freeze({
+        docId: '29575462448733991',
+        clientDocId: '29575462448733991'
+    }),
+    NewsletterFetchAdminCapabilities: Object.freeze({
+        docId: '9801384413216421',
+        clientDocId: '9801384413216421'
+    }),
+    NewsletterFetchDirectoryList: Object.freeze({
+        docId: '26125047313831973',
+        clientDocId: '26125047313831973'
+    }),
+    NewsletterFetchDirectoryCategoriesPreview: Object.freeze({
+        docId: '35266481849605779',
+        clientDocId: '35266481849605779'
+    }),
+    NewsletterFetchIsDomainPreviewable: Object.freeze({
+        docId: '9849510985088294',
+        clientDocId: '9849510985088294'
+    }),
+    NewsletterFetchDehydrated: Object.freeze({
+        docId: '30328461880085868',
+        clientDocId: '30328461880085868'
+    }),
+    NewsletterLogExposures: Object.freeze({
+        docId: '25260800823586918',
+        clientDocId: '25260800823586918'
     })
 }) satisfies Readonly<Record<string, WaMexPersistId>>


### PR DESCRIPTION
Adds full newsletter coordinator with discovery/admin/messaging ops, all stanzas and MEX variables validated against wa-web. client.sendMessage routes to newsletter when JID matches @newsletter, returning the same WaMessagePublishResult shape (with optional upload summary).

- Plaintext message dispatch: text/media/poll-creation/poll-vote/edit/ react/revoke, with publishMessageNode for ack tracking and retry
- Streaming media upload (single-pass sha256+write, no full materialization for streams)
- Incoming newsletter handler with reaction events
- TOS auto-accept for create/follow/admin invite via ab props
- Live updates subscribe, fetchMessages/MessageUpdates IQs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive newsletter support to the WhatsApp client
  * Send and edit newsletter messages with text, media, and poll content
  * Manage newsletter reactions and revokes
  * Create, update, and administer newsletters
  * Follow, unfollow, and mute newsletters
  * Browse newsletter directory and search recommendations
  * Subscribe to live updates and access message history
  * Send view receipts for newsletter messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->