### PR TITLE
feat(client): typed sendReceipt with event-based overload + auto-aggregation

### DIFF
--- a/packages/fake-server/src/__tests__/receipts.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/receipts.cross-check.test.ts
@@ -67,11 +67,7 @@ test('client.sendReceipt emits a real <receipt/> stanza captured by the fake ser
 
         const stanzaPromise = server.expectStanza({ tag: 'receipt' }, { timeoutMs: 5_000 })
 
-        await client.sendReceipt({
-            to: peerJid,
-            id: messageId,
-            type: 'read'
-        })
+        await client.sendReceipt(peerJid, messageId, { type: 'read' })
 
         const stanza = await stanzaPromise
         assert.equal(stanza.tag, 'receipt')

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -54,6 +54,7 @@ import {
 import type {
     WaMessagePublishResult,
     WaSendMessageContent,
+    WaSendReceiptEventOptions,
     WaSendReceiptInput,
     WaSendReceiptOptions
 } from '@message/types'
@@ -769,7 +770,7 @@ export class WaClient extends EventEmitter {
 
     public sendReceipt(
         target: WaIncomingMessageEvent | readonly WaIncomingMessageEvent[],
-        options?: WaSendReceiptOptions
+        options?: WaSendReceiptEventOptions
     ): Promise<void>
     public sendReceipt(
         jid: string,
@@ -778,7 +779,7 @@ export class WaClient extends EventEmitter {
     ): Promise<void>
     public async sendReceipt(
         first: string | WaIncomingMessageEvent | readonly WaIncomingMessageEvent[],
-        second?: string | readonly string[] | WaSendReceiptOptions,
+        second?: string | readonly string[] | WaSendReceiptEventOptions,
         third?: WaSendReceiptOptions
     ): Promise<void> {
         if (typeof first === 'string') {
@@ -787,7 +788,7 @@ export class WaClient extends EventEmitter {
             return
         }
         const events = Array.isArray(first) ? first : [first as WaIncomingMessageEvent]
-        const options = (second as WaSendReceiptOptions | undefined) ?? {}
+        const options = (second as WaSendReceiptEventOptions | undefined) ?? {}
         const targets = events.map((event) => {
             if (!event.chatJid || !event.stanzaId) {
                 throw new Error('sendReceipt event is missing chatJid or stanzaId')
@@ -796,13 +797,14 @@ export class WaClient extends EventEmitter {
                 chatJid: event.chatJid,
                 id: event.stanzaId,
                 senderJid: event.senderJid,
-                isGroupChat: event.isGroupChat
+                isGroupChat: event.isGroupChat,
+                isBroadcastChat: event.isBroadcastChat
             }
         })
         for (const group of aggregateReceiptTargets(targets)) {
             await this.dispatchReceipt(group.jid, group.ids, {
                 ...options,
-                participant: options.participant ?? group.participant
+                participant: group.participant
             })
         }
     }

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -22,6 +22,7 @@ import type { WaPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordin
 import type { WaProfileCoordinator } from '@client/coordinators/WaProfileCoordinator'
 import type { WaTrustedContactTokenCoordinator } from '@client/coordinators/WaTrustedContactTokenCoordinator'
 import { parseChatEventFromAppStateMutation } from '@client/events/chat'
+import { aggregateReceiptTargets } from '@client/events/receipt'
 import { processHistorySyncNotification } from '@client/history-sync'
 import { persistIncomingMailboxEntities } from '@client/mailbox'
 import {
@@ -53,7 +54,8 @@ import {
 import type {
     WaMessagePublishResult,
     WaSendMessageContent,
-    WaSendReceiptInput
+    WaSendReceiptInput,
+    WaSendReceiptOptions
 } from '@message/types'
 import type { WaMessageClient } from '@message/WaMessageClient'
 import { proto, type Proto } from '@proto'
@@ -765,7 +767,62 @@ export class WaClient extends EventEmitter {
         assertIqResult(result, 'client.logout')
     }
 
-    public sendReceipt(input: WaSendReceiptInput): Promise<void> {
+    public sendReceipt(
+        target: WaIncomingMessageEvent | readonly WaIncomingMessageEvent[],
+        options?: WaSendReceiptOptions
+    ): Promise<void>
+    public sendReceipt(
+        jid: string,
+        ids: string | readonly string[],
+        options?: WaSendReceiptOptions
+    ): Promise<void>
+    public async sendReceipt(
+        first: string | WaIncomingMessageEvent | readonly WaIncomingMessageEvent[],
+        second?: string | readonly string[] | WaSendReceiptOptions,
+        third?: WaSendReceiptOptions
+    ): Promise<void> {
+        if (typeof first === 'string') {
+            const ids = second as string | readonly string[]
+            await this.dispatchReceipt(first, ids, third ?? {})
+            return
+        }
+        const events = Array.isArray(first) ? first : [first as WaIncomingMessageEvent]
+        const options = (second as WaSendReceiptOptions | undefined) ?? {}
+        const targets = events.map((event) => {
+            if (!event.chatJid || !event.stanzaId) {
+                throw new Error('sendReceipt event is missing chatJid or stanzaId')
+            }
+            return {
+                chatJid: event.chatJid,
+                id: event.stanzaId,
+                senderJid: event.senderJid,
+                isGroupChat: event.isGroupChat
+            }
+        })
+        for (const group of aggregateReceiptTargets(targets)) {
+            await this.dispatchReceipt(group.jid, group.ids, {
+                ...options,
+                participant: options.participant ?? group.participant
+            })
+        }
+    }
+
+    private dispatchReceipt(
+        jid: string,
+        ids: string | readonly string[],
+        options: WaSendReceiptOptions
+    ): Promise<void> {
+        const idArray = typeof ids === 'string' ? [ids] : ids
+        if (idArray.length === 0) {
+            throw new Error('sendReceipt requires at least one message id')
+        }
+        const [id, ...rest] = idArray
+        const input: WaSendReceiptInput = {
+            ...options,
+            to: jid,
+            id,
+            listIds: rest.length > 0 ? rest : undefined
+        }
         return this.messageDispatch.sendReceipt(input)
     }
 

--- a/src/client/events/__tests__/events.test.ts
+++ b/src/client/events/__tests__/events.test.ts
@@ -409,6 +409,22 @@ test('aggregateReceiptTargets groups by chat and sender, batching same-author id
         { chatJid: 'group3@g.us', id: 'E1', isGroupChat: true }
     ])
     assert.equal(noSender[0].participant, undefined)
+
+    const broadcastInferred = aggregateReceiptTargets([
+        { chatJid: 'list@broadcast', id: 'F1', senderJid: 'dave@s.whatsapp.net' }
+    ])
+    assert.equal(broadcastInferred[0].participant, 'dave@s.whatsapp.net')
+
+    const broadcastExplicit = aggregateReceiptTargets([
+        {
+            chatJid: 'list@broadcast',
+            id: 'G1',
+            senderJid: 'erin@s.whatsapp.net',
+            isBroadcastChat: true,
+            isGroupChat: false
+        }
+    ])
+    assert.equal(broadcastExplicit[0].participant, 'erin@s.whatsapp.net')
 })
 
 test('privacy token parser rejects non-numeric token timestamp', () => {

--- a/src/client/events/__tests__/events.test.ts
+++ b/src/client/events/__tests__/events.test.ts
@@ -6,6 +6,7 @@ import { parseChatstateNode } from '@client/events/chatstate'
 import { parseGroupNotificationEvents } from '@client/events/group'
 import { parsePresenceNode } from '@client/events/presence'
 import { parsePrivacyTokenNotification } from '@client/events/privacy-token'
+import { aggregateReceiptTargets } from '@client/events/receipt'
 import { parseRegistrationNotification } from '@client/events/registration'
 import {
     WA_NOTIFICATION_TYPES,
@@ -369,6 +370,45 @@ test('presence parser distinguishes user/group variants and last-seen flavors', 
         }),
         { type: 'available' }
     )
+})
+
+test('aggregateReceiptTargets groups by chat and sender, batching same-author ids', () => {
+    const groups = aggregateReceiptTargets([
+        { chatJid: 'peer@s.whatsapp.net', id: 'A1', isGroupChat: false },
+        { chatJid: 'peer@s.whatsapp.net', id: 'A2', isGroupChat: false }
+    ])
+    assert.deepEqual(groups, [
+        { jid: 'peer@s.whatsapp.net', participant: undefined, ids: ['A1', 'A2'] }
+    ])
+
+    const groupReceipts = aggregateReceiptTargets([
+        { chatJid: 'group@g.us', id: 'B1', senderJid: 'alice@s.whatsapp.net', isGroupChat: true },
+        { chatJid: 'group@g.us', id: 'B2', senderJid: 'alice@s.whatsapp.net', isGroupChat: true },
+        { chatJid: 'group@g.us', id: 'B3', senderJid: 'bob@s.whatsapp.net', isGroupChat: true }
+    ])
+    assert.deepEqual(groupReceipts, [
+        { jid: 'group@g.us', participant: 'alice@s.whatsapp.net', ids: ['B1', 'B2'] },
+        { jid: 'group@g.us', participant: 'bob@s.whatsapp.net', ids: ['B3'] }
+    ])
+
+    const mixed = aggregateReceiptTargets([
+        { chatJid: 'peer@s.whatsapp.net', id: 'C1', isGroupChat: false },
+        { chatJid: 'group@g.us', id: 'C2', senderJid: 'alice@s.whatsapp.net', isGroupChat: true }
+    ])
+    assert.deepEqual(mixed, [
+        { jid: 'peer@s.whatsapp.net', participant: undefined, ids: ['C1'] },
+        { jid: 'group@g.us', participant: 'alice@s.whatsapp.net', ids: ['C2'] }
+    ])
+
+    const inferred = aggregateReceiptTargets([
+        { chatJid: 'group2@g.us', id: 'D1', senderJid: 'carol@s.whatsapp.net' }
+    ])
+    assert.equal(inferred[0].participant, 'carol@s.whatsapp.net')
+
+    const noSender = aggregateReceiptTargets([
+        { chatJid: 'group3@g.us', id: 'E1', isGroupChat: true }
+    ])
+    assert.equal(noSender[0].participant, undefined)
 })
 
 test('privacy token parser rejects non-numeric token timestamp', () => {

--- a/src/client/events/receipt.ts
+++ b/src/client/events/receipt.ts
@@ -1,0 +1,35 @@
+import { isGroupJid } from '@protocol/jid'
+
+interface ReceiptTarget {
+    readonly chatJid: string
+    readonly id: string
+    readonly senderJid?: string
+    readonly isGroupChat?: boolean
+}
+
+interface AggregatedReceiptGroup {
+    readonly jid: string
+    readonly ids: readonly string[]
+    readonly participant?: string
+}
+
+export function aggregateReceiptTargets(
+    targets: readonly ReceiptTarget[]
+): readonly AggregatedReceiptGroup[] {
+    const groups = new Map<string, { jid: string; participant?: string; ids: string[] }>()
+    for (const target of targets) {
+        const isGroup = target.isGroupChat ?? isGroupJid(target.chatJid)
+        const participant =
+            isGroup && target.senderJid && target.senderJid !== target.chatJid
+                ? target.senderJid
+                : undefined
+        const key = `${target.chatJid}|${participant ?? ''}`
+        let group = groups.get(key)
+        if (!group) {
+            group = { jid: target.chatJid, participant, ids: [] }
+            groups.set(key, group)
+        }
+        group.ids.push(target.id)
+    }
+    return [...groups.values()]
+}

--- a/src/client/events/receipt.ts
+++ b/src/client/events/receipt.ts
@@ -1,10 +1,11 @@
-import { isGroupJid } from '@protocol/jid'
+import { isGroupOrBroadcastJid } from '@protocol/jid'
 
 interface ReceiptTarget {
     readonly chatJid: string
     readonly id: string
     readonly senderJid?: string
     readonly isGroupChat?: boolean
+    readonly isBroadcastChat?: boolean
 }
 
 interface AggregatedReceiptGroup {
@@ -13,14 +14,20 @@ interface AggregatedReceiptGroup {
     readonly participant?: string
 }
 
+function needsParticipant(target: ReceiptTarget): boolean {
+    if (target.isGroupChat !== undefined || target.isBroadcastChat !== undefined) {
+        return target.isGroupChat === true || target.isBroadcastChat === true
+    }
+    return isGroupOrBroadcastJid(target.chatJid)
+}
+
 export function aggregateReceiptTargets(
     targets: readonly ReceiptTarget[]
 ): readonly AggregatedReceiptGroup[] {
     const groups = new Map<string, { jid: string; participant?: string; ids: string[] }>()
     for (const target of targets) {
-        const isGroup = target.isGroupChat ?? isGroupJid(target.chatJid)
         const participant =
-            isGroup && target.senderJid && target.senderJid !== target.chatJid
+            needsParticipant(target) && target.senderJid && target.senderJid !== target.chatJid
                 ? target.senderJid
                 : undefined
         const key = `${target.chatJid}|${participant ?? ''}`

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -140,3 +140,5 @@ export interface WaSendReceiptInput {
 }
 
 export type WaSendReceiptOptions = Omit<WaSendReceiptInput, 'to' | 'id' | 'listIds'>
+
+export type WaSendReceiptEventOptions = Omit<WaSendReceiptOptions, 'participant'>

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -1,6 +1,7 @@
 import type { Readable } from 'node:stream'
 
 import type { Proto } from '@proto'
+import type { WaOutboundReceiptType } from '@protocol/message'
 import type { BinaryNode } from '@transport/types'
 
 export interface WaMessagePublishOptions {
@@ -127,7 +128,7 @@ export interface WaEncryptedMessageInput {
 export interface WaSendReceiptInput {
     readonly to: string
     readonly id: string
-    readonly type?: string
+    readonly type?: WaOutboundReceiptType
     readonly participant?: string
     readonly recipient?: string
     readonly category?: string
@@ -137,3 +138,5 @@ export interface WaSendReceiptInput {
     readonly listIds?: readonly string[]
     readonly content?: readonly BinaryNode[]
 }
+
+export type WaSendReceiptOptions = Omit<WaSendReceiptInput, 'to' | 'id' | 'listIds'>

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -26,6 +26,7 @@ export {
     WA_RETRYABLE_ACK_CODES,
     WA_STANZA_MSG_TYPES
 } from '@protocol/message'
+export type { WaOutboundReceiptType } from '@protocol/message'
 export {
     WA_APP_STATE_COLLECTIONS,
     WA_APP_STATE_COLLECTION_STATES,

--- a/src/protocol/message.ts
+++ b/src/protocol/message.ts
@@ -25,6 +25,13 @@ export const WA_MESSAGE_TYPES = Object.freeze({
     RECEIPT_TYPE_RETRY: 'retry'
 } as const)
 
+export type WaOutboundReceiptType =
+    | typeof WA_MESSAGE_TYPES.RECEIPT_TYPE_READ
+    | typeof WA_MESSAGE_TYPES.RECEIPT_TYPE_READ_SELF
+    | typeof WA_MESSAGE_TYPES.RECEIPT_TYPE_PLAYED
+    | typeof WA_MESSAGE_TYPES.RECEIPT_TYPE_PLAYED_SELF
+    | typeof WA_MESSAGE_TYPES.RECEIPT_TYPE_INACTIVE
+
 export const WA_RETRYABLE_ACK_CODES = Object.freeze(['408', '429', '500', '503'] as const)
 
 export const WA_STANZA_MSG_TYPES = Object.freeze({


### PR DESCRIPTION
- WaSendReceiptInput.type now restricted to WaOutboundReceiptType union (read | read-self | played | played-self | inactive)
- WaClient.sendReceipt overloads:
    sendReceipt(jid, ids, opts?)            // raw, ids string|string[]
    sendReceipt(event|events, opts?)        // pulls jid/id/participant from inbound event
- aggregateReceiptTargets groups events by (chat, sender) so batch calls
  fan out into the minimum number of stanzas, mirroring Baileys readMessages
- WaSendReceiptOptions exposes the safe subset (no to/id/listIds) for the
  new public surface; raw WaSendReceiptInput stays internal