### PR TITLE
fix(newsletter): correct mex variables + add robustness checks

### DIFF
--- a/src/client/coordinators/WaNewsletterCoordinator.ts
+++ b/src/client/coordinators/WaNewsletterCoordinator.ts
@@ -30,6 +30,7 @@ export type {
     WaNewsletterFollower,
     WaNewsletterFollowersOptions,
     WaNewsletterFollowersPage,
+    WaNewsletterInsightMetricRequest,
     WaNewsletterMetadata,
     WaNewsletterMexEnvelope,
     WaNewsletterMuteInput,

--- a/src/client/newsletter/admin.ts
+++ b/src/client/newsletter/admin.ts
@@ -23,6 +23,7 @@ import type {
     WaNewsletterCreateInput,
     WaNewsletterFollowersOptions,
     WaNewsletterFollowersPage,
+    WaNewsletterInsightMetricRequest,
     WaNewsletterMetadata,
     WaNewsletterMexEnvelope,
     WaNewsletterPollVoter,
@@ -36,6 +37,7 @@ import {
     type WaTosQueryResult
 } from '@transport/node/builders/tos'
 import { WA_MEX_PERSIST_IDS } from '@transport/node/mex/persist-ids'
+import { assertIqResult } from '@transport/node/query'
 import { bytesToBase64 } from '@util/bytes'
 
 export interface WaNewsletterAdminOps {
@@ -53,7 +55,7 @@ export interface WaNewsletterAdminOps {
     ) => Promise<WaNewsletterFollowersPage>
     readonly fetchInsights: (
         newsletterJid: string,
-        metrics?: readonly string[]
+        metrics: readonly WaNewsletterInsightMetricRequest[]
     ) => Promise<WaNewsletterMexEnvelope>
     readonly fetchReports: () => Promise<WaNewsletterMexEnvelope>
     readonly fetchPendingInvites: (newsletterJid: string) => Promise<readonly string[]>
@@ -156,18 +158,22 @@ export function createAdminOps(deps: WaNewsletterMexDeps): WaNewsletterAdminOps 
             )
             return parseFollowers(envelope)
         },
-        fetchInsights: (newsletterJid, metrics) =>
-            runMexEnvelope(
+        fetchInsights: (newsletterJid, metrics) => {
+            if (metrics.length === 0) {
+                throw new Error('newsletter fetchInsights requires at least one metric request')
+            }
+            return runMexEnvelope(
                 deps,
                 WA_MEX_PERSIST_IDS.NewsletterFetchInsights,
                 'NewsletterFetchInsights',
                 {
                     input: {
                         newsletter_id: newsletterJid,
-                        metrics: metrics ?? []
+                        metrics
                     }
                 }
-            ),
+            )
+        },
         fetchReports: () =>
             runMexEnvelope(
                 deps,
@@ -215,7 +221,7 @@ export function createAdminOps(deps: WaNewsletterMexDeps): WaNewsletterAdminOps 
                 {
                     input: {
                         id: input.newsletterJid,
-                        server_id: input.messageServerId
+                        server_id: String(input.messageServerId)
                     }
                 }
             )
@@ -298,13 +304,18 @@ export function createAdminOps(deps: WaNewsletterMexDeps): WaNewsletterAdminOps 
                 'newsletter.query_tos',
                 buildTosQueryIq(noticeIds)
             )
+            assertIqResult(response, 'newsletter.query_tos')
             return parseTosQueryResponse(response)
         },
         acceptTos: async (noticeIds) => {
             if (!deps.queryWithContext) {
                 throw new Error('newsletter acceptTos requires queryWithContext')
             }
-            await deps.queryWithContext('newsletter.accept_tos', buildTosUpdateIq(noticeIds))
+            const response = await deps.queryWithContext(
+                'newsletter.accept_tos',
+                buildTosUpdateIq(noticeIds)
+            )
+            assertIqResult(response, 'newsletter.accept_tos')
         }
     }
 }

--- a/src/client/newsletter/discovery.ts
+++ b/src/client/newsletter/discovery.ts
@@ -81,7 +81,8 @@ export function createDiscoveryOps(deps: WaNewsletterMexDeps): WaNewsletterDisco
                 fetch_viewer_metadata: opts?.fetchViewerMetadata ?? true,
                 fetch_full_image: opts?.fetchFullImage ?? keyType !== 'INVITE',
                 fetch_creation_time: opts?.fetchCreationTime ?? true,
-                fetch_wamo_sub: opts?.fetchWamoSub ?? false
+                fetch_wamo_sub: opts?.fetchWamoSub ?? false,
+                fetch_status_metadata: false
             }
         )
         if (!data?.xwa2_newsletter) {
@@ -98,7 +99,8 @@ export function createDiscoveryOps(deps: WaNewsletterMexDeps): WaNewsletterDisco
             const data = await runMex<{
                 readonly xwa2_newsletter_subscribed?: readonly MexNewsletterEnvelope[]
             } | null>(deps, WA_MEX_PERSIST_IDS.NewsletterFetchAll, 'NewsletterFetchAll', {
-                fetch_wamo_sub: opts?.fetchWamoSub ?? false
+                fetch_wamo_sub: opts?.fetchWamoSub ?? false,
+                fetch_status_metadata: false
             })
             const list = data?.xwa2_newsletter_subscribed ?? []
             return list.map(parseNewsletterMetadata)
@@ -114,7 +116,8 @@ export function createDiscoveryOps(deps: WaNewsletterMexDeps): WaNewsletterDisco
                         categories: opts?.categories ?? [],
                         limit: opts?.limit ?? 100,
                         start_cursor: opts?.startCursor
-                    }
+                    },
+                    fetch_status_metadata: false
                 }
             )
             return parseDirectorySearch(envelope)
@@ -128,7 +131,8 @@ export function createDiscoveryOps(deps: WaNewsletterMexDeps): WaNewsletterDisco
                     input: {
                         limit: opts?.limit ?? 25,
                         country_codes: opts?.countryCodes ?? []
-                    }
+                    },
+                    fetch_status_metadata: false
                 }
             )
             return parseRecommended(envelope)
@@ -143,7 +147,8 @@ export function createDiscoveryOps(deps: WaNewsletterMexDeps): WaNewsletterDisco
                         newsletter_id: newsletterJid,
                         limit: opts?.limit ?? 10,
                         country_codes: opts?.countryCodes ?? []
-                    }
+                    },
+                    fetch_status_metadata: false
                 }
             )
             return parseSimilar(envelope)
@@ -162,7 +167,8 @@ export function createDiscoveryOps(deps: WaNewsletterMexDeps): WaNewsletterDisco
                         },
                         limit: opts.limit ?? 25,
                         start_cursor: opts.startCursor
-                    }
+                    },
+                    fetch_status_metadata: false
                 }
             )
             return parseDirectoryList(envelope)
@@ -177,7 +183,8 @@ export function createDiscoveryOps(deps: WaNewsletterMexDeps): WaNewsletterDisco
                         categories: opts.categories,
                         country_code: opts.countryCode || undefined,
                         per_category_limit: opts.perCategoryLimit ?? 10
-                    }
+                    },
+                    fetch_status_metadata: false
                 }
             )
             return parseDirectoryCategoriesPreview(envelope)

--- a/src/client/newsletter/types.ts
+++ b/src/client/newsletter/types.ts
@@ -38,6 +38,12 @@ export interface WaNewsletterFetchOptions {
     readonly viewRole?: keyof typeof WA_NEWSLETTER_VIEW_ROLES
 }
 
+export interface WaNewsletterInsightMetricRequest {
+    readonly id: number
+    readonly type: string
+    readonly group_by?: { readonly number_of_days?: number }
+}
+
 export interface WaNewsletterDirectorySearchOptions {
     readonly searchText?: string
     readonly startCursor?: string

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -1387,9 +1387,21 @@ test('newsletter fetch IQs build the right history/update stanzas', async () => 
     const fetchUpdates = buildNewsletterMessageUpdatesIq({
         newsletterJid: '120363025343298869@newsletter',
         count: 100,
-        since: 1700000000
+        since: 1700000000,
+        after: 50
     })
     assert.ok(Array.isArray(fetchUpdates.content))
     assert.equal(fetchUpdates.content[0].tag, 'message_updates')
     assert.equal(fetchUpdates.content[0].attrs.since, '1700000000')
+    assert.equal(fetchUpdates.content[0].attrs.after, '50')
+
+    assert.throws(
+        () =>
+            buildNewsletterMessageUpdatesIq({
+                newsletterJid: '120363025343298869@newsletter',
+                count: 100,
+                since: 1700000000
+            }),
+        /before or after/
+    )
 })

--- a/src/transport/node/builders/newsletter.ts
+++ b/src/transport/node/builders/newsletter.ts
@@ -247,6 +247,9 @@ export interface BuildNewsletterMessageUpdatesIqInput {
 export function buildNewsletterMessageUpdatesIq(
     input: BuildNewsletterMessageUpdatesIqInput
 ): BinaryNode {
+    if (input.before === undefined && input.after === undefined) {
+        throw new Error('newsletter message updates require before or after')
+    }
     const attrs: Record<string, string> = {
         count: String(input.count)
     }


### PR DESCRIPTION
Validated end-to-end against real WhatsApp via MCP server.

Mex variable fixes (server returned 400 Bad Request):
- listSubscribed/fetch/fetchByInvite/searchDirectory/fetchRecommended/ fetchSimilar/fetchDirectoryList/fetchDirectoryCategoriesPreview now send fetch_status_metadata: false, which the GraphQL fragments declare as a required variable
- fetchMessageReactionSenders sends server_id as String() (was raw number)
- fetchInsights metric request type was wrong (string id) — now matches wa-web shape (numeric enum id, e.g. FollowersOverPeriod = 6)

Robustness:
- queryTosState/acceptTos call assertIqResult before parsing, surfacing clean "iq failed" errors instead of "missing <tos> node" when the server returns an error response
- buildNewsletterMessageUpdatesIq throws if neither before nor after is given (was silent timeout — wa-web's mixin requires one of them)
- fetchInsights throws on empty metrics array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for structured metrics specification in newsletter insights retrieval.

* **Bug Fixes**
  * Enhanced input validation for newsletter operations to prevent incomplete or invalid requests.
  * Improved performance of newsletter discovery operations by optimizing metadata handling.

* **Tests**
  * Expanded test coverage for newsletter message update operations with additional validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->