### PR TITLE
feat(message): contextInfo support with quote/forward/mentions in send options

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -676,9 +676,10 @@ export function buildWaClientDependencies(input: {
                 })
             )
         },
-        sendNewsletterMessage: (newsletterJid, content, sendOptions) =>
+        sendNewsletterMessage: (newsletterJid, content, sendOptions, contextInfo) =>
             newsletterCoordinator.sendMessage(newsletterJid, content, {
-                stanzaId: sendOptions.id
+                stanzaId: sendOptions.id,
+                contextInfo
             }),
         getIcdcHashLength: () => abPropsCoordinator.getConfigValue('md_icdc_hash_length'),
         mobileMessageIdFormat: options.mobileTransport !== undefined

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -97,7 +97,8 @@ interface WaMessageDispatchCoordinatorOptions {
     readonly sendNewsletterMessage?: (
         newsletterJid: string,
         content: WaSendMessageContent,
-        options: WaSendMessageOptions
+        options: WaSendMessageOptions,
+        contextInfo: WaSendContextInfo | null
     ) => Promise<WaMessagePublishResult>
     readonly getIcdcHashLength?: () => number
     readonly mobileMessageIdFormat?: boolean
@@ -141,7 +142,8 @@ export class WaMessageDispatchCoordinator {
         | ((
               newsletterJid: string,
               content: WaSendMessageContent,
-              options: WaSendMessageOptions
+              options: WaSendMessageOptions,
+              contextInfo: WaSendContextInfo | null
           ) => Promise<WaMessagePublishResult>)
         | undefined
     private readonly getIcdcHashLength: (() => number) | undefined
@@ -301,8 +303,16 @@ export class WaMessageDispatchCoordinator {
             if (!this.sendNewsletterMessage) {
                 throw new Error('newsletter sendMessage requires sendNewsletterMessage dependency')
             }
+            const newsletterCtx = resolveSendContextInfo({
+                contentLevel: pickContentContextInfo(content),
+                optionsLevel: options.contextInfo,
+                quote: options.quote,
+                forward: options.forward,
+                mentions: options.mentions
+            })
+            assertNewsletterContextInfoCompatible(newsletterCtx)
             const sendOptions = await this.withResolvedMessageId(options)
-            return this.sendNewsletterMessage(recipientJid, content, sendOptions)
+            return this.sendNewsletterMessage(recipientJid, content, sendOptions, newsletterCtx)
         }
         const [built, sendOptions] = await Promise.all([
             this.buildMessageContent(content),
@@ -1287,4 +1297,18 @@ function pickContentContextInfo(content: WaSendMessageContent): WaSendContextInf
         return content.contextInfo
     }
     return undefined
+}
+
+function assertNewsletterContextInfoCompatible(ctx: WaSendContextInfo | null): void {
+    if (!ctx) return
+    const unsupported: string[] = []
+    if (ctx.quotedMessageId !== undefined) unsupported.push('quote')
+    if (ctx.mentionedJids?.length) unsupported.push('mentions')
+    if (ctx.isSpoiler === true) unsupported.push('isSpoiler')
+    if (ctx.groupSubject !== undefined || ctx.parentGroupJid !== undefined) {
+        unsupported.push('group invite reply (groupSubject/parentGroupJid)')
+    }
+    if (unsupported.length > 0) {
+        throw new Error(`newsletter sends do not support: ${unsupported.join(', ')}`)
+    }
 }

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -9,12 +9,19 @@ import type { Logger } from '@infra/log/types'
 import { PromiseDedup } from '@infra/perf/PromiseDedup'
 import { ensureMessageSecret } from '@message'
 import {
+    isSendMediaMessage,
+    isSendTextMessage,
     needsSecretPersistence,
     resolveEditAttr,
     resolveEncMediaType,
     resolveMessageTypeAttr,
     resolveMetaAttrs
 } from '@message/content'
+import {
+    applyContextInfo,
+    resolveSendContextInfo,
+    type WaSendContextInfo
+} from '@message/context-info'
 import { wrapDeviceSentMessage } from '@message/device-sent'
 import { type IcdcMeta, injectDeviceListMetadata, resolveIcdcMeta } from '@message/icdc'
 import { writeRandomPadMax16 } from '@message/padding'
@@ -301,7 +308,14 @@ export class WaMessageDispatchCoordinator {
             this.buildMessageContent(content),
             this.withResolvedMessageId(options)
         ])
-        const message = built.message
+        const ctx = resolveSendContextInfo({
+            contentLevel: pickContentContextInfo(content),
+            optionsLevel: options.contextInfo,
+            quote: options.quote,
+            forward: options.forward,
+            mentions: options.mentions
+        })
+        const message = ctx ? applyContextInfo(built.message, ctx) : built.message
         const upload = built.upload
         const messageWithSecret = await ensureMessageSecret(message)
         const rawSecret = messageWithSecret.messageContextInfo?.messageSecret
@@ -1265,4 +1279,12 @@ export class WaMessageDispatchCoordinator {
         }
         throw new Error(`${context} requires registered meJid`)
     }
