### PR TITLE
feat(mcp-server): add http+watch dev mode and persist signal stores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "": {
             "name": "zapo-js",
             "version": "0.3.0",
+            "dev": true,
             "hasInstallScript": true,
             "workspaces": [
                 "packages/*"
@@ -3410,6 +3411,25 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "bin": {
+                "cross-env": "src/bin/cross-env.js",
+                "cross-env-shell": "src/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=10.14",
+                "npm": ">=6",
+                "yarn": ">=1"
             }
         },
         "node_modules/cross-spawn": {
@@ -9060,6 +9080,7 @@
                 "@zapo-js/fake-server": "file:../fake-server",
                 "@zapo-js/store-sqlite": "file:../store-sqlite",
                 "better-sqlite3": "^12.6.2",
+                "cross-env": "^7.0.3",
                 "zapo-js": "file:../.."
             },
             "engines": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -24,7 +24,8 @@
         "build": "tsc -p tsconfig.build.cjs.json",
         "typecheck": "tsc --noEmit",
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\"",
-        "start": "node --import tsx src/bin.ts"
+        "start": "node --import tsx src/bin.ts",
+        "dev": "cross-env MCP_TRANSPORT=http MCP_AUTH_PATH=../../.auth/state.sqlite node --watch --import tsx src/bin.ts"
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -43,6 +44,7 @@
         "@zapo-js/fake-server": "file:../fake-server",
         "@zapo-js/store-sqlite": "file:../store-sqlite",
         "better-sqlite3": "^12.6.2",
+        "cross-env": "^7.0.3",
         "zapo-js": "file:../.."
     },
     "engines": {

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -437,6 +437,9 @@ export class McpRuntime {
             providers: {
                 auth: 'sqlite',
                 signal: 'sqlite',
+                preKey: 'sqlite',
+                session: 'sqlite',
+                identity: 'sqlite',
                 senderKey: 'sqlite',
                 appState: 'sqlite',
                 messages: 'sqlite',


### PR DESCRIPTION
Two improvements to the MCP dev workflow:

1. New `npm run dev --workspace @zapo-js/mcp-server` script: runs the server on HTTP transport (port 3737) under `node --watch` with tsx as the loader. Resolves zapo-js directly from src/ via the workspace tsconfig paths, so iterating on the core lib needs no rebuild step and Claude Code reconnects automatically on each restart — no manual /mcp reconnect. Documented in AGENTS.md §13. Adds cross-env devDep for cross-platform env var setting in the script.

2. Persist preKey/session/identity stores to sqlite. createStore() defaults these to memory when not specified, which silently dropped Signal session state across MCP restarts and forced re-establishing every device session on reconnect. Now matches the persistent set used by the example client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development tooling with improved watch capabilities and environment configuration
  * Optimized backend data persistence layer to support additional data storage types

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/56)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->