### PR TITLE
feat(client): full group metadata parsing + membership approval methods

### DIFF
--- a/src/client/coordinators/WaGroupCoordinator.ts
+++ b/src/client/coordinators/WaGroupCoordinator.ts
@@ -21,6 +21,7 @@ import {
     findNodeChild,
     getNodeChildrenByTag,
     getNodeChildrenByTagFromChildren,
+    getNodeTextContent,
     hasNodeChild
 } from '@transport/node/helpers'
 import { dispatchMexQuery, type WaMexQuerySocket } from '@transport/node/mex/client'
@@ -259,14 +260,6 @@ function parseGroupParticipants(node: BinaryNode): readonly WaGroupParticipant[]
     return participants
 }
 
-function readChildText(node: BinaryNode | undefined): string | undefined {
-    if (!node) return undefined
-    const content = node.content
-    if (typeof content === 'string') return content
-    if (content instanceof Uint8Array) return new TextDecoder().decode(content)
-    return undefined
-}
-
 const APPEAL_STATUSES = new Set(['approved', 'in_review', 'none', 'rejected'])
 
 function parseMembershipApprovalRequests(node: BinaryNode): readonly WaMembershipRequest[] {
@@ -329,6 +322,9 @@ function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
     const appealStatusType = appealStatusNode?.attrs.type
     const appealUpdateTimeNode = findNodeChild(target, 'appeal_update_time')
     const evolutionVersionNode = findNodeChild(target, 'evolution_version')
+    const memberAddModeNode = findNodeChild(target, 'member_add_mode')
+    const memberLinkModeNode = findNodeChild(target, 'member_link_mode')
+    const memberShareNode = findNodeChild(target, 'member_share_group_history_mode')
 
     const addressingModeRaw = attrs.addressing_mode
     const addressingMode: 'lid' | 'pn' | undefined =
@@ -375,11 +371,11 @@ function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
         evolutionVersion: evolutionVersionNode?.attrs.value
             ? Number(evolutionVersionNode.attrs.value)
             : undefined,
-        memberAddMode: readChildText(findNodeChild(target, 'member_add_mode')),
-        memberLinkMode: readChildText(findNodeChild(target, 'member_link_mode')),
-        memberShareGroupHistoryMode: readChildText(
-            findNodeChild(target, 'member_share_group_history_mode')
-        ),
+        memberAddMode: memberAddModeNode ? getNodeTextContent(memberAddModeNode) : undefined,
+        memberLinkMode: memberLinkModeNode ? getNodeTextContent(memberLinkModeNode) : undefined,
+        memberShareGroupHistoryMode: memberShareNode
+            ? getNodeTextContent(memberShareNode)
+            : undefined,
         growthLockedExpiration: growthLockedNode?.attrs.expiration
             ? Number(growthLockedNode.attrs.expiration)
             : undefined,

--- a/src/client/coordinators/WaGroupCoordinator.ts
+++ b/src/client/coordinators/WaGroupCoordinator.ts
@@ -9,9 +9,13 @@ import {
     buildUnlinkSubGroupsIq
 } from '@transport/node/builders/community'
 import {
+    buildCancelMembershipRequestsIq,
     buildCreateGroupIq,
+    buildGetMembershipApprovalRequestsIq,
     buildGroupParticipantChangeIq,
-    buildLeaveGroupIq
+    buildJoinLinkedGroupIq,
+    buildLeaveGroupIq,
+    buildMembershipRequestsActionIq
 } from '@transport/node/builders/group'
 import {
     findNodeChild,
@@ -29,6 +33,11 @@ export interface WaGroupParticipant {
     readonly type: string
     readonly isAdmin: boolean
     readonly isSuperAdmin: boolean
+    readonly lid?: string
+    readonly phoneNumber?: string
+    readonly displayName?: string
+    readonly username?: string
+    readonly expirationSeconds?: number
 }
 
 export interface WaGroupMetadata {
@@ -44,15 +53,46 @@ export interface WaGroupMetadata {
     readonly restrict: boolean
     readonly announce: boolean
     readonly ephemeral?: number
+    readonly ephemeralTrigger?: number
     readonly size?: number
+    readonly addressingMode?: 'lid' | 'pn'
     readonly isParentGroup: boolean
     readonly isClosedCommunity: boolean
     readonly defaultSubgroup: boolean
     readonly generalSubgroup: boolean
     readonly hiddenSubgroup: boolean
     readonly allowNonAdminSubGroupCreation: boolean
+    readonly membershipApprovalEnabled: boolean
+    readonly noFrequentlyForwarded: boolean
+    readonly support: boolean
+    readonly suspended: boolean
+    readonly incognito: boolean
+    readonly allowAdminReports: boolean
+    readonly autoAddDisabled: boolean
+    readonly groupHistory: boolean
+    readonly capi: boolean
+    readonly groupSafetyCheck: boolean
+    readonly participantLabelEnabled: boolean
+    readonly limitSharingEnabled: boolean
+    readonly evolutionVersion?: number
+    readonly memberAddMode?: string
+    readonly memberLinkMode?: string
+    readonly memberShareGroupHistoryMode?: string
+    readonly growthLockedExpiration?: number
+    readonly appealStatus?: 'approved' | 'in_review' | 'none' | 'rejected'
+    readonly appealUpdateTime?: number
     readonly linkedParentJid?: string
     readonly participants: readonly WaGroupParticipant[]
+}
+
+export interface WaMembershipRequest {
+    readonly jid: string
+    readonly requestor?: string
+    readonly requestorPhone?: string
+    readonly requestorUsername?: string
+    readonly parentGroupJid?: string
+    readonly requestTime: number
+    readonly requestMethod?: string
 }
 
 export interface WaGroupCreateOptions {
@@ -166,6 +206,26 @@ export interface WaGroupCoordinator {
         communityJid: string
     ) => Promise<readonly WaGroupParticipant[]>
     readonly fetchSubGroups: (communityJid: string) => Promise<WaCommunitySubGroupsResult>
+    readonly queryMembershipApprovalRequests: (
+        groupJid: string
+    ) => Promise<readonly WaMembershipRequest[]>
+    readonly approveMembershipRequests: (
+        groupJid: string,
+        participantJids: readonly string[]
+    ) => Promise<void>
+    readonly rejectMembershipRequests: (
+        groupJid: string,
+        participantJids: readonly string[]
+    ) => Promise<void>
+    readonly cancelMembershipRequests: (
+        groupJid: string,
+        participantJids: readonly string[]
+    ) => Promise<void>
+    readonly joinLinkedGroup: (
+        communityJid: string,
+        subGroupJid: string,
+        options?: { readonly type?: string }
+    ) => Promise<BinaryNode>
 }
 
 type WaGroupParticipantChangeAction = 'add' | 'remove' | 'promote' | 'demote'
@@ -186,12 +246,51 @@ function parseGroupParticipants(node: BinaryNode): readonly WaGroupParticipant[]
             isAdmin:
                 type === WA_GROUP_PARTICIPANT_TYPES.ADMIN ||
                 type === WA_GROUP_PARTICIPANT_TYPES.SUPERADMIN,
-            isSuperAdmin: type === WA_GROUP_PARTICIPANT_TYPES.SUPERADMIN
+            isSuperAdmin: type === WA_GROUP_PARTICIPANT_TYPES.SUPERADMIN,
+            lid: participant.lidJid,
+            phoneNumber: participant.phoneJid,
+            displayName: participant.displayName,
+            username: participant.username,
+            expirationSeconds: participant.expirationSeconds
         }
         participantsCount += 1
     }
     participants.length = participantsCount
     return participants
+}
+
+function readChildText(node: BinaryNode | undefined): string | undefined {
+    if (!node) return undefined
+    const content = node.content
+    if (typeof content === 'string') return content
+    if (content instanceof Uint8Array) return new TextDecoder().decode(content)
+    return undefined
+}
+
+const APPEAL_STATUSES = new Set(['approved', 'in_review', 'none', 'rejected'])
+
+function parseMembershipApprovalRequests(node: BinaryNode): readonly WaMembershipRequest[] {
+    const container = findNodeChild(node, 'membership_approval_requests')
+    if (!container) return []
+    const requestNodes = getNodeChildrenByTag(container, 'membership_approval_request')
+    const requests: WaMembershipRequest[] = []
+    for (const requestNode of requestNodes) {
+        const jid = requestNode.attrs.jid
+        if (!jid) continue
+        const requestTime = requestNode.attrs.request_time
+            ? Number(requestNode.attrs.request_time)
+            : 0
+        requests.push({
+            jid,
+            requestor: requestNode.attrs.requestor,
+            requestorPhone: requestNode.attrs.requestor_pn,
+            requestorUsername: requestNode.attrs.requestor_username,
+            parentGroupJid: requestNode.attrs.parent_group_jid,
+            requestTime,
+            requestMethod: requestNode.attrs.request_method
+        })
+    }
+    return requests
 }
 
 function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
@@ -213,9 +312,27 @@ function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
     const ephemeral = ephemeralNode?.attrs.expiration
         ? Number(ephemeralNode.attrs.expiration)
         : undefined
+    const ephemeralTrigger = ephemeralNode?.attrs.trigger
+        ? Number(ephemeralNode.attrs.trigger)
+        : undefined
 
     const parentNode = findNodeChild(target, 'parent')
     const linkedParentNode = findNodeChild(target, 'linked_parent')
+
+    const membershipApprovalNode = findNodeChild(target, WA_NODE_TAGS.MEMBERSHIP_APPROVAL_MODE)
+    const groupJoinNode = membershipApprovalNode
+        ? findNodeChild(membershipApprovalNode, WA_NODE_TAGS.GROUP_JOIN)
+        : undefined
+
+    const growthLockedNode = findNodeChild(target, 'growth_locked')
+    const appealStatusNode = findNodeChild(target, 'appeal_status')
+    const appealStatusType = appealStatusNode?.attrs.type
+    const appealUpdateTimeNode = findNodeChild(target, 'appeal_update_time')
+    const evolutionVersionNode = findNodeChild(target, 'evolution_version')
+
+    const addressingModeRaw = attrs.addressing_mode
+    const addressingMode: 'lid' | 'pn' | undefined =
+        addressingModeRaw === 'lid' ? 'lid' : addressingModeRaw === 'pn' ? 'pn' : undefined
 
     const rawJid = attrs.id ?? attrs.jid ?? ''
     const jid = rawJid && !rawJid.includes('@') ? `${rawJid}@${WA_DEFAULTS.GROUP_SERVER}` : rawJid
@@ -233,7 +350,9 @@ function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
         restrict: hasNodeChild(target, WA_NODE_TAGS.LOCKED),
         announce: hasNodeChild(target, WA_NODE_TAGS.ANNOUNCEMENT),
         ephemeral,
+        ephemeralTrigger,
         size: attrs.size ? Number(attrs.size) : undefined,
+        addressingMode,
         isParentGroup: parentNode !== undefined,
         isClosedCommunity:
             parentNode?.attrs.default_membership_approval_mode === 'request_required',
@@ -241,6 +360,36 @@ function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
         generalSubgroup: hasNodeChild(target, 'general_chat'),
         hiddenSubgroup: hasNodeChild(target, 'hidden_group'),
         allowNonAdminSubGroupCreation: hasNodeChild(target, 'allow_non_admin_sub_group_creation'),
+        membershipApprovalEnabled: groupJoinNode?.attrs.state === 'on',
+        noFrequentlyForwarded: hasNodeChild(target, 'no_frequently_forwarded'),
+        support: hasNodeChild(target, 'support'),
+        suspended: hasNodeChild(target, 'suspended'),
+        incognito: hasNodeChild(target, 'incognito'),
+        allowAdminReports: hasNodeChild(target, 'allow_admin_reports'),
+        autoAddDisabled: hasNodeChild(target, 'auto_add_disabled'),
+        groupHistory: hasNodeChild(target, 'group_history'),
+        capi: hasNodeChild(target, 'capi'),
+        groupSafetyCheck: hasNodeChild(target, 'group_safety_check'),
+        participantLabelEnabled: hasNodeChild(target, 'participant_label_enabled'),
+        limitSharingEnabled: hasNodeChild(target, 'limit_sharing_enabled'),
+        evolutionVersion: evolutionVersionNode?.attrs.value
+            ? Number(evolutionVersionNode.attrs.value)
+            : undefined,
+        memberAddMode: readChildText(findNodeChild(target, 'member_add_mode')),
+        memberLinkMode: readChildText(findNodeChild(target, 'member_link_mode')),
+        memberShareGroupHistoryMode: readChildText(
+            findNodeChild(target, 'member_share_group_history_mode')
+        ),
+        growthLockedExpiration: growthLockedNode?.attrs.expiration
+            ? Number(growthLockedNode.attrs.expiration)
+            : undefined,
+        appealStatus:
+            appealStatusType && APPEAL_STATUSES.has(appealStatusType)
+                ? (appealStatusType as 'approved' | 'in_review' | 'none' | 'rejected')
+                : undefined,
+        appealUpdateTime: appealUpdateTimeNode?.attrs.value
+            ? Number(appealUpdateTimeNode.attrs.value)
+            : undefined,
         linkedParentJid: linkedParentNode?.attrs.jid ?? parentNode?.attrs.jid,
         participants: parseGroupParticipants(target)
     }
@@ -561,6 +710,42 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
                 subGroups.push(parseSubGroupNode(edge.node, false))
             }
             return { communityJid, announcementGroup, subGroups }
+        },
+
+        queryMembershipApprovalRequests: async (groupJid) => {
+            const node = buildGetMembershipApprovalRequestsIq(groupJid)
+            const result = await queryWithContext('group.membershipRequests', node)
+            assertIqResult(result, 'group.membershipRequests')
+            return parseMembershipApprovalRequests(result)
+        },
+
+        approveMembershipRequests: async (groupJid, participantJids) => {
+            const node = buildMembershipRequestsActionIq({ groupJid, approve: participantJids })
+            const result = await queryWithContext('group.membershipRequests.approve', node)
+            assertIqResult(result, 'group.membershipRequests.approve')
+        },
+
+        rejectMembershipRequests: async (groupJid, participantJids) => {
+            const node = buildMembershipRequestsActionIq({ groupJid, reject: participantJids })
+            const result = await queryWithContext('group.membershipRequests.reject', node)
+            assertIqResult(result, 'group.membershipRequests.reject')
+        },
+
+        cancelMembershipRequests: async (groupJid, participantJids) => {
+            const node = buildCancelMembershipRequestsIq({ groupJid, participantJids })
+            const result = await queryWithContext('group.membershipRequests.cancel', node)
+            assertIqResult(result, 'group.membershipRequests.cancel')
+        },
+
+        joinLinkedGroup: async (communityJid, subGroupJid, options) => {
+            const node = buildJoinLinkedGroupIq({
+                groupJid: communityJid,
+                subGroupJid,
+                type: options?.type
+            })
+            const result = await queryWithContext('community.joinLinkedGroup', node)
+            assertIqResult(result, 'community.joinLinkedGroup')
+            return result
         }
     }
 }

--- a/src/client/coordinators/__tests__/group-community-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/group-community-coordinator.test.ts
@@ -259,3 +259,149 @@ test('fetchSubGroups throws when mex transport not configured', async () => {
     const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
     await assert.rejects(() => coordinator.fetchSubGroups('parent@g.us'), /mex transport/)
 })
+
+test('queryGroupMetadata extracts the extended field set', async () => {
+    const groupResponse: BinaryNode = {
+        tag: 'iq',
+        attrs: { type: 'result', id: '1' },
+        content: [
+            {
+                tag: 'group',
+                attrs: {
+                    id: '120363@g.us',
+                    subject: 'Sample',
+                    addressing_mode: 'lid',
+                    creator: 'creator@lid',
+                    creation: '1700000000',
+                    s_t: '1700000010',
+                    s_o: 'subjowner@lid',
+                    size: '5'
+                },
+                content: [
+                    { tag: 'announcement', attrs: {} },
+                    { tag: 'no_frequently_forwarded', attrs: {} },
+                    { tag: 'incognito', attrs: {} },
+                    {
+                        tag: 'ephemeral',
+                        attrs: { expiration: '604800', trigger: '4' }
+                    },
+                    {
+                        tag: 'membership_approval_mode',
+                        attrs: {},
+                        content: [{ tag: 'group_join', attrs: { state: 'on' } }]
+                    },
+                    {
+                        tag: 'growth_locked',
+                        attrs: { type: 'invite', expiration: '1700099999' }
+                    },
+                    { tag: 'appeal_status', attrs: { type: 'in_review' } },
+                    { tag: 'appeal_update_time', attrs: { value: '1700000050' } },
+                    { tag: 'evolution_version', attrs: { value: '7' } },
+                    { tag: 'member_add_mode', attrs: {}, content: 'admin_add' },
+                    {
+                        tag: 'member_share_group_history_mode',
+                        attrs: {},
+                        content: 'all_member_share'
+                    },
+                    {
+                        tag: 'participant',
+                        attrs: {
+                            jid: '111@lid',
+                            type: 'admin',
+                            phone_number: '5511999999999@s.whatsapp.net',
+                            display_name: 'Alice'
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+    const mock = createMockQuery([groupResponse])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    const meta = await coordinator.queryGroupMetadata('120363@g.us')
+
+    assert.equal(meta.addressingMode, 'lid')
+    assert.equal(meta.announce, true)
+    assert.equal(meta.noFrequentlyForwarded, true)
+    assert.equal(meta.incognito, true)
+    assert.equal(meta.ephemeral, 604800)
+    assert.equal(meta.ephemeralTrigger, 4)
+    assert.equal(meta.membershipApprovalEnabled, true)
+    assert.equal(meta.growthLockedExpiration, 1700099999)
+    assert.equal(meta.appealStatus, 'in_review')
+    assert.equal(meta.appealUpdateTime, 1700000050)
+    assert.equal(meta.evolutionVersion, 7)
+    assert.equal(meta.memberAddMode, 'admin_add')
+    assert.equal(meta.memberShareGroupHistoryMode, 'all_member_share')
+    assert.equal(meta.participants.length, 1)
+    assert.equal(meta.participants[0].phoneNumber, '5511999999999@s.whatsapp.net')
+    assert.equal(meta.participants[0].displayName, 'Alice')
+    assert.equal(meta.participants[0].isAdmin, true)
+})
+
+test('queryMembershipApprovalRequests parses pending requests', async () => {
+    const response: BinaryNode = iqResult([
+        {
+            tag: 'membership_approval_requests',
+            attrs: {},
+            content: [
+                {
+                    tag: 'membership_approval_request',
+                    attrs: {
+                        jid: 'requester1@lid',
+                        request_time: '1700000000',
+                        request_method: 'invitelink'
+                    }
+                },
+                {
+                    tag: 'membership_approval_request',
+                    attrs: {
+                        jid: 'requester2@lid',
+                        requestor: 'inviter@lid',
+                        requestor_pn: '5511000000000@s.whatsapp.net',
+                        request_time: '1700000005'
+                    }
+                }
+            ]
+        }
+    ])
+    const mock = createMockQuery([response])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    const requests = await coordinator.queryMembershipApprovalRequests('parent@g.us')
+    assert.equal(requests.length, 2)
+    assert.equal(requests[0].jid, 'requester1@lid')
+    assert.equal(requests[0].requestMethod, 'invitelink')
+    assert.equal(requests[1].requestor, 'inviter@lid')
+    assert.equal(requests[1].requestorPhone, '5511000000000@s.whatsapp.net')
+    assert.equal(requests[1].requestTime, 1700000005)
+})
+
+test('approve/reject/cancel/joinLinkedGroup send the correct stanza shape', async () => {
+    const mock = createMockQuery([iqResult(), iqResult(), iqResult(), iqResult()])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    await coordinator.approveMembershipRequests('parent@g.us', ['a@lid'])
+    await coordinator.rejectMembershipRequests('parent@g.us', ['b@lid'])
+    await coordinator.cancelMembershipRequests('parent@g.us', ['c@lid'])
+    await coordinator.joinLinkedGroup('parent@g.us', 'sub@g.us')
+
+    const approveRoot = (mock.calls[0].node.content as BinaryNode[])[0]
+    assert.equal(approveRoot.tag, 'membership_requests_action')
+    const approveChild = (approveRoot.content as BinaryNode[]).find((c) => c.tag === 'approve')
+    assert.ok(approveChild)
+    assert.equal((approveChild.content as BinaryNode[])[0].attrs.jid, 'a@lid')
+
+    const rejectRoot = (mock.calls[1].node.content as BinaryNode[])[0]
+    const rejectChild = (rejectRoot.content as BinaryNode[]).find((c) => c.tag === 'reject')
+    assert.equal((rejectChild?.content as BinaryNode[])[0].attrs.jid, 'b@lid')
+
+    const cancelRoot = (mock.calls[2].node.content as BinaryNode[])[0]
+    assert.equal(cancelRoot.tag, 'cancel_membership_requests')
+    assert.equal((cancelRoot.content as BinaryNode[])[0].attrs.jid, 'c@lid')
+
+    const joinRoot = (mock.calls[3].node.content as BinaryNode[])[0]
+    assert.equal(joinRoot.tag, 'join_linked_group')
+    assert.equal(joinRoot.attrs.jid, 'sub@g.us')
+})

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -40,9 +40,13 @@ import {
 } from '@transport/node/builders/email'
 import { buildAckNode, buildIqResultNode, buildReceiptNode } from '@transport/node/builders/global'
 import {
+    buildCancelMembershipRequestsIq,
     buildCreateGroupIq,
+    buildGetMembershipApprovalRequestsIq,
     buildGroupParticipantChangeIq,
-    buildLeaveGroupIq
+    buildJoinLinkedGroupIq,
+    buildLeaveGroupIq,
+    buildMembershipRequestsActionIq
 } from '@transport/node/builders/group'
 import {
     buildDirectMessageFanoutNode,
@@ -291,6 +295,57 @@ test('group builders support create participant updates and leave', () => {
     assert.equal(leave.attrs.type, 'set')
     assert.ok(Array.isArray(leave.content))
     assert.equal(leave.content[0].tag, 'leave')
+})
+
+test('membership approval + join-linked-group builders shape iqs', () => {
+    const list = buildGetMembershipApprovalRequestsIq('parent@g.us')
+    assert.equal(list.attrs.to, 'parent@g.us')
+    assert.equal(list.attrs.type, 'get')
+    assert.equal((list.content as BinaryNode[])[0].tag, 'membership_approval_requests')
+
+    const action = buildMembershipRequestsActionIq({
+        groupJid: 'parent@g.us',
+        approve: ['a@s.whatsapp.net'],
+        reject: ['b@s.whatsapp.net', 'c@s.whatsapp.net']
+    })
+    const actionRoot = (action.content as BinaryNode[])[0]
+    assert.equal(actionRoot.tag, 'membership_requests_action')
+    const actionChildren = actionRoot.content as BinaryNode[]
+    const approveNode = actionChildren.find((n) => n.tag === 'approve')
+    const rejectNode = actionChildren.find((n) => n.tag === 'reject')
+    assert.equal((approveNode?.content as BinaryNode[]).length, 1)
+    assert.equal((rejectNode?.content as BinaryNode[]).length, 2)
+
+    assert.throws(
+        () => buildMembershipRequestsActionIq({ groupJid: 'p@g.us' }),
+        /approve or reject/
+    )
+
+    const cancel = buildCancelMembershipRequestsIq({
+        groupJid: 'parent@g.us',
+        participantJids: ['x@s.whatsapp.net']
+    })
+    assert.equal((cancel.content as BinaryNode[])[0].tag, 'cancel_membership_requests')
+    assert.throws(
+        () => buildCancelMembershipRequestsIq({ groupJid: 'p@g.us', participantJids: [] }),
+        /at least one participant/
+    )
+
+    const join = buildJoinLinkedGroupIq({
+        groupJid: 'parent@g.us',
+        subGroupJid: 'sub@g.us',
+        type: 'community'
+    })
+    const joinRoot = (join.content as BinaryNode[])[0]
+    assert.equal(joinRoot.tag, 'join_linked_group')
+    assert.equal(joinRoot.attrs.jid, 'sub@g.us')
+    assert.equal(joinRoot.attrs.type, 'community')
+
+    const joinNoType = buildJoinLinkedGroupIq({
+        groupJid: 'parent@g.us',
+        subGroupJid: 'sub@g.us'
+    })
+    assert.equal((joinNoType.content as BinaryNode[])[0].attrs.type, undefined)
 })
 
 test('group create accepts community/subgroup options', () => {

--- a/src/transport/node/builders/group.ts
+++ b/src/transport/node/builders/group.ts
@@ -92,3 +92,72 @@ export function buildLeaveGroupIq(groupJids: readonly string[]): BinaryNode {
         }
     ])
 }
+
+export function buildGetMembershipApprovalRequestsIq(groupJid: string): BinaryNode {
+    return buildIqNode('get', groupJid, WA_XMLNS.GROUPS, [
+        { tag: 'membership_approval_requests', attrs: {} }
+    ])
+}
+
+export function buildMembershipRequestsActionIq(input: {
+    readonly groupJid: string
+    readonly approve?: readonly string[]
+    readonly reject?: readonly string[]
+}): BinaryNode {
+    const approve = input.approve ?? []
+    const reject = input.reject ?? []
+    if (approve.length === 0 && reject.length === 0) {
+        throw new Error('membership_requests_action requires at least one approve or reject jid')
+    }
+    const children: BinaryNode[] = []
+    if (approve.length > 0) {
+        children.push({
+            tag: 'approve',
+            attrs: {},
+            content: approve.map((jid) => ({ tag: 'participant', attrs: { jid } }))
+        })
+    }
+    if (reject.length > 0) {
+        children.push({
+            tag: 'reject',
+            attrs: {},
+            content: reject.map((jid) => ({ tag: 'participant', attrs: { jid } }))
+        })
+    }
+    return buildIqNode('set', input.groupJid, WA_XMLNS.GROUPS, [
+        { tag: 'membership_requests_action', attrs: {}, content: children }
+    ])
+}
+
+export function buildCancelMembershipRequestsIq(input: {
+    readonly groupJid: string
+    readonly participantJids: readonly string[]
+}): BinaryNode {
+    if (input.participantJids.length === 0) {
+        throw new Error('cancel_membership_requests requires at least one participant')
+    }
+    return buildIqNode('set', input.groupJid, WA_XMLNS.GROUPS, [
+        {
+            tag: 'cancel_membership_requests',
+            attrs: {},
+            content: input.participantJids.map((jid) => ({
+                tag: 'participant',
+                attrs: { jid }
+            }))
+        }
+    ])
+}
+
+export function buildJoinLinkedGroupIq(input: {
+    readonly groupJid: string
+    readonly subGroupJid: string
+    readonly type?: string
+}): BinaryNode {
+    const attrs: Record<string, string> = { jid: input.subGroupJid }
+    if (input.type) {
+        attrs.type = input.type
+    }
+    return buildIqNode('set', input.groupJid, WA_XMLNS.GROUPS, [
+        { tag: 'join_linked_group', attrs }
+    ])
+}


### PR DESCRIPTION
Two complementary improvements to the group coordinator, validated end-to-end via MCP against real WhatsApp.

1. parseGroupMetadata + parseGroupParticipants now extract every field wa-web's GroupInfoMixin parses (was 19 fields, now 30+):

   Group-level: addressingMode (lid/pn), ephemeralTrigger, membershipApprovalEnabled, noFrequentlyForwarded, support, suspended, incognito, allowAdminReports, autoAddDisabled, groupHistory, capi, groupSafetyCheck, participantLabelEnabled, limitSharingEnabled, evolutionVersion, memberAddMode, memberLinkMode, memberShareGroupHistoryMode, growthLockedExpiration, appealStatus, appealUpdateTime.

   Participant-level: lid, phoneNumber, displayName, username, expirationSeconds (the events parser already extracted these — only the coordinator was discarding them).

2. Five new methods backing the membership approval flow (required for admin management of closed groups and communities) plus the join-linked-group flow:

   - queryMembershipApprovalRequests(groupJid) -> WaMembershipRequest[] (`<membership_approval_requests/>`)
   - approveMembershipRequests(groupJid, jids[]) -> void
   - rejectMembershipRequests(groupJid, jids[]) -> void (both wrap `<membership_requests_action><approve|reject>...`)
   - cancelMembershipRequests(groupJid, jids[]) -> void (`<cancel_membership_requests>...`)
   - joinLinkedGroup(communityJid, subGroupJid, opts?) -> BinaryNode (`<join_linked_group jid="..."/>`)

   Stanza shapes validated against /wa-web (WASmaxOutGroups* sources).