+}
+
+function pickContentContextInfo(content: WaSendMessageContent): WaSendContextInfo | undefined {
+    if (typeof content !== 'object' || content === null) return undefined
+    if (isSendTextMessage(content) || isSendMediaMessage(content)) {
+        return content.contextInfo
+    }
+    return undefined
 }

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -21,7 +21,7 @@ import { MEDIA_CONN_CACHE_GRACE_MS, MEDIA_UPLOAD_PATHS } from '@media/constants'
 import type { MediaCryptoType, WaMediaConn } from '@media/types'
 import { WaMediaCrypto } from '@media/WaMediaCrypto'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
-import { isSendMediaMessage } from '@message/content'
+import { isSendMediaMessage, isSendTextMessage } from '@message/content'
 import type {
     WaMessageBuildResult,
     WaMessageUploadInfo,
@@ -53,6 +53,9 @@ export async function buildMediaMessageContent(
 ): Promise<WaMessageBuildResult> {
     if (typeof content === 'string') {
         return { message: { conversation: content } }
+    }
+    if (isSendTextMessage(content)) {
+        return { message: { extendedTextMessage: { text: content.text } } }
     }
     if (isSendMediaMessage(content)) {
         return buildMediaMessage(options, content)

--- a/src/client/newsletter/content.ts
+++ b/src/client/newsletter/content.ts
@@ -11,6 +11,7 @@ import { NEWSLETTER_MEDIA_UPLOAD_PATHS, type NewsletterMediaKind } from '@media/
 import type { WaMediaConn } from '@media/types'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
 import { isSendMediaMessage, isSendTextMessage, resolveMessageTypeAttr } from '@message/content'
+import { applyContextInfo, type WaSendContextInfo } from '@message/context-info'
 import type { WaSendMediaMessage, WaSendMessageContent } from '@message/types'
 import { proto, type Proto } from '@proto'
 import { base64ToBytes } from '@util/bytes'
@@ -199,10 +200,11 @@ function toUploadMedia(media: WaSendMediaMessage['media']): Uint8Array | string 
 
 export async function buildNewsletterMessageContent(
     options: BuildNewsletterContentOptions,
-    content: WaSendMessageContent
+    content: WaSendMessageContent,
+    ctx?: WaSendContextInfo | null
 ): Promise<WaNewsletterBuiltContent> {
     if (typeof content === 'string') {
-        const message: Proto.IMessage = { conversation: content }
+        const message = applyContextInfo({ conversation: content }, ctx)
         return {
             kind: 'text',
             plaintext: proto.Message.encode(message).finish(),
@@ -212,7 +214,7 @@ export async function buildNewsletterMessageContent(
     }
 
     if (isSendTextMessage(content)) {
-        const message: Proto.IMessage = { extendedTextMessage: { text: content.text } }
+        const message = applyContextInfo({ extendedTextMessage: { text: content.text } }, ctx)
         return {
             kind: 'text',
             plaintext: proto.Message.encode(message).finish(),
@@ -245,7 +247,7 @@ export async function buildNewsletterMessageContent(
                 mediaConn
             }
         )
-        const message = buildMediaProtoMessage(content, upload)
+        const message = applyContextInfo(buildMediaProtoMessage(content, upload), ctx)
         return {
             kind: 'media',
             plaintext: proto.Message.encode(message).finish(),
@@ -254,7 +256,7 @@ export async function buildNewsletterMessageContent(
         }
     }
 
-    const protoMessage = content
+    const protoMessage = applyContextInfo(content, ctx)
     const messageTypeAttr = resolveMessageTypeAttr(protoMessage)
     const isPollCreation = messageTypeAttr === 'poll' && Boolean(protoMessage.pollCreationMessage)
     const mediaTypeAttr = pickMediaTypeFromMessage(protoMessage)

--- a/src/client/newsletter/content.ts
+++ b/src/client/newsletter/content.ts
@@ -10,7 +10,7 @@ import type { Logger } from '@infra/log/types'
 import { NEWSLETTER_MEDIA_UPLOAD_PATHS, type NewsletterMediaKind } from '@media/constants'
 import type { WaMediaConn } from '@media/types'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
-import { isSendMediaMessage, resolveMessageTypeAttr } from '@message/content'
+import { isSendMediaMessage, isSendTextMessage, resolveMessageTypeAttr } from '@message/content'
 import type { WaSendMediaMessage, WaSendMessageContent } from '@message/types'
 import { proto, type Proto } from '@proto'
 import { base64ToBytes } from '@util/bytes'
@@ -203,6 +203,16 @@ export async function buildNewsletterMessageContent(
 ): Promise<WaNewsletterBuiltContent> {
     if (typeof content === 'string') {
         const message: Proto.IMessage = { conversation: content }
+        return {
+            kind: 'text',
+            plaintext: proto.Message.encode(message).finish(),
+            mediaType: null,
+            upload: null
+        }
+    }
+
+    if (isSendTextMessage(content)) {
+        const message: Proto.IMessage = { extendedTextMessage: { text: content.text } }
         return {
             kind: 'text',
             plaintext: proto.Message.encode(message).finish(),

--- a/src/client/newsletter/messaging.ts
+++ b/src/client/newsletter/messaging.ts
@@ -14,6 +14,7 @@ import type {
 } from '@client/newsletter/types'
 import type { WaMediaConn } from '@media/types'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
+import type { WaSendContextInfo } from '@message/context-info'
 import type {
     WaMessagePublishOptions,
     WaMessagePublishResult,
@@ -84,7 +85,8 @@ export interface WaNewsletterMessagingOps {
 
 async function buildContent(
     deps: WaNewsletterMessagingDeps,
-    content: WaSendMessageContent
+    content: WaSendMessageContent,
+    ctx?: WaSendContextInfo | null
 ): Promise<WaNewsletterBuiltContent> {
     return buildNewsletterMessageContent(
         {
@@ -92,7 +94,8 @@ async function buildContent(
             mediaTransfer: deps.mediaTransfer,
             getMediaConn: deps.getMediaConn
         },
-        content
+        content,
+        ctx
     )
 }
 
@@ -176,7 +179,7 @@ export function createMessagingOps(deps: WaNewsletterMessagingDeps): WaNewslette
             sendOptions
         ): Promise<WaNewsletterSendResult> => {
             const stanzaId = await resolveStanzaId(sendOptions?.stanzaId)
-            const built = await buildContent(deps, content)
+            const built = await buildContent(deps, content, sendOptions?.contextInfo)
             const node = buildDispatchNode(newsletterJid, stanzaId, built, null)
             const result = await deps.publishMessageNode(node)
             return { ...result, upload: toUploadSummary(built) }

--- a/src/client/newsletter/types.ts
+++ b/src/client/newsletter/types.ts
@@ -1,3 +1,4 @@
+import type { WaSendContextInfo } from '@message/context-info'
 import type { WaMessagePublishResult } from '@message/types'
 import type {
     WA_NEWSLETTER_VIEW_ROLES,
@@ -117,6 +118,7 @@ export interface WaNewsletterAdminInviteResult {
 
 export interface WaNewsletterSendOptions {
     readonly stanzaId?: string
+    readonly contextInfo?: WaSendContextInfo | null
 }
 
 export type WaNewsletterSendResult = WaMessagePublishResult

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -8,6 +8,7 @@ import type {
 import type { IncomingPresenceType, PresenceLastSeen } from '@client/events/presence'
 import type { WaMediaProcessor } from '@media/processor'
 import type { WaDecodedAddon } from '@message/addon-crypto'
+import type { WaQuoteRef, WaSendContextInfo } from '@message/context-info'
 import type { WaMessagePublishOptions } from '@message/types'
 import type { Proto } from '@proto'
 import type { WaConnectionCode, WaConnectionOpenReason, WaDisconnectReason } from '@protocol/stream'
@@ -166,6 +167,10 @@ export interface WaSendMessageOptions extends WaMessagePublishOptions {
     readonly id?: string
     readonly expectedIdentity?: Uint8Array
     readonly subtype?: string
+    readonly contextInfo?: WaSendContextInfo
+    readonly quote?: WaIncomingMessageEvent | WaQuoteRef
+    readonly forward?: boolean | { readonly score?: number }
+    readonly mentions?: readonly string[]
 }
 
 export interface WaClearChatOptions {

--- a/src/message/__tests__/context-info.test.ts
+++ b/src/message/__tests__/context-info.test.ts
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    applyContextInfo,
+    buildContextInfoProto,
+    resolveSendContextInfo
+} from '@message/context-info'
+
+test('buildContextInfoProto maps friendly fields to proto fields', () => {
+    const proto = buildContextInfoProto({
+        quotedMessageId: 'msg-1',
+        quotedParticipant: 'sender@s.whatsapp.net',
+        quotedRemoteJid: 'group@g.us',
+        quotedMessage: { conversation: 'orig' },
+        isForwarded: true,
+        forwardingScore: 2,
+        mentionedJids: ['a@s.whatsapp.net', 'b@s.whatsapp.net'],
+        isSpoiler: true,
+        expirationSeconds: 3600,
+        groupSubject: 'Grupo X',
+        parentGroupJid: 'parent@g.us'
+    })
+    assert.equal(proto.stanzaId, 'msg-1')
+    assert.equal(proto.participant, 'sender@s.whatsapp.net')
+    assert.equal(proto.remoteJid, 'group@g.us')
+    assert.deepEqual(proto.quotedMessage, { conversation: 'orig' })
+    assert.equal(proto.isForwarded, true)
+    assert.equal(proto.forwardingScore, 2)
+    assert.deepEqual(proto.mentionedJid, ['a@s.whatsapp.net', 'b@s.whatsapp.net'])
+    assert.equal(proto.isSpoiler, true)
+    assert.equal(proto.expiration, 3600)
+    assert.equal(proto.groupSubject, 'Grupo X')
+    assert.equal(proto.parentGroupJid, 'parent@g.us')
+})
+
+test('buildContextInfoProto raw escape hatch overrides friendly fields', () => {
+    const proto = buildContextInfoProto({
+        isForwarded: true,
+        raw: { isForwarded: false, afterReadDuration: 60 }
+    })
+    assert.equal(proto.isForwarded, false)
+    assert.equal(proto.afterReadDuration, 60)
+})
+
+test('applyContextInfo injects into the matching submessage', () => {
+    const out = applyContextInfo(
+        { imageMessage: { url: 'u', mimetype: 'image/jpeg' } },
+        { quotedMessageId: 'q-1' }
+    )
+    assert.equal(out.imageMessage?.contextInfo?.stanzaId, 'q-1')
+})
+
+test('applyContextInfo merges into existing contextInfo', () => {
+    const out = applyContextInfo(
+        {
+            extendedTextMessage: {
+                text: 'hi',
+                contextInfo: { mentionedJid: ['x@s.whatsapp.net'] }
+            }
+        },
+        { quotedMessageId: 'q-1' }
+    )
+    assert.equal(out.extendedTextMessage?.contextInfo?.stanzaId, 'q-1')
+    assert.deepEqual(out.extendedTextMessage?.contextInfo?.mentionedJid, ['x@s.whatsapp.net'])
+})
+
+test('applyContextInfo promotes conversation to extendedTextMessage', () => {
+    const out = applyContextInfo({ conversation: 'hello' }, { isSpoiler: true })
+    assert.equal(out.conversation, undefined)
+    assert.equal(out.extendedTextMessage?.text, 'hello')
+    assert.equal(out.extendedTextMessage?.contextInfo?.isSpoiler, true)
+})
+
+test('applyContextInfo creates extendedTextMessage when message is empty', () => {
+    const out = applyContextInfo({}, { isForwarded: true })
+    assert.equal(out.extendedTextMessage?.contextInfo?.isForwarded, true)
+})
+
+test('applyContextInfo is a no-op when ctx is null/empty', () => {
+    const original: { conversation: string } = { conversation: 'x' }
+    assert.equal(applyContextInfo(original, null), original)
+    assert.equal(applyContextInfo(original, undefined), original)
+    assert.equal(applyContextInfo(original, {}), original)
+})
+
+test('resolveSendContextInfo returns null when nothing was provided', () => {
+    assert.equal(resolveSendContextInfo({}), null)
+})
+
+test('resolveSendContextInfo resolves quote from WaIncomingMessageEvent shape', () => {
+    const result = resolveSendContextInfo({
+        quote: { stanzaId: 'm-1', chatJid: 'group@g.us', senderJid: 'a@s.whatsapp.net' }
+    })
+    assert.deepEqual(result, {
+        quotedMessageId: 'm-1',
+        quotedParticipant: 'a@s.whatsapp.net',
+        quotedRemoteJid: 'group@g.us',
+        quotedMessage: undefined
+    })
+})
+
+test('resolveSendContextInfo resolves quote from WaQuoteRef shape', () => {
+    const result = resolveSendContextInfo({
+        quote: {
+            stanzaId: 'm-2',
+            participant: 'a@s.whatsapp.net',
+            remoteJid: 'group@g.us',
+            message: { conversation: 'orig' }
+        }
+    })
+    assert.equal(result?.quotedMessageId, 'm-2')
+    assert.equal(result?.quotedParticipant, 'a@s.whatsapp.net')
+    assert.deepEqual(result?.quotedMessage, { conversation: 'orig' })
+})
+
+test('resolveSendContextInfo applies forward with default score', () => {
+    const result = resolveSendContextInfo({ forward: true })
+    assert.equal(result?.isForwarded, true)
+    assert.equal(result?.forwardingScore, 1)
+})
+
+test('resolveSendContextInfo increments forward score from existing context', () => {
+    const result = resolveSendContextInfo({
+        contentLevel: { forwardingScore: 3 },
+        forward: true
+    })
+    assert.equal(result?.forwardingScore, 4)
+})
+
+test('resolveSendContextInfo respects explicit forward score', () => {
+    const result = resolveSendContextInfo({ forward: { score: 4 } })
+    assert.equal(result?.forwardingScore, 4)
+})
+
+test('resolveSendContextInfo populates mentions', () => {
+    const result = resolveSendContextInfo({ mentions: ['a@s.whatsapp.net'] })
+    assert.deepEqual(result?.mentionedJids, ['a@s.whatsapp.net'])
+})
+
+test('resolveSendContextInfo merges content-level + options-level + quote + forward + mentions', () => {
+    const result = resolveSendContextInfo({
+        contentLevel: { isSpoiler: true },
+        optionsLevel: { groupSubject: 'G' },
+        quote: { stanzaId: 'q-1', chatJid: 'g@g.us', senderJid: 'a@s.whatsapp.net' },
+        forward: true,
+        mentions: ['a@s.whatsapp.net']
+    })
+    assert.equal(result?.isSpoiler, true)
+    assert.equal(result?.groupSubject, 'G')
+    assert.equal(result?.quotedMessageId, 'q-1')
+    assert.equal(result?.isForwarded, true)
+    assert.deepEqual(result?.mentionedJids, ['a@s.whatsapp.net'])
+})

--- a/src/message/content.ts
+++ b/src/message/content.ts
@@ -1,4 +1,4 @@
-import type { WaSendMediaMessage } from '@message/types'
+import type { WaSendMediaMessage, WaSendTextMessage } from '@message/types'
 import { proto, type Proto } from '@proto'
 import {
     WA_EDIT_ATTRS,
@@ -10,6 +10,16 @@ import {
 
 export function isSendMediaMessage(content: unknown): content is WaSendMediaMessage {
     return !!content && typeof content === 'object' && 'type' in content && 'media' in content
+}
+
+export function isSendTextMessage(content: unknown): content is WaSendTextMessage {
+    return (
+        !!content &&
+        typeof content === 'object' &&
+        'type' in content &&
+        (content as { type: unknown }).type === 'text' &&
+        'text' in content
+    )
 }
 
 export function unwrapMessage(message: Proto.IMessage): Proto.IMessage {

--- a/src/message/context-info.ts
+++ b/src/message/context-info.ts
@@ -1,0 +1,164 @@
+import type { Proto } from '@proto'
+
+export interface WaSendContextInfo {
+    readonly quotedMessageId?: string
+    readonly quotedParticipant?: string
+    readonly quotedRemoteJid?: string
+    readonly quotedMessage?: Proto.IMessage
+
+    readonly isForwarded?: boolean
+    readonly forwardingScore?: number
+
+    readonly mentionedJids?: readonly string[]
+
+    readonly isSpoiler?: boolean
+    readonly expirationSeconds?: number
+
+    readonly groupSubject?: string
+    readonly parentGroupJid?: string
+
+    readonly raw?: Proto.IContextInfo
+}
+
+export interface WaQuoteRef {
+    readonly stanzaId: string
+    readonly participant?: string
+    readonly remoteJid?: string
+    readonly message?: Proto.IMessage
+}
+
+export function buildContextInfoProto(input: WaSendContextInfo): Proto.IContextInfo {
+    const ctx: Proto.IContextInfo = {}
+
+    if (input.quotedMessageId !== undefined) ctx.stanzaId = input.quotedMessageId
+    if (input.quotedParticipant !== undefined) ctx.participant = input.quotedParticipant
+    if (input.quotedRemoteJid !== undefined) ctx.remoteJid = input.quotedRemoteJid
+    if (input.quotedMessage !== undefined) ctx.quotedMessage = input.quotedMessage
+
+    if (input.isForwarded !== undefined) ctx.isForwarded = input.isForwarded
+    if (input.forwardingScore !== undefined) ctx.forwardingScore = input.forwardingScore
+
+    if (input.mentionedJids && input.mentionedJids.length > 0) {
+        ctx.mentionedJid = [...input.mentionedJids]
+    }
+
+    if (input.isSpoiler !== undefined) ctx.isSpoiler = input.isSpoiler
+    if (input.expirationSeconds !== undefined) ctx.expiration = input.expirationSeconds
+
+    if (input.groupSubject !== undefined) ctx.groupSubject = input.groupSubject
+    if (input.parentGroupJid !== undefined) ctx.parentGroupJid = input.parentGroupJid
+
+    if (input.raw) {
+        Object.assign(ctx, input.raw)
+    }
+
+    return ctx
+}
+
+interface ContextInfoCarrier {
+    contextInfo?: Proto.IContextInfo | null
+}
+
+export function applyContextInfo(
+    message: Proto.IMessage,
+    ctx: WaSendContextInfo | null | undefined
+): Proto.IMessage {
+    if (!ctx) return message
+    const proto = buildContextInfoProto(ctx)
+    if (!hasAnyKey(proto)) return message
+
+    const next: Proto.IMessage = { ...message }
+
+    if (typeof next.conversation === 'string' && !next.extendedTextMessage) {
+        next.extendedTextMessage = { text: next.conversation }
+        delete next.conversation
+    }
+
+    if (!hasAnyKey(next)) {
+        next.extendedTextMessage = {}
+    }
+
+    const target = pickContextInfoTarget(next)
+    if (!target) {
+        throw new Error('cannot apply contextInfo: no compatible submessage found')
+    }
+    target.contextInfo = { ...(target.contextInfo ?? undefined), ...proto }
+    return next
+}
+
+type WaQuoteSource =
+    | WaQuoteRef
+    | {
+          readonly stanzaId?: string
+          readonly chatJid?: string
+          readonly senderJid?: string
+          readonly message?: Proto.IMessage
+      }
+
+type WaForwardSource = boolean | { readonly score?: number }
+
+export interface WaSendContextResolveInput {
+    readonly contentLevel?: WaSendContextInfo
+    readonly optionsLevel?: WaSendContextInfo
+    readonly quote?: WaQuoteSource
+    readonly forward?: WaForwardSource
+    readonly mentions?: readonly string[]
+}
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] }
+
+export function resolveSendContextInfo(input: WaSendContextResolveInput): WaSendContextInfo | null {
+    const ctx: Mutable<WaSendContextInfo> = {
+        ...(input.contentLevel ?? {}),
+        ...(input.optionsLevel ?? {})
+    }
+
+    if (input.quote) {
+        const q = input.quote
+        ctx.quotedMessageId = q.stanzaId ?? ctx.quotedMessageId
+        ctx.quotedParticipant =
+            ('participant' in q ? q.participant : undefined) ??
+            ('senderJid' in q ? q.senderJid : undefined) ??
+            ctx.quotedParticipant
+        ctx.quotedRemoteJid =
+            ('remoteJid' in q ? q.remoteJid : undefined) ??
+            ('chatJid' in q ? q.chatJid : undefined) ??
+            ctx.quotedRemoteJid
+        ctx.quotedMessage = q.message ?? ctx.quotedMessage
+    }
+
+    if (input.forward) {
+        const explicit = typeof input.forward === 'object' ? input.forward.score : undefined
+        const base = ctx.forwardingScore ?? 0
+        ctx.isForwarded = true
+        ctx.forwardingScore = explicit ?? (base > 0 ? base + 1 : 1)
+    }
+
+    if (input.mentions?.length) {
+        ctx.mentionedJids = input.mentions
+    }
+
+    return hasAnyKey(ctx) ? ctx : null
+}
+
+function pickContextInfoTarget(message: Proto.IMessage): ContextInfoCarrier | null {
+    for (const key of Object.keys(message)) {
+        const value = (message as Record<string, unknown>)[key]
+        if (
+            value &&
+            typeof value === 'object' &&
+            !Array.isArray(value) &&
+            !(value instanceof Uint8Array)
+        ) {
+            return value as ContextInfoCarrier
+        }
+    }
+    return null
+}
+
+function hasAnyKey(value: object): boolean {
+    for (const _ in value) {
+        return true
+    }
+    return false
+}

--- a/src/message/context-info.ts
+++ b/src/message/context-info.ts
@@ -82,8 +82,23 @@ export function applyContextInfo(
     if (!target) {
         throw new Error('cannot apply contextInfo: no compatible submessage found')
     }
-    target.contextInfo = { ...(target.contextInfo ?? undefined), ...proto }
+    target.contextInfo = { ...target.contextInfo, ...proto }
     return next
+}
+
+function pickContextInfoTarget(message: Proto.IMessage): ContextInfoCarrier | null {
+    for (const key of Object.keys(message)) {
+        const value = (message as Record<string, unknown>)[key]
+        if (
+            value &&
+            typeof value === 'object' &&
+            !Array.isArray(value) &&
+            !(value instanceof Uint8Array)
+        ) {
+            return value as ContextInfoCarrier
+        }
+    }
+    return null
 }
 
 type WaQuoteSource =
@@ -139,21 +154,6 @@ export function resolveSendContextInfo(input: WaSendContextResolveInput): WaSend
     }
 
     return hasAnyKey(ctx) ? ctx : null
-}
-
-function pickContextInfoTarget(message: Proto.IMessage): ContextInfoCarrier | null {
-    for (const key of Object.keys(message)) {
-        const value = (message as Record<string, unknown>)[key]
-        if (
-            value &&
-            typeof value === 'object' &&
-            !Array.isArray(value) &&
-            !(value instanceof Uint8Array)
-        ) {
-            return value as ContextInfoCarrier
-        }
-    }
-    return null
 }
 
 function hasAnyKey(value: object): boolean {

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -1,5 +1,6 @@
 import type { Readable } from 'node:stream'
 
+import type { WaSendContextInfo } from '@message/context-info'
 import type { Proto } from '@proto'
 import type { WaOutboundReceiptType } from '@protocol/message'
 import type { BinaryNode } from '@transport/types'
@@ -54,6 +55,7 @@ type MediaFieldsFilledByBuilder =
     | 'mediaKeyTimestamp'
     | 'streamingSidecar'
     | 'metadataUrl'
+    | 'contextInfo'
 
 type UserMediaFields<T> = {
     readonly [K in keyof Omit<T, MediaFieldsFilledByBuilder>]?: T[K]
@@ -63,12 +65,20 @@ interface WaSendMediaBase {
     readonly media: MediaInput
     readonly mimetype: string
     readonly fileLength?: number
+    readonly contextInfo?: WaSendContextInfo
 }
 
 interface WaSendMediaBaseOptionalMime {
     readonly media: MediaInput
     readonly mimetype?: string
     readonly fileLength?: number
+    readonly contextInfo?: WaSendContextInfo
+}
+
+export interface WaSendTextMessage {
+    readonly type: 'text'
+    readonly text: string
+    readonly contextInfo?: WaSendContextInfo
 }
 
 interface WaSendImageMessage extends WaSendMediaBase, UserMediaFields<Proto.Message.IImageMessage> {
@@ -105,7 +115,7 @@ export type WaSendMediaMessage =
     | WaSendDocumentMessage
     | WaSendStickerMessage
 
-export type WaSendMessageContent = string | Proto.IMessage | WaSendMediaMessage
+export type WaSendMessageContent = string | WaSendTextMessage | Proto.IMessage | WaSendMediaMessage
 
 export interface WaEncryptedMessageInput {
     readonly to: string


### PR DESCRIPTION
- WaSendContextInfo: friendly subset of Proto.IContextInfo (12 fields covering quote, forward, mentions, spoiler, ephemeral, group invite reply) + raw escape hatch for the remaining ~50 proto fields
- WaSendMessageOptions gains: contextInfo, quote (event or WaQuoteRef), forward (boolean | { score }), mentions
- WaSendTextMessage type added to the content union for explicit extendedTextMessage construction
- string content stays as conversation (wa-web parity); applyContextInfo auto-promotes to extendedTextMessage when ctx is present
- pickContextInfoTarget uses runtime detection (no whitelist/blacklist) so new submessages from the proto are auto-covered
- WaIncomingMessageEvent shape works directly as quote source thanks to structural compat (chatJid/senderJid map to remoteJid/participant)
- validated end-to-end (reply, forward score=127, mention, spoiler, plus a combined-everything message)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages now support quoting and replies with full context preservation
  * Added forwarding capability with configurable scoring metrics
  * Messages can include mentions and enriched metadata

* **Tests**
  * Added comprehensive test coverage for message context handling and metadata operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->