### PR TITLE
feat(client): add community (parent group) support

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -538,7 +538,8 @@ export function buildWaClientDependencies(input: {
     const getCurrentSignedIdentity = () => getCurrentCredentials()?.signedIdentity
 
     const groupCoordinator = createGroupCoordinator({
-        queryWithContext: runtime.queryWithContext
+        queryWithContext: runtime.queryWithContext,
+        mexSocket: { query: runtime.query }
     })
 
     const newsletterCoordinator = createNewsletterCoordinator({

--- a/src/client/coordinators/WaGroupCoordinator.ts
+++ b/src/client/coordinators/WaGroupCoordinator.ts
@@ -3,15 +3,24 @@ import { WA_DEFAULTS } from '@protocol/defaults'
 import { WA_GROUP_PARTICIPANT_TYPES, type WaGroupSetting } from '@protocol/group'
 import { WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
 import {
+    buildDeactivateCommunityIq,
+    buildLinkedGroupsParticipantsIq,
+    buildLinkSubGroupsIq,
+    buildUnlinkSubGroupsIq
+} from '@transport/node/builders/community'
+import {
     buildCreateGroupIq,
     buildGroupParticipantChangeIq,
     buildLeaveGroupIq
 } from '@transport/node/builders/group'
 import {
     findNodeChild,
+    getNodeChildrenByTag,
     getNodeChildrenByTagFromChildren,
     hasNodeChild
 } from '@transport/node/helpers'
+import { dispatchMexQuery, type WaMexQuerySocket } from '@transport/node/mex/client'
+import { WA_MEX_PERSIST_IDS } from '@transport/node/mex/persist-ids'
 import { assertIqResult, buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
@@ -36,11 +45,58 @@ export interface WaGroupMetadata {
     readonly announce: boolean
     readonly ephemeral?: number
     readonly size?: number
+    readonly isParentGroup: boolean
+    readonly isClosedCommunity: boolean
+    readonly defaultSubgroup: boolean
+    readonly generalSubgroup: boolean
+    readonly hiddenSubgroup: boolean
+    readonly allowNonAdminSubGroupCreation: boolean
+    readonly linkedParentJid?: string
     readonly participants: readonly WaGroupParticipant[]
 }
 
 export interface WaGroupCreateOptions {
     readonly description?: string
+    readonly linkedParentJid?: string
+}
+
+export interface WaCommunityCreateOptions {
+    readonly description?: string
+    readonly membershipApprovalMode?: 'open' | 'request_required'
+    readonly allowNonAdminSubGroupCreation?: boolean
+    readonly createGeneralChat?: boolean
+}
+
+export interface WaCommunitySubGroupResult {
+    readonly jid: string
+    readonly error?: number
+}
+
+export interface WaLinkSubGroupsResult {
+    readonly linkedJids: readonly string[]
+    readonly failed: readonly WaCommunitySubGroupResult[]
+}
+
+export interface WaUnlinkSubGroupsResult {
+    readonly unlinkedJids: readonly string[]
+    readonly failed: readonly WaCommunitySubGroupResult[]
+}
+
+export interface WaCommunitySubGroup {
+    readonly jid: string
+    readonly subject?: string
+    readonly subjectTime?: number
+    readonly defaultSubgroup: boolean
+    readonly generalSubgroup: boolean
+    readonly hiddenSubgroup: boolean
+    readonly membershipApprovalMode: boolean
+    readonly pendingMembershipRequests: number
+}
+
+export interface WaCommunitySubGroupsResult {
+    readonly communityJid: string
+    readonly announcementGroup: WaCommunitySubGroup | null
+    readonly subGroups: readonly WaCommunitySubGroup[]
 }
 
 interface WaGroupCoordinatorOptions {
@@ -50,6 +106,7 @@ interface WaGroupCoordinatorOptions {
         timeoutMs?: number,
         contextData?: Readonly<Record<string, unknown>>
     ) => Promise<BinaryNode>
+    readonly mexSocket?: WaMexQuerySocket
 }
 
 export interface WaGroupCoordinator {
@@ -91,6 +148,24 @@ export interface WaGroupCoordinator {
     readonly leaveGroup: (groupJids: readonly string[]) => Promise<BinaryNode>
     readonly revokeInvite: (groupJid: string) => Promise<BinaryNode>
     readonly joinGroupViaInvite: (code: string) => Promise<BinaryNode>
+    readonly createCommunity: (
+        subject: string,
+        options?: WaCommunityCreateOptions
+    ) => Promise<WaGroupMetadata>
+    readonly deactivateCommunity: (communityJid: string) => Promise<void>
+    readonly linkSubGroups: (
+        communityJid: string,
+        subGroupJids: readonly string[]
+    ) => Promise<WaLinkSubGroupsResult>
+    readonly unlinkSubGroups: (
+        communityJid: string,
+        subGroupJids: readonly string[],
+        options?: { readonly removeOrphanedMembers?: boolean }
+    ) => Promise<WaUnlinkSubGroupsResult>
+    readonly queryLinkedGroupsParticipants: (
+        communityJid: string
+    ) => Promise<readonly WaGroupParticipant[]>
+    readonly fetchSubGroups: (communityJid: string) => Promise<WaCommunitySubGroupsResult>
 }
 
 type WaGroupParticipantChangeAction = 'add' | 'remove' | 'promote' | 'demote'
@@ -139,6 +214,9 @@ function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
         ? Number(ephemeralNode.attrs.expiration)
         : undefined
 
+    const parentNode = findNodeChild(target, 'parent')
+    const linkedParentNode = findNodeChild(target, 'linked_parent')
+
     return {
         jid: attrs.id ?? attrs.jid ?? '',
         subject: attrs.subject ?? '',
@@ -153,6 +231,14 @@ function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
         announce: hasNodeChild(target, WA_NODE_TAGS.ANNOUNCEMENT),
         ephemeral,
         size: attrs.size ? Number(attrs.size) : undefined,
+        isParentGroup: parentNode !== undefined,
+        isClosedCommunity:
+            parentNode?.attrs.default_membership_approval_mode === 'request_required',
+        defaultSubgroup: hasNodeChild(target, 'default_sub_group'),
+        generalSubgroup: hasNodeChild(target, 'general_chat'),
+        hiddenSubgroup: hasNodeChild(target, 'hidden_group'),
+        allowNonAdminSubGroupCreation: hasNodeChild(target, 'allow_non_admin_sub_group_creation'),
+        linkedParentJid: linkedParentNode?.attrs.jid ?? parentNode?.attrs.jid,
         participants: parseGroupParticipants(target)
     }
 }
@@ -163,11 +249,48 @@ const SETTING_TAGS: Readonly<
     announcement: { on: 'announcement', off: 'not_announcement' },
     restrict: { on: 'locked', off: 'unlocked' },
     ephemeral: { on: 'ephemeral', off: 'not_ephemeral' },
-    membership_approval_mode: { on: 'membership_approval_mode', off: 'membership_approval_mode' }
+    membership_approval_mode: { on: 'membership_approval_mode', off: 'membership_approval_mode' },
+    allow_non_admin_sub_group_creation: {
+        on: 'allow_non_admin_sub_group_creation',
+        off: 'not_allow_non_admin_sub_group_creation'
+    }
+}
+
+interface MexSubGroupNode {
+    readonly id?: string
+    readonly subject?: { readonly value?: string; readonly creation_time?: string | number }
+    readonly properties?: {
+        readonly general_chat?: boolean | null
+        readonly membership_approval_mode_enabled?: boolean | null
+        readonly hidden_group?: boolean | null
+    } | null
+    readonly membership_approval_requests?: { readonly total_count?: string | number } | null
+}
+
+interface MexFetchAllSubgroupsResult {
+    readonly xwa2_group_query_by_id?: {
+        readonly default_sub_group?: MexSubGroupNode | null
+        readonly sub_groups?: { readonly edges?: readonly { readonly node?: MexSubGroupNode }[] }
+    } | null
+}
+
+function parseSubGroupNode(node: MexSubGroupNode, defaultSubgroup: boolean): WaCommunitySubGroup {
+    const totalCount = node.membership_approval_requests?.total_count
+    const creationTime = node.subject?.creation_time
+    return {
+        jid: node.id ?? '',
+        subject: node.subject?.value,
+        subjectTime: creationTime !== undefined ? Number(creationTime) : undefined,
+        defaultSubgroup,
+        generalSubgroup: node.properties?.general_chat === true,
+        hiddenSubgroup: node.properties?.hidden_group === true,
+        membershipApprovalMode: node.properties?.membership_approval_mode_enabled === true,
+        pendingMembershipRequests: totalCount !== undefined ? Number(totalCount) : 0
+    }
 }
 
 export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGroupCoordinator {
-    const { queryWithContext } = options
+    const { queryWithContext, mexSocket } = options
 
     const changeParticipants = async (
         action: WaGroupParticipantChangeAction,
@@ -232,7 +355,8 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
             const node = buildCreateGroupIq({
                 subject,
                 participants,
-                description: opts?.description
+                description: opts?.description,
+                linkedParentJid: opts?.linkedParentJid
             })
             const result = await queryWithContext('group.create', node)
             assertIqResult(result, 'group.create')
@@ -322,6 +446,118 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
             const result = await queryWithContext('group.joinViaInvite', node)
             assertIqResult(result, 'group.joinViaInvite')
             return result
+        },
+
+        createCommunity: async (subject, opts) => {
+            const node = buildCreateGroupIq({
+                subject,
+                participants: [],
+                description: opts?.description,
+                parent:
+                    opts?.membershipApprovalMode === 'open'
+                        ? true
+                        : { defaultMembershipApprovalMode: 'request_required' },
+                allowNonAdminSubGroupCreation: opts?.allowNonAdminSubGroupCreation,
+                createGeneralChat: opts?.createGeneralChat
+            })
+            const result = await queryWithContext('community.create', node)
+            assertIqResult(result, 'community.create')
+            return parseGroupMetadata(result)
+        },
+
+        deactivateCommunity: async (communityJid) => {
+            const node = buildDeactivateCommunityIq(communityJid)
+            const result = await queryWithContext('community.deactivate', node)
+            assertIqResult(result, 'community.deactivate')
+        },
+
+        linkSubGroups: async (communityJid, subGroupJids) => {
+            const node = buildLinkSubGroupsIq({
+                communityJid,
+                subGroups: subGroupJids.map((jid) => ({ jid }))
+            })
+            const result = await queryWithContext('community.linkSubGroups', node)
+            assertIqResult(result, 'community.linkSubGroups')
+
+            const linksNode = findNodeChild(result, 'links')
+            const linkNode = linksNode ? findNodeChild(linksNode, 'link') : undefined
+            const groupNodes = linkNode ? getNodeChildrenByTag(linkNode, 'group') : []
+            const linkedJids: string[] = []
+            const failed: WaCommunitySubGroupResult[] = []
+            for (const groupNode of groupNodes) {
+                const jid = groupNode.attrs.jid
+                if (!jid) continue
+                const errorAttr = findNodeChild(groupNode, 'error')?.attrs.code
+                if (errorAttr !== undefined) {
+                    failed.push({ jid, error: Number(errorAttr) })
+                } else {
+                    linkedJids.push(jid)
+                }
+            }
+            return { linkedJids, failed }
+        },
+
+        unlinkSubGroups: async (communityJid, subGroupJids, options) => {
+            const node = buildUnlinkSubGroupsIq({
+                communityJid,
+                subGroupJids,
+                removeOrphanedMembers: options?.removeOrphanedMembers
+            })
+            const result = await queryWithContext('community.unlinkSubGroups', node)
+            assertIqResult(result, 'community.unlinkSubGroups')
+
+            const unlinkNode = findNodeChild(result, 'unlink')
+            const groupNodes = unlinkNode ? getNodeChildrenByTag(unlinkNode, 'group') : []
+            const unlinkedJids: string[] = []
+            const failed: WaCommunitySubGroupResult[] = []
+            for (const groupNode of groupNodes) {
+                const jid = groupNode.attrs.jid
+                if (!jid) continue
+                const errorAttr = findNodeChild(groupNode, 'error')?.attrs.code
+                if (errorAttr !== undefined) {
+                    failed.push({ jid, error: Number(errorAttr) })
+                } else {
+                    unlinkedJids.push(jid)
+                }
+            }
+            return { unlinkedJids, failed }
+        },
+
+        queryLinkedGroupsParticipants: async (communityJid) => {
+            const node = buildLinkedGroupsParticipantsIq(communityJid)
+            const result = await queryWithContext('community.linkedGroupsParticipants', node)
+            assertIqResult(result, 'community.linkedGroupsParticipants')
+            const container = findNodeChild(result, 'linked_groups_participants')
+            return container ? parseGroupParticipants(container) : []
+        },
+
+        fetchSubGroups: async (communityJid) => {
+            if (!mexSocket) {
+                throw new Error('community.fetchSubGroups requires a mex transport')
+            }
+            const { data } = await dispatchMexQuery(mexSocket, {
+                docId: WA_MEX_PERSIST_IDS.CommunityFetchAllSubgroups.docId,
+                clientDocId: WA_MEX_PERSIST_IDS.CommunityFetchAllSubgroups.clientDocId,
+                opName: 'CommunityFetchAllSubgroups',
+                variables: {
+                    group_id: communityJid,
+                    query_context: 'PRIMARY',
+                    sub_group_hint: null
+                }
+            })
+            const envelope = (data ?? {}) as MexFetchAllSubgroupsResult
+            const groupQuery = envelope.xwa2_group_query_by_id
+            const announcementNode = groupQuery?.default_sub_group
+            const announcementGroup = announcementNode
+                ? parseSubGroupNode(announcementNode, true)
+                : null
+            const edges = groupQuery?.sub_groups?.edges ?? []
+            const subGroups: WaCommunitySubGroup[] = []
+            for (const edge of edges) {
+                if (!edge?.node) continue
+                subGroups.push(parseSubGroupNode(edge.node, false))
+            }
+            return { communityJid, announcementGroup, subGroups }
         }
     }
 }

--- a/src/client/coordinators/WaGroupCoordinator.ts
+++ b/src/client/coordinators/WaGroupCoordinator.ts
@@ -217,8 +217,11 @@ function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
     const parentNode = findNodeChild(target, 'parent')
     const linkedParentNode = findNodeChild(target, 'linked_parent')
 
+    const rawJid = attrs.id ?? attrs.jid ?? ''
+    const jid = rawJid && !rawJid.includes('@') ? `${rawJid}@${WA_DEFAULTS.GROUP_SERVER}` : rawJid
+
     return {
-        jid: attrs.id ?? attrs.jid ?? '',
+        jid,
         subject: attrs.subject ?? '',
         subjectOwner: attrs.s_o ?? attrs.subject_owner,
         subjectTime: attrs.s_t ? Number(attrs.s_t) : undefined,
@@ -541,8 +544,8 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
                 opName: 'CommunityFetchAllSubgroups',
                 variables: {
                     group_id: communityJid,
-                    query_context: 'PRIMARY',
-                    sub_group_hint: null
+                    query_context: 'INTERACTIVE',
+                    sub_group_hint_id: undefined
                 }
             })
             const envelope = (data ?? {}) as MexFetchAllSubgroupsResult

--- a/src/client/coordinators/WaGroupCoordinator.ts
+++ b/src/client/coordinators/WaGroupCoordinator.ts
@@ -89,7 +89,7 @@ export interface WaCommunitySubGroup {
     readonly defaultSubgroup: boolean
     readonly generalSubgroup: boolean
     readonly hiddenSubgroup: boolean
-    readonly membershipApprovalMode: boolean
+    readonly membershipApprovalEnabled: boolean
     readonly pendingMembershipRequests: number
 }
 
@@ -287,7 +287,7 @@ function parseSubGroupNode(node: MexSubGroupNode, defaultSubgroup: boolean): WaC
         defaultSubgroup,
         generalSubgroup: node.properties?.general_chat === true,
         hiddenSubgroup: node.properties?.hidden_group === true,
-        membershipApprovalMode: node.properties?.membership_approval_mode_enabled === true,
+        membershipApprovalEnabled: node.properties?.membership_approval_mode_enabled === true,
         pendingMembershipRequests: totalCount !== undefined ? Number(totalCount) : 0
     }
 }

--- a/src/client/coordinators/__tests__/group-community-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/group-community-coordinator.test.ts
@@ -1,0 +1,261 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createGroupCoordinator } from '@client/coordinators/WaGroupCoordinator'
+import type { BinaryNode } from '@transport/types'
+
+interface QueryCall {
+    readonly context: string
+    readonly node: BinaryNode
+}
+
+function createMockQuery(responses: readonly BinaryNode[]): {
+    queryWithContext: Parameters<typeof createGroupCoordinator>[0]['queryWithContext']
+    calls: QueryCall[]
+} {
+    let index = 0
+    const calls: QueryCall[] = []
+    const queryWithContext: Parameters<
+        typeof createGroupCoordinator
+    >[0]['queryWithContext'] = async (context, node) => {
+        calls.push({ context, node })
+        const response = responses[index]
+        index += 1
+        if (!response) throw new Error(`no mock response at index ${index - 1}`)
+        return response
+    }
+    return { queryWithContext, calls }
+}
+
+function iqResult(content?: BinaryNode[]): BinaryNode {
+    return {
+        tag: 'iq',
+        attrs: { type: 'result', id: '1' },
+        ...(content ? { content } : {})
+    }
+}
+
+test('createCommunity sends parent stanza with request_required by default', async () => {
+    const groupResponse: BinaryNode = {
+        tag: 'iq',
+        attrs: { type: 'result', id: '1' },
+        content: [
+            {
+                tag: 'group',
+                attrs: { id: 'parent@g.us', subject: 'Comm' },
+                content: [
+                    {
+                        tag: 'parent',
+                        attrs: { default_membership_approval_mode: 'request_required' }
+                    }
+                ]
+            }
+        ]
+    }
+    const mock = createMockQuery([groupResponse])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    const meta = await coordinator.createCommunity('Comm', { description: 'Hi' })
+
+    assert.equal(meta.isParentGroup, true)
+    assert.equal(meta.isClosedCommunity, true)
+
+    const create = (mock.calls[0].node.content as BinaryNode[])[0]
+    const children = create.content as BinaryNode[]
+    const parent = children.find((c) => c.tag === 'parent')
+    assert.equal(parent?.attrs.default_membership_approval_mode, 'request_required')
+    const description = children.find((c) => c.tag === 'description')
+    assert.ok(description)
+})
+
+test('createCommunity with membershipApprovalMode=open omits the attr', async () => {
+    const groupResponse: BinaryNode = {
+        tag: 'iq',
+        attrs: { type: 'result', id: '1' },
+        content: [
+            { tag: 'group', attrs: { id: 'open@g.us' }, content: [{ tag: 'parent', attrs: {} }] }
+        ]
+    }
+    const mock = createMockQuery([groupResponse])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    await coordinator.createCommunity('Open', { membershipApprovalMode: 'open' })
+    const create = (mock.calls[0].node.content as BinaryNode[])[0]
+    const parent = (create.content as BinaryNode[]).find((c) => c.tag === 'parent')
+    assert.equal(parent?.attrs.default_membership_approval_mode, undefined)
+})
+
+test('linkSubGroups parses success and per-group errors', async () => {
+    const response: BinaryNode = iqResult([
+        {
+            tag: 'links',
+            attrs: { link_type: 'sub_group' },
+            content: [
+                {
+                    tag: 'link',
+                    attrs: { link_type: 'sub_group' },
+                    content: [
+                        { tag: 'group', attrs: { jid: 'ok@g.us' } },
+                        {
+                            tag: 'group',
+                            attrs: { jid: 'fail@g.us' },
+                            content: [{ tag: 'error', attrs: { code: '403' } }]
+                        }
+                    ]
+                }
+            ]
+        }
+    ])
+    const mock = createMockQuery([response])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    const result = await coordinator.linkSubGroups('parent@g.us', ['ok@g.us', 'fail@g.us'])
+    assert.deepEqual(result.linkedJids, ['ok@g.us'])
+    assert.deepEqual(result.failed, [{ jid: 'fail@g.us', error: 403 }])
+})
+
+test('unlinkSubGroups passes removeOrphanedMembers and parses results', async () => {
+    const response: BinaryNode = iqResult([
+        {
+            tag: 'unlink',
+            attrs: { unlink_type: 'sub_group' },
+            content: [{ tag: 'group', attrs: { jid: 'a@g.us' } }]
+        }
+    ])
+    const mock = createMockQuery([response])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    const result = await coordinator.unlinkSubGroups('parent@g.us', ['a@g.us'], {
+        removeOrphanedMembers: true
+    })
+    assert.deepEqual(result.unlinkedJids, ['a@g.us'])
+    const unlink = (mock.calls[0].node.content as BinaryNode[])[0]
+    const groupNode = (unlink.content as BinaryNode[])[0]
+    assert.equal(groupNode.attrs.remove_orphaned_members, 'true')
+})
+
+test('deactivateCommunity sends delete_parent', async () => {
+    const mock = createMockQuery([iqResult()])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+    await coordinator.deactivateCommunity('parent@g.us')
+    const root = (mock.calls[0].node.content as BinaryNode[])[0]
+    assert.equal(root.tag, 'delete_parent')
+})
+
+test('queryLinkedGroupsParticipants returns flattened participants', async () => {
+    const response: BinaryNode = iqResult([
+        {
+            tag: 'linked_groups_participants',
+            attrs: {},
+            content: [
+                { tag: 'participant', attrs: { jid: 'u1@s.whatsapp.net', type: 'admin' } },
+                { tag: 'participant', attrs: { jid: 'u2@s.whatsapp.net' } }
+            ]
+        }
+    ])
+    const mock = createMockQuery([response])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    const participants = await coordinator.queryLinkedGroupsParticipants('parent@g.us')
+    assert.equal(participants.length, 2)
+    assert.equal(participants[0].isAdmin, true)
+    assert.equal(participants[1].isAdmin, false)
+})
+
+test('setSetting toggles allow_non_admin_sub_group_creation enable/disable', async () => {
+    const mock = createMockQuery([iqResult(), iqResult()])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    await coordinator.setSetting('parent@g.us', 'allow_non_admin_sub_group_creation', true)
+    await coordinator.setSetting('parent@g.us', 'allow_non_admin_sub_group_creation', false)
+
+    const enableTag = (mock.calls[0].node.content as BinaryNode[])[0].tag
+    const disableTag = (mock.calls[1].node.content as BinaryNode[])[0].tag
+    assert.equal(enableTag, 'allow_non_admin_sub_group_creation')
+    assert.equal(disableTag, 'not_allow_non_admin_sub_group_creation')
+})
+
+test('fetchSubGroups parses default + linked subgroups via mex', async () => {
+    const json = JSON.stringify({
+        data: {
+            xwa2_group_query_by_id: {
+                default_sub_group: {
+                    id: 'announce@g.us',
+                    subject: { value: 'Announcements', creation_time: '1700000000' },
+                    properties: null,
+                    membership_approval_requests: null
+                },
+                sub_groups: {
+                    edges: [
+                        {
+                            node: {
+                                id: 'sub1@g.us',
+                                subject: { value: 'Sub 1', creation_time: '1700000010' },
+                                properties: {
+                                    general_chat: true,
+                                    membership_approval_mode_enabled: false,
+                                    hidden_group: false
+                                },
+                                membership_approval_requests: { total_count: '2' }
+                            }
+                        },
+                        {
+                            node: {
+                                id: 'sub2@g.us',
+                                subject: { value: 'Sub 2', creation_time: '1700000020' },
+                                properties: {
+                                    general_chat: false,
+                                    membership_approval_mode_enabled: true,
+                                    hidden_group: true
+                                },
+                                membership_approval_requests: { total_count: '0' }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    })
+    const bytes = new TextEncoder().encode(json)
+    const mexResponse: BinaryNode = {
+        tag: 'iq',
+        attrs: { type: 'result', id: '1' },
+        content: [{ tag: 'result', attrs: {}, content: bytes }]
+    }
+    const mexCalls: BinaryNode[] = []
+    const mexSocket = {
+        query: async (node: BinaryNode) => {
+            mexCalls.push(node)
+            return Promise.resolve(mexResponse)
+        }
+    }
+
+    const mock = createMockQuery([])
+    const coordinator = createGroupCoordinator({
+        queryWithContext: mock.queryWithContext,
+        mexSocket
+    })
+
+    const result = await coordinator.fetchSubGroups('parent@g.us')
+    assert.equal(result.communityJid, 'parent@g.us')
+    assert.equal(result.announcementGroup?.jid, 'announce@g.us')
+    assert.equal(result.announcementGroup?.defaultSubgroup, true)
+    assert.equal(result.subGroups.length, 2)
+    assert.equal(result.subGroups[0].generalSubgroup, true)
+    assert.equal(result.subGroups[0].pendingMembershipRequests, 2)
+    assert.equal(result.subGroups[1].hiddenSubgroup, true)
+    assert.equal(result.subGroups[1].membershipApprovalMode, true)
+
+    const queryNode = mexCalls[0].content?.[0] as BinaryNode | undefined
+    assert.ok(queryNode)
+    assert.equal(queryNode.attrs.query_id, '9935467776504344')
+    const body = JSON.parse(queryNode.content as string)
+    assert.equal(body.variables.group_id, 'parent@g.us')
+    assert.equal(body.variables.query_context, 'PRIMARY')
+})
+
+test('fetchSubGroups throws when mex transport not configured', async () => {
+    const mock = createMockQuery([])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+    await assert.rejects(() => coordinator.fetchSubGroups('parent@g.us'), /mex transport/)
+})

--- a/src/client/coordinators/__tests__/group-community-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/group-community-coordinator.test.ts
@@ -244,7 +244,7 @@ test('fetchSubGroups parses default + linked subgroups via mex', async () => {
     assert.equal(result.subGroups[0].generalSubgroup, true)
     assert.equal(result.subGroups[0].pendingMembershipRequests, 2)
     assert.equal(result.subGroups[1].hiddenSubgroup, true)
-    assert.equal(result.subGroups[1].membershipApprovalMode, true)
+    assert.equal(result.subGroups[1].membershipApprovalEnabled, true)
 
     const queryNode = mexCalls[0].content?.[0] as BinaryNode | undefined
     assert.ok(queryNode)

--- a/src/client/coordinators/__tests__/group-community-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/group-community-coordinator.test.ts
@@ -251,7 +251,7 @@ test('fetchSubGroups parses default + linked subgroups via mex', async () => {
     assert.equal(queryNode.attrs.query_id, '9935467776504344')
     const body = JSON.parse(queryNode.content as string)
     assert.equal(body.variables.group_id, 'parent@g.us')
-    assert.equal(body.variables.query_context, 'PRIMARY')
+    assert.equal(body.variables.query_context, 'INTERACTIVE')
 })
 
 test('fetchSubGroups throws when mex transport not configured', async () => {

--- a/src/protocol/group.ts
+++ b/src/protocol/group.ts
@@ -4,4 +4,9 @@ export const WA_GROUP_PARTICIPANT_TYPES = Object.freeze({
     REGULAR: 'participant'
 } as const)
 
-export type WaGroupSetting = 'announcement' | 'restrict' | 'ephemeral' | 'membership_approval_mode'
+export type WaGroupSetting =
+    | 'announcement'
+    | 'restrict'
+    | 'ephemeral'
+    | 'membership_approval_mode'
+    | 'allow_non_admin_sub_group_creation'

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -24,6 +24,12 @@ import {
     buildGroupsDirtySyncIq,
     buildNewsletterMetadataSyncIq
 } from '@transport/node/builders/account-sync'
+import {
+    buildDeactivateCommunityIq,
+    buildLinkedGroupsParticipantsIq,
+    buildLinkSubGroupsIq,
+    buildUnlinkSubGroupsIq
+} from '@transport/node/builders/community'
 import { buildRemoveCompanionDeviceIq } from '@transport/node/builders/device'
 import {
     buildConfirmEmailIq,
@@ -285,6 +291,92 @@ test('group builders support create participant updates and leave', () => {
     assert.equal(leave.attrs.type, 'set')
     assert.ok(Array.isArray(leave.content))
     assert.equal(leave.content[0].tag, 'leave')
+})
+
+test('group create accepts community/subgroup options', () => {
+    const community = buildCreateGroupIq({
+        subject: 'My Community',
+        participants: [],
+        parent: { defaultMembershipApprovalMode: 'request_required' },
+        allowNonAdminSubGroupCreation: true,
+        createGeneralChat: true
+    })
+    const create = (community.content as BinaryNode[])[0]
+    const children = create.content as BinaryNode[]
+    const parent = children.find((c) => c.tag === 'parent')
+    assert.ok(parent)
+    assert.equal(parent.attrs.default_membership_approval_mode, 'request_required')
+    assert.ok(children.find((c) => c.tag === 'allow_non_admin_sub_group_creation'))
+    assert.ok(children.find((c) => c.tag === 'create_general_chat'))
+
+    const openCommunity = buildCreateGroupIq({
+        subject: 'Open',
+        participants: [],
+        parent: true
+    })
+    const openParent = ((openCommunity.content as BinaryNode[])[0].content as BinaryNode[]).find(
+        (c) => c.tag === 'parent'
+    )
+    assert.ok(openParent)
+    assert.equal(openParent.attrs.default_membership_approval_mode, undefined)
+
+    const subgroup = buildCreateGroupIq({
+        subject: 'Sub',
+        participants: ['5511999999999@s.whatsapp.net'],
+        linkedParentJid: 'parent@g.us'
+    })
+    const linkedParent = ((subgroup.content as BinaryNode[])[0].content as BinaryNode[]).find(
+        (c) => c.tag === 'linked_parent'
+    )
+    assert.ok(linkedParent)
+    assert.equal(linkedParent.attrs.jid, 'parent@g.us')
+})
+
+test('community builders shape link/unlink/delete/linked-participants iqs', () => {
+    const link = buildLinkSubGroupsIq({
+        communityJid: 'parent@g.us',
+        subGroups: [{ jid: 'a@g.us' }, { jid: 'b@g.us', hidden: true }]
+    })
+    assert.equal(link.attrs.to, 'parent@g.us')
+    assert.equal(link.attrs.type, 'set')
+    const links = (link.content as BinaryNode[])[0]
+    assert.equal(links.tag, 'links')
+    const linkChild = (links.content as BinaryNode[])[0]
+    assert.equal(linkChild.attrs.link_type, 'sub_group')
+    const groups = linkChild.content as BinaryNode[]
+    assert.equal(groups.length, 2)
+    assert.equal(groups[0].attrs.jid, 'a@g.us')
+    assert.equal((groups[0].content as BinaryNode[] | undefined)?.length, undefined)
+    const hiddenChildren = groups[1].content as BinaryNode[]
+    assert.equal(hiddenChildren[0].tag, 'hidden_group')
+
+    assert.throws(() => buildLinkSubGroupsIq({ communityJid: 'p@g.us', subGroups: [] }))
+
+    const unlink = buildUnlinkSubGroupsIq({
+        communityJid: 'parent@g.us',
+        subGroupJids: ['a@g.us', 'b@g.us'],
+        removeOrphanedMembers: true
+    })
+    const unlinkRoot = (unlink.content as BinaryNode[])[0]
+    assert.equal(unlinkRoot.tag, 'unlink')
+    assert.equal(unlinkRoot.attrs.unlink_type, 'sub_group')
+    const unlinkGroups = unlinkRoot.content as BinaryNode[]
+    assert.equal(unlinkGroups[0].attrs.remove_orphaned_members, 'true')
+
+    const unlinkNoOrphan = buildUnlinkSubGroupsIq({
+        communityJid: 'parent@g.us',
+        subGroupJids: ['x@g.us']
+    })
+    const noOrphanGroup = ((unlinkNoOrphan.content as BinaryNode[])[0].content as BinaryNode[])[0]
+    assert.equal(noOrphanGroup.attrs.remove_orphaned_members, undefined)
+
+    const deactivate = buildDeactivateCommunityIq('parent@g.us')
+    assert.equal(deactivate.attrs.to, 'parent@g.us')
+    assert.equal((deactivate.content as BinaryNode[])[0].tag, 'delete_parent')
+
+    const linkedParticipants = buildLinkedGroupsParticipantsIq('parent@g.us')
+    assert.equal(linkedParticipants.attrs.type, 'get')
+    assert.equal((linkedParticipants.content as BinaryNode[])[0].tag, 'linked_groups_participants')
 })
 
 test('message builders create fanout nodes and validate participant requirements', () => {

--- a/src/transport/node/builders/community.ts
+++ b/src/transport/node/builders/community.ts
@@ -1,0 +1,67 @@
+import { WA_XMLNS } from '@protocol/nodes'
+import { buildIqNode } from '@transport/node/query'
+import type { BinaryNode } from '@transport/types'
+
+export interface BuildLinkSubGroupsIqInput {
+    readonly communityJid: string
+    readonly subGroups: readonly { readonly jid: string; readonly hidden?: boolean }[]
+}
+
+export function buildLinkSubGroupsIq(input: BuildLinkSubGroupsIqInput): BinaryNode {
+    if (input.subGroups.length === 0) {
+        throw new Error('linkSubGroups requires at least one subgroup')
+    }
+    return buildIqNode('set', input.communityJid, WA_XMLNS.GROUPS, [
+        {
+            tag: 'links',
+            attrs: {},
+            content: [
+                {
+                    tag: 'link',
+                    attrs: { link_type: 'sub_group' },
+                    content: input.subGroups.map(({ jid, hidden }) => ({
+                        tag: 'group',
+                        attrs: { jid },
+                        ...(hidden ? { content: [{ tag: 'hidden_group', attrs: {} }] } : {})
+                    }))
+                }
+            ]
+        }
+    ])
+}
+
+export interface BuildUnlinkSubGroupsIqInput {
+    readonly communityJid: string
+    readonly subGroupJids: readonly string[]
+    readonly removeOrphanedMembers?: boolean
+}
+
+export function buildUnlinkSubGroupsIq(input: BuildUnlinkSubGroupsIqInput): BinaryNode {
+    if (input.subGroupJids.length === 0) {
+        throw new Error('unlinkSubGroups requires at least one subgroup')
+    }
+    const groupAttrs: Record<string, string> = {}
+    if (input.removeOrphanedMembers) {
+        groupAttrs.remove_orphaned_members = 'true'
+    }
+    return buildIqNode('set', input.communityJid, WA_XMLNS.GROUPS, [
+        {
+            tag: 'unlink',
+            attrs: { unlink_type: 'sub_group' },
+            content: input.subGroupJids.map((jid) => ({
+                tag: 'group',
+                attrs: { jid, ...groupAttrs }
+            }))
+        }
+    ])
+}
+
+export function buildDeactivateCommunityIq(communityJid: string): BinaryNode {
+    return buildIqNode('set', communityJid, WA_XMLNS.GROUPS, [{ tag: 'delete_parent', attrs: {} }])
+}
+
+export function buildLinkedGroupsParticipantsIq(communityJid: string): BinaryNode {
+    return buildIqNode('get', communityJid, WA_XMLNS.GROUPS, [
+        { tag: 'linked_groups_participants', attrs: {} }
+    ])
+}

--- a/src/transport/node/builders/group.ts
+++ b/src/transport/node/builders/group.ts
@@ -3,11 +3,19 @@ import { WA_XMLNS } from '@protocol/nodes'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
-export function buildCreateGroupIq(input: {
+export interface BuildCreateGroupIqInput {
     readonly subject: string
     readonly participants: readonly string[]
     readonly description?: string
-}): BinaryNode {
+    readonly linkedParentJid?: string
+    readonly parent?:
+        | true
+        | { readonly defaultMembershipApprovalMode?: 'request_required' | undefined }
+    readonly allowNonAdminSubGroupCreation?: boolean
+    readonly createGeneralChat?: boolean
+}
+
+export function buildCreateGroupIq(input: BuildCreateGroupIqInput): BinaryNode {
     const children: BinaryNode[] = input.participants.map((jid) => ({
         tag: 'participant',
         attrs: { jid }
@@ -19,6 +27,29 @@ export function buildCreateGroupIq(input: {
             attrs: { id: `${Date.now()}` },
             content: [{ tag: 'body', attrs: {}, content: input.description }]
         })
+    }
+
+    if (input.parent !== undefined) {
+        const parentAttrs: Record<string, string> = {}
+        if (
+            input.parent !== true &&
+            input.parent.defaultMembershipApprovalMode === 'request_required'
+        ) {
+            parentAttrs.default_membership_approval_mode = 'request_required'
+        }
+        children.push({ tag: 'parent', attrs: parentAttrs })
+    }
+
+    if (input.linkedParentJid) {
+        children.push({ tag: 'linked_parent', attrs: { jid: input.linkedParentJid } })
+    }
+
+    if (input.allowNonAdminSubGroupCreation) {
+        children.push({ tag: 'allow_non_admin_sub_group_creation', attrs: {} })
+    }
+
+    if (input.createGeneralChat) {
+        children.push({ tag: 'create_general_chat', attrs: {} })
     }
 
     return buildIqNode('set', WA_DEFAULTS.GROUP_SERVER, WA_XMLNS.GROUPS, [

--- a/src/transport/node/mex/persist-ids.ts
+++ b/src/transport/node/mex/persist-ids.ts
@@ -131,5 +131,9 @@ export const WA_MEX_PERSIST_IDS = Object.freeze({
     NewsletterLogExposures: Object.freeze({
         docId: '25260800823586918',
         clientDocId: '25260800823586918'
+    }),
+    CommunityFetchAllSubgroups: Object.freeze({
+        docId: '9935467776504344',
+        clientDocId: '9935467776504344'
     })
 }) satisfies Readonly<Record<string, WaMexPersistId>>


### PR DESCRIPTION
Adds 6 new methods on WaGroupCoordinator: createCommunity,

deactivateCommunity, linkSubGroups, unlinkSubGroups,

queryLinkedGroupsParticipants, fetchSubGroups. Extends createGroup

with linkedParentJid and setSetting with allow_non_admin_sub_group_creation.

Subgroup listing uses Mex GraphQL (xwa2_group_query_by_id); other

operations use w:g2 IQs. Stanza shapes validated against /wa-web.