### PR TITLE
feat(mcp-server): add MCP server exposing WaClient as dynamic tools

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,7 +48,8 @@ module.exports = [
                     './packages/store-redis/tsconfig.json',
                     './packages/store-mongo/tsconfig.json',
                     './packages/media-utils/tsconfig.json',
-                    './packages/fake-server/tsconfig.json'
+                    './packages/fake-server/tsconfig.json',
+                    './packages/mcp-server/tsconfig.json'
                 ]
             }
         }
@@ -81,7 +82,8 @@ module.exports = [
                         './packages/store-redis/tsconfig.json',
                         './packages/store-mongo/tsconfig.json',
                         './packages/media-utils/tsconfig.json',
-                        './packages/fake-server/tsconfig.json'
+                        './packages/fake-server/tsconfig.json',
+                        './packages/mcp-server/tsconfig.json'
                     ]
                 }
             }
@@ -115,6 +117,7 @@ module.exports = [
         files: [
             'src/store/**/*.ts',
             'packages/store-*/**/*.ts',
+            'packages/mcp-server/src/**/*.ts',
             'src/**/__tests__/**/*.ts',
             'packages/**/__tests__/**/*.ts',
             'bench/**/*.ts'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9049,7 +9049,9 @@
             "name": "@zapo-js/mcp-server",
             "version": "0.0.0",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.29.0"
+                "@modelcontextprotocol/sdk": "^1.29.0",
+                "@zapo-js/store-sqlite": ">=0.1.0",
+                "zapo-js": ">=0.1.0"
             },
             "bin": {
                 "zapo-mcp-server": "dist/bin.js"
@@ -9064,18 +9066,10 @@
                 "node": ">=20.9.0"
             },
             "peerDependencies": {
-                "@zapo-js/store-sqlite": ">=0.1.0",
-                "better-sqlite3": ">=11.0.0",
-                "zapo-js": ">=0.1.0"
+                "better-sqlite3": ">=11.0.0"
             },
             "peerDependenciesMeta": {
-                "@zapo-js/store-sqlite": {
-                    "optional": true
-                },
                 "better-sqlite3": {
-                    "optional": true
-                },
-                "zapo-js": {
                     "optional": true
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1059,6 +1059,18 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@hono/node-server": {
+            "version": "1.19.14",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+            "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.14.1"
+            },
+            "peerDependencies": {
+                "hono": "^4"
+            }
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1685,6 +1697,68 @@
             "engines": {
                 "node": ">=6 <7 || >=8"
             }
+        },
+        "node_modules/@modelcontextprotocol/sdk": {
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+            "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@hono/node-server": "^1.19.9",
+                "ajv": "^8.17.1",
+                "ajv-formats": "^3.0.1",
+                "content-type": "^1.0.5",
+                "cors": "^2.8.5",
+                "cross-spawn": "^7.0.5",
+                "eventsource": "^3.0.2",
+                "eventsource-parser": "^3.0.0",
+                "express": "^5.2.1",
+                "express-rate-limit": "^8.2.1",
+                "hono": "^4.11.4",
+                "jose": "^6.1.3",
+                "json-schema-typed": "^8.0.2",
+                "pkce-challenge": "^5.0.0",
+                "raw-body": "^3.0.0",
+                "zod": "^3.25 || ^4.0",
+                "zod-to-json-schema": "^3.25.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@cfworker/json-schema": "^4.1.1",
+                "zod": "^3.25 || ^4.0"
+            },
+            "peerDependenciesMeta": {
+                "@cfworker/json-schema": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
         },
         "node_modules/@mongodb-js/saslprep": {
             "version": "1.4.6",
@@ -2449,6 +2523,10 @@
             "resolved": "packages/fake-server",
             "link": true
         },
+        "node_modules/@zapo-js/mcp-server": {
+            "resolved": "packages/mcp-server",
+            "link": true
+        },
         "node_modules/@zapo-js/media-utils": {
             "resolved": "packages/media-utils",
             "link": true
@@ -2472,6 +2550,19 @@
         "node_modules/@zapo-js/store-sqlite": {
             "resolved": "packages/store-sqlite",
             "link": true
+        },
+        "node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/acorn": {
             "version": "8.16.0",
@@ -2512,6 +2603,45 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
             }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
         },
         "node_modules/ansi-colors": {
             "version": "4.1.3",
@@ -2869,6 +2999,30 @@
                 "readable-stream": "^3.4.0"
             }
         },
+        "node_modules/body-parser": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^1.0.5",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.0",
+                "iconv-lite": "^0.7.0",
+                "on-finished": "^2.4.1",
+                "qs": "^6.14.1",
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
@@ -2930,6 +3084,15 @@
                 "ieee754": "^1.1.13"
             }
         },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/c8": {
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/c8/-/c8-11.0.0.tgz",
@@ -2987,7 +3150,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -3001,7 +3163,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -3187,6 +3348,28 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/content-disposition": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3194,11 +3377,45 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
+        },
+        "node_modules/cors": {
+            "version": "2.8.6",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+            "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+            "license": "MIT",
+            "dependencies": {
+                "object-assign": "^4",
+                "vary": "^1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -3277,7 +3494,6 @@
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -3370,6 +3586,15 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/detect-indent": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -3420,7 +3645,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
@@ -3431,12 +3655,27 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
+        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/end-of-stream": {
             "version": "1.4.5",
@@ -3549,7 +3788,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -3559,7 +3797,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -3569,7 +3806,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -3676,6 +3912,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
@@ -4188,6 +4430,36 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/eventsource": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+            "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+            "license": "MIT",
+            "dependencies": {
+                "eventsource-parser": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/eventsource-parser": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+            "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/expand-template": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -4196,6 +4468,67 @@
             "license": "(MIT OR WTFPL)",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/express": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express-rate-limit": {
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+            "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ip-address": "^10.2.0"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": ">= 4.11"
             }
         },
         "node_modules/extendable-error": {
@@ -4216,7 +4549,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-glob": {
@@ -4269,6 +4601,22 @@
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fastq": {
             "version": "1.20.1",
@@ -4329,6 +4677,27 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/finalhandler": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/find-up": {
@@ -4402,6 +4771,24 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/fs-constants": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -4443,7 +4830,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4514,7 +4900,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -4539,7 +4924,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
@@ -4680,7 +5064,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -4752,7 +5135,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -4781,7 +5163,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -4797,12 +5178,41 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/hono": {
+            "version": "4.12.18",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+            "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
         },
         "node_modules/human-id": {
             "version": "4.1.3",
@@ -4818,7 +5228,6 @@
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
             "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4893,7 +5302,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/ini": {
@@ -4941,6 +5349,24 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/ioredis"
+            }
+        },
+        "node_modules/ip-address": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
             }
         },
         "node_modules/is-array-buffer": {
@@ -5230,6 +5656,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "license": "MIT"
+        },
         "node_modules/is-property": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -5416,7 +5848,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/istanbul-lib-coverage": {
@@ -5458,6 +5889,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/jose": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+            "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
         "node_modules/joycon": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -5494,6 +5934,12 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -5646,10 +6092,18 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/memory-pager": {
@@ -5658,6 +6112,18 @@
             "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -5694,6 +6160,31 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/mimic-response": {
@@ -5824,7 +6315,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/mylas": {
@@ -5907,6 +6397,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/node-abi": {
             "version": "3.88.0",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.88.0.tgz",
@@ -5930,11 +6429,19 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -6037,11 +6544,22 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -6178,6 +6696,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6192,7 +6719,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -6220,6 +6746,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-to-regexp": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/path-type": {
@@ -6437,6 +6973,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/pkce-challenge": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+            "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
         "node_modules/plimit-lit": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
@@ -6574,6 +7119,19 @@
             ],
             "license": "MIT"
         },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/pump": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -6593,6 +7151,21 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/quansync": {
@@ -6649,6 +7222,30 @@
             "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
         },
         "node_modules/rc": {
             "version": "1.2.8",
@@ -6844,6 +7441,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/resolve": {
             "version": "1.22.11",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -6894,6 +7500,22 @@
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/run-parallel": {
@@ -7010,7 +7632,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/secure-json-parse": {
@@ -7041,6 +7662,51 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/set-function-length": {
@@ -7092,6 +7758,12 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
+        },
         "node_modules/sharp": {
             "version": "0.33.5",
             "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
@@ -7136,7 +7808,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -7149,7 +7820,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -7159,7 +7829,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -7179,7 +7848,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
             "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -7196,7 +7864,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -7215,7 +7882,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -7391,6 +8057,15 @@
             "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
@@ -7667,6 +8342,15 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
         "node_modules/tr46": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
@@ -7823,6 +8507,20 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/type-is": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/typed-array-buffer": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -7975,6 +8673,15 @@
                 "node": ">= 4.0.0"
             }
         },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/unrs-resolver": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -8042,6 +8749,15 @@
                 "node": ">=10.12.0"
             }
         },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/webidl-conversions": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -8070,7 +8786,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -8203,7 +8918,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/ws": {
@@ -8293,6 +9007,24 @@
             "resolved": "",
             "link": true
         },
+        "node_modules/zod": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zod-to-json-schema": {
+            "version": "3.25.2",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+            "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+            "license": "ISC",
+            "peerDependencies": {
+                "zod": "^3.25.28 || ^4"
+            }
+        },
         "packages/fake-server": {
             "name": "@zapo-js/fake-server",
             "version": "0.3.0",
@@ -8311,6 +9043,41 @@
             },
             "peerDependencies": {
                 "zapo-js": ">=0.1.0"
+            }
+        },
+        "packages/mcp-server": {
+            "name": "@zapo-js/mcp-server",
+            "version": "0.0.0",
+            "dependencies": {
+                "@modelcontextprotocol/sdk": "^1.29.0"
+            },
+            "bin": {
+                "zapo-mcp-server": "dist/bin.js"
+            },
+            "devDependencies": {
+                "@zapo-js/fake-server": "file:../fake-server",
+                "@zapo-js/store-sqlite": "file:../store-sqlite",
+                "better-sqlite3": "^12.6.2",
+                "zapo-js": "file:../.."
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "peerDependencies": {
+                "@zapo-js/store-sqlite": ">=0.1.0",
+                "better-sqlite3": ">=11.0.0",
+                "zapo-js": ">=0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "@zapo-js/store-sqlite": {
+                    "optional": true
+                },
+                "better-sqlite3": {
+                    "optional": true
+                },
+                "zapo-js": {
+                    "optional": true
+                }
             }
         },
         "packages/media-utils": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,57 @@
+{
+    "name": "@zapo-js/mcp-server",
+    "version": "0.0.0",
+    "description": "MCP server exposing zapo-js WaClient as dynamic tools for end-to-end testing",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "bin": {
+        "zapo-mcp-server": "./dist/bin.js"
+    },
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "require": "./dist/index.js",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": [
+        "dist"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsc -p tsconfig.build.cjs.json",
+        "typecheck": "tsc --noEmit",
+        "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\"",
+        "start": "node --import tsx src/bin.ts"
+    },
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0"
+    },
+    "peerDependencies": {
+        "@zapo-js/store-sqlite": ">=0.1.0",
+        "better-sqlite3": ">=11.0.0",
+        "zapo-js": ">=0.1.0"
+    },
+    "peerDependenciesMeta": {
+        "@zapo-js/store-sqlite": {
+            "optional": true
+        },
+        "better-sqlite3": {
+            "optional": true
+        },
+        "zapo-js": {
+            "optional": true
+        }
+    },
+    "devDependencies": {
+        "@zapo-js/fake-server": "file:../fake-server",
+        "@zapo-js/store-sqlite": "file:../store-sqlite",
+        "better-sqlite3": "^12.6.2",
+        "zapo-js": "file:../.."
+    },
+    "engines": {
+        "node": ">=20.9.0"
+    }
+}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -27,21 +27,15 @@
         "start": "node --import tsx src/bin.ts"
     },
     "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0"
-    },
-    "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@zapo-js/store-sqlite": ">=0.1.0",
-        "better-sqlite3": ">=11.0.0",
         "zapo-js": ">=0.1.0"
     },
+    "peerDependencies": {
+        "better-sqlite3": ">=11.0.0"
+    },
     "peerDependenciesMeta": {
-        "@zapo-js/store-sqlite": {
-            "optional": true
-        },
         "better-sqlite3": {
-            "optional": true
-        },
-        "zapo-js": {
             "optional": true
         }
     },

--- a/packages/mcp-server/src/__tests__/fake-server.cross-check.test.ts
+++ b/packages/mcp-server/src/__tests__/fake-server.cross-check.test.ts
@@ -1,0 +1,229 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import { FakeWaServer } from '@zapo-js/fake-server'
+import type { WaClient, WaClientEventMap } from 'zapo-js'
+
+import { type BufferedEvent, McpRuntime } from '../runtime'
+import { type ToolDefinition, TOOLS } from '../tools'
+
+/**
+ * Inline parser for the auth_qr string. Format is `ref,noisePub,identityPub,advSecret,platform`
+ * with base64url-encoded fields. Mirrors fake-server's `parsePairingQrString` helper, which is
+ * not exposed via the package's "exports" surface.
+ */
+const parsePairingQr = (
+    qr: string
+): { advSecretKey: Uint8Array; identityPublicKey: Uint8Array } => {
+    const parts = qr.split(',')
+    if (parts.length < 5) {
+        throw new Error(`pairing qr must have at least 5 parts, got ${parts.length}`)
+    }
+    const advSecret = decodeBase64Url(parts[parts.length - 2])
+    const identityPub = decodeBase64Url(parts[parts.length - 3])
+    return { advSecretKey: advSecret, identityPublicKey: identityPub }
+}
+
+const decodeBase64Url = (input: string): Uint8Array => {
+    let s = input.replace(/-/g, '+').replace(/_/g, '/')
+    const rem = s.length % 4
+    if (rem === 2) s += '=='
+    else if (rem === 3) s += '='
+    return new Uint8Array(Buffer.from(s, 'base64'))
+}
+
+const CONNECT_TIMEOUT_MS = 60_000
+const PEER_JID = '5511777777777@s.whatsapp.net'
+const DEVICE_JID = '5511999999999:1@s.whatsapp.net'
+
+const findTool = (name: string): ToolDefinition => {
+    const tool = TOOLS.find((t) => t.name === name)
+    if (!tool) throw new Error(`tool ${name} not registered`)
+    return tool
+}
+
+const waitForEvent = (
+    runtime: McpRuntime,
+    type: string,
+    predicate: (ev: BufferedEvent) => boolean = () => true,
+    timeoutMs = CONNECT_TIMEOUT_MS
+): Promise<BufferedEvent> => {
+    return new Promise((resolve, reject) => {
+        const start = Date.now()
+        const tick = (): void => {
+            const events = runtime.listEvents({ types: [type], limit: 200 })
+            const match = events.find(predicate)
+            if (match) {
+                resolve(match)
+                return
+            }
+            if (Date.now() - start > timeoutMs) {
+                reject(new Error(`timeout waiting for ${type}`))
+                return
+            }
+            setTimeout(tick, 25)
+        }
+        tick()
+    })
+}
+
+const waitForMessage = (
+    client: WaClient,
+    predicate: (event: Parameters<WaClientEventMap['message']>[0]) => boolean,
+    timeoutMs = 8_000
+): Promise<Parameters<WaClientEventMap['message']>[0]> => {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('message timeout')), timeoutMs)
+        const listener: WaClientEventMap['message'] = (event) => {
+            if (predicate(event)) {
+                clearTimeout(timer)
+                client.off('message', listener)
+                resolve(event)
+            }
+        }
+        client.on('message', listener)
+    })
+}
+
+test('mcp runtime drives pairing + send/receive against fake-server', async () => {
+    const server = await FakeWaServer.start()
+    const dir = await mkdtemp(join(tmpdir(), 'mcp-fake-flow-'))
+    const runtime = new McpRuntime({
+        authPath: join(dir, 'state.sqlite'),
+        sessionId: 'mcp-fake-flow',
+        logLevel: 'error',
+        bufferSize: 1000,
+        captureNoisyEvents: false,
+        historyEnabled: false,
+        logBufferSize: 500,
+        chatSocketUrls: [server.url],
+        noiseRootCa: server.noiseRootCa,
+        transport: 'stdio',
+        httpHost: '127.0.0.1',
+        httpPort: 0,
+        httpPath: '/mcp'
+    })
+
+    const callTool = findTool('call')
+    const eventsTool = findTool('events')
+    const lifecycleTool = findTool('lifecycle')
+
+    try {
+        const status = (await lifecycleTool.handler({ action: 'start' }, runtime)) as {
+            ok: boolean
+        }
+        assert.equal(status.ok, true)
+
+        const client = runtime.getClient()
+        assert.ok(client, 'client should exist after lifecycle.start')
+
+        // Capture pairing material the moment auth_qr fires.
+        const materialPromise = new Promise<{
+            readonly advSecretKey: Uint8Array
+            readonly identityPublicKey: Uint8Array
+        }>((resolve) => {
+            client.once('auth_qr', (event) => {
+                resolve(parsePairingQr(event.qr))
+            })
+        })
+        const pairedPromise = new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(
+                () => reject(new Error('auth_paired timeout')),
+                CONNECT_TIMEOUT_MS
+            )
+            client.once('auth_paired', () => {
+                clearTimeout(timer)
+                resolve()
+            })
+        })
+
+        // Drive connect through the call tool — same code path Claude would use.
+        const connectPromise = callTool.handler({ path: 'connect' }, runtime)
+
+        const pipeline = await server.waitForAuthenticatedPipeline()
+        await server.runPairing(pipeline, { deviceJid: DEVICE_JID }, () => materialPromise)
+
+        const pipelineAfterPairPromise = server.waitForNextAuthenticatedPipeline()
+        await pairedPromise
+        const pipelineAfterPair = await pipelineAfterPairPromise
+        await connectPromise
+
+        // Buffer should reflect every milestone.
+        await waitForEvent(runtime, 'auth_qr')
+        await waitForEvent(runtime, 'auth_paired')
+        await waitForEvent(
+            runtime,
+            'connection',
+            (ev) => (ev.payload as { status?: string }).status === 'open'
+        )
+
+        // Set up an inbound peer message and verify the buffer captures it.
+        const peer = await server.createFakePeer({ jid: PEER_JID }, pipelineAfterPair)
+        await server.triggerPreKeyUpload(pipelineAfterPair)
+
+        const inboundReceived = waitForMessage(
+            client,
+            (event) => event.message?.conversation === 'hello via fake-server'
+        )
+        await peer.sendConversation('hello via fake-server')
+        await inboundReceived
+
+        const messageEvent = await waitForEvent(
+            runtime,
+            'message',
+            (ev) =>
+                (ev.payload as { message?: { conversation?: string } }).message?.conversation ===
+                'hello via fake-server'
+        )
+        assert.ok(messageEvent.seq > 0)
+
+        // Outbound: drive sendMessage via the call tool, peer should observe it.
+        const peerExpect = peer.expectMessage({ timeoutMs: 8_000 })
+        const sendResult = (await callTool.handler(
+            {
+                path: 'sendMessage',
+                args: [PEER_JID, { conversation: 'hello via mcp call tool' }]
+            },
+            runtime
+        )) as { kind: string; result: unknown }
+        assert.equal(sendResult.kind, 'call')
+        const peerReceived = await peerExpect
+        assert.equal(peerReceived.message.conversation, 'hello via mcp call tool')
+
+        // Read events with `since` to confirm filtering: should only include events after the message.
+        const lastSeq = messageEvent.seq
+        const fresh = (await eventsTool.handler({ since: lastSeq, limit: 50 }, runtime)) as {
+            events: { seq: number }[]
+        }
+        for (const ev of fresh.events) {
+            assert.ok(ev.seq > lastSeq, `expected seq > ${lastSeq}, got ${ev.seq}`)
+        }
+
+        // lifecycle status should report a connected, paired client.
+        const stateResult = (await lifecycleTool.handler({ action: 'status' }, runtime)) as {
+            clientCreated: boolean
+            state: unknown
+        }
+        assert.equal(stateResult.clientCreated, true)
+        assert.ok(stateResult.state !== null)
+    } finally {
+        try {
+            await runtime.destroyClient()
+        } catch (error) {
+            process.stderr.write(`destroyClient error: ${(error as Error)?.stack ?? error}\n`)
+        }
+        try {
+            await server.stop()
+        } catch (error) {
+            process.stderr.write(`server.stop error: ${(error as Error)?.stack ?? error}\n`)
+        }
+        try {
+            await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
+        } catch (error) {
+            process.stderr.write(`rm error: ${(error as Error)?.message ?? error}\n`)
+        }
+    }
+})

--- a/packages/mcp-server/src/__tests__/http-transport.test.ts
+++ b/packages/mcp-server/src/__tests__/http-transport.test.ts
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict'
+import { type ChildProcess, spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { join } from 'node:path'
+import test from 'node:test'
+
+const BIN = join(__dirname, '..', 'bin.ts')
+
+const waitForPort = async (port: number, host = '127.0.0.1', timeoutMs = 10_000): Promise<void> => {
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+        try {
+            const res = await fetch(`http://${host}:${port}/healthz`).catch(() => null)
+            if (res) return
+        } catch {
+            /* swallow */
+        }
+        // Try a real probe: open a TCP connection by attempting a HEAD; the server returns 405 on non-POST
+        try {
+            const probe = await fetch(`http://${host}:${port}/mcp`, { method: 'HEAD' })
+            if (probe.status === 405 || probe.status === 404) return
+        } catch {
+            /* not yet listening */
+        }
+        await new Promise((r) => setTimeout(r, 50))
+    }
+    throw new Error(`port ${port} not reachable after ${timeoutMs}ms`)
+}
+
+const findFreePort = async (): Promise<number> => {
+    const net = await import('node:net')
+    return new Promise((resolve, reject) => {
+        const server = net.createServer()
+        server.unref()
+        server.on('error', reject)
+        server.listen(0, '127.0.0.1', () => {
+            const address = server.address()
+            if (typeof address === 'object' && address) {
+                const port = address.port
+                server.close(() => resolve(port))
+            } else {
+                reject(new Error('failed to bind'))
+            }
+        })
+    })
+}
+
+const callMcp = async (
+    url: string,
+    payload: unknown,
+    extraHeaders: Record<string, string> = {}
+): Promise<{ status: number; body: unknown; sessionId?: string | null }> => {
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream',
+            ...extraHeaders
+        },
+        body: JSON.stringify(payload)
+    })
+    const text = await res.text()
+    let body: unknown
+    if (text.startsWith('event:') || text.includes('\nevent:')) {
+        // SSE response — parse the first data: line
+        const dataLine = text.split('\n').find((l) => l.startsWith('data:'))
+        body = dataLine ? JSON.parse(dataLine.slice('data:'.length).trim()) : null
+    } else if (text.length > 0) {
+        body = JSON.parse(text)
+    } else {
+        body = null
+    }
+    return { status: res.status, body, sessionId: res.headers.get('mcp-session-id') }
+}
+
+const startServer = async (
+    port: number
+): Promise<{ child: ChildProcess; stop: () => Promise<void> }> => {
+    const child = spawn(process.execPath, ['--import', 'tsx', BIN], {
+        env: {
+            ...process.env,
+            MCP_TRANSPORT: 'http',
+            MCP_HTTP_PORT: String(port),
+            MCP_LOG_LEVEL: 'error'
+        },
+        stdio: ['ignore', 'pipe', 'pipe']
+    })
+    child.stdout?.on('data', () => undefined)
+    child.stderr?.on('data', () => undefined)
+    await waitForPort(port)
+    return {
+        child,
+        stop: async () => {
+            child.kill('SIGTERM')
+            await once(child, 'exit').catch(() => undefined)
+        }
+    }
+}
+
+test('mcp server over http handles initialize + tools/list + tools/call', async () => {
+    const port = await findFreePort()
+    const { stop } = await startServer(port)
+    const url = `http://127.0.0.1:${port}/mcp`
+    try {
+        const init = await callMcp(url, {
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: '2025-06-18',
+                capabilities: {},
+                clientInfo: { name: 'http-smoke', version: '0' }
+            }
+        })
+        assert.equal(init.status, 200)
+        const initBody = init.body as { result?: { protocolVersion?: string } }
+        assert.ok(initBody.result?.protocolVersion, 'initialize should return protocolVersion')
+
+        const list = await callMcp(url, {
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'tools/list',
+            params: {}
+        })
+        assert.equal(list.status, 200)
+        const listBody = list.body as { result?: { tools?: { name: string }[] } }
+        const names = (listBody.result?.tools ?? []).map((t) => t.name)
+        assert.ok(names.includes('call'))
+        assert.ok(names.includes('lifecycle'))
+
+        const call = await callMcp(url, {
+            jsonrpc: '2.0',
+            id: 3,
+            method: 'tools/call',
+            params: { name: 'lifecycle', arguments: { action: 'status' } }
+        })
+        assert.equal(call.status, 200)
+        const callBody = call.body as {
+            result?: { content?: { type: string; text: string }[] }
+        }
+        const text = callBody.result?.content?.[0]?.text
+        assert.ok(text, 'lifecycle.status should return content')
+        const parsed = JSON.parse(text)
+        assert.equal(parsed.config.sessionId, 'default_2')
+        assert.equal(parsed.clientCreated, false)
+    } finally {
+        await stop()
+    }
+})
+
+test('mcp server over http rejects non-POST and unknown paths', async () => {
+    const port = await findFreePort()
+    const { stop } = await startServer(port)
+    try {
+        const wrongPath = await fetch(`http://127.0.0.1:${port}/wrong`)
+        assert.equal(wrongPath.status, 404)
+
+        const wrongMethod = await fetch(`http://127.0.0.1:${port}/mcp`)
+        assert.equal(wrongMethod.status, 405)
+        assert.equal(wrongMethod.headers.get('allow'), 'POST')
+    } finally {
+        await stop()
+    }
+})

--- a/packages/mcp-server/src/__tests__/restart-process-exit.test.ts
+++ b/packages/mcp-server/src/__tests__/restart-process-exit.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { join } from 'node:path'
+import test from 'node:test'
+
+const BIN = join(__dirname, '..', 'bin.ts')
+
+interface JsonRpcMessage {
+    readonly id?: number
+    readonly result?: unknown
+    readonly error?: unknown
+}
+
+const expectId = (raw: string, id: number): JsonRpcMessage => {
+    const lines = raw.split('\n').filter((l) => l.trim())
+    for (const line of lines) {
+        let parsed: JsonRpcMessage
+        try {
+            parsed = JSON.parse(line)
+        } catch {
+            continue
+        }
+        if (parsed.id === id) return parsed
+    }
+    throw new Error(`no response with id=${id} in:\n${raw}`)
+}
+
+test('restart process_exit terminates the stdio server after responding', async () => {
+    const child = spawn(process.execPath, ['--import', 'tsx', BIN], {
+        env: { ...process.env, MCP_LOG_LEVEL: 'error' },
+        stdio: ['pipe', 'pipe', 'pipe']
+    })
+    let stdoutBuffer = ''
+    child.stdout.on('data', (chunk) => {
+        stdoutBuffer += chunk.toString('utf8')
+    })
+
+    const send = (msg: unknown): void => {
+        child.stdin.write(`${JSON.stringify(msg)}\n`)
+    }
+
+    try {
+        send({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: '2025-06-18',
+                capabilities: {},
+                clientInfo: { name: 'restart-smoke', version: '0' }
+            }
+        })
+        send({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} })
+        send({
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'tools/call',
+            params: { name: 'restart', arguments: { mode: 'process_exit' } }
+        })
+
+        const exitTuple = (await once(child, 'exit')) as unknown as readonly [
+            number | null,
+            NodeJS.Signals | null
+        ]
+        const [code] = exitTuple
+        assert.equal(code, 0, 'process should exit cleanly')
+
+        const restartResponse = expectId(stdoutBuffer, 2)
+        assert.ok(restartResponse.result, 'restart should send a result before exiting')
+        const text = (restartResponse.result as { content: { text: string }[] }).content[0].text
+        const parsed = JSON.parse(text) as { mode: string; ok: boolean; note: string }
+        assert.equal(parsed.ok, true)
+        assert.equal(parsed.mode, 'process_exit')
+        assert.match(parsed.note, /process will exit/)
+    } finally {
+        if (child.exitCode === null && child.signalCode === null) {
+            child.kill('SIGKILL')
+        }
+    }
+})

--- a/packages/mcp-server/src/__tests__/runtime-logger.test.ts
+++ b/packages/mcp-server/src/__tests__/runtime-logger.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import { McpRuntime, type RuntimeConfig } from '../runtime'
+
+const baseConfig = (overrides: Partial<RuntimeConfig> = {}): RuntimeConfig => ({
+    authPath: '/unused',
+    sessionId: 'logger-test',
+    logLevel: 'info',
+    bufferSize: 100,
+    captureNoisyEvents: false,
+    historyEnabled: false,
+    logBufferSize: 50,
+    transport: 'stdio',
+    httpHost: '127.0.0.1',
+    httpPort: 0,
+    httpPath: '/mcp',
+    ...overrides
+})
+
+test('BufferedTeeLogger captures entries into the runtime ring buffer', () => {
+    const runtime = new McpRuntime(baseConfig())
+    const logger = runtime.getLogger()
+    logger.info('boot', { sessionId: 'abc' })
+    logger.warn('about to retry')
+    logger.error('exploded', { code: 42 })
+    // trace is below info, must be filtered
+    logger.trace('noisy detail')
+
+    const entries = runtime.listLogs({ limit: 10 })
+    assert.equal(entries.length, 3)
+    assert.equal(entries[0].level, 'info')
+    assert.equal(entries[0].message, 'boot')
+    assert.deepStrictEqual(entries[0].context, { sessionId: 'abc' })
+    assert.equal(entries[1].level, 'warn')
+    assert.equal(entries[1].context, null)
+    assert.equal(entries[2].level, 'error')
+    assert.deepStrictEqual(entries[2].context, { code: 42 })
+})
+
+test('BufferedTeeLogger respects bufferLimit by dropping oldest entries', () => {
+    const runtime = new McpRuntime(baseConfig({ logBufferSize: 3 }))
+    const logger = runtime.getLogger()
+    for (let i = 1; i <= 5; i += 1) {
+        logger.info(`entry-${i}`)
+    }
+    const entries = runtime.listLogs({ limit: 10 })
+    assert.equal(entries.length, 3)
+    assert.deepStrictEqual(
+        entries.map((e) => e.message),
+        ['entry-3', 'entry-4', 'entry-5']
+    )
+})
+
+test('BufferedTeeLogger mirrors entries to the configured log file as JSONL', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mcp-log-'))
+    const logFilePath = join(dir, 'out.log')
+    const runtime = new McpRuntime(baseConfig({ logFilePath }))
+    try {
+        runtime.getLogger().info('hello file', { run: 1 })
+        runtime.getLogger().error('written', { code: 7 })
+        await runtime.closeLogFile()
+
+        const contents = await readFile(logFilePath, 'utf8')
+        const lines = contents.trim().split('\n')
+        assert.equal(lines.length, 2)
+        const first = JSON.parse(lines[0])
+        const second = JSON.parse(lines[1])
+        assert.equal(first.level, 'info')
+        assert.equal(first.message, 'hello file')
+        assert.deepStrictEqual(first.context, { run: 1 })
+        assert.equal(second.level, 'error')
+        assert.equal(second.message, 'written')
+        assert.deepStrictEqual(second.context, { code: 7 })
+    } finally {
+        await rm(dir, { recursive: true, force: true })
+    }
+})

--- a/packages/mcp-server/src/__tests__/serializer.test.ts
+++ b/packages/mcp-server/src/__tests__/serializer.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { decodeFromJson, encodeForJson } from '../serializer'
+
+test('encodes Uint8Array as $bytes base64', () => {
+    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef])
+    const encoded = encodeForJson(bytes)
+    assert.deepStrictEqual(encoded, { $bytes: '3q2+7w==' })
+})
+
+test('encodes nested Uint8Array inside object', () => {
+    const encoded = encodeForJson({ key: new Uint8Array([1, 2, 3]) })
+    assert.deepStrictEqual(encoded, { key: { $bytes: 'AQID' } })
+})
+
+test('encodes BigInt as $bigint string', () => {
+    const encoded = encodeForJson(123456789n)
+    assert.deepStrictEqual(encoded, { $bigint: '123456789' })
+})
+
+test('encodes Date as $date iso', () => {
+    const d = new Date('2026-01-01T00:00:00.000Z')
+    const encoded = encodeForJson(d)
+    assert.deepStrictEqual(encoded, { $date: '2026-01-01T00:00:00.000Z' })
+})
+
+test('encodes Error as $error with name/message/stack', () => {
+    const err = new Error('boom')
+    err.name = 'CustomError'
+    const encoded = encodeForJson(err) as {
+        $error: { name: string; message: string; stack?: string }
+    }
+    assert.equal(encoded.$error.name, 'CustomError')
+    assert.equal(encoded.$error.message, 'boom')
+    assert.equal(typeof encoded.$error.stack, 'string')
+})
+
+test('encodes Map and Set with markers', () => {
+    const m = new Map<string, number>([
+        ['a', 1],
+        ['b', 2]
+    ])
+    const s = new Set([1, 2, 3])
+    assert.deepStrictEqual(encodeForJson(m), {
+        $map: [
+            ['a', 1],
+            ['b', 2]
+        ]
+    })
+    assert.deepStrictEqual(encodeForJson(s), { $set: [1, 2, 3] })
+})
+
+test('breaks circular references with [Circular]', () => {
+    const obj: { self?: unknown; v: number } = { v: 1 }
+    obj.self = obj
+    const encoded = encodeForJson(obj) as { v: number; self: string }
+    assert.equal(encoded.v, 1)
+    assert.equal(encoded.self, '[Circular]')
+})
+
+test('decodes $bytes back to Uint8Array', () => {
+    const decoded = decodeFromJson({ $bytes: 'AQID' })
+    assert.ok(decoded instanceof Uint8Array)
+    assert.deepStrictEqual(Array.from(decoded), [1, 2, 3])
+})
+
+test('decodes nested $bytes inside arrays', () => {
+    const decoded = decodeFromJson([{ $bytes: 'AQID' }, 'plain']) as unknown[]
+    assert.ok(decoded[0] instanceof Uint8Array)
+    assert.equal(decoded[1], 'plain')
+})
+
+test('decodes $bigint back to BigInt', () => {
+    const decoded = decodeFromJson({ $bigint: '999999999999' })
+    assert.equal(decoded, 999999999999n)
+})
+
+test('encode/decode roundtrip preserves structure', () => {
+    const input = {
+        text: 'hello',
+        bytes: new Uint8Array([1, 2, 3]),
+        big: 42n,
+        nested: { list: [1, 'two', new Uint8Array([9])] }
+    }
+    const encoded = encodeForJson(input)
+    const json = JSON.parse(JSON.stringify(encoded))
+    const decoded = decodeFromJson(json) as typeof input
+    assert.equal(decoded.text, 'hello')
+    assert.deepStrictEqual(Array.from(decoded.bytes), [1, 2, 3])
+    assert.equal(decoded.big, 42n)
+    assert.deepStrictEqual(Array.from(decoded.nested.list[2] as Uint8Array), [9])
+})

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -1,0 +1,372 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { BufferedEvent, LogEntry, McpRuntime, RuntimeConfig } from '../runtime'
+import { TOOLS } from '../tools'
+
+class FakeClient {
+    public greet(name: string): string {
+        return `hello ${name}`
+    }
+
+    public async multiply(a: number, b: number): Promise<number> {
+        return a * b
+    }
+
+    public roundtrip(bytes: Uint8Array): Uint8Array {
+        const out = new Uint8Array(bytes.length)
+        for (let i = 0; i < bytes.length; i += 1) {
+            out[i] = bytes[i]
+        }
+        return out
+    }
+
+    public get group(): {
+        create(
+            name: string,
+            members: readonly string[]
+        ): { name: string; members: readonly string[] }
+    } {
+        return {
+            create: (name, members) => ({ name, members })
+        }
+    }
+
+    public readonly options = { timeout: 1000, retries: 3 }
+
+    public throwIt(): never {
+        throw new Error('boom')
+    }
+}
+
+const buildFakeRuntime = (client: FakeClient): McpRuntime => {
+    const events: BufferedEvent[] = []
+    const logs: LogEntry[] = []
+    const config: RuntimeConfig = {
+        authPath: '/tmp/test.sqlite',
+        sessionId: 'test',
+        logLevel: 'error',
+        bufferSize: 100,
+        captureNoisyEvents: false,
+        historyEnabled: false,
+        logBufferSize: 100,
+        transport: 'stdio',
+        httpHost: '127.0.0.1',
+        httpPort: 0,
+        httpPath: '/mcp'
+    }
+    const fake = {
+        getConfig: () => config,
+        getLogger: () => ({
+            trace() {},
+            debug() {},
+            info() {},
+            warn() {},
+            error() {}
+        }),
+        ensureClient: async () => client,
+        getClient: () => client,
+        async destroyClient() {},
+        listEvents: () => events,
+        clearEvents: () => {
+            const n = events.length
+            events.length = 0
+            return n
+        },
+        bufferSize: () => events.length,
+        listLogs: (
+            filter: {
+                since?: number
+                limit?: number
+                levels?: readonly string[]
+                drain?: boolean
+            } = {}
+        ) => {
+            const lvSet = filter.levels && filter.levels.length > 0 ? new Set(filter.levels) : null
+            const since = filter.since ?? 0
+            const limit = filter.limit && filter.limit > 0 ? filter.limit : 100
+            const matched = logs.filter((e) => e.seq > since && (!lvSet || lvSet.has(e.level)))
+            const tail = matched.length > limit ? matched.slice(matched.length - limit) : matched
+            if (filter.drain) {
+                const seqs = new Set(tail.map((e) => e.seq))
+                for (let i = logs.length - 1; i >= 0; i -= 1) {
+                    if (seqs.has(logs[i].seq)) logs.splice(i, 1)
+                }
+            }
+            return tail
+        },
+        clearLogs: () => {
+            const n = logs.length
+            logs.length = 0
+            return n
+        },
+        bufferLogsSize: () => logs.length,
+        async closeLogFile() {},
+        resetSequences: () => undefined,
+        // test-only helpers: push synthetic entries
+        __pushLog: (entry: LogEntry) => {
+            logs.push(entry)
+        },
+        __pushEvent: (entry: BufferedEvent) => {
+            events.push(entry)
+        }
+    }
+    return fake as unknown as McpRuntime
+}
+
+const findTool = (name: string) => {
+    const tool = TOOLS.find((t) => t.name === name)
+    if (!tool) throw new Error(`tool ${name} not found`)
+    return tool
+}
+
+test('call tool invokes a top-level method with positional args', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('call')
+    const result = (await tool.handler({ path: 'greet', args: ['world'] }, runtime)) as {
+        kind: string
+        result: unknown
+    }
+    assert.equal(result.kind, 'call')
+    assert.equal(result.result, 'hello world')
+})
+
+test('call tool awaits returned promises and roundtrips Uint8Array', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('call')
+    const productResult = (await tool.handler({ path: 'multiply', args: [6, 7] }, runtime)) as {
+        result: unknown
+    }
+    assert.equal(productResult.result, 42)
+
+    const bytesResult = (await tool.handler(
+        { path: 'roundtrip', args: [{ $bytes: 'AQID' }] },
+        runtime
+    )) as { result: { $bytes: string } }
+    assert.equal(bytesResult.result.$bytes, 'AQID')
+})
+
+test('call tool walks dotted paths into nested objects', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('call')
+    const result = (await tool.handler(
+        { path: 'group.create', args: ['my-group', ['a@s', 'b@s']] },
+        runtime
+    )) as { result: { name: string; members: string[] } }
+    assert.equal(result.result.name, 'my-group')
+    assert.deepStrictEqual(result.result.members, ['a@s', 'b@s'])
+})
+
+test('call tool returns non-function values without invoking them', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('call')
+    const result = (await tool.handler({ path: 'options' }, runtime)) as {
+        kind: string
+        value: unknown
+    }
+    assert.equal(result.kind, 'value')
+    assert.deepStrictEqual(result.value, { timeout: 1000, retries: 3 })
+})
+
+test('call tool rejects empty path', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('call')
+    await assert.rejects(() => tool.handler({ path: '' }, runtime), /non-empty string/)
+})
+
+test('inspect tool lists methods and getters by origin class', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('inspect')
+    const result = (await tool.handler({}, runtime)) as {
+        constructorName: string
+        members: { name: string; kind: string; origin: string }[]
+    }
+    assert.equal(result.constructorName, 'FakeClient')
+    const greet = result.members.find((m) => m.name === 'greet')
+    assert.ok(greet)
+    assert.equal(greet.kind, 'function')
+    assert.equal(greet.origin, 'FakeClient')
+    const groupMember = result.members.find((m) => m.name === 'group')
+    assert.ok(groupMember)
+    assert.equal(groupMember.kind, 'getter')
+})
+
+test('inspect tool walks into a coordinator path', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('inspect')
+    const result = (await tool.handler({ path: 'group' }, runtime)) as {
+        members: { name: string }[]
+    }
+    const create = result.members.find((m) => m.name === 'create')
+    assert.ok(create)
+})
+
+test('lifecycle status returns config and clientCreated flag', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('lifecycle')
+    const result = (await tool.handler({ action: 'status' }, runtime)) as {
+        clientCreated: boolean
+        config: { sessionId: string }
+    }
+    assert.equal(result.clientCreated, true)
+    assert.equal(result.config.sessionId, 'test')
+})
+
+test('lifecycle rejects unknown actions', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('lifecycle')
+    await assert.rejects(() => tool.handler({ action: 'nope' }, runtime), /status.*start.*destroy/)
+})
+
+test('call tool with root=lib invokes a pure helper without touching client', async () => {
+    let ensureCalls = 0
+    const proxy = new Proxy({} as object, {
+        get() {
+            return undefined
+        }
+    })
+    const runtime = buildFakeRuntime(proxy as never)
+    const original = (runtime as unknown as { ensureClient: () => Promise<unknown> }).ensureClient
+    ;(runtime as unknown as { ensureClient: () => Promise<unknown> }).ensureClient = async () => {
+        ensureCalls += 1
+        return original.call(runtime)
+    }
+    const tool = findTool('call')
+    const result = (await tool.handler(
+        { root: 'lib', path: 'isGroupJid', args: ['12345-67@g.us'] },
+        runtime
+    )) as { result: unknown; rootLabel: string }
+    assert.equal(result.result, true)
+    assert.equal(result.rootLabel, 'zapo-js')
+    assert.equal(ensureCalls, 0)
+})
+
+test('call tool with root=lib reads a constant and walks proto', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('call')
+    const constResult = (await tool.handler({ root: 'lib', path: 'WA_DEFAULTS' }, runtime)) as {
+        kind: string
+        value: Record<string, unknown>
+    }
+    assert.equal(constResult.kind, 'value')
+    assert.equal(typeof constResult.value, 'object')
+    assert.ok(constResult.value !== null)
+
+    const protoResult = (await tool.handler({ root: 'lib', path: 'proto' }, runtime)) as {
+        value: object
+    }
+    assert.equal(typeof protoResult.value, 'object')
+})
+
+test('inspect tool with root=lib lists module exports', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('inspect')
+    const result = (await tool.handler({ root: 'lib' }, runtime)) as {
+        members: { name: string; kind: string }[]
+        rootLabel: string
+    }
+    assert.equal(result.rootLabel, 'zapo-js')
+    const names = new Set(result.members.map((m) => m.name))
+    assert.ok(names.has('WaClient'))
+    assert.ok(names.has('createStore'))
+    assert.ok(names.has('parsePhoneJid'))
+    assert.ok(names.has('proto'))
+})
+
+test('parseRoot rejects invalid root values', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('call')
+    await assert.rejects(
+        () => tool.handler({ root: 'banana', path: 'foo' }, runtime),
+        /one of client \| lib/
+    )
+})
+
+test('logs tool returns entries filtered by level and since', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const push = (runtime as unknown as { __pushLog: (e: LogEntry) => void }).__pushLog
+    push({ seq: 1, timestampMs: 1, level: 'info', message: 'hello', context: null })
+    push({ seq: 2, timestampMs: 2, level: 'warn', message: 'careful', context: null })
+    push({ seq: 3, timestampMs: 3, level: 'error', message: 'broken', context: { code: 42 } })
+
+    const tool = findTool('logs')
+    const all = (await tool.handler({}, runtime)) as { count: number; logs: LogEntry[] }
+    assert.equal(all.count, 3)
+
+    const onlyErrors = (await tool.handler({ levels: ['warn', 'error'] }, runtime)) as {
+        logs: LogEntry[]
+    }
+    assert.equal(onlyErrors.logs.length, 2)
+    assert.deepStrictEqual(
+        onlyErrors.logs.map((l) => l.level),
+        ['warn', 'error']
+    )
+
+    const newer = (await tool.handler({ since: 1 }, runtime)) as { logs: LogEntry[] }
+    assert.deepStrictEqual(
+        newer.logs.map((l) => l.seq),
+        [2, 3]
+    )
+})
+
+test('logs tool with drain removes returned entries', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const push = (runtime as unknown as { __pushLog: (e: LogEntry) => void }).__pushLog
+    push({ seq: 1, timestampMs: 1, level: 'info', message: 'a', context: null })
+    push({ seq: 2, timestampMs: 2, level: 'info', message: 'b', context: null })
+
+    const tool = findTool('logs')
+    const drained = (await tool.handler({ drain: true }, runtime)) as {
+        count: number
+        bufferSize: number
+    }
+    assert.equal(drained.count, 2)
+    assert.equal(drained.bufferSize, 0)
+})
+
+test('logs tool rejects invalid levels', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('logs')
+    await assert.rejects(() => tool.handler({ levels: ['fatal'] }, runtime), /invalid level/)
+})
+
+test('logs_clear tool drops every entry', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const push = (runtime as unknown as { __pushLog: (e: LogEntry) => void }).__pushLog
+    push({ seq: 1, timestampMs: 1, level: 'info', message: 'a', context: null })
+    push({ seq: 2, timestampMs: 2, level: 'info', message: 'b', context: null })
+
+    const tool = findTool('logs_clear')
+    const result = (await tool.handler({}, runtime)) as { dropped: number }
+    assert.equal(result.dropped, 2)
+    assert.equal(runtime.bufferLogsSize(), 0)
+})
+
+test('restart tool soft mode destroys client + clears buffers', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const fake = runtime as unknown as {
+        __pushLog: (e: LogEntry) => void
+        __pushEvent: (e: BufferedEvent) => void
+    }
+    // Seed both buffers + force destroyClient/resetSequences accounting.
+    fake.__pushLog?.({ seq: 1, timestampMs: 1, level: 'info', message: 'a', context: null })
+    fake.__pushEvent?.({ seq: 1, type: 'message', timestampMs: 1, payload: {} })
+
+    const tool = findTool('restart')
+    const result = (await tool.handler({}, runtime)) as {
+        ok: boolean
+        mode: string
+        eventsCleared: number
+        logsCleared: number
+    }
+    assert.equal(result.ok, true)
+    assert.equal(result.mode, 'soft')
+    assert.equal(runtime.bufferSize(), 0)
+    assert.equal(runtime.bufferLogsSize(), 0)
+})
+
+test('restart tool rejects invalid mode', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('restart')
+    await assert.rejects(() => tool.handler({ mode: 'hard' }, runtime), /soft \| process_exit/)
+})

--- a/packages/mcp-server/src/bin.ts
+++ b/packages/mcp-server/src/bin.ts
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
+import { toError } from 'zapo-js/util'
+
 import { runMcpServer } from './server'
 
 void runMcpServer().catch((error) => {
-    process.stderr.write(`fatal: ${(error as Error)?.stack ?? String(error)}\n`)
+    const err = toError(error)
+    process.stderr.write(`fatal: ${err.stack ?? err.message}\n`)
     process.exit(1)
 })

--- a/packages/mcp-server/src/bin.ts
+++ b/packages/mcp-server/src/bin.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { runMcpServer } from './server'
+
+void runMcpServer().catch((error) => {
+    process.stderr.write(`fatal: ${(error as Error)?.stack ?? String(error)}\n`)
+    process.exit(1)
+})

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,7 @@
+export { runMcpServer } from './server'
+export type { RunMcpServerOptions } from './server'
+export { McpRuntime, buildRuntimeConfigFromEnv } from './runtime'
+export type { BufferedEvent, LogEntry, RuntimeConfig } from './runtime'
+export { TOOLS } from './tools'
+export type { ToolDefinition } from './tools'
+export { encodeForJson, decodeFromJson } from './serializer'

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -1,0 +1,552 @@
+import { createWriteStream, type WriteStream } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+
+import { createSqliteStore } from '@zapo-js/store-sqlite'
+import { createStore, type Logger, type LogLevel, WaClient, type WaStore } from 'zapo-js'
+
+import { encodeForJson } from './serializer'
+
+const DEFAULT_BUFFER_SIZE = 1000
+const DEFAULT_LOG_BUFFER_SIZE = 500
+
+const LOG_LEVEL_PRIORITY: Readonly<Record<LogLevel, number>> = {
+    trace: 10,
+    debug: 20,
+    info: 30,
+    warn: 40,
+    error: 50
+}
+
+export interface LogEntry {
+    readonly seq: number
+    readonly timestampMs: number
+    readonly level: LogLevel
+    readonly message: string
+    readonly context: Record<string, unknown> | null
+}
+
+/**
+ * Logger that fans out every write to:
+ *   - process.stderr  (stdout is reserved for MCP JSON-RPC framing)
+ *   - a bounded in-memory ring buffer queryable via the `logs` MCP tool
+ *   - an optional append-only file (controlled by MCP_LOG_FILE)
+ */
+class BufferedTeeLogger implements Logger {
+    public readonly level: LogLevel
+    private readonly minPriority: number
+    private readonly bufferLimit: number
+    private readonly buffer: LogEntry[] = []
+    private nextSeq = 1
+    private fileStream: WriteStream | null = null
+
+    public constructor(
+        level: LogLevel = 'info',
+        bufferLimit = DEFAULT_LOG_BUFFER_SIZE,
+        filePath?: string
+    ) {
+        this.level = level
+        this.minPriority = LOG_LEVEL_PRIORITY[level]
+        this.bufferLimit = bufferLimit > 0 ? bufferLimit : DEFAULT_LOG_BUFFER_SIZE
+        if (filePath) {
+            this.fileStream = createWriteStream(filePath, { flags: 'a' })
+            this.fileStream.on('error', (err) => {
+                process.stderr.write(`[mcp] log file write error: ${err.message}\n`)
+            })
+        }
+    }
+
+    public trace(message: string, context?: Record<string, unknown>): void {
+        this.write('trace', message, context)
+    }
+    public debug(message: string, context?: Record<string, unknown>): void {
+        this.write('debug', message, context)
+    }
+    public info(message: string, context?: Record<string, unknown>): void {
+        this.write('info', message, context)
+    }
+    public warn(message: string, context?: Record<string, unknown>): void {
+        this.write('warn', message, context)
+    }
+    public error(message: string, context?: Record<string, unknown>): void {
+        this.write('error', message, context)
+    }
+
+    public listLogs(
+        filter: {
+            readonly levels?: readonly LogLevel[]
+            readonly since?: number
+            readonly limit?: number
+            readonly drain?: boolean
+        } = {}
+    ): readonly LogEntry[] {
+        const levels = filter.levels && filter.levels.length > 0 ? new Set(filter.levels) : null
+        const since = filter.since ?? 0
+        const limit = filter.limit && filter.limit > 0 ? filter.limit : 100
+        const matched: LogEntry[] = []
+        for (let i = 0; i < this.buffer.length; i += 1) {
+            const entry = this.buffer[i]
+            if (entry.seq <= since) continue
+            if (levels && !levels.has(entry.level)) continue
+            matched.push(entry)
+        }
+        const tail = matched.length > limit ? matched.slice(matched.length - limit) : matched
+        if (filter.drain && tail.length > 0) {
+            const drainSet = new Set(tail.map((e) => e.seq))
+            for (let i = this.buffer.length - 1; i >= 0; i -= 1) {
+                if (drainSet.has(this.buffer[i].seq)) {
+                    this.buffer.splice(i, 1)
+                }
+            }
+        }
+        return tail
+    }
+
+    public clearLogs(): number {
+        const n = this.buffer.length
+        this.buffer.length = 0
+        return n
+    }
+
+    public resetSequence(): void {
+        this.nextSeq = 1
+    }
+
+    public bufferLogsSize(): number {
+        return this.buffer.length
+    }
+
+    public async closeFile(): Promise<void> {
+        const stream = this.fileStream
+        if (!stream) return
+        this.fileStream = null
+        await new Promise<void>((resolveClose) => {
+            stream.end(() => resolveClose())
+        })
+    }
+
+    private write(level: LogLevel, message: string, context?: Record<string, unknown>): void {
+        if (LOG_LEVEL_PRIORITY[level] < this.minPriority) {
+            return
+        }
+        const ts = Date.now()
+        const iso = new Date(ts).toISOString()
+        const ctxStr =
+            context && Object.keys(context).length > 0 ? ` ${JSON.stringify(context)}` : ''
+        process.stderr.write(`[${iso}] ${level} ${message}${ctxStr}\n`)
+
+        const entry: LogEntry = {
+            seq: this.nextSeq,
+            timestampMs: ts,
+            level,
+            message,
+            context: context && Object.keys(context).length > 0 ? context : null
+        }
+        this.nextSeq += 1
+        this.buffer.push(entry)
+        const overflow = this.buffer.length - this.bufferLimit
+        if (overflow > 0) {
+            this.buffer.splice(0, overflow)
+        }
+
+        if (this.fileStream) {
+            this.fileStream.write(
+                `${JSON.stringify({ ts: iso, level, message, context: entry.context })}\n`
+            )
+        }
+    }
+}
+
+const ALL_EVENT_NAMES = [
+    'auth_qr',
+    'auth_pairing_code',
+    'auth_pairing_refresh',
+    'auth_paired',
+    'connection_success',
+    'client_error',
+    'connection',
+    'transport_frame_in',
+    'transport_frame_out',
+    'transport_node_in',
+    'transport_node_out',
+    'transport_decode_error',
+    'message',
+    'message_addon',
+    'message_protocol',
+    'message_receipt',
+    'newsletter_reaction',
+    'newsletter_event',
+    'presence',
+    'chatstate',
+    'call',
+    'notification',
+    'registration_code_received',
+    'account_takeover_notice',
+    'failure',
+    'stanza_error',
+    'stanza_unhandled',
+    'group_event',
+    'chat_event',
+    'history_sync_chunk',
+    'privacy_token_update',
+    'offline_resume'
+] as const
+
+const NOISY_EVENT_NAMES: ReadonlySet<string> = new Set([
+    'transport_frame_in',
+    'transport_frame_out',
+    'transport_node_in',
+    'transport_node_out'
+])
+
+export interface BufferedEvent {
+    readonly seq: number
+    readonly type: string
+    readonly timestampMs: number
+    readonly payload: unknown
+}
+
+export type McpTransportMode = 'stdio' | 'http'
+
+export interface RuntimeConfig {
+    readonly authPath: string
+    readonly sessionId: string
+    readonly logLevel: LogLevel
+    readonly bufferSize: number
+    readonly captureNoisyEvents: boolean
+    readonly deviceBrowser?: string
+    readonly deviceOsDisplayName?: string
+    readonly historyEnabled: boolean
+    /** Max log entries kept in memory for the `logs` MCP tool. */
+    readonly logBufferSize: number
+    /** Optional file path that mirrors every log line as JSONL. */
+    readonly logFilePath?: string
+    /** Override the chat socket URL list (used when pointing at a fake server). */
+    readonly chatSocketUrls?: readonly string[]
+    /** Override the Noise root CA — required when pointing at a fake server. */
+    readonly noiseRootCa?: { readonly publicKey: Uint8Array; readonly serial: number }
+    /** Transport mode for the MCP server: stdio (default) or http (StreamableHTTP, useful with nodemon). */
+    readonly transport: McpTransportMode
+    /** HTTP listen host (only when transport=http). */
+    readonly httpHost: string
+    /** HTTP listen port (only when transport=http). */
+    readonly httpPort: number
+    /** HTTP path prefix for the MCP endpoint (only when transport=http). */
+    readonly httpPath: string
+}
+
+export const buildRuntimeConfigFromEnv = (env = process.env): RuntimeConfig => {
+    const authPath = env.MCP_AUTH_PATH
+        ? resolve(env.MCP_AUTH_PATH)
+        : resolve(process.cwd(), '.auth', 'state.sqlite')
+    const sessionId = env.MCP_SESSION_ID ?? 'default_2'
+    const logLevel = resolveLogLevel(env.MCP_LOG_LEVEL)
+    const bufferSize = parsePositiveInt(env.MCP_EVENT_BUFFER_SIZE) ?? DEFAULT_BUFFER_SIZE
+    const captureNoisyEvents = env.MCP_CAPTURE_TRANSPORT === '1'
+    const historyEnabled = env.MCP_HISTORY_DISABLED !== '1'
+    const chatSocketUrls = parseUrlList(env.MCP_CHAT_SOCKET_URLS)
+    const noiseRootCa = parseNoiseRootCa(env.MCP_FAKE_NOISE_PUBKEY_HEX, env.MCP_FAKE_NOISE_SERIAL)
+    const logBufferSize = parsePositiveInt(env.MCP_LOG_BUFFER_SIZE) ?? DEFAULT_LOG_BUFFER_SIZE
+    const logFilePath = env.MCP_LOG_FILE ? resolve(env.MCP_LOG_FILE) : undefined
+    const transport = parseTransportMode(env.MCP_TRANSPORT)
+    const httpHost = env.MCP_HTTP_HOST ?? '127.0.0.1'
+    const httpPort = parsePositiveInt(env.MCP_HTTP_PORT) ?? 3737
+    const httpPath = env.MCP_HTTP_PATH ?? '/mcp'
+    return {
+        authPath,
+        sessionId,
+        logLevel,
+        bufferSize,
+        captureNoisyEvents,
+        deviceBrowser: env.MCP_DEVICE_BROWSER,
+        deviceOsDisplayName: env.MCP_DEVICE_OS_DISPLAY,
+        historyEnabled,
+        chatSocketUrls,
+        noiseRootCa,
+        logBufferSize,
+        logFilePath,
+        transport,
+        httpHost,
+        httpPort,
+        httpPath
+    }
+}
+
+const parseTransportMode = (raw: string | undefined): McpTransportMode => {
+    if (raw === 'http') return 'http'
+    if (raw === 'stdio' || raw === undefined || raw === '') return 'stdio'
+    throw new Error(`MCP_TRANSPORT must be "stdio" or "http", got "${raw}"`)
+}
+
+const parseUrlList = (raw: string | undefined): readonly string[] | undefined => {
+    if (!raw) return undefined
+    const list = raw
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+    return list.length > 0 ? list : undefined
+}
+
+const parseNoiseRootCa = (
+    pubkeyHex: string | undefined,
+    serialRaw: string | undefined
+): { publicKey: Uint8Array; serial: number } | undefined => {
+    if (!pubkeyHex || !serialRaw) return undefined
+    const cleaned = pubkeyHex.trim()
+    if (cleaned.length === 0) return undefined
+    if (cleaned.length % 2 !== 0) {
+        throw new Error('MCP_FAKE_NOISE_PUBKEY_HEX must be even-length hex')
+    }
+    const bytes = new Uint8Array(cleaned.length / 2)
+    for (let i = 0; i < bytes.length; i += 1) {
+        const byte = Number.parseInt(cleaned.slice(i * 2, i * 2 + 2), 16)
+        if (Number.isNaN(byte)) {
+            throw new Error('MCP_FAKE_NOISE_PUBKEY_HEX contains non-hex characters')
+        }
+        bytes[i] = byte
+    }
+    const serial = Number.parseInt(serialRaw.trim(), 10)
+    if (!Number.isFinite(serial)) {
+        throw new Error('MCP_FAKE_NOISE_SERIAL must be a number')
+    }
+    return { publicKey: bytes, serial }
+}
+
+const resolveLogLevel = (raw: string | undefined): LogLevel => {
+    switch (raw) {
+        case 'trace':
+        case 'debug':
+        case 'info':
+        case 'warn':
+        case 'error':
+            return raw
+        default:
+            return 'info'
+    }
+}
+
+const parsePositiveInt = (raw: string | undefined): number | null => {
+    if (!raw) return null
+    const parsed = Number.parseInt(raw, 10)
+    if (!Number.isFinite(parsed) || parsed <= 0) return null
+    return parsed
+}
+
+export class McpRuntime {
+    private readonly config: RuntimeConfig
+    private readonly logger: BufferedTeeLogger
+    private readonly buffer: BufferedEvent[] = []
+    private nextSeq = 1
+    private client: WaClient | null = null
+    private store: WaStore | null = null
+    private listenersDetach: Array<() => void> = []
+
+    public constructor(config: RuntimeConfig) {
+        this.config = config
+        this.logger = new BufferedTeeLogger(
+            config.logLevel,
+            config.logBufferSize,
+            config.logFilePath
+        )
+    }
+
+    public listLogs(
+        filter: {
+            readonly levels?: readonly LogLevel[]
+            readonly since?: number
+            readonly limit?: number
+            readonly drain?: boolean
+        } = {}
+    ): readonly LogEntry[] {
+        return this.logger.listLogs(filter)
+    }
+
+    public clearLogs(): number {
+        return this.logger.clearLogs()
+    }
+
+    public bufferLogsSize(): number {
+        return this.logger.bufferLogsSize()
+    }
+
+    public async closeLogFile(): Promise<void> {
+        await this.logger.closeFile()
+    }
+
+    /** Reset event + log seq counters back to 1. Call after a hard state wipe. */
+    public resetSequences(): void {
+        this.nextSeq = 1
+        this.logger.resetSequence()
+    }
+
+    public getConfig(): RuntimeConfig {
+        return this.config
+    }
+
+    public getLogger(): Logger {
+        return this.logger
+    }
+
+    public async ensureClient(): Promise<WaClient> {
+        if (this.client) {
+            return this.client
+        }
+        await mkdir(dirname(this.config.authPath), { recursive: true })
+        this.store = createStore({
+            backends: {
+                sqlite: createSqliteStore({
+                    path: this.config.authPath,
+                    driver: 'auto'
+                })
+            },
+            providers: {
+                auth: 'sqlite',
+                signal: 'sqlite',
+                senderKey: 'sqlite',
+                appState: 'sqlite',
+                messages: 'sqlite',
+                threads: 'sqlite',
+                contacts: 'sqlite',
+                privacyToken: 'sqlite'
+            }
+        })
+        const client = new WaClient(
+            {
+                store: this.store,
+                sessionId: this.config.sessionId,
+                connectTimeoutMs: 60_000,
+                deviceBrowser: this.config.deviceBrowser ?? 'Chrome',
+                deviceOsDisplayName: this.config.deviceOsDisplayName ?? 'Windows',
+                history: {
+                    enabled: this.config.historyEnabled,
+                    requireFullSync: true
+                },
+                nodeQueryTimeoutMs: 30_000,
+                chatSocketUrls: this.config.chatSocketUrls,
+                testHooks: this.config.noiseRootCa
+                    ? { noiseRootCa: this.config.noiseRootCa }
+                    : undefined
+            },
+            this.logger
+        )
+        this.attachListeners(client)
+        this.client = client
+        this.logger.info('mcp client created', {
+            sessionId: this.config.sessionId,
+            authPath: this.config.authPath
+        })
+        return client
+    }
+
+    public getClient(): WaClient | null {
+        return this.client
+    }
+
+    public async destroyClient(): Promise<void> {
+        if (this.client) {
+            try {
+                await this.client.disconnect()
+            } catch (error) {
+                this.logger.warn('disconnect during destroy failed', {
+                    message: (error as Error)?.message ?? String(error)
+                })
+            }
+            this.detachListeners()
+            this.client = null
+        }
+        if (this.store) {
+            try {
+                await this.store.destroy()
+            } catch (error) {
+                this.logger.warn('store destroy failed', {
+                    message: (error as Error)?.message ?? String(error)
+                })
+            }
+            this.store = null
+        }
+    }
+
+    public listEvents(
+        filter: {
+            readonly types?: readonly string[]
+            readonly since?: number
+            readonly limit?: number
+            readonly drain?: boolean
+        } = {}
+    ): readonly BufferedEvent[] {
+        const types = filter.types && filter.types.length > 0 ? new Set(filter.types) : null
+        const since = filter.since ?? 0
+        const limit = filter.limit && filter.limit > 0 ? filter.limit : 50
+        const matched: BufferedEvent[] = []
+        for (let i = 0; i < this.buffer.length; i += 1) {
+            const ev = this.buffer[i]
+            if (ev.seq <= since) continue
+            if (types && !types.has(ev.type)) continue
+            matched.push(ev)
+        }
+        const tail = matched.length > limit ? matched.slice(matched.length - limit) : matched
+        if (filter.drain && tail.length > 0) {
+            const drainSet = new Set(tail.map((e) => e.seq))
+            for (let i = this.buffer.length - 1; i >= 0; i -= 1) {
+                if (drainSet.has(this.buffer[i].seq)) {
+                    this.buffer.splice(i, 1)
+                }
+            }
+        }
+        return tail
+    }
+
+    public clearEvents(): number {
+        const n = this.buffer.length
+        this.buffer.length = 0
+        return n
+    }
+
+    public bufferSize(): number {
+        return this.buffer.length
+    }
+
+    private attachListeners(client: WaClient): void {
+        this.detachListeners()
+        for (const name of ALL_EVENT_NAMES) {
+            if (!this.config.captureNoisyEvents && NOISY_EVENT_NAMES.has(name)) {
+                continue
+            }
+            const handler = (payload: unknown): void => {
+                this.recordEvent(name, payload)
+            }
+            client.on(name, handler as never)
+            this.listenersDetach.push(() => {
+                client.off(name, handler as never)
+            })
+        }
+    }
+
+    private detachListeners(): void {
+        for (const detach of this.listenersDetach) {
+            try {
+                detach()
+            } catch {
+                /* ignore */
+            }
+        }
+        this.listenersDetach = []
+    }
+
+    private recordEvent(type: string, rawPayload: unknown): void {
+        const seq = this.nextSeq
+        this.nextSeq += 1
+        const encoded = encodeForJson(rawPayload)
+        const event: BufferedEvent = {
+            seq,
+            type,
+            timestampMs: Date.now(),
+            payload: encoded
+        }
+        this.buffer.push(event)
+        const overflow = this.buffer.length - this.config.bufferSize
+        if (overflow > 0) {
+            this.buffer.splice(0, overflow)
+        }
+    }
+}

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from 'node:path'
 
 import { createSqliteStore } from '@zapo-js/store-sqlite'
 import { createStore, type Logger, type LogLevel, WaClient, type WaStore } from 'zapo-js'
+import { toError } from 'zapo-js/util'
 
 import { encodeForJson } from './serializer'
 
@@ -58,7 +59,7 @@ class BufferedTeeLogger implements Logger {
                 })
             } catch (err) {
                 process.stderr.write(
-                    `[mcp] disabling log file mirror, could not open ${filePath}: ${(err as Error).message}\n`
+                    `[mcp] disabling log file mirror, could not open ${filePath}: ${toError(err).message}\n`
                 )
                 this.fileStream = null
             }
@@ -180,7 +181,7 @@ const safeStringify = (value: unknown): string => {
     try {
         return JSON.stringify(encodeForJson(value))
     } catch (err) {
-        return JSON.stringify({ $stringifyError: (err as Error).message })
+        return JSON.stringify({ $stringifyError: toError(err).message })
     }
 }
 
@@ -486,7 +487,7 @@ export class McpRuntime {
                 await this.client.disconnect()
             } catch (error) {
                 this.logger.warn('disconnect during destroy failed', {
-                    message: (error as Error)?.message ?? String(error)
+                    message: toError(error).message
                 })
             }
             this.detachListeners()
@@ -497,7 +498,7 @@ export class McpRuntime {
                 await this.store.destroy()
             } catch (error) {
                 this.logger.warn('store destroy failed', {
-                    message: (error as Error)?.message ?? String(error)
+                    message: toError(error).message
                 })
             }
             this.store = null

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -1,4 +1,4 @@
-import { createWriteStream, type WriteStream } from 'node:fs'
+import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs'
 import { mkdir } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
@@ -49,10 +49,19 @@ class BufferedTeeLogger implements Logger {
         this.minPriority = LOG_LEVEL_PRIORITY[level]
         this.bufferLimit = bufferLimit > 0 ? bufferLimit : DEFAULT_LOG_BUFFER_SIZE
         if (filePath) {
-            this.fileStream = createWriteStream(filePath, { flags: 'a' })
-            this.fileStream.on('error', (err) => {
-                process.stderr.write(`[mcp] log file write error: ${err.message}\n`)
-            })
+            try {
+                mkdirSync(dirname(filePath), { recursive: true })
+                this.fileStream = createWriteStream(filePath, { flags: 'a' })
+                this.fileStream.on('error', (err) => {
+                    process.stderr.write(`[mcp] log file write error: ${err.message}\n`)
+                    this.fileStream = null
+                })
+            } catch (err) {
+                process.stderr.write(
+                    `[mcp] disabling log file mirror, could not open ${filePath}: ${(err as Error).message}\n`
+                )
+                this.fileStream = null
+            }
         }
     }
 
@@ -131,8 +140,9 @@ class BufferedTeeLogger implements Logger {
         }
         const ts = Date.now()
         const iso = new Date(ts).toISOString()
-        const ctxStr =
-            context && Object.keys(context).length > 0 ? ` ${JSON.stringify(context)}` : ''
+        const safeCtx =
+            context && Object.keys(context).length > 0 ? safeStringify(context) : null
+        const ctxStr = safeCtx ? ` ${safeCtx}` : ''
         process.stderr.write(`[${iso}] ${level} ${message}${ctxStr}\n`)
 
         const entry: LogEntry = {
@@ -150,10 +160,27 @@ class BufferedTeeLogger implements Logger {
         }
 
         if (this.fileStream) {
-            this.fileStream.write(
-                `${JSON.stringify({ ts: iso, level, message, context: entry.context })}\n`
-            )
+            const line = safeStringify({
+                ts: iso,
+                level,
+                message,
+                context: entry.context
+            })
+            this.fileStream.write(`${line}\n`)
         }
+    }
+}
+
+/**
+ * JSON.stringify-safe wrapper. Routes through encodeForJson so BigInt, Uint8Array,
+ * cycles and other non-JSON values turn into the runtime's marker shape instead of
+ * throwing — a logger that crashes on log payload is worse than a noisy log.
+ */
+const safeStringify = (value: unknown): string => {
+    try {
+        return JSON.stringify(encodeForJson(value))
+    } catch (err) {
+        return JSON.stringify({ $stringifyError: (err as Error).message })
     }
 }
 
@@ -340,6 +367,7 @@ export class McpRuntime {
     private client: WaClient | null = null
     private store: WaStore | null = null
     private listenersDetach: Array<() => void> = []
+    private clientInitPromise: Promise<WaClient> | null = null
 
     public constructor(config: RuntimeConfig) {
         this.config = config
@@ -387,10 +415,20 @@ export class McpRuntime {
         return this.logger
     }
 
-    public async ensureClient(): Promise<WaClient> {
+    public ensureClient(): Promise<WaClient> {
         if (this.client) {
-            return this.client
+            return Promise.resolve(this.client)
         }
+        if (this.clientInitPromise) {
+            return this.clientInitPromise
+        }
+        this.clientInitPromise = this.initClient().finally(() => {
+            this.clientInitPromise = null
+        })
+        return this.clientInitPromise
+    }
+
+    private async initClient(): Promise<WaClient> {
         await mkdir(dirname(this.config.authPath), { recursive: true })
         this.store = createStore({
             backends: {

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -4,7 +4,7 @@ import { dirname, resolve } from 'node:path'
 
 import { createSqliteStore } from '@zapo-js/store-sqlite'
 import { createStore, type Logger, type LogLevel, WaClient, type WaStore } from 'zapo-js'
-import { toError } from 'zapo-js/util'
+import { hexToBytes, resolvePositive, toError } from 'zapo-js/util'
 
 import { encodeForJson } from './serializer'
 
@@ -141,8 +141,7 @@ class BufferedTeeLogger implements Logger {
         }
         const ts = Date.now()
         const iso = new Date(ts).toISOString()
-        const safeCtx =
-            context && Object.keys(context).length > 0 ? safeStringify(context) : null
+        const safeCtx = context && Object.keys(context).length > 0 ? safeStringify(context) : null
         const ctxStr = safeCtx ? ` ${safeCtx}` : ''
         process.stderr.write(`[${iso}] ${level} ${message}${ctxStr}\n`)
 
@@ -269,16 +268,24 @@ export const buildRuntimeConfigFromEnv = (env = process.env): RuntimeConfig => {
         : resolve(process.cwd(), '.auth', 'state.sqlite')
     const sessionId = env.MCP_SESSION_ID ?? 'default_2'
     const logLevel = resolveLogLevel(env.MCP_LOG_LEVEL)
-    const bufferSize = parsePositiveInt(env.MCP_EVENT_BUFFER_SIZE) ?? DEFAULT_BUFFER_SIZE
+    const bufferSize = parseEnvPositiveInt(
+        env.MCP_EVENT_BUFFER_SIZE,
+        'MCP_EVENT_BUFFER_SIZE',
+        DEFAULT_BUFFER_SIZE
+    )
     const captureNoisyEvents = env.MCP_CAPTURE_TRANSPORT === '1'
     const historyEnabled = env.MCP_HISTORY_DISABLED !== '1'
     const chatSocketUrls = parseUrlList(env.MCP_CHAT_SOCKET_URLS)
     const noiseRootCa = parseNoiseRootCa(env.MCP_FAKE_NOISE_PUBKEY_HEX, env.MCP_FAKE_NOISE_SERIAL)
-    const logBufferSize = parsePositiveInt(env.MCP_LOG_BUFFER_SIZE) ?? DEFAULT_LOG_BUFFER_SIZE
+    const logBufferSize = parseEnvPositiveInt(
+        env.MCP_LOG_BUFFER_SIZE,
+        'MCP_LOG_BUFFER_SIZE',
+        DEFAULT_LOG_BUFFER_SIZE
+    )
     const logFilePath = env.MCP_LOG_FILE ? resolve(env.MCP_LOG_FILE) : undefined
     const transport = parseTransportMode(env.MCP_TRANSPORT)
     const httpHost = env.MCP_HTTP_HOST ?? '127.0.0.1'
-    const httpPort = parsePositiveInt(env.MCP_HTTP_PORT) ?? 3737
+    const httpPort = parseEnvPositiveInt(env.MCP_HTTP_PORT, 'MCP_HTTP_PORT', 3737)
     const httpPath = env.MCP_HTTP_PATH ?? '/mcp'
     return {
         authPath,
@@ -322,22 +329,12 @@ const parseNoiseRootCa = (
     if (!pubkeyHex || !serialRaw) return undefined
     const cleaned = pubkeyHex.trim()
     if (cleaned.length === 0) return undefined
-    if (cleaned.length % 2 !== 0) {
-        throw new Error('MCP_FAKE_NOISE_PUBKEY_HEX must be even-length hex')
-    }
-    const bytes = new Uint8Array(cleaned.length / 2)
-    for (let i = 0; i < bytes.length; i += 1) {
-        const byte = Number.parseInt(cleaned.slice(i * 2, i * 2 + 2), 16)
-        if (Number.isNaN(byte)) {
-            throw new Error('MCP_FAKE_NOISE_PUBKEY_HEX contains non-hex characters')
-        }
-        bytes[i] = byte
-    }
+    const publicKey = hexToBytes(cleaned)
     const serial = Number.parseInt(serialRaw.trim(), 10)
     if (!Number.isFinite(serial)) {
         throw new Error('MCP_FAKE_NOISE_SERIAL must be a number')
     }
-    return { publicKey: bytes, serial }
+    return { publicKey, serial }
 }
 
 const resolveLogLevel = (raw: string | undefined): LogLevel => {
@@ -353,11 +350,10 @@ const resolveLogLevel = (raw: string | undefined): LogLevel => {
     }
 }
 
-const parsePositiveInt = (raw: string | undefined): number | null => {
-    if (!raw) return null
+const parseEnvPositiveInt = (raw: string | undefined, name: string, fallback: number): number => {
+    if (!raw) return fallback
     const parsed = Number.parseInt(raw, 10)
-    if (!Number.isFinite(parsed) || parsed <= 0) return null
-    return parsed
+    return resolvePositive(Number.isFinite(parsed) ? parsed : Number.NaN, fallback, name)
 }
 
 export class McpRuntime {

--- a/packages/mcp-server/src/serializer.ts
+++ b/packages/mcp-server/src/serializer.ts
@@ -1,0 +1,168 @@
+/**
+ * JSON-friendly serializer with markers for non-JSON types.
+ *
+ * Markers used:
+ *   { "$bytes": "<base64>" }       - Uint8Array
+ *   { "$bigint": "<digits>" }      - BigInt
+ *   { "$date": "<iso>" }           - Date
+ *   { "$set": [...] }              - Set
+ *   { "$map": [[k, v], ...] }      - Map
+ *   { "$error": { name, message, stack?, code? } }
+ *   { "$function": "<name>" }      - Function (encoded only)
+ *   "[Circular]"                   - Cycle marker
+ */
+
+const BYTES = '$bytes'
+const BIGINT = '$bigint'
+const DATE = '$date'
+const SET = '$set'
+const MAP = '$map'
+const ERROR_KEY = '$error'
+const FUNCTION_KEY = '$function'
+
+const MAX_DEPTH = 32
+
+export const encodeForJson = (value: unknown): unknown => {
+    return encode(value, new WeakSet(), 0)
+}
+
+export const decodeFromJson = (value: unknown): unknown => {
+    return decode(value, 0)
+}
+
+const encode = (value: unknown, seen: WeakSet<object>, depth: number): unknown => {
+    if (depth > MAX_DEPTH) {
+        return '[MaxDepthReached]'
+    }
+    if (value === null || value === undefined) {
+        return value ?? null
+    }
+    const type = typeof value
+    if (type === 'string' || type === 'number' || type === 'boolean') {
+        return value
+    }
+    if (type === 'bigint') {
+        return { [BIGINT]: (value as bigint).toString() }
+    }
+    if (type === 'function') {
+        return { [FUNCTION_KEY]: (value as { name?: string }).name ?? '' }
+    }
+    if (type !== 'object') {
+        return String(value)
+    }
+    const obj = value as object
+    if (seen.has(obj)) {
+        return '[Circular]'
+    }
+    seen.add(obj)
+    try {
+        if (obj instanceof Uint8Array) {
+            return { [BYTES]: bytesToBase64(obj) }
+        }
+        if (obj instanceof Date) {
+            return { [DATE]: obj.toISOString() }
+        }
+        if (obj instanceof Error) {
+            const err = obj as Error & { code?: unknown }
+            return {
+                [ERROR_KEY]: {
+                    name: err.name,
+                    message: err.message,
+                    stack: err.stack,
+                    code:
+                        typeof err.code === 'string' || typeof err.code === 'number'
+                            ? err.code
+                            : undefined
+                }
+            }
+        }
+        if (obj instanceof Map) {
+            const entries: unknown[] = []
+            for (const [k, v] of obj.entries()) {
+                entries.push([encode(k, seen, depth + 1), encode(v, seen, depth + 1)])
+            }
+            return { [MAP]: entries }
+        }
+        if (obj instanceof Set) {
+            const entries: unknown[] = []
+            for (const v of obj.values()) {
+                entries.push(encode(v, seen, depth + 1))
+            }
+            return { [SET]: entries }
+        }
+        if (Array.isArray(obj)) {
+            const out: unknown[] = new Array(obj.length)
+            for (let i = 0; i < obj.length; i += 1) {
+                out[i] = encode(obj[i], seen, depth + 1)
+            }
+            return out
+        }
+        const out: Record<string, unknown> = {}
+        for (const key of Object.keys(obj)) {
+            out[key] = encode((obj as Record<string, unknown>)[key], seen, depth + 1)
+        }
+        return out
+    } finally {
+        seen.delete(obj)
+    }
+}
+
+const decode = (value: unknown, depth: number): unknown => {
+    if (depth > MAX_DEPTH) {
+        return value
+    }
+    if (value === null || value === undefined) {
+        return value
+    }
+    if (typeof value !== 'object') {
+        return value
+    }
+    if (Array.isArray(value)) {
+        const out: unknown[] = new Array(value.length)
+        for (let i = 0; i < value.length; i += 1) {
+            out[i] = decode(value[i], depth + 1)
+        }
+        return out
+    }
+    const obj = value as Record<string, unknown>
+    if (BYTES in obj && typeof obj[BYTES] === 'string') {
+        return base64ToBytes(obj[BYTES])
+    }
+    if (BIGINT in obj && typeof obj[BIGINT] === 'string') {
+        return BigInt(obj[BIGINT])
+    }
+    if (DATE in obj && typeof obj[DATE] === 'string') {
+        return new Date(obj[DATE])
+    }
+    if (SET in obj && Array.isArray(obj[SET])) {
+        const arr = obj[SET] as unknown[]
+        const set = new Set<unknown>()
+        for (let i = 0; i < arr.length; i += 1) {
+            set.add(decode(arr[i], depth + 1))
+        }
+        return set
+    }
+    if (MAP in obj && Array.isArray(obj[MAP])) {
+        const arr = obj[MAP] as unknown[]
+        const map = new Map<unknown, unknown>()
+        for (let i = 0; i < arr.length; i += 1) {
+            const entry = arr[i] as [unknown, unknown]
+            map.set(decode(entry[0], depth + 1), decode(entry[1], depth + 1))
+        }
+        return map
+    }
+    const out: Record<string, unknown> = {}
+    for (const key of Object.keys(obj)) {
+        out[key] = decode(obj[key], depth + 1)
+    }
+    return out
+}
+
+const bytesToBase64 = (bytes: Uint8Array): string => {
+    return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('base64')
+}
+
+const base64ToBytes = (s: string): Uint8Array => {
+    const buf = Buffer.from(s, 'base64')
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+}

--- a/packages/mcp-server/src/serializer.ts
+++ b/packages/mcp-server/src/serializer.ts
@@ -12,6 +12,8 @@
  *   "[Circular]"                   - Cycle marker
  */
 
+import { base64ToBytes, bytesToBase64 } from 'zapo-js/util'
+
 const BYTES = '$bytes'
 const BIGINT = '$bigint'
 const DATE = '$date'
@@ -158,11 +160,3 @@ const decode = (value: unknown, depth: number): unknown => {
     return out
 }
 
-const bytesToBase64 = (bytes: Uint8Array): string => {
-    return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('base64')
-}
-
-const base64ToBytes = (s: string): Uint8Array => {
-    const buf = Buffer.from(s, 'base64')
-    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
-}

--- a/packages/mcp-server/src/serializer.ts
+++ b/packages/mcp-server/src/serializer.ts
@@ -159,4 +159,3 @@ const decode = (value: unknown, depth: number): unknown => {
     }
     return out
 }
-

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,0 +1,312 @@
+import {
+    createServer as createHttpServer,
+    type IncomingMessage,
+    type Server as NodeHttpServer,
+    type ServerResponse
+} from 'node:http'
+
+import { buildRuntimeConfigFromEnv, McpRuntime, type RuntimeConfig } from './runtime'
+import { encodeForJson } from './serializer'
+import { type ToolDefinition, TOOLS } from './tools'
+
+interface SdkBundle {
+    readonly Server: new (
+        info: { name: string; version: string },
+        options: { capabilities: { tools: Record<string, unknown> } }
+    ) => SdkServer
+    readonly StdioServerTransport: new () => SdkTransport
+    readonly StreamableHTTPServerTransport: new (options: {
+        sessionIdGenerator: undefined | (() => string)
+    }) => SdkHttpTransport
+    readonly ListToolsRequestSchema: unknown
+    readonly CallToolRequestSchema: unknown
+}
+
+interface SdkServer {
+    setRequestHandler(schema: unknown, handler: (request: unknown) => Promise<unknown>): void
+    connect(transport: SdkTransport | SdkHttpTransport): Promise<void>
+    close(): Promise<void>
+}
+
+interface SdkTransport {
+    /* opaque */
+}
+
+interface SdkHttpTransport {
+    handleRequest(req: IncomingMessage, res: ServerResponse, body?: unknown): Promise<void>
+    close(): Promise<void>
+}
+
+const loadSdk = async (): Promise<SdkBundle> => {
+    // The MCP SDK is ESM-only and uses subpath exports with `.js` suffix.
+    // eslint-plugin-import's resolver does not currently follow these exports
+    // for dynamic-import call sites, so suppress the unresolved warnings. The
+    // bundles are validated at runtime by the smoke tests.
+    /* eslint-disable import/no-unresolved */
+    const [serverModule, stdioModule, httpModule, typesModule] = await Promise.all([
+        import('@modelcontextprotocol/sdk/server/index.js'),
+        import('@modelcontextprotocol/sdk/server/stdio.js'),
+        import('@modelcontextprotocol/sdk/server/streamableHttp.js'),
+        import('@modelcontextprotocol/sdk/types.js')
+    ])
+    /* eslint-enable import/no-unresolved */
+    return {
+        Server: (serverModule as { Server: SdkBundle['Server'] }).Server,
+        StdioServerTransport: (
+            stdioModule as { StdioServerTransport: SdkBundle['StdioServerTransport'] }
+        ).StdioServerTransport,
+        StreamableHTTPServerTransport: (
+            httpModule as {
+                StreamableHTTPServerTransport: SdkBundle['StreamableHTTPServerTransport']
+            }
+        ).StreamableHTTPServerTransport,
+        ListToolsRequestSchema: (typesModule as { ListToolsRequestSchema: unknown })
+            .ListToolsRequestSchema,
+        CallToolRequestSchema: (typesModule as { CallToolRequestSchema: unknown })
+            .CallToolRequestSchema
+    }
+}
+
+export interface RunMcpServerOptions {
+    readonly name?: string
+    readonly version?: string
+}
+
+const buildMcpServer = (
+    sdk: SdkBundle,
+    runtime: McpRuntime,
+    options: RunMcpServerOptions
+): SdkServer => {
+    const server = new sdk.Server(
+        {
+            name: options.name ?? '@zapo-js/mcp-server',
+            version: options.version ?? '0.0.0'
+        },
+        { capabilities: { tools: {} } }
+    )
+
+    const toolsByName = new Map<string, ToolDefinition>()
+    for (const tool of TOOLS) {
+        toolsByName.set(tool.name, tool)
+    }
+
+    server.setRequestHandler(sdk.ListToolsRequestSchema, async () => {
+        return {
+            tools: TOOLS.map((tool) => ({
+                name: tool.name,
+                description: tool.description,
+                inputSchema: tool.inputSchema
+            }))
+        }
+    })
+
+    server.setRequestHandler(sdk.CallToolRequestSchema, async (request) => {
+        const req = request as { params: { name: string; arguments?: unknown } }
+        const tool = toolsByName.get(req.params.name)
+        if (!tool) {
+            return {
+                isError: true,
+                content: [{ type: 'text', text: `unknown tool "${req.params.name}"` }]
+            }
+        }
+        try {
+            const result = await tool.handler(req.params.arguments ?? {}, runtime)
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: JSON.stringify(encodeForJson(result), null, 2)
+                    }
+                ]
+            }
+        } catch (error) {
+            const err = error as Error
+            runtime.getLogger().warn('tool handler failed', {
+                tool: tool.name,
+                message: err?.message ?? String(error)
+            })
+            return {
+                isError: true,
+                content: [
+                    {
+                        type: 'text',
+                        text: JSON.stringify(
+                            encodeForJson({
+                                error: {
+                                    name: err?.name ?? 'Error',
+                                    message: err?.message ?? String(error),
+                                    stack: err?.stack
+                                }
+                            }),
+                            null,
+                            2
+                        )
+                    }
+                ]
+            }
+        }
+    })
+
+    return server
+}
+
+const runStdioTransport = async (
+    sdk: SdkBundle,
+    runtime: McpRuntime,
+    options: RunMcpServerOptions
+): Promise<{ shutdown: () => Promise<void> }> => {
+    const server = buildMcpServer(sdk, runtime, options)
+    const transport = new sdk.StdioServerTransport()
+    await server.connect(transport)
+    runtime.getLogger().info('mcp server connected via stdio')
+    return {
+        shutdown: async () => {
+            try {
+                await server.close()
+            } catch {
+                /* swallow */
+            }
+        }
+    }
+}
+
+const readJsonBody = (req: IncomingMessage): Promise<unknown> => {
+    return new Promise((resolve, reject) => {
+        const chunks: Buffer[] = []
+        let total = 0
+        const MAX_BODY = 8 * 1024 * 1024
+        req.on('data', (chunk: Buffer) => {
+            total += chunk.length
+            if (total > MAX_BODY) {
+                req.destroy(new Error('request body too large'))
+                return
+            }
+            chunks.push(chunk)
+        })
+        req.on('end', () => {
+            const raw = Buffer.concat(chunks).toString('utf8')
+            if (raw.length === 0) {
+                resolve(undefined)
+                return
+            }
+            try {
+                resolve(JSON.parse(raw))
+            } catch (error) {
+                reject(error instanceof Error ? error : new Error(String(error)))
+            }
+        })
+        req.on('error', reject)
+    })
+}
+
+const runHttpTransport = async (
+    sdk: SdkBundle,
+    runtime: McpRuntime,
+    options: RunMcpServerOptions,
+    config: Pick<RuntimeConfig, 'httpHost' | 'httpPort' | 'httpPath'>
+): Promise<{ shutdown: () => Promise<void>; httpServer: NodeHttpServer }> => {
+    const route = config.httpPath
+    const httpServer = createHttpServer(async (req, res) => {
+        const url = req.url ?? ''
+        const pathOnly = url.split('?')[0]
+        if (pathOnly !== route) {
+            res.writeHead(404, { 'content-type': 'application/json' }).end(
+                JSON.stringify({ error: 'not found', expected: route })
+            )
+            return
+        }
+        if (req.method !== 'POST') {
+            res.writeHead(405, { 'content-type': 'application/json', allow: 'POST' }).end(
+                JSON.stringify({ error: 'method not allowed; use POST' })
+            )
+            return
+        }
+        let body: unknown
+        try {
+            body = await readJsonBody(req)
+        } catch (error) {
+            res.writeHead(400, { 'content-type': 'application/json' }).end(
+                JSON.stringify({ error: 'invalid json body', message: (error as Error).message })
+            )
+            return
+        }
+
+        const server = buildMcpServer(sdk, runtime, options)
+        const transport = new sdk.StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
+        res.on('close', () => {
+            transport.close().catch(() => undefined)
+            server.close().catch(() => undefined)
+        })
+        try {
+            await server.connect(transport)
+            await transport.handleRequest(req, res, body)
+        } catch (error) {
+            runtime.getLogger().warn('http request failed', {
+                message: (error as Error)?.message ?? String(error)
+            })
+            if (!res.headersSent) {
+                res.writeHead(500, { 'content-type': 'application/json' }).end(
+                    JSON.stringify({ error: 'internal', message: (error as Error)?.message })
+                )
+            }
+        }
+    })
+
+    await new Promise<void>((resolve, reject) => {
+        httpServer.once('error', reject)
+        httpServer.listen(config.httpPort, config.httpHost, () => {
+            httpServer.off('error', reject)
+            resolve()
+        })
+    })
+    runtime.getLogger().info('mcp server listening', {
+        url: `http://${config.httpHost}:${config.httpPort}${route}`
+    })
+
+    return {
+        httpServer,
+        shutdown: async () => {
+            await new Promise<void>((resolve) => {
+                httpServer.close(() => resolve())
+            })
+        }
+    }
+}
+
+export const runMcpServer = async (options: RunMcpServerOptions = {}): Promise<void> => {
+    const config = buildRuntimeConfigFromEnv()
+    const runtime = new McpRuntime(config)
+    runtime.getLogger().info('starting mcp server', {
+        sessionId: config.sessionId,
+        authPath: config.authPath,
+        transport: config.transport
+    })
+
+    const sdk = await loadSdk()
+    const { shutdown: shutdownTransport } =
+        config.transport === 'http'
+            ? await runHttpTransport(sdk, runtime, options, config)
+            : await runStdioTransport(sdk, runtime, options)
+
+    const shutdown = async (signal: string): Promise<void> => {
+        runtime.getLogger().info('shutting down', { signal })
+        try {
+            await runtime.destroyClient()
+        } catch {
+            /* swallow */
+        }
+        try {
+            await shutdownTransport()
+        } catch {
+            /* swallow */
+        }
+        try {
+            await runtime.closeLogFile()
+        } catch {
+            /* swallow */
+        }
+        process.exit(0)
+    }
+    process.on('SIGINT', () => void shutdown('SIGINT'))
+    process.on('SIGTERM', () => void shutdown('SIGTERM'))
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -5,6 +5,8 @@ import {
     type ServerResponse
 } from 'node:http'
 
+import { toError } from 'zapo-js/util'
+
 import { buildRuntimeConfigFromEnv, McpRuntime, type RuntimeConfig } from './runtime'
 import { encodeForJson } from './serializer'
 import { type ToolDefinition, TOOLS } from './tools'
@@ -120,10 +122,10 @@ const buildMcpServer = (
                 ]
             }
         } catch (error) {
-            const err = error as Error
+            const err = toError(error)
             runtime.getLogger().warn('tool handler failed', {
                 tool: tool.name,
-                message: err?.message ?? String(error)
+                message: err.message
             })
             return {
                 isError: true,
@@ -133,9 +135,9 @@ const buildMcpServer = (
                         text: JSON.stringify(
                             encodeForJson({
                                 error: {
-                                    name: err?.name ?? 'Error',
-                                    message: err?.message ?? String(error),
-                                    stack: err?.stack
+                                    name: err.name,
+                                    message: err.message,
+                                    stack: err.stack
                                 }
                             }),
                             null,
@@ -253,7 +255,7 @@ const runHttpTransport = async (
             body = await readJsonBody(req)
         } catch (error) {
             res.writeHead(400, { 'content-type': 'application/json' }).end(
-                JSON.stringify({ error: 'invalid json body', message: (error as Error).message })
+                JSON.stringify({ error: 'invalid json body', message: toError(error).message })
             )
             return
         }
@@ -275,12 +277,11 @@ const runHttpTransport = async (
             await server.connect(transport)
             await transport.handleRequest(req, res, body)
         } catch (error) {
-            runtime.getLogger().warn('http request failed', {
-                message: (error as Error)?.message ?? String(error)
-            })
+            const err = toError(error)
+            runtime.getLogger().warn('http request failed', { message: err.message })
             if (!res.headersSent) {
                 res.writeHead(500, { 'content-type': 'application/json' }).end(
-                    JSON.stringify({ error: 'internal', message: (error as Error)?.message })
+                    JSON.stringify({ error: 'internal', message: err.message })
                 )
             }
         }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -209,10 +209,10 @@ const readJsonBody = (req: IncomingMessage): Promise<unknown> => {
         // Connection went away mid-upload (client closed, network reset, ...).
         // Without these handlers neither `end` nor `error` necessarily fires
         // and the Promise hangs the request handler forever.
-        req.on('aborted', () =>
-            settle(() => reject(new Error('request aborted by client')))
+        req.on('aborted', () => settle(() => reject(new Error('request aborted by client'))))
+        req.on('close', () =>
+            settle(() => reject(new Error('request closed before body finished')))
         )
-        req.on('close', () => settle(() => reject(new Error('request closed before body finished'))))
     })
 }
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -174,7 +174,13 @@ const readJsonBody = (req: IncomingMessage): Promise<unknown> => {
     return new Promise((resolve, reject) => {
         const chunks: Buffer[] = []
         let total = 0
+        let settled = false
         const MAX_BODY = 8 * 1024 * 1024
+        const settle = (fn: () => void): void => {
+            if (settled) return
+            settled = true
+            fn()
+        }
         req.on('data', (chunk: Buffer) => {
             total += chunk.length
             if (total > MAX_BODY) {
@@ -184,20 +190,31 @@ const readJsonBody = (req: IncomingMessage): Promise<unknown> => {
             chunks.push(chunk)
         })
         req.on('end', () => {
-            const raw = Buffer.concat(chunks).toString('utf8')
-            if (raw.length === 0) {
-                resolve(undefined)
-                return
-            }
-            try {
-                resolve(JSON.parse(raw))
-            } catch (error) {
-                reject(error instanceof Error ? error : new Error(String(error)))
-            }
+            settle(() => {
+                const raw = Buffer.concat(chunks).toString('utf8')
+                if (raw.length === 0) {
+                    resolve(undefined)
+                    return
+                }
+                try {
+                    resolve(JSON.parse(raw))
+                } catch (error) {
+                    reject(error instanceof Error ? error : new Error(String(error)))
+                }
+            })
         })
-        req.on('error', reject)
+        req.on('error', (err) => settle(() => reject(err)))
+        // Connection went away mid-upload (client closed, network reset, ...).
+        // Without these handlers neither `end` nor `error` necessarily fires
+        // and the Promise hangs the request handler forever.
+        req.on('aborted', () =>
+            settle(() => reject(new Error('request aborted by client')))
+        )
+        req.on('close', () => settle(() => reject(new Error('request closed before body finished'))))
     })
 }
+
+const LOOPBACK_HOSTS: ReadonlySet<string> = new Set(['127.0.0.1', 'localhost', '::1'])
 
 const runHttpTransport = async (
     sdk: SdkBundle,
@@ -206,6 +223,16 @@ const runHttpTransport = async (
     config: Pick<RuntimeConfig, 'httpHost' | 'httpPort' | 'httpPath'>
 ): Promise<{ shutdown: () => Promise<void>; httpServer: NodeHttpServer }> => {
     const route = config.httpPath
+    if (!LOOPBACK_HOSTS.has(config.httpHost)) {
+        // The HTTP transport has no auth and the `call` tool exposes the entire
+        // WaClient + zapo-js surface. Binding to a non-loopback interface puts
+        // that on the network — definitely not what you want by accident.
+        runtime.getLogger().warn('mcp http transport bound to non-loopback host without auth', {
+            host: config.httpHost,
+            port: config.httpPort,
+            advice: 'switch back to MCP_HTTP_HOST=127.0.0.1 unless you have a reverse proxy enforcing auth'
+        })
+    }
     const httpServer = createHttpServer(async (req, res) => {
         const url = req.url ?? ''
         const pathOnly = url.split('?')[0]
@@ -231,6 +258,13 @@ const runHttpTransport = async (
             return
         }
 
+        // Stateless on purpose: each request gets a fresh Server + transport
+        // pair. The actual MCP session state (WaClient, event/log buffers) is
+        // shared via the singleton `runtime`, so request-scoped objects only
+        // carry protocol plumbing. This also makes nodemon-style restarts
+        // free of session-id bookkeeping (no client to invalidate). If we
+        // ever want true MCP `mcp-session-id` resume we'd swap to a session
+        // map keyed by sessionIdGenerator + that header.
         const server = buildMcpServer(sdk, runtime, options)
         const transport = new sdk.StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
         res.on('close', () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -1,4 +1,5 @@
 import * as ZapoLib from 'zapo-js'
+import { toError } from 'zapo-js/util'
 
 import type { McpRuntime } from './runtime'
 import { decodeFromJson, encodeForJson } from './serializer'
@@ -87,7 +88,7 @@ const callTool: ToolDefinition = {
                     ;(invoked as Promise<unknown>).catch((error: unknown) => {
                         runtime.getLogger().warn('noAwait call rejected', {
                             path,
-                            message: (error as Error)?.message ?? String(error)
+                            message: toError(error).message
                         })
                     })
                 }
@@ -375,7 +376,7 @@ const lifecycleTool: ToolDefinition = {
                     try {
                         state = client.getState()
                     } catch (error) {
-                        state = { error: (error as Error)?.message ?? String(error) }
+                        state = { error: toError(error).message }
                     }
                 }
                 return {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -1,0 +1,589 @@
+import * as ZapoLib from 'zapo-js'
+
+import type { McpRuntime } from './runtime'
+import { decodeFromJson, encodeForJson } from './serializer'
+
+export interface ToolDefinition {
+    readonly name: string
+    readonly description: string
+    readonly inputSchema: Record<string, unknown>
+    readonly handler: (input: unknown, runtime: McpRuntime) => Promise<unknown>
+}
+
+type Root = 'client' | 'lib'
+
+const ROOT_VALUES: readonly Root[] = ['client', 'lib']
+
+const resolveRoot = async (
+    root: Root,
+    runtime: McpRuntime
+): Promise<{ readonly object: Record<string, unknown>; readonly label: string }> => {
+    if (root === 'lib') {
+        return { object: ZapoLib as unknown as Record<string, unknown>, label: 'zapo-js' }
+    }
+    const client = await runtime.ensureClient()
+    return { object: client as unknown as Record<string, unknown>, label: 'WaClient' }
+}
+
+const parseRoot = (raw: unknown): Root => {
+    if (raw === undefined || raw === null) return 'client'
+    if (typeof raw === 'string' && (ROOT_VALUES as readonly string[]).includes(raw)) {
+        return raw as Root
+    }
+    throw new Error(`"root" must be one of ${ROOT_VALUES.join(' | ')}`)
+}
+
+const callTool: ToolDefinition = {
+    name: 'call',
+    description:
+        'Resolve a dotted path on a root object and either return the value or call it as a function with the given args. ' +
+        'Roots: "client" (default) = WaClient instance; "lib" = the zapo-js module namespace ' +
+        '(pure helpers like parsePhoneJid/isGroupJid/normalizeRecipientJid, the WA_* constants, the proto namespace at "proto.*", and createStore). ' +
+        'Examples: { path: "connect" } -> client.connect(); { path: "group.create", args: [...] } -> client.group.create(...); ' +
+        '{ root: "lib", path: "parsePhoneJid", args: ["+5511999999999"] }; ' +
+        '{ root: "lib", path: "WA_DEFAULTS" } returns the constants object. ' +
+        'Args are decoded recursively: { "$bytes": "<base64>" } -> Uint8Array, { "$bigint": "<digits>" } -> BigInt. ' +
+        'Result is encoded the same way for transport. ' +
+        'Pass `noAwait: true` to fire-and-forget when the function returns a long-running Promise (e.g. client.connect() blocks until pairing finishes); ' +
+        'the tool returns immediately and you observe the outcome via `events`/`logs`.',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            root: {
+                type: 'string',
+                enum: ['client', 'lib'],
+                description:
+                    '"client" (default) walks WaClient instance; "lib" walks the zapo-js module namespace (no client init needed).'
+            },
+            path: {
+                type: 'string',
+                description:
+                    'Dotted property path. Examples: "sendMessage", "group.metadata", "proto.Message.create" (under root="lib").'
+            },
+            args: {
+                type: 'array',
+                description:
+                    'Positional arguments. Each item is decoded (e.g. $bytes/$bigint markers).',
+                items: {}
+            },
+            noAwait: {
+                type: 'boolean',
+                description:
+                    'When true, invoke the function and return immediately without awaiting its Promise. Useful for client.connect() during pairing. Rejections are logged via the runtime logger.'
+            }
+        },
+        required: ['path'],
+        additionalProperties: false
+    },
+    handler: async (input, runtime) => {
+        const { path, args, root, noAwait } = parseCallInput(input)
+        const { object, label } = await resolveRoot(root, runtime)
+        const { parent, value, lastKey } = resolvePath(object, path)
+        if (typeof value === 'function') {
+            const decoded = (decodeFromJson(args) as unknown[]) ?? []
+            const invoked = (value as (...a: unknown[]) => unknown).apply(parent, decoded)
+            if (noAwait) {
+                if (invoked && typeof (invoked as Promise<unknown>).then === 'function') {
+                    ;(invoked as Promise<unknown>).catch((error: unknown) => {
+                        runtime.getLogger().warn('noAwait call rejected', {
+                            path,
+                            message: (error as Error)?.message ?? String(error)
+                        })
+                    })
+                }
+                return {
+                    kind: 'call',
+                    root,
+                    rootLabel: label,
+                    path,
+                    arity: (value as { length?: number }).length ?? 0,
+                    lastKey,
+                    noAwait: true,
+                    fired: true
+                }
+            }
+            const result = await Promise.resolve(invoked)
+            return {
+                kind: 'call',
+                root,
+                rootLabel: label,
+                path,
+                arity: (value as { length?: number }).length ?? 0,
+                lastKey,
+                result: encodeForJson(result)
+            }
+        }
+        return {
+            kind: 'value',
+            root,
+            rootLabel: label,
+            path,
+            lastKey,
+            value: encodeForJson(value)
+        }
+    }
+}
+
+const inspectTool: ToolDefinition = {
+    name: 'inspect',
+    description:
+        'List the properties and methods reachable at a path on the chosen root. ' +
+        'Roots: "client" (default) = WaClient instance + coordinators; "lib" = the zapo-js module namespace ' +
+        '(use { root: "lib" } to see exported helpers, WA_* constants, "proto", "createStore", etc.). ' +
+        'Returns own + inherited members up to (but excluding) Object.prototype, with origin class name.',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            root: {
+                type: 'string',
+                enum: ['client', 'lib'],
+                description:
+                    '"client" (default) inspects WaClient; "lib" inspects the zapo-js module namespace.'
+            },
+            path: {
+                type: 'string',
+                description: 'Dotted path. Empty/omitted = the root itself.'
+            },
+            includeEventEmitter: {
+                type: 'boolean',
+                description:
+                    'Include EventEmitter-inherited methods (on/off/emit/etc). Default false.'
+            }
+        },
+        additionalProperties: false
+    },
+    handler: async (input, runtime) => {
+        const { path, includeEventEmitter, root } = parseInspectInput(input)
+        const { object, label } = await resolveRoot(root, runtime)
+        const { value } = resolvePath(object, path)
+        if (value === null || value === undefined) {
+            return { root, rootLabel: label, path, value: encodeForJson(value), members: [] }
+        }
+        if (typeof value !== 'object' && typeof value !== 'function') {
+            return { root, rootLabel: label, path, scalar: encodeForJson(value), members: [] }
+        }
+        const members = collectMembers(value, includeEventEmitter)
+        return {
+            root,
+            rootLabel: label,
+            path,
+            constructorName: getConstructorName(value),
+            memberCount: members.length,
+            members
+        }
+    }
+}
+
+const eventsTool: ToolDefinition = {
+    name: 'events',
+    description:
+        'Read recent buffered WaClient events. Filter by types and/or sequence id. ' +
+        'Use this to wait for QR codes, pairing codes, incoming messages, group events, etc. ' +
+        'Each event has a monotonic seq — pass `since: <seq>` next call to fetch only newer ones.',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            types: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                    'Event type filter, e.g. ["auth_qr","auth_pairing_code","connection","message"]. Empty/omitted = all types.'
+            },
+            since: {
+                type: 'number',
+                description: 'Return only events with seq > since.'
+            },
+            limit: {
+                type: 'number',
+                description: 'Max events to return (default 50).'
+            },
+            drain: {
+                type: 'boolean',
+                description: 'If true, returned events are removed from the buffer.'
+            }
+        },
+        additionalProperties: false
+    },
+    handler: async (input, runtime) => {
+        const filter = parseEventsInput(input)
+        const events = runtime.listEvents(filter)
+        return {
+            count: events.length,
+            bufferSize: runtime.bufferSize(),
+            events
+        }
+    }
+}
+
+const eventsClearTool: ToolDefinition = {
+    name: 'events_clear',
+    description: 'Clear the entire event buffer. Returns the number of events dropped.',
+    inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false
+    },
+    handler: async (_input, runtime) => {
+        const dropped = runtime.clearEvents()
+        return { dropped }
+    }
+}
+
+const VALID_LOG_LEVELS = ['trace', 'debug', 'info', 'warn', 'error'] as const
+
+const logsTool: ToolDefinition = {
+    name: 'logs',
+    description:
+        'Read recent buffered log entries from the WaClient/MCP runtime logger. ' +
+        'Each entry has a monotonic seq, timestampMs, level, message and optional context object. ' +
+        'Pass `since: <seq>` to fetch only newer entries on the next call. ' +
+        'Logs are also written to stderr and (if MCP_LOG_FILE is set) appended to that file as JSONL.',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            levels: {
+                type: 'array',
+                items: { type: 'string', enum: VALID_LOG_LEVELS as unknown as string[] },
+                description: 'Filter by levels, e.g. ["warn","error"]. Empty/omitted = all.'
+            },
+            since: {
+                type: 'number',
+                description: 'Return only entries with seq > since.'
+            },
+            limit: {
+                type: 'number',
+                description: 'Max entries to return (default 100).'
+            },
+            drain: {
+                type: 'boolean',
+                description: 'If true, returned entries are removed from the buffer.'
+            }
+        },
+        additionalProperties: false
+    },
+    handler: async (input, runtime) => {
+        const filter = parseLogsInput(input)
+        const logs = runtime.listLogs(filter)
+        return {
+            count: logs.length,
+            bufferSize: runtime.bufferLogsSize(),
+            logs
+        }
+    }
+}
+
+const logsClearTool: ToolDefinition = {
+    name: 'logs_clear',
+    description:
+        'Clear the entire log buffer (stderr + log file are unaffected). Returns the number of entries dropped.',
+    inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false
+    },
+    handler: async (_input, runtime) => {
+        const dropped = runtime.clearLogs()
+        return { dropped }
+    }
+}
+
+const RESTART_MODES = ['soft', 'process_exit'] as const
+
+const restartTool: ToolDefinition = {
+    name: 'restart',
+    description:
+        'Restart the runtime state. ' +
+        '"soft" (default): disconnect + drop the WaClient, clear the event and log buffers, ' +
+        'reset their seq counters; the process stays alive, and the next tool call recreates ' +
+        'everything from the same config — code changes loaded into the Node module cache ' +
+        'are NOT picked up. ' +
+        '"process_exit": same cleanup, then exit the process with code 0 so a supervisor ' +
+        '(nodemon, Claude Code respawn-on-reconnect, etc.) starts a fresh process. With no ' +
+        'supervisor, the caller must reconnect the MCP server manually (e.g. /mcp in Claude ' +
+        'Code) for the next tool call to land. The exit is scheduled ~150ms after the response ' +
+        'is sent so the JSON-RPC reply has time to flush.',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            mode: {
+                type: 'string',
+                enum: RESTART_MODES as unknown as string[],
+                description:
+                    '"soft" (default) keeps the process; "process_exit" terminates the process so a supervisor can respawn it.'
+            }
+        },
+        additionalProperties: false
+    },
+    handler: async (input, runtime) => {
+        const mode = parseRestartInput(input)
+        const eventsBefore = runtime.bufferSize()
+        const logsBefore = runtime.bufferLogsSize()
+        await runtime.destroyClient()
+        runtime.clearEvents()
+        runtime.clearLogs()
+        runtime.resetSequences()
+
+        if (mode === 'process_exit') {
+            setTimeout(() => {
+                runtime
+                    .closeLogFile()
+                    .catch(() => undefined)
+                    .finally(() => process.exit(0))
+            }, 150)
+            return {
+                ok: true,
+                mode,
+                eventsCleared: eventsBefore,
+                logsCleared: logsBefore,
+                note: 'process will exit ~150ms after this response; reconnect the MCP transport for the next tool call'
+            }
+        }
+        return {
+            ok: true,
+            mode,
+            eventsCleared: eventsBefore,
+            logsCleared: logsBefore
+        }
+    }
+}
+
+const lifecycleTool: ToolDefinition = {
+    name: 'lifecycle',
+    description:
+        'Manage the underlying WaClient instance. Actions: ' +
+        '"status" reports config + whether client is created, ' +
+        '"start" creates the client (no connect), ' +
+        '"destroy" disconnects + drops the client (next call recreates it).',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            action: {
+                type: 'string',
+                enum: ['status', 'start', 'destroy']
+            }
+        },
+        required: ['action'],
+        additionalProperties: false
+    },
+    handler: async (input, runtime) => {
+        const action = parseLifecycleInput(input)
+        switch (action) {
+            case 'status': {
+                const client = runtime.getClient()
+                let state: unknown = null
+                if (client) {
+                    try {
+                        state = client.getState()
+                    } catch (error) {
+                        state = { error: (error as Error)?.message ?? String(error) }
+                    }
+                }
+                return {
+                    config: runtime.getConfig(),
+                    clientCreated: client !== null,
+                    state: encodeForJson(state),
+                    bufferSize: runtime.bufferSize()
+                }
+            }
+            case 'start': {
+                await runtime.ensureClient()
+                return { ok: true }
+            }
+            case 'destroy': {
+                await runtime.destroyClient()
+                return { ok: true }
+            }
+        }
+    }
+}
+
+export const TOOLS: readonly ToolDefinition[] = [
+    callTool,
+    inspectTool,
+    eventsTool,
+    eventsClearTool,
+    logsTool,
+    logsClearTool,
+    lifecycleTool,
+    restartTool
+]
+
+const parseCallInput = (
+    input: unknown
+): { path: string; args: unknown[]; root: Root; noAwait: boolean } => {
+    if (!input || typeof input !== 'object') {
+        throw new Error('call: input must be an object')
+    }
+    const obj = input as Record<string, unknown>
+    if (typeof obj.path !== 'string' || obj.path.length === 0) {
+        throw new Error('call: "path" must be a non-empty string')
+    }
+    const args = Array.isArray(obj.args) ? (obj.args as unknown[]) : []
+    const root = parseRoot(obj.root)
+    const noAwait = obj.noAwait === true
+    return { path: obj.path, args, root, noAwait }
+}
+
+const parseInspectInput = (
+    input: unknown
+): { path: string; includeEventEmitter: boolean; root: Root } => {
+    const obj = (input ?? {}) as Record<string, unknown>
+    const path = typeof obj.path === 'string' ? obj.path : ''
+    const includeEventEmitter = obj.includeEventEmitter === true
+    const root = parseRoot(obj.root)
+    return { path, includeEventEmitter, root }
+}
+
+const parseEventsInput = (
+    input: unknown
+): { types?: readonly string[]; since?: number; limit?: number; drain?: boolean } => {
+    const obj = (input ?? {}) as Record<string, unknown>
+    const types =
+        Array.isArray(obj.types) && obj.types.every((t) => typeof t === 'string')
+            ? obj.types
+            : undefined
+    const since = typeof obj.since === 'number' ? obj.since : undefined
+    const limit = typeof obj.limit === 'number' ? obj.limit : undefined
+    const drain = obj.drain === true
+    return { types, since, limit, drain }
+}
+
+const parseLogsInput = (
+    input: unknown
+): {
+    levels?: readonly ('trace' | 'debug' | 'info' | 'warn' | 'error')[]
+    since?: number
+    limit?: number
+    drain?: boolean
+} => {
+    const obj = (input ?? {}) as Record<string, unknown>
+    let levels: readonly ('trace' | 'debug' | 'info' | 'warn' | 'error')[] | undefined
+    if (Array.isArray(obj.levels)) {
+        const filtered: ('trace' | 'debug' | 'info' | 'warn' | 'error')[] = []
+        for (const candidate of obj.levels) {
+            if (
+                candidate === 'trace' ||
+                candidate === 'debug' ||
+                candidate === 'info' ||
+                candidate === 'warn' ||
+                candidate === 'error'
+            ) {
+                filtered.push(candidate)
+            } else {
+                throw new Error(`logs: invalid level "${String(candidate)}"`)
+            }
+        }
+        levels = filtered.length > 0 ? filtered : undefined
+    }
+    const since = typeof obj.since === 'number' ? obj.since : undefined
+    const limit = typeof obj.limit === 'number' ? obj.limit : undefined
+    const drain = obj.drain === true
+    return { levels, since, limit, drain }
+}
+
+const parseLifecycleInput = (input: unknown): 'status' | 'start' | 'destroy' => {
+    const obj = (input ?? {}) as Record<string, unknown>
+    if (obj.action === 'status' || obj.action === 'start' || obj.action === 'destroy') {
+        return obj.action
+    }
+    throw new Error('lifecycle: "action" must be "status" | "start" | "destroy"')
+}
+
+const parseRestartInput = (input: unknown): 'soft' | 'process_exit' => {
+    const obj = (input ?? {}) as Record<string, unknown>
+    if (obj.mode === undefined || obj.mode === null) return 'soft'
+    if (obj.mode === 'soft' || obj.mode === 'process_exit') return obj.mode
+    throw new Error(`restart: "mode" must be one of ${RESTART_MODES.join(' | ')}`)
+}
+
+const resolvePath = (
+    root: Record<string, unknown>,
+    path: string
+): { parent: unknown; value: unknown; lastKey: string | null } => {
+    if (path.length === 0) {
+        return { parent: null, value: root, lastKey: null }
+    }
+    const parts = path.split('.')
+    let parent: unknown = null
+    let current: unknown = root
+    let lastKey: string | null = null
+    for (let i = 0; i < parts.length; i += 1) {
+        const key = parts[i]
+        if (key.length === 0) {
+            throw new Error(`call: empty segment at index ${i} in path "${path}"`)
+        }
+        if (current === null || current === undefined) {
+            throw new Error(
+                `call: cannot read "${key}" on null/undefined at "${parts.slice(0, i).join('.')}"`
+            )
+        }
+        parent = current
+        current = (current as Record<string, unknown>)[key]
+        lastKey = key
+    }
+    return { parent, value: current, lastKey }
+}
+
+interface MemberDescriptor {
+    readonly name: string
+    readonly kind: 'function' | 'getter' | 'value'
+    readonly origin: string
+    readonly arity?: number
+    readonly typeOf?: string
+}
+
+const collectMembers = (
+    target: object,
+    includeEventEmitter: boolean
+): readonly MemberDescriptor[] => {
+    const seen = new Set<string>()
+    const out: MemberDescriptor[] = []
+    let current: object | null = target
+    let originName = getConstructorName(target)
+    while (current !== null && current !== Object.prototype && current !== Function.prototype) {
+        const isProtoLayer = current !== target
+        if (isProtoLayer) {
+            originName = getConstructorName(current)
+        }
+        if (!includeEventEmitter && originName === 'EventEmitter') {
+            current = Object.getPrototypeOf(current) as object | null
+            continue
+        }
+        const descriptors = Object.getOwnPropertyDescriptors(current)
+        for (const name of Object.keys(descriptors)) {
+            if (name === 'constructor') continue
+            if (name.startsWith('_')) continue
+            if (seen.has(name)) continue
+            seen.add(name)
+            const desc = descriptors[name]
+            if (typeof desc.get === 'function' && typeof desc.value === 'undefined') {
+                out.push({ name, kind: 'getter', origin: originName })
+                continue
+            }
+            const value = (current as Record<string, unknown>)[name]
+            if (typeof value === 'function') {
+                out.push({
+                    name,
+                    kind: 'function',
+                    origin: originName,
+                    arity: (value as { length?: number }).length ?? 0
+                })
+            } else {
+                out.push({
+                    name,
+                    kind: 'value',
+                    origin: originName,
+                    typeOf: typeof value
+                })
+            }
+        }
+        current = Object.getPrototypeOf(current) as object | null
+    }
+    out.sort((a, b) => a.name.localeCompare(b.name))
+    return out
+}
+
+const getConstructorName = (obj: object): string => {
+    const ctor = (obj as { constructor?: { name?: string } }).constructor
+    return ctor?.name ?? 'Object'
+}

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -510,11 +510,16 @@ const resolvePath = (
     for (let i = 0; i < parts.length; i += 1) {
         const key = parts[i]
         if (key.length === 0) {
-            throw new Error(`call: empty segment at index ${i} in path "${path}"`)
+            throw new Error(`path: empty segment at index ${i} in "${path}"`)
+        }
+        if (FORBIDDEN_PATH_SEGMENTS.has(key)) {
+            throw new Error(
+                `path: segment "${key}" at index ${i} is not allowed (prototype-chain traversal)`
+            )
         }
         if (current === null || current === undefined) {
             throw new Error(
-                `call: cannot read "${key}" on null/undefined at "${parts.slice(0, i).join('.')}"`
+                `path: cannot read "${key}" on null/undefined at "${parts.slice(0, i).join('.')}"`
             )
         }
         parent = current
@@ -523,6 +528,19 @@ const resolvePath = (
     }
     return { parent, value: current, lastKey }
 }
+
+/**
+ * Walking arbitrary string keys against a JS object would happily traverse the
+ * prototype chain — `__proto__`, `constructor`, `prototype` are all accessible
+ * and dangerous (prototype pollution, escape from intended object surface).
+ * The runtime is local-only today but the HTTP transport could be exposed,
+ * so block these keys at the resolver.
+ */
+const FORBIDDEN_PATH_SEGMENTS: ReadonlySet<string> = new Set([
+    '__proto__',
+    'prototype',
+    'constructor'
+])
 
 interface MemberDescriptor {
     readonly name: string

--- a/packages/mcp-server/tsconfig.build.cjs.json
+++ b/packages/mcp-server/tsconfig.build.cjs.json
@@ -1,0 +1,14 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.build.paths.json"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.paths.json"],
+    "compilerOptions": {
+        "types": ["node"],
+        "rootDir": "../..",
+        "noEmit": true
+    },
+    "include": ["src"],
+    "exclude": ["dist", "node_modules"]
+}

--- a/packages/tsconfig.paths.json
+++ b/packages/tsconfig.paths.json
@@ -38,7 +38,8 @@
             "@store/*": ["src/store/*"],
             "@transport": ["src/transport/index.ts"],
             "@transport/*": ["src/transport/*"],
-            "@util/*": ["src/util/*"]
+            "@util/*": ["src/util/*"],
+            "@zapo-js/*": ["packages/*/src"]
         }
     }
 }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,4 +1,11 @@
-export { bytesToHex, hexToBytes, toBytesView, uint8Equal } from '@util/bytes'
+export {
+    base64ToBytes,
+    bytesToBase64,
+    bytesToHex,
+    hexToBytes,
+    toBytesView,
+    uint8Equal
+} from '@util/bytes'
 export {
     asBytes,
     asNumber,
@@ -10,5 +17,5 @@ export {
     toBoolOrUndef
 } from '@util/coercion'
 export { normalizeQueryLimit } from '@util/collections'
-export { toSafeNumber } from '@util/primitives'
+export { toError, toSafeNumber } from '@util/primitives'
 export { isBunRuntime } from '@util/runtime'


### PR DESCRIPTION
New optional package @zapo-js/mcp-server that runs an MCP server (stdio or HTTP transport) exposing the WaClient instance and the zapo-js module namespace through a small dynamic tool surface:

  - call/inspect — walk dotted paths on either root and either return the value or invoke the function (Uint8Array/BigInt round-trip via $bytes /$bigint markers; noAwait flag for fire-and-forget like client.connect during pairing).
  - events/events_clear — bounded ring buffer of every WaClientEventMap event with seq filtering for incremental polling.
  - logs/logs_clear — BufferedTeeLogger captures runtime+lib logs into a queryable buffer; mirrors to stderr and (optionally) to MCP_LOG_FILE as JSONL.
  - lifecycle — status/start/destroy for the WaClient instance.
  - restart — soft (drop client + clear buffers) or process_exit (also exits the process so a supervisor can respawn it).

The server lazily creates a single WaClient backed by the sqlite store from @zapo-js/store-sqlite (path/session via env). HTTP transport uses StreamableHTTPServerTransport for nodemon-style hot reload.

Includes an end-to-end cross-check test that drives pairing + send/recv against @zapo-js/fake-server entirely through the runtime + tool handlers.