### PR TITLE
feat(client): add chatstate send + presence subscribe with enriched events

### DIFF
--- a/packages/fake-server/src/__tests__/presence-chatstate.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/presence-chatstate.cross-check.test.ts
@@ -7,21 +7,35 @@ import { buildIncomingPresence } from '../protocol/push/presence'
 
 import { createZapoClient } from './helpers/zapo-client'
 
-test('fake server pushes a presence stanza and the lib emits the presence event', async () => {
+test('fake server pushes presence stanzas and the lib emits enriched presence events', async () => {
     const server = await FakeWaServer.start()
     const { client } = createZapoClient(server, { sessionId: 'presence-stanza' })
     const peerJid = '5511777777777@s.whatsapp.net'
+    const groupJid = '120363000000000000@g.us'
 
-    const presencePromise = new Promise<{
+    const events: {
         readonly chatJid?: string
-    }>((resolve, reject) => {
+        readonly type: 'available' | 'unavailable'
+        readonly lastSeen?: { readonly kind: string; readonly unixSeconds?: number }
+        readonly groupOnlineCount?: number
+    }[] = []
+    const expected = 3
+    const presencePromise = new Promise<void>((resolve, reject) => {
         const timer = setTimeout(
-            () => reject(new Error('timed out waiting for presence event')),
+            () => reject(new Error('timed out waiting for presence events')),
             5_000
         )
-        client.once('presence', (event) => {
-            clearTimeout(timer)
-            resolve({ chatJid: event.chatJid })
+        client.on('presence', (event) => {
+            events.push({
+                chatJid: event.chatJid,
+                type: event.type,
+                lastSeen: event.lastSeen,
+                groupOnlineCount: event.groupOnlineCount
+            })
+            if (events.length >= expected) {
+                clearTimeout(timer)
+                resolve()
+            }
         })
     })
 
@@ -29,40 +43,126 @@ test('fake server pushes a presence stanza and the lib emits the presence event'
         await client.connect()
         const pipeline = await server.waitForAuthenticatedPipeline()
         await pipeline.sendStanza(buildIncomingPresence({ from: peerJid, type: 'available' }))
+        await pipeline.sendStanza(
+            buildIncomingPresence({ from: peerJid, type: 'unavailable', last: 1700000000 })
+        )
+        await pipeline.sendStanza(buildIncomingPresence({ from: groupJid, type: 'unavailable' }))
 
-        const event = await presencePromise
-        assert.equal(event.chatJid, peerJid)
+        await presencePromise
+
+        assert.deepEqual(events[0], {
+            chatJid: peerJid,
+            type: 'available',
+            lastSeen: undefined,
+            groupOnlineCount: undefined
+        })
+        assert.deepEqual(events[1], {
+            chatJid: peerJid,
+            type: 'unavailable',
+            lastSeen: { kind: 'timestamp', unixSeconds: 1700000000 },
+            groupOnlineCount: undefined
+        })
+        assert.deepEqual(events[2], {
+            chatJid: groupJid,
+            type: 'unavailable',
+            lastSeen: undefined,
+            groupOnlineCount: 0
+        })
     } finally {
         await client.disconnect().catch(() => undefined)
         await server.stop()
     }
 })
 
-test('fake server pushes a chatstate stanza and the lib emits the chatstate event', async () => {
+test('fake server pushes chatstate stanzas and the lib emits enriched chatstate events', async () => {
     const server = await FakeWaServer.start()
     const { client } = createZapoClient(server, { sessionId: 'chatstate-stanza' })
     const peerJid = '5511777777777@s.whatsapp.net'
 
-    const chatstatePromise = new Promise<{
+    const events: {
         readonly chatJid?: string
-    }>((resolve, reject) => {
+        readonly state: 'composing' | 'paused'
+        readonly media?: 'audio'
+    }[] = []
+    const chatstatePromise = new Promise<void>((resolve, reject) => {
         const timer = setTimeout(
-            () => reject(new Error('timed out waiting for chatstate event')),
+            () => reject(new Error('timed out waiting for chatstate events')),
             5_000
         )
-        client.once('chatstate', (event) => {
-            clearTimeout(timer)
-            resolve({ chatJid: event.chatJid })
+        client.on('chatstate', (event) => {
+            events.push({ chatJid: event.chatJid, state: event.state, media: event.media })
+            if (events.length >= 2) {
+                clearTimeout(timer)
+                resolve()
+            }
         })
     })
 
     try {
         await client.connect()
         const pipeline = await server.waitForAuthenticatedPipeline()
-        await pipeline.sendStanza(buildChatstate({ from: peerJid, state: { kind: 'composing' } }))
+        await pipeline.sendStanza(
+            buildChatstate({ from: peerJid, state: { kind: 'composing', media: 'audio' } })
+        )
+        await pipeline.sendStanza(buildChatstate({ from: peerJid, state: { kind: 'paused' } }))
 
-        const event = await chatstatePromise
-        assert.equal(event.chatJid, peerJid)
+        await chatstatePromise
+
+        assert.deepEqual(events[0], {
+            chatJid: peerJid,
+            state: 'composing',
+            media: 'audio'
+        })
+        assert.deepEqual(events[1], {
+            chatJid: peerJid,
+            state: 'paused',
+            media: undefined
+        })
+    } finally {
+        await client.disconnect().catch(() => undefined)
+        await server.stop()
+    }
+})
+
+test('the lib sends presence subscribe and chatstate stanzas the server captures', async () => {
+    const server = await FakeWaServer.start()
+    const { client } = createZapoClient(server, { sessionId: 'chatstate-out' })
+    const peerJid = '5511777777777@s.whatsapp.net'
+
+    try {
+        await client.connect()
+        await server.waitForAuthenticatedPipeline()
+
+        const subscribePromise = server.expectStanza(
+            { tag: 'presence', type: 'subscribe', to: peerJid },
+            { timeoutMs: 2_000 }
+        )
+        await client.subscribePresence(peerJid)
+        await subscribePromise
+
+        await client.sendChatstate(peerJid, { state: 'composing' })
+        await client.sendChatstate(peerJid, { state: 'composing', media: 'audio' })
+        const pausedPromise = server.expectStanza(
+            { tag: 'chatstate', to: peerJid, childTag: 'paused' },
+            { timeoutMs: 2_000 }
+        )
+        await client.sendChatstate(peerJid, { state: 'paused' })
+        await pausedPromise
+
+        const chatstates = server
+            .capturedStanzaSnapshot()
+            .filter((node) => node.tag === 'chatstate' && node.attrs.to === peerJid)
+        assert.equal(chatstates.length, 3)
+        const childOf = (node: { readonly content?: unknown }) =>
+            Array.isArray(node.content) ? node.content[0] : null
+        const composing = childOf(chatstates[0])
+        const recording = childOf(chatstates[1])
+        const paused = childOf(chatstates[2])
+        assert.equal(composing?.tag, 'composing')
+        assert.equal(composing?.attrs.media, undefined)
+        assert.equal(recording?.tag, 'composing')
+        assert.equal(recording?.attrs.media, 'audio')
+        assert.equal(paused?.tag, 'paused')
     } finally {
         await client.disconnect().catch(() => undefined)
         await server.stop()

--- a/packages/fake-server/src/__tests__/presence-chatstate.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/presence-chatstate.cross-check.test.ts
@@ -26,6 +26,9 @@ test('fake server pushes presence stanzas and the lib emits enriched presence ev
             5_000
         )
         client.on('presence', (event) => {
+            if (event.chatJid !== peerJid && event.chatJid !== groupJid) {
+                return
+            }
             events.push({
                 chatJid: event.chatJid,
                 type: event.type,
@@ -90,6 +93,9 @@ test('fake server pushes chatstate stanzas and the lib emits enriched chatstate 
             5_000
         )
         client.on('chatstate', (event) => {
+            if (event.chatJid !== peerJid) {
+                return
+            }
             events.push({ chatJid: event.chatJid, state: event.state, media: event.media })
             if (events.length >= 2) {
                 clearTimeout(timer)

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -77,8 +77,16 @@ import type { WaSignalStore } from '@store/contracts/signal.store'
 import type { WaThreadStore } from '@store/contracts/thread.store'
 import { NOOP_MESSAGE_SECRET_STORE } from '@store/noop.store'
 import type { WaKeepAlive } from '@transport/keepalive/WaKeepAlive'
+import {
+    buildChatstateNode,
+    type BuildChatstateNodeInput
+} from '@transport/node/builders/chatstate'
 import { buildRemoveCompanionDeviceIq } from '@transport/node/builders/device'
-import { buildPresenceNode } from '@transport/node/builders/presence'
+import {
+    buildPresenceNode,
+    buildPresenceSubscribeNode,
+    type BuildPresenceSubscribeNodeInput
+} from '@transport/node/builders/presence'
 import { assertIqResult, queryWithContext as queryNodeWithContext } from '@transport/node/query'
 import type { WaNodeOrchestrator } from '@transport/node/WaNodeOrchestrator'
 import type { WaNodeTransport } from '@transport/node/WaNodeTransport'
@@ -270,6 +278,25 @@ export class WaClient extends EventEmitter {
             buildPresenceNode({ type, name: credentials?.meDisplayName ?? undefined }),
             false
         )
+    }
+
+    public async sendChatstate(
+        jid: string,
+        options: Omit<BuildChatstateNodeInput, 'jid'>
+    ): Promise<void> {
+        await this.nodeOrchestrator.sendNode(buildChatstateNode({ jid, ...options }), false)
+    }
+
+    /**
+     * Subscribes to presence updates (online/offline + chatstate) for a chat.
+     * The subscription is per-jid and lives only for the current connection;
+     * after a reconnect the caller must re-subscribe to keep receiving events.
+     */
+    public async subscribePresence(
+        jid: string,
+        options?: Omit<BuildPresenceSubscribeNodeInput, 'jid'>
+    ): Promise<void> {
+        await this.nodeOrchestrator.sendNode(buildPresenceSubscribeNode({ jid, ...options }), false)
     }
 
     public async query(

--- a/src/client/coordinators/WaIncomingNodeCoordinator.ts
+++ b/src/client/coordinators/WaIncomingNodeCoordinator.ts
@@ -1,6 +1,8 @@
 import type { WaSuccessPersistAttributes } from '@auth/types'
 import type { WaOfflineResumeCoordinator } from '@client/coordinators/WaOfflineResumeCoordinator'
 import type { WaDirtyBit } from '@client/dirty'
+import { parseChatstateNode } from '@client/events/chatstate'
+import { parsePresenceNode } from '@client/events/presence'
 import {
     createIncomingBaseEvent,
     createIncomingFailureHandler,
@@ -298,20 +300,27 @@ export class WaIncomingNodeCoordinator {
             })
         })
         this.registerIncomingHandler({
-            tag: 'presence',
+            tag: WA_NODE_TAGS.PRESENCE,
             // eslint-disable-next-line @typescript-eslint/require-await
             handler: async (node) => {
-                runtime.emitIncomingPresence(createIncomingBaseEvent(node))
+                runtime.emitIncomingPresence({
+                    ...createIncomingBaseEvent(node),
+                    ...parsePresenceNode(node)
+                })
                 return true
             }
         })
         this.registerIncomingHandler({
-            tag: 'chatstate',
+            tag: WA_NODE_TAGS.CHATSTATE,
             // eslint-disable-next-line @typescript-eslint/require-await
             handler: async (node) => {
+                const parsed = parseChatstateNode(node)
+                if (!parsed) {
+                    return false
+                }
                 runtime.emitIncomingChatstate({
                     ...createIncomingBaseEvent(node),
-                    participantJid: node.attrs.participant
+                    ...parsed
                 })
                 return true
             }

--- a/src/client/events/__tests__/events.test.ts
+++ b/src/client/events/__tests__/events.test.ts
@@ -333,6 +333,42 @@ test('presence parser distinguishes user/group variants and last-seen flavors', 
         }),
         { type: 'unavailable', groupOnlineCount: 0 }
     )
+
+    assert.deepEqual(
+        parsePresenceNode({
+            tag: 'presence',
+            attrs: { from: 'peer@s.whatsapp.net', type: 'unavailable', last: '10foo' }
+        }),
+        { type: 'unavailable', lastSeen: { kind: 'unknown' } }
+    )
+
+    assert.deepEqual(
+        parsePresenceNode({
+            tag: 'presence',
+            attrs: { from: 'peer@s.whatsapp.net', type: 'unavailable', last: '-1' }
+        }),
+        { type: 'unavailable', lastSeen: { kind: 'unknown' } }
+    )
+
+    assert.deepEqual(
+        parsePresenceNode({
+            tag: 'presence',
+            attrs: {
+                from: 'peer@s.whatsapp.net',
+                type: 'unavailable',
+                last: '99999999999999999999'
+            }
+        }),
+        { type: 'unavailable', lastSeen: { kind: 'unknown' } }
+    )
+
+    assert.deepEqual(
+        parsePresenceNode({
+            tag: 'presence',
+            attrs: { from: 'group@g.us', count: '7foo' }
+        }),
+        { type: 'available' }
+    )
 })
 
 test('privacy token parser rejects non-numeric token timestamp', () => {

--- a/src/client/events/__tests__/events.test.ts
+++ b/src/client/events/__tests__/events.test.ts
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import { parseChatEventFromAppStateMutation } from '@client/events/chat'
+import { parseChatstateNode } from '@client/events/chatstate'
 import { parseGroupNotificationEvents } from '@client/events/group'
+import { parsePresenceNode } from '@client/events/presence'
 import { parsePrivacyTokenNotification } from '@client/events/privacy-token'
 import { parseRegistrationNotification } from '@client/events/registration'
 import {
@@ -214,6 +216,122 @@ test('registration parser returns null when child tag is unknown or attrs are mi
             attrs: { type: WA_NOTIFICATION_TYPES.REGISTRATION }
         }),
         null
+    )
+})
+
+test('chatstate parser extracts state, media and participant', () => {
+    const composing = parseChatstateNode({
+        tag: 'chatstate',
+        attrs: { from: 'group@g.us', participant: 'peer@s.whatsapp.net' },
+        content: [{ tag: 'composing', attrs: {} }]
+    })
+    assert.deepEqual(composing, {
+        state: 'composing',
+        participantJid: 'peer@s.whatsapp.net'
+    })
+
+    const recording = parseChatstateNode({
+        tag: 'chatstate',
+        attrs: { from: 'peer@s.whatsapp.net' },
+        content: [{ tag: 'composing', attrs: { media: 'audio' } }]
+    })
+    assert.deepEqual(recording, { state: 'composing', media: 'audio' })
+
+    const paused = parseChatstateNode({
+        tag: 'chatstate',
+        attrs: { from: 'peer@s.whatsapp.net' },
+        content: [{ tag: 'paused', attrs: {} }]
+    })
+    assert.deepEqual(paused, { state: 'paused' })
+
+    assert.equal(
+        parseChatstateNode({
+            tag: 'chatstate',
+            attrs: { from: 'peer@s.whatsapp.net' }
+        }),
+        null
+    )
+    assert.equal(
+        parseChatstateNode({
+            tag: 'chatstate',
+            attrs: { from: 'peer@s.whatsapp.net' },
+            content: [{ tag: 'unknown', attrs: {} }]
+        }),
+        null
+    )
+})
+
+test('presence parser distinguishes user/group variants and last-seen flavors', () => {
+    assert.deepEqual(
+        parsePresenceNode({
+            tag: 'presence',
+            attrs: { from: 'peer@s.whatsapp.net', type: 'available' }
+        }),
+        { type: 'available' }
+    )
+
+    assert.deepEqual(
+        parsePresenceNode({
+            tag: 'presence',
+            attrs: { from: 'peer@s.whatsapp.net' }
+        }),
+        { type: 'available' }
+    )
+
+    assert.deepEqual(
+        parsePresenceNode({
+            tag: 'presence',
+            attrs: { from: 'peer@s.whatsapp.net', type: 'unavailable', last: '1700000000' }
+        }),
+        { type: 'unavailable', lastSeen: { kind: 'timestamp', unixSeconds: 1700000000 } }
+    )
+
+    assert.deepEqual(
+        parsePresenceNode({
+            tag: 'presence',
+            attrs: { from: 'peer@s.whatsapp.net', type: 'unavailable', last: '0' }
+        }),
+        { type: 'unavailable', lastSeen: { kind: 'timestamp', unixSeconds: 0 } }
+    )
+
+    assert.deepEqual(
+        parsePresenceNode({
+            tag: 'presence',
+            attrs: { from: 'peer@s.whatsapp.net', type: 'unavailable', last: 'deny' }
+        }),
+        { type: 'unavailable', lastSeen: { kind: 'privacy_denied' } }
+    )
+
+    assert.deepEqual(
+        parsePresenceNode({
+            tag: 'presence',
+            attrs: { from: 'peer@s.whatsapp.net', type: 'unavailable', last: 'none' }
+        }),
+        { type: 'unavailable', lastSeen: { kind: 'never_online' } }
+    )
+
+    assert.deepEqual(
+        parsePresenceNode({
+            tag: 'presence',
+            attrs: { from: 'peer@s.whatsapp.net', type: 'unavailable', last: 'error' }
+        }),
+        { type: 'unavailable', lastSeen: { kind: 'unknown' } }
+    )
+
+    assert.deepEqual(
+        parsePresenceNode({
+            tag: 'presence',
+            attrs: { from: 'group@g.us', count: '7' }
+        }),
+        { type: 'available', groupOnlineCount: 7 }
+    )
+
+    assert.deepEqual(
+        parsePresenceNode({
+            tag: 'presence',
+            attrs: { from: 'group@g.us', type: 'unavailable' }
+        }),
+        { type: 'unavailable', groupOnlineCount: 0 }
     )
 })
 

--- a/src/client/events/chatstate.ts
+++ b/src/client/events/chatstate.ts
@@ -1,0 +1,33 @@
+import { WA_NODE_TAGS } from '@protocol/nodes'
+import { WA_CHATSTATE_MEDIA } from '@protocol/presence'
+import type { ChatstateMedia, ChatstateState } from '@transport/node/builders/chatstate'
+import { getFirstNodeChild } from '@transport/node/helpers'
+import type { BinaryNode } from '@transport/types'
+
+interface ParsedChatstate {
+    readonly state: ChatstateState
+    readonly media?: ChatstateMedia
+    readonly participantJid?: string
+}
+
+export function parseChatstateNode(node: BinaryNode): ParsedChatstate | null {
+    const child = getFirstNodeChild(node)
+    if (!child) {
+        return null
+    }
+    if (child.tag !== WA_NODE_TAGS.COMPOSING && child.tag !== WA_NODE_TAGS.PAUSED) {
+        return null
+    }
+    const result: {
+        state: ChatstateState
+        media?: ChatstateMedia
+        participantJid?: string
+    } = { state: child.tag }
+    if (child.tag === WA_NODE_TAGS.COMPOSING && child.attrs.media === WA_CHATSTATE_MEDIA.AUDIO) {
+        result.media = WA_CHATSTATE_MEDIA.AUDIO
+    }
+    if (node.attrs.participant !== undefined) {
+        result.participantJid = node.attrs.participant
+    }
+    return result
+}

--- a/src/client/events/presence.ts
+++ b/src/client/events/presence.ts
@@ -1,6 +1,7 @@
 import { isGroupJid } from '@protocol/jid'
 import { WA_PRESENCE_LAST_SENTINELS, WA_PRESENCE_TYPES } from '@protocol/presence'
 import type { BinaryNode } from '@transport/types'
+import { parseOptionalInt } from '@util/primitives'
 
 export type IncomingPresenceType =
     | typeof WA_PRESENCE_TYPES.AVAILABLE
@@ -28,19 +29,11 @@ function parseLastSeen(value: string): PresenceLastSeen {
     if (value === WA_PRESENCE_LAST_SENTINELS.ERROR) {
         return { kind: 'unknown' }
     }
-    const unixSeconds = Number.parseInt(value, 10)
-    if (!Number.isFinite(unixSeconds)) {
+    const unixSeconds = parseOptionalInt(value)
+    if (unixSeconds === undefined) {
         return { kind: 'unknown' }
     }
     return { kind: 'timestamp', unixSeconds }
-}
-
-function parseGroupOnlineCount(value: string): number | undefined {
-    const count = Number.parseInt(value, 10)
-    if (!Number.isFinite(count) || count < 0) {
-        return undefined
-    }
-    return count
 }
 
 export function parsePresenceNode(node: BinaryNode): ParsedPresence {
@@ -58,11 +51,9 @@ export function parsePresenceNode(node: BinaryNode): ParsedPresence {
     } = { type }
 
     if (isGroup) {
-        if (node.attrs.count !== undefined) {
-            const count = parseGroupOnlineCount(node.attrs.count)
-            if (count !== undefined) {
-                result.groupOnlineCount = count
-            }
+        const count = parseOptionalInt(node.attrs.count)
+        if (count !== undefined) {
+            result.groupOnlineCount = count
         } else if (type === WA_PRESENCE_TYPES.UNAVAILABLE) {
             result.groupOnlineCount = 0
         }

--- a/src/client/events/presence.ts
+++ b/src/client/events/presence.ts
@@ -1,0 +1,76 @@
+import { isGroupJid } from '@protocol/jid'
+import { WA_PRESENCE_LAST_SENTINELS, WA_PRESENCE_TYPES } from '@protocol/presence'
+import type { BinaryNode } from '@transport/types'
+
+export type IncomingPresenceType =
+    | typeof WA_PRESENCE_TYPES.AVAILABLE
+    | typeof WA_PRESENCE_TYPES.UNAVAILABLE
+
+export type PresenceLastSeen =
+    | { readonly kind: 'timestamp'; readonly unixSeconds: number }
+    | { readonly kind: 'privacy_denied' }
+    | { readonly kind: 'never_online' }
+    | { readonly kind: 'unknown' }
+
+interface ParsedPresence {
+    readonly type: IncomingPresenceType
+    readonly lastSeen?: PresenceLastSeen
+    readonly groupOnlineCount?: number
+}
+
+function parseLastSeen(value: string): PresenceLastSeen {
+    if (value === WA_PRESENCE_LAST_SENTINELS.DENY) {
+        return { kind: 'privacy_denied' }
+    }
+    if (value === WA_PRESENCE_LAST_SENTINELS.NONE) {
+        return { kind: 'never_online' }
+    }
+    if (value === WA_PRESENCE_LAST_SENTINELS.ERROR) {
+        return { kind: 'unknown' }
+    }
+    const unixSeconds = Number.parseInt(value, 10)
+    if (!Number.isFinite(unixSeconds)) {
+        return { kind: 'unknown' }
+    }
+    return { kind: 'timestamp', unixSeconds }
+}
+
+function parseGroupOnlineCount(value: string): number | undefined {
+    const count = Number.parseInt(value, 10)
+    if (!Number.isFinite(count) || count < 0) {
+        return undefined
+    }
+    return count
+}
+
+export function parsePresenceNode(node: BinaryNode): ParsedPresence {
+    const from = node.attrs.from
+    const isGroup = from !== undefined && isGroupJid(from)
+    const type: IncomingPresenceType =
+        node.attrs.type === WA_PRESENCE_TYPES.UNAVAILABLE
+            ? WA_PRESENCE_TYPES.UNAVAILABLE
+            : WA_PRESENCE_TYPES.AVAILABLE
+
+    const result: {
+        type: IncomingPresenceType
+        lastSeen?: PresenceLastSeen
+        groupOnlineCount?: number
+    } = { type }
+
+    if (isGroup) {
+        if (node.attrs.count !== undefined) {
+            const count = parseGroupOnlineCount(node.attrs.count)
+            if (count !== undefined) {
+                result.groupOnlineCount = count
+            }
+        } else if (type === WA_PRESENCE_TYPES.UNAVAILABLE) {
+            result.groupOnlineCount = 0
+        }
+        return result
+    }
+
+    if (type === WA_PRESENCE_TYPES.UNAVAILABLE && node.attrs.last !== undefined) {
+        result.lastSeen = parseLastSeen(node.attrs.last)
+    }
+    return result
+}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -5,12 +5,14 @@ import type {
     WaAuthDangerousOptions,
     WaAuthSocketOptions
 } from '@auth/types'
+import type { IncomingPresenceType, PresenceLastSeen } from '@client/events/presence'
 import type { WaMediaProcessor } from '@media/processor'
 import type { WaDecodedAddon } from '@message/addon-crypto'
 import type { WaMessagePublishOptions } from '@message/types'
 import type { Proto } from '@proto'
 import type { WaConnectionCode, WaConnectionOpenReason, WaDisconnectReason } from '@protocol/stream'
 import type { WaStore } from '@store/types'
+import type { ChatstateMedia, ChatstateState } from '@transport/node/builders/chatstate'
 import type { BinaryNode, WaProxyTransport } from '@transport/types'
 
 export interface WaClientProxyOptions {
@@ -225,9 +227,15 @@ export interface WaIncomingReceiptEvent extends WaIncomingBaseEvent {
     readonly recipientJid?: string
 }
 
-export interface WaIncomingPresenceEvent extends WaIncomingBaseEvent {}
+export interface WaIncomingPresenceEvent extends WaIncomingBaseEvent {
+    readonly type: IncomingPresenceType
+    readonly lastSeen?: PresenceLastSeen
+    readonly groupOnlineCount?: number
+}
 
 export interface WaIncomingChatstateEvent extends WaIncomingBaseEvent {
+    readonly state: ChatstateState
+    readonly media?: ChatstateMedia
     readonly participantJid?: string
 }
 

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -49,6 +49,12 @@ export {
     WA_REGISTRATION_NOTIFICATION_TAGS
 } from '@protocol/notification'
 export {
+    WA_CHATSTATE_MEDIA,
+    WA_PRESENCE_LAST_SENTINELS,
+    WA_PRESENCE_TYPES
+} from '@protocol/presence'
+export type { WaChatstateMedia, WaPresenceLastSentinel, WaPresenceType } from '@protocol/presence'
+export {
     WA_PRIVACY_TOKEN_NOTIFICATION_TYPE,
     WA_PRIVACY_TOKEN_TAGS,
     WA_PRIVACY_TOKEN_TYPES,

--- a/src/protocol/nodes.ts
+++ b/src/protocol/nodes.ts
@@ -63,7 +63,11 @@ export const WA_NODE_TAGS = Object.freeze({
     MEMBERSHIP_APPROVAL_MODE: 'membership_approval_mode',
     GROUP_JOIN: 'group_join',
     ABPROPS: 'abprops',
-    PLAINTEXT: 'plaintext'
+    PLAINTEXT: 'plaintext',
+    PRESENCE: 'presence',
+    CHATSTATE: 'chatstate',
+    COMPOSING: 'composing',
+    PAUSED: 'paused'
 } as const)
 
 export const WA_IQ_TYPES = Object.freeze({

--- a/src/protocol/presence.ts
+++ b/src/protocol/presence.ts
@@ -1,0 +1,20 @@
+export const WA_PRESENCE_TYPES = Object.freeze({
+    AVAILABLE: 'available',
+    UNAVAILABLE: 'unavailable',
+    SUBSCRIBE: 'subscribe'
+} as const)
+
+export const WA_PRESENCE_LAST_SENTINELS = Object.freeze({
+    DENY: 'deny',
+    NONE: 'none',
+    ERROR: 'error'
+} as const)
+
+export const WA_CHATSTATE_MEDIA = Object.freeze({
+    AUDIO: 'audio'
+} as const)
+
+export type WaPresenceType = (typeof WA_PRESENCE_TYPES)[keyof typeof WA_PRESENCE_TYPES]
+export type WaPresenceLastSentinel =
+    (typeof WA_PRESENCE_LAST_SENTINELS)[keyof typeof WA_PRESENCE_LAST_SENTINELS]
+export type WaChatstateMedia = (typeof WA_CHATSTATE_MEDIA)[keyof typeof WA_CHATSTATE_MEDIA]

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -24,6 +24,7 @@ import {
     buildGroupsDirtySyncIq,
     buildNewsletterMetadataSyncIq
 } from '@transport/node/builders/account-sync'
+import { buildChatstateNode } from '@transport/node/builders/chatstate'
 import {
     buildDeactivateCommunityIq,
     buildLinkedGroupsParticipantsIq,
@@ -65,7 +66,7 @@ import {
     buildPreKeyUploadIq,
     buildSignedPreKeyRotateIq
 } from '@transport/node/builders/prekeys'
-import { buildPresenceNode } from '@transport/node/builders/presence'
+import { buildPresenceNode, buildPresenceSubscribeNode } from '@transport/node/builders/presence'
 import {
     buildBlocklistChangeIq,
     buildGetBlocklistIq,
@@ -106,6 +107,54 @@ test('presence and offline builders generate expected lightweight nodes', () => 
         attrs: { count: '200' },
         content: undefined
     })
+})
+
+test('chatstate builder composes composing/paused with optional media and rejects unsupported jids', () => {
+    const composing = buildChatstateNode({
+        jid: '5511999999999@s.whatsapp.net',
+        state: 'composing'
+    })
+    assert.deepEqual(composing, {
+        tag: 'chatstate',
+        attrs: { to: '5511999999999@s.whatsapp.net' },
+        content: [{ tag: 'composing', attrs: {} }]
+    })
+
+    const recording = buildChatstateNode({
+        jid: '5511999999999@s.whatsapp.net',
+        state: 'composing',
+        media: 'audio'
+    })
+    assert.deepEqual(recording.content, [{ tag: 'composing', attrs: { media: 'audio' } }])
+
+    const paused = buildChatstateNode({ jid: 'group@g.us', state: 'paused' })
+    assert.deepEqual(paused.content, [{ tag: 'paused', attrs: {} }])
+
+    assert.throws(() => buildChatstateNode({ jid: '12345@newsletter', state: 'composing' }))
+    assert.throws(() => buildChatstateNode({ jid: '12345@broadcast', state: 'composing' }))
+    assert.throws(() => buildChatstateNode({ jid: 'group@g.us', state: 'paused', media: 'audio' }))
+})
+
+test('presence subscribe builder emits subscribe stanza with optional name/context', () => {
+    const subscribe = buildPresenceSubscribeNode({ jid: '5511999999999@s.whatsapp.net' })
+    assert.deepEqual(subscribe, {
+        tag: 'presence',
+        attrs: { type: 'subscribe', to: '5511999999999@s.whatsapp.net' }
+    })
+
+    const subscribeWithExtras = buildPresenceSubscribeNode({
+        jid: '5511999999999@s.whatsapp.net',
+        name: 'Vinicius',
+        context: 'group@g.us'
+    })
+    assert.deepEqual(subscribeWithExtras.attrs, {
+        type: 'subscribe',
+        to: '5511999999999@s.whatsapp.net',
+        name: 'Vinicius',
+        context: 'group@g.us'
+    })
+
+    assert.throws(() => buildPresenceSubscribeNode({ jid: '12345@newsletter' }))
 })
 
 test('usync builder composes query/list nodes with defaults and overrides', () => {

--- a/src/transport/node/builders/chatstate.ts
+++ b/src/transport/node/builders/chatstate.ts
@@ -1,0 +1,41 @@
+import { isBroadcastJid, isNewsletterJid, splitJid } from '@protocol/jid'
+import { WA_NODE_TAGS } from '@protocol/nodes'
+import { type WaChatstateMedia } from '@protocol/presence'
+import type { BinaryNode } from '@transport/types'
+
+export type ChatstateState = typeof WA_NODE_TAGS.COMPOSING | typeof WA_NODE_TAGS.PAUSED
+export type ChatstateMedia = WaChatstateMedia
+
+export interface BuildChatstateNodeInput {
+    readonly jid: string
+    readonly state: ChatstateState
+    readonly media?: ChatstateMedia
+}
+
+function assertChatstateJid(jid: string): void {
+    if (isNewsletterJid(jid) || isBroadcastJid(jid)) {
+        throw new Error(`chatstate is not supported for jid: ${jid}`)
+    }
+    splitJid(jid)
+}
+
+export function buildChatstateNode(input: BuildChatstateNodeInput): BinaryNode {
+    assertChatstateJid(input.jid)
+    if (input.state !== WA_NODE_TAGS.COMPOSING && input.media !== undefined) {
+        throw new Error('chatstate media is only valid with composing state')
+    }
+    const childAttrs: Record<string, string> = {}
+    if (input.media !== undefined) {
+        childAttrs.media = input.media
+    }
+    return {
+        tag: WA_NODE_TAGS.CHATSTATE,
+        attrs: { to: input.jid },
+        content: [
+            {
+                tag: input.state,
+                attrs: childAttrs
+            }
+        ]
+    }
+}

--- a/src/transport/node/builders/presence.ts
+++ b/src/transport/node/builders/presence.ts
@@ -1,7 +1,10 @@
+import { isBroadcastJid, isNewsletterJid, splitJid } from '@protocol/jid'
+import { WA_NODE_TAGS } from '@protocol/nodes'
+import { WA_PRESENCE_TYPES } from '@protocol/presence'
 import type { BinaryNode } from '@transport/types'
 
 export interface BuildPresenceNodeInput {
-    readonly type?: 'available' | 'unavailable'
+    readonly type?: typeof WA_PRESENCE_TYPES.AVAILABLE | typeof WA_PRESENCE_TYPES.UNAVAILABLE
     readonly name?: string
 }
 
@@ -14,7 +17,38 @@ export function buildPresenceNode(input?: BuildPresenceNodeInput): BinaryNode {
         attrs.name = input.name
     }
     return {
-        tag: 'presence',
+        tag: WA_NODE_TAGS.PRESENCE,
+        attrs
+    }
+}
+
+export interface BuildPresenceSubscribeNodeInput {
+    readonly jid: string
+    readonly name?: string
+    readonly context?: string
+}
+
+function assertSubscribeJid(jid: string): void {
+    if (isNewsletterJid(jid) || isBroadcastJid(jid)) {
+        throw new Error(`presence subscribe is not supported for jid: ${jid}`)
+    }
+    splitJid(jid)
+}
+
+export function buildPresenceSubscribeNode(input: BuildPresenceSubscribeNodeInput): BinaryNode {
+    assertSubscribeJid(input.jid)
+    const attrs: Record<string, string> = {
+        type: WA_PRESENCE_TYPES.SUBSCRIBE,
+        to: input.jid
+    }
+    if (input.name !== undefined) {
+        attrs.name = input.name
+    }
+    if (input.context !== undefined) {
+        attrs.context = input.context
+    }
+    return {
+        tag: WA_NODE_TAGS.PRESENCE,
         attrs
     }
 }


### PR DESCRIPTION
- buildChatstateNode + sendChatstate(jid, opts): composing/paused (+ media=audio)
- buildPresenceSubscribeNode + subscribePresence(jid): opt-in to presence/chatstate pushes
- parsePresenceNode/parseChatstateNode enrich events with type, state, media, lastSeen (timestamp/deny/none/error) and groupOnlineCount
- centralize presence/chatstate constants in @protocol/presence + WA_NODE_TAGS
- validated against /wa-web (WAWebPresenceChatAction, WASmaxOutChatstate*, WASmaxInPresence*) and end-to-end via fake-server cross-check + live MCP run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to send chatstate updates (composing/paused status).
  * Added ability to subscribe to presence and chatstate updates for contacts.
  * Presence events now include status type, last seen timestamp, and group member counts.
  * Chatstate events now include composition state, media information, and participant details.

* **Tests**
  * Added comprehensive test coverage for presence and chatstate event parsing and server communication.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/58)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->