### PR TITLE
feat(client): status broadcast + business broadcast list + account events

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -12,6 +12,7 @@ import type { WaConnectionManager } from '@client/connection/WaConnectionManager
 import type { WaReceiptQueue } from '@client/connection/WaReceiptQueue'
 import type { WaAppStateMutationCoordinator } from '@client/coordinators/WaAppStateMutationCoordinator'
 import type { WaBotCoordinator } from '@client/coordinators/WaBotCoordinator'
+import type { WaBroadcastListCoordinator } from '@client/coordinators/WaBroadcastListCoordinator'
 import type { WaBusinessCoordinator } from '@client/coordinators/WaBusinessCoordinator'
 import type { WaEmailCoordinator } from '@client/coordinators/WaEmailCoordinator'
 import type { WaGroupCoordinator } from '@client/coordinators/WaGroupCoordinator'
@@ -21,7 +22,9 @@ import type { WaNewsletterCoordinator } from '@client/coordinators/WaNewsletterC
 import type { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTasksCoordinator'
 import type { WaPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordinator'
 import type { WaProfileCoordinator } from '@client/coordinators/WaProfileCoordinator'
+import type { WaStatusCoordinator } from '@client/coordinators/WaStatusCoordinator'
 import type { WaTrustedContactTokenCoordinator } from '@client/coordinators/WaTrustedContactTokenCoordinator'
+import { parseAccountEventFromAppStateMutation } from '@client/events/account'
 import { parseChatEventFromAppStateMutation } from '@client/events/chat'
 import { aggregateReceiptTargets } from '@client/events/receipt'
 import { processHistorySyncNotification } from '@client/history-sync'
@@ -146,6 +149,8 @@ export class WaClient extends EventEmitter {
     public readonly messageDispatch!: WaMessageDispatchCoordinator
     public readonly messageClient!: WaMessageClient
     public readonly groupCoordinator!: WaGroupCoordinator
+    public readonly statusCoordinator!: WaStatusCoordinator
+    public readonly broadcastListCoordinator!: WaBroadcastListCoordinator
     public readonly newsletterCoordinator!: WaNewsletterCoordinator
     public readonly privacyCoordinator!: WaPrivacyCoordinator
     public readonly profileCoordinator!: WaProfileCoordinator
@@ -762,6 +767,12 @@ export class WaClient extends EventEmitter {
     public get group(): WaGroupCoordinator {
         return this.groupCoordinator
     }
+    public get status(): WaStatusCoordinator {
+        return this.statusCoordinator
+    }
+    public get broadcastList(): WaBroadcastListCoordinator {
+        return this.broadcastListCoordinator
+    }
     public get newsletter(): WaNewsletterCoordinator {
         return this.newsletterCoordinator
     }
@@ -931,6 +942,11 @@ export class WaClient extends EventEmitter {
                 }
                 try {
                     this.handleNctSaltMutation(mutation)
+                    const accountEvent = parseAccountEventFromAppStateMutation(mutation)
+                    if (accountEvent) {
+                        this.emit('account_event', accountEvent)
+                        continue
+                    }
                     const event = parseChatEventFromAppStateMutation(mutation)
                     if (!event) {
                         continue

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -7,6 +7,10 @@ import { WaAbPropsCoordinator } from '@client/coordinators/WaAbPropsCoordinator'
 import { WaAppStateMutationCoordinator } from '@client/coordinators/WaAppStateMutationCoordinator'
 import { createBotCoordinator, type WaBotCoordinator } from '@client/coordinators/WaBotCoordinator'
 import {
+    createBroadcastListCoordinator,
+    type WaBroadcastListCoordinator
+} from '@client/coordinators/WaBroadcastListCoordinator'
+import {
     createBusinessCoordinator,
     type WaBusinessCoordinator
 } from '@client/coordinators/WaBusinessCoordinator'
@@ -35,6 +39,10 @@ import {
     type WaProfileCoordinator
 } from '@client/coordinators/WaProfileCoordinator'
 import { WaRetryCoordinator } from '@client/coordinators/WaRetryCoordinator'
+import {
+    createStatusCoordinator,
+    type WaStatusCoordinator
+} from '@client/coordinators/WaStatusCoordinator'
 import {
     createStreamControlHandler,
     type WaStreamControlHandler
@@ -157,6 +165,8 @@ interface WaClientDependencies {
     readonly incomingNode: WaIncomingNodeCoordinator
     readonly passiveTasks: WaPassiveTasksCoordinator
     readonly groupCoordinator: WaGroupCoordinator
+    readonly statusCoordinator: WaStatusCoordinator
+    readonly broadcastListCoordinator: WaBroadcastListCoordinator
     readonly newsletterCoordinator: WaNewsletterCoordinator
     readonly privacyCoordinator: WaPrivacyCoordinator
     readonly profileCoordinator: WaProfileCoordinator
@@ -732,6 +742,20 @@ export function buildWaClientDependencies(input: {
         syncAppState: runtime.syncAppStateWithOptions
     })
 
+    const statusCoordinator = createStatusCoordinator({
+        appStateMutations,
+        buildMessageContent: async (content) =>
+            buildMediaMessageContent(mediaMessageBuildOptions, content),
+        publishStatusMessage: (input) => messageDispatch.publishStatusMessage(input)
+    })
+
+    const broadcastListCoordinator = createBroadcastListCoordinator({
+        appStateMutations,
+        buildMessageContent: async (content) =>
+            buildMediaMessageContent(mediaMessageBuildOptions, content),
+        publishBroadcastListMessage: (input) => messageDispatch.publishBroadcastListMessage(input)
+    })
+
     connectionManager = new WaConnectionManager({
         logger,
         options,
@@ -1179,6 +1203,8 @@ export function buildWaClientDependencies(input: {
         incomingNode,
         passiveTasks,
         groupCoordinator,
+        statusCoordinator,
+        broadcastListCoordinator,
         newsletterCoordinator,
         privacyCoordinator,
         profileCoordinator,

--- a/src/client/coordinators/WaAppStateMutationCoordinator.ts
+++ b/src/client/coordinators/WaAppStateMutationCoordinator.ts
@@ -474,6 +474,9 @@ export class WaAppStateMutationCoordinator {
             typeof input.mode === 'number'
                 ? input.mode
                 : proto.SyncActionValue.StatusPrivacyAction.StatusDistributionMode[input.mode]
+        if (typeof modeValue !== 'number' || !Number.isInteger(modeValue)) {
+            throw new Error(`setStatusPrivacy: invalid mode ${String(input.mode)}`)
+        }
         const userJid = input.userJids ? [...input.userJids] : []
         const value: Proto.ISyncActionValue = {
             statusPrivacy: {
@@ -496,6 +499,9 @@ export class WaAppStateMutationCoordinator {
 
     public async setUserStatusMute(jid: string, muted: boolean): Promise<void> {
         const indexJid = this.normalizeChatMutationJid(jid)
+        if (isGroupOrBroadcastJid(indexJid)) {
+            throw new Error(`setUserStatusMute requires a user jid, got ${jid}`)
+        }
         const timestamp = Date.now()
         await this.enqueueAndFlush([
             this.createAccountSetMutation({

--- a/src/client/coordinators/WaAppStateMutationCoordinator.ts
+++ b/src/client/coordinators/WaAppStateMutationCoordinator.ts
@@ -11,8 +11,9 @@ import type {
     WaDeleteMessageForMeOptions
 } from '@client/types'
 import type { Logger } from '@infra/log/types'
-import type { Proto } from '@proto'
+import { proto, type Proto } from '@proto'
 import {
+    WA_APP_STATE_ACCOUNT_MUTATION_SPECS,
     WA_APP_STATE_CHAT_MUTATION_SPECS,
     WA_APP_STATE_COLLECTION_STATES
 } from '@protocol/constants'
@@ -26,6 +27,10 @@ import {
 import type { WaMessageStore, WaStoredMessageRecord } from '@store/contracts/message.store'
 import { resolvePositive } from '@util/coercion'
 import { toError } from '@util/primitives'
+
+type StatusDistributionMode = Proto.SyncActionValue.StatusPrivacyAction.StatusDistributionMode
+type StatusDistributionModeKey =
+    keyof typeof proto.SyncActionValue.StatusPrivacyAction.StatusDistributionMode
 
 const WA_APP_STATE_MUTATION_FLUSH_SUCCESS_STATES = new Set<string>([
     WA_APP_STATE_COLLECTION_STATES.SUCCESS,
@@ -43,6 +48,28 @@ interface WaAppStateMutationCoordinatorOptions {
 
 type WaAppStateChatMutationSpec =
     (typeof WA_APP_STATE_CHAT_MUTATION_SPECS)[keyof typeof WA_APP_STATE_CHAT_MUTATION_SPECS]
+
+type WaAppStateAccountMutationSpec =
+    (typeof WA_APP_STATE_ACCOUNT_MUTATION_SPECS)[keyof typeof WA_APP_STATE_ACCOUNT_MUTATION_SPECS]
+
+export interface WaSetStatusPrivacyInput {
+    readonly mode: StatusDistributionModeKey | StatusDistributionMode
+    readonly userJids?: readonly string[]
+    readonly shareToFB?: boolean
+    readonly shareToIG?: boolean
+}
+
+export interface WaBroadcastListParticipant {
+    readonly lidJid: string
+    readonly pnJid?: string
+}
+
+export interface WaSetBroadcastListInput {
+    readonly id: string
+    readonly listName: string
+    readonly participants: readonly WaBroadcastListParticipant[]
+    readonly labelIds?: readonly string[]
+}
 
 export class WaAppStateMutationCoordinator {
     private readonly logger: Logger
@@ -437,6 +464,109 @@ export class WaAppStateMutationCoordinator {
                 ...input.value,
                 timestamp: input.timestamp
             },
+            version: input.spec.version,
+            timestamp: input.timestamp
+        }
+    }
+
+    public async setStatusPrivacy(input: WaSetStatusPrivacyInput): Promise<void> {
+        const modeValue =
+            typeof input.mode === 'number'
+                ? input.mode
+                : proto.SyncActionValue.StatusPrivacyAction.StatusDistributionMode[input.mode]
+        const userJid = input.userJids ? [...input.userJids] : []
+        const value: Proto.ISyncActionValue = {
+            statusPrivacy: {
+                mode: modeValue,
+                userJid,
+                ...(input.shareToFB === undefined ? {} : { shareToFB: input.shareToFB }),
+                ...(input.shareToIG === undefined ? {} : { shareToIG: input.shareToIG })
+            }
+        }
+        const timestamp = Date.now()
+        await this.enqueueAndFlush([
+            this.createAccountSetMutation({
+                spec: WA_APP_STATE_ACCOUNT_MUTATION_SPECS.STATUS_PRIVACY,
+                indexArgs: [],
+                value,
+                timestamp
+            })
+        ])
+    }
+
+    public async setUserStatusMute(jid: string, muted: boolean): Promise<void> {
+        const indexJid = this.normalizeChatMutationJid(jid)
+        const timestamp = Date.now()
+        await this.enqueueAndFlush([
+            this.createAccountSetMutation({
+                spec: WA_APP_STATE_ACCOUNT_MUTATION_SPECS.USER_STATUS_MUTE,
+                indexArgs: [indexJid],
+                value: { userStatusMuteAction: { muted } },
+                timestamp
+            })
+        ])
+    }
+
+    public async setBroadcastList(input: WaSetBroadcastListInput): Promise<void> {
+        const participants = input.participants.map((entry) => ({
+            lidJid: entry.lidJid,
+            ...(entry.pnJid === undefined ? {} : { pnJid: entry.pnJid })
+        }))
+        const value: Proto.ISyncActionValue = {
+            businessBroadcastListAction: {
+                participants,
+                listName: input.listName,
+                labelIds: input.labelIds ? [...input.labelIds] : []
+            }
+        }
+        const timestamp = Date.now()
+        await this.enqueueAndFlush([
+            this.createAccountSetMutation({
+                spec: WA_APP_STATE_ACCOUNT_MUTATION_SPECS.BUSINESS_BROADCAST_LIST,
+                indexArgs: [input.id],
+                value,
+                timestamp
+            })
+        ])
+    }
+
+    public async removeBroadcastList(id: string): Promise<void> {
+        const timestamp = Date.now()
+        await this.enqueueAndFlush([
+            this.createAccountRemoveMutation({
+                spec: WA_APP_STATE_ACCOUNT_MUTATION_SPECS.BUSINESS_BROADCAST_LIST,
+                indexArgs: [id],
+                timestamp
+            })
+        ])
+    }
+
+    private createAccountSetMutation(input: {
+        readonly spec: WaAppStateAccountMutationSpec
+        readonly indexArgs: readonly string[]
+        readonly value: Proto.ISyncActionValue
+        readonly timestamp: number
+    }): WaAppStateMutationInput {
+        return {
+            collection: input.spec.collection,
+            operation: 'set',
+            index: JSON.stringify([input.spec.action, ...input.indexArgs]),
+            value: { ...input.value, timestamp: input.timestamp },
+            version: input.spec.version,
+            timestamp: input.timestamp
+        }
+    }
+
+    private createAccountRemoveMutation(input: {
+        readonly spec: WaAppStateAccountMutationSpec
+        readonly indexArgs: readonly string[]
+        readonly timestamp: number
+    }): WaAppStateMutationInput {
+        return {
+            collection: input.spec.collection,
+            operation: 'remove',
+            index: JSON.stringify([input.spec.action, ...input.indexArgs]),
+            previousValue: { timestamp: input.timestamp },
             version: input.spec.version,
             timestamp: input.timestamp
         }

--- a/src/client/coordinators/WaBroadcastListCoordinator.ts
+++ b/src/client/coordinators/WaBroadcastListCoordinator.ts
@@ -3,15 +3,16 @@ import type {
     WaSetBroadcastListInput
 } from '@client/coordinators/WaAppStateMutationCoordinator'
 import type { WaSendMessageOptions } from '@client/types'
-import type { WaMessagePublishResult, WaSendMessageContent } from '@message/types'
+import type {
+    WaMessageBuildResult,
+    WaMessagePublishResult,
+    WaSendMessageContent
+} from '@message/types'
 import type { Proto } from '@proto'
 
 export interface WaBroadcastListCoordinatorOptions {
     readonly appStateMutations: WaAppStateMutationCoordinator
-    readonly buildMessageContent: (content: WaSendMessageContent) => Promise<{
-        readonly message: Proto.IMessage
-        readonly upload?: unknown
-    }>
+    readonly buildMessageContent: (content: WaSendMessageContent) => Promise<WaMessageBuildResult>
     readonly publishBroadcastListMessage: (input: {
         readonly listJid: string
         readonly message: Proto.IMessage
@@ -43,12 +44,13 @@ export function createBroadcastListCoordinator(
         removeList: (id) => options.appStateMutations.removeBroadcastList(id),
         sendMessage: async (input) => {
             const built = await options.buildMessageContent(input.content)
-            return options.publishBroadcastListMessage({
+            const published = await options.publishBroadcastListMessage({
                 listJid: input.listJid,
                 message: built.message,
                 recipients: input.recipients,
                 options: input.options
             })
+            return built.upload ? { ...published, upload: built.upload } : published
         }
     }
 }

--- a/src/client/coordinators/WaBroadcastListCoordinator.ts
+++ b/src/client/coordinators/WaBroadcastListCoordinator.ts
@@ -1,0 +1,54 @@
+import type {
+    WaAppStateMutationCoordinator,
+    WaSetBroadcastListInput
+} from '@client/coordinators/WaAppStateMutationCoordinator'
+import type { WaSendMessageOptions } from '@client/types'
+import type { WaMessagePublishResult, WaSendMessageContent } from '@message/types'
+import type { Proto } from '@proto'
+
+export interface WaBroadcastListCoordinatorOptions {
+    readonly appStateMutations: WaAppStateMutationCoordinator
+    readonly buildMessageContent: (content: WaSendMessageContent) => Promise<{
+        readonly message: Proto.IMessage
+        readonly upload?: unknown
+    }>
+    readonly publishBroadcastListMessage: (input: {
+        readonly listJid: string
+        readonly message: Proto.IMessage
+        readonly recipients: readonly string[]
+        readonly options?: WaSendMessageOptions
+    }) => Promise<WaMessagePublishResult>
+}
+
+export interface WaSendBroadcastListMessageInput {
+    readonly listJid: string
+    readonly content: WaSendMessageContent
+    readonly recipients: readonly string[]
+    readonly options?: WaSendMessageOptions
+}
+
+export interface WaBroadcastListCoordinator {
+    readonly setList: (input: WaSetBroadcastListInput) => Promise<void>
+    readonly removeList: (id: string) => Promise<void>
+    readonly sendMessage: (
+        input: WaSendBroadcastListMessageInput
+    ) => Promise<WaMessagePublishResult>
+}
+
+export function createBroadcastListCoordinator(
+    options: WaBroadcastListCoordinatorOptions
+): WaBroadcastListCoordinator {
+    return {
+        setList: (input) => options.appStateMutations.setBroadcastList(input),
+        removeList: (id) => options.appStateMutations.removeBroadcastList(id),
+        sendMessage: async (input) => {
+            const built = await options.buildMessageContent(input.content)
+            return options.publishBroadcastListMessage({
+                listJid: input.listJid,
+                message: built.message,
+                recipients: input.recipients,
+                options: input.options
+            })
+        }
+    }
+}

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -469,6 +469,7 @@ export class WaMessageDispatchCoordinator {
             message: input.message,
             options: input.options ?? {},
             logTag: 'status',
+            replayStatusSetting: statusSetting,
             // Bare `<to jid=user>` ack hints route the skmsg through primary
             // devices that already hold the sender key.
             customize: async ({
@@ -547,6 +548,7 @@ export class WaMessageDispatchCoordinator {
         readonly message: Proto.IMessage
         readonly options: WaSendMessageOptions
         readonly logTag: string
+        readonly replayStatusSetting?: string
         readonly customize?: (fanout: {
             readonly fanoutDeviceJids: readonly string[]
             readonly distributionParticipants: readonly {
@@ -630,7 +632,8 @@ export class WaMessageDispatchCoordinator {
             mode: 'plaintext',
             to: input.groupJid,
             type: messageNode.attrs.type,
-            plaintext
+            plaintext,
+            ...(input.replayStatusSetting ? { statusSetting: input.replayStatusSetting } : {})
         }
         const result = await this.retryTracker.track(
             {

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -42,7 +42,7 @@ import type {
 } from '@message/types'
 import type { WaMessageClient } from '@message/WaMessageClient'
 import { proto, type Proto } from '@proto'
-import { WA_DEFAULTS } from '@protocol/constants'
+import { WA_DEFAULTS, type WaStatusDistributionSetting } from '@protocol/constants'
 import {
     isBotJid,
     isGroupJid,
@@ -433,6 +433,233 @@ export class WaMessageDispatchCoordinator {
 
     public async sendReceipt(input: WaSendReceiptInput): Promise<void> {
         await this.messageClient.sendReceipt(input)
+    }
+
+    public async publishStatusMessage(input: {
+        readonly message: Proto.IMessage
+        readonly recipients: readonly string[]
+        readonly statusSetting?: WaStatusDistributionSetting
+        readonly options?: WaSendMessageOptions
+    }): Promise<WaMessagePublishResult> {
+        if (input.recipients.length === 0) {
+            throw new Error('publishStatusMessage requires at least one recipient')
+        }
+        this.requireCurrentMeJid('publishStatusMessage')
+        const meLid = this.getCurrentMeLid()
+        if (!meLid) {
+            throw new Error('publishStatusMessage requires current me lid')
+        }
+        const senderJid = normalizeDeviceJid(meLid)
+        const meUserLid = toUserJid(meLid)
+        const seen = new Set<string>()
+        const recipientsWithSelf: string[] = []
+        for (const jid of input.recipients) {
+            if (seen.has(jid)) continue
+            seen.add(jid)
+            recipientsWithSelf.push(jid)
+        }
+        if (!seen.has(meUserLid)) {
+            recipientsWithSelf.push(meUserLid)
+        }
+        const statusSetting = input.statusSetting ?? 'contacts'
+        return this.publishSenderKeyFanout({
+            groupJid: WA_DEFAULTS.STATUS_BROADCAST_JID,
+            senderJid,
+            recipients: recipientsWithSelf,
+            message: input.message,
+            options: input.options ?? {},
+            logTag: 'status',
+            // Bare `<to jid=user>` ack hints route the skmsg through primary
+            // devices that already hold the sender key.
+            customize: async ({
+                fanoutDeviceJids,
+                distributionParticipants,
+                messageWithSecret,
+                sendOptions
+            }) => {
+                const distributedAddressKeys = new Set<string>()
+                for (let i = 0; i < distributionParticipants.length; i += 1) {
+                    distributedAddressKeys.add(
+                        signalAddressKey(distributionParticipants[i].address)
+                    )
+                }
+                const ackHints: { readonly jid: string }[] = []
+                const seenAck = new Set<string>()
+                for (let i = 0; i < fanoutDeviceJids.length; i += 1) {
+                    const deviceJid = fanoutDeviceJids[i]
+                    const address = parseSignalAddressFromJid(deviceJid)
+                    if (distributedAddressKeys.has(signalAddressKey(address))) continue
+                    if (address.device !== 0) continue
+                    const userJid = toUserJid(deviceJid)
+                    if (seenAck.has(userJid)) continue
+                    seenAck.add(userJid)
+                    ackHints.push({ jid: userJid })
+                }
+                const reportingArtifacts = await this.tryBuildReportingTokenArtifacts({
+                    message: messageWithSecret,
+                    stanzaId: sendOptions.id,
+                    senderUserJid: toUserJid(senderJid),
+                    remoteJid: WA_DEFAULTS.STATUS_BROADCAST_JID,
+                    context: 'status'
+                })
+                return {
+                    extraParticipants: ackHints,
+                    metaNode: buildMetaNode({ status_setting: statusSetting }),
+                    reportingNode: reportingArtifacts?.node
+                }
+            }
+        })
+    }
+
+    public async publishBroadcastListMessage(input: {
+        readonly listJid: string
+        readonly message: Proto.IMessage
+        readonly recipients: readonly string[]
+        readonly options?: WaSendMessageOptions
+    }): Promise<WaMessagePublishResult> {
+        if (input.recipients.length === 0) {
+            throw new Error('publishBroadcastListMessage requires at least one recipient')
+        }
+        const meJid = this.requireCurrentMeJid('publishBroadcastListMessage')
+        const senderJid = normalizeDeviceJid(meJid)
+        return this.publishSenderKeyFanout({
+            groupJid: input.listJid,
+            senderJid,
+            recipients: input.recipients,
+            message: input.message,
+            options: input.options ?? {},
+            logTag: 'broadcast list',
+            customize: ({ fanoutDeviceJids }) => {
+                const phashTargets = new Array<string>(fanoutDeviceJids.length + 1)
+                for (let i = 0; i < fanoutDeviceJids.length; i += 1) {
+                    phashTargets[i] = fanoutDeviceJids[i]
+                }
+                phashTargets[fanoutDeviceJids.length] = senderJid
+                return Promise.resolve({ phash: computePhashV2(phashTargets) })
+            }
+        })
+    }
+
+    private async publishSenderKeyFanout(input: {
+        readonly groupJid: string
+        readonly senderJid: string
+        readonly recipients: readonly string[]
+        readonly message: Proto.IMessage
+        readonly options: WaSendMessageOptions
+        readonly logTag: string
+        readonly customize?: (fanout: {
+            readonly fanoutDeviceJids: readonly string[]
+            readonly distributionParticipants: readonly {
+                readonly jid: string
+                readonly address: SignalAddress
+                readonly encType: 'msg' | 'pkmsg'
+                readonly ciphertext: Uint8Array
+            }[]
+            readonly messageWithSecret: Proto.IMessage
+            readonly sendOptions: WaSendMessageOptions
+        }) => Promise<{
+            readonly extraParticipants?: readonly { readonly jid: string }[]
+            readonly metaNode?: BinaryNode
+            readonly reportingNode?: BinaryNode
+            readonly phash?: string
+        }>
+    }): Promise<WaMessagePublishResult> {
+        const sendOptions = await this.withResolvedMessageId(input.options)
+        const sender = parseSignalAddressFromJid(input.senderJid)
+        const messageWithSecret = await ensureMessageSecret(input.message)
+        const plaintext = await writeRandomPadMax16(
+            proto.Message.encode(messageWithSecret).finish()
+        )
+        const {
+            distributionMessage,
+            ciphertext: groupCiphertext,
+            keyId: senderKeyId
+        } = await this.senderKeyManager.prepareGroupEncryption(input.groupJid, sender, plaintext)
+        const { fanoutDeviceJids, distributionParticipants } =
+            await this.encryptGroupDistributionParticipants(
+                input.groupJid,
+                senderKeyId,
+                distributionMessage,
+                input.recipients
+            )
+        let shouldAttachDeviceIdentity = false
+        for (let i = 0; i < distributionParticipants.length; i += 1) {
+            if (distributionParticipants[i].encType === 'pkmsg') {
+                shouldAttachDeviceIdentity = true
+                break
+            }
+        }
+        const extras = input.customize
+            ? await input.customize({
+                  fanoutDeviceJids,
+                  distributionParticipants,
+                  messageWithSecret,
+                  sendOptions
+              })
+            : {}
+        const participants: {
+            readonly jid: string
+            readonly encType?: 'msg' | 'pkmsg'
+            readonly ciphertext?: Uint8Array
+        }[] = distributionParticipants.map((p) => ({
+            jid: p.jid,
+            encType: p.encType,
+            ciphertext: p.ciphertext
+        }))
+        if (extras.extraParticipants) {
+            for (const entry of extras.extraParticipants) {
+                participants.push(entry)
+            }
+        }
+        const messageNode = buildGroupSenderKeyMessageNode({
+            to: input.groupJid,
+            type: resolveMessageTypeAttr(messageWithSecret),
+            id: sendOptions.id,
+            phash: extras.phash,
+            edit: resolveEditAttr(messageWithSecret, sendOptions.subtype) ?? undefined,
+            mediatype: resolveEncMediaType(messageWithSecret) ?? undefined,
+            groupCiphertext: groupCiphertext.ciphertext,
+            participants,
+            deviceIdentity: shouldAttachDeviceIdentity
+                ? this.getEncodedSignedDeviceIdentity()
+                : undefined,
+            metaNode: extras.metaNode,
+            reportingNode: extras.reportingNode
+        })
+        const replayPayload: WaRetryReplayPayload = {
+            mode: 'plaintext',
+            to: input.groupJid,
+            type: messageNode.attrs.type,
+            plaintext
+        }
+        const result = await this.retryTracker.track(
+            {
+                messageIdHint: sendOptions.id ?? messageNode.attrs.id,
+                toJid: input.groupJid,
+                type: messageNode.attrs.type,
+                replayPayload,
+                eligibleRequesterDeviceJids: undefined
+            },
+            async () => this.messageClient.publishNode(messageNode, sendOptions)
+        )
+        const distributedAddresses = new Array<SignalAddress>(distributionParticipants.length)
+        for (let i = 0; i < distributionParticipants.length; i += 1) {
+            distributedAddresses[i] = distributionParticipants[i].address
+        }
+        try {
+            await this.senderKeyManager.markSenderKeyDistributed(
+                input.groupJid,
+                senderKeyId,
+                distributedAddresses
+            )
+        } catch (error) {
+            this.logger.warn(`failed to mark ${input.logTag} sender key distribution targets`, {
+                groupJid: input.groupJid,
+                participants: distributedAddresses.length,
+                message: toError(error).message
+            })
+        }
+        return result
     }
 
     public async requestAppStateSyncKeys(

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -6,7 +6,8 @@ import {
     isGroupOrBroadcastJid,
     normalizeDeviceJid,
     parseJidFull,
-    type parseSignalAddressFromJid
+    type parseSignalAddressFromJid,
+    toUserJid
 } from '@protocol/jid'
 import {
     MAX_RETRY_ATTEMPTS,
@@ -264,11 +265,12 @@ export class WaRetryCoordinator {
         context: WaRetryDecryptFailureContext,
         prepared: RetryDecryptFailurePreparation
     ): Promise<void> {
+        const recipient = context.recipient ?? this.resolvePeerRetryRecipient(context)
         const retryReceiptNode = buildRetryReceiptNode({
             stanzaId: context.stanzaId,
             to: context.from,
             participant: context.participant,
-            recipient: context.recipient,
+            recipient,
             originalMsgId: context.stanzaId,
             retryCount: prepared.retryCount,
             t: prepared.timestamp,
@@ -282,10 +284,31 @@ export class WaRetryCoordinator {
             id: context.stanzaId,
             to: context.from,
             participant: context.participant,
+            recipient,
             retryCount: prepared.retryCount,
             reason: prepared.retryReason,
             withKeys: prepared.retryKeys !== undefined
         })
+    }
+
+    private resolvePeerRetryRecipient(context: WaRetryDecryptFailureContext): string | undefined {
+        if (!context.participant) {
+            return undefined
+        }
+        const meLid = this.getCurrentMeLid()
+        if (!meLid) {
+            return undefined
+        }
+        try {
+            const participantUser = toUserJid(context.participant)
+            const meUserLid = toUserJid(meLid)
+            if (participantUser !== meUserLid) {
+                return undefined
+            }
+            return meUserLid
+        } catch {
+            return undefined
+        }
     }
 
     private async handleParsedRetryRequest(

--- a/src/client/coordinators/WaStatusCoordinator.ts
+++ b/src/client/coordinators/WaStatusCoordinator.ts
@@ -3,17 +3,18 @@ import type {
     WaSetStatusPrivacyInput
 } from '@client/coordinators/WaAppStateMutationCoordinator'
 import type { WaSendMessageOptions } from '@client/types'
-import type { WaMessagePublishResult, WaSendMessageContent } from '@message/types'
+import type {
+    WaMessageBuildResult,
+    WaMessagePublishResult,
+    WaSendMessageContent
+} from '@message/types'
 import { proto, type Proto } from '@proto'
 import { WA_DEFAULTS } from '@protocol/defaults'
 import type { WaStatusDistributionSetting } from '@protocol/status'
 
 export interface WaStatusCoordinatorOptions {
     readonly appStateMutations: WaAppStateMutationCoordinator
-    readonly buildMessageContent: (content: WaSendMessageContent) => Promise<{
-        readonly message: Proto.IMessage
-        readonly upload?: unknown
-    }>
+    readonly buildMessageContent: (content: WaSendMessageContent) => Promise<WaMessageBuildResult>
     readonly publishStatusMessage: (input: {
         readonly message: Proto.IMessage
         readonly recipients: readonly string[]
@@ -57,12 +58,13 @@ export function createStatusCoordinator(options: WaStatusCoordinatorOptions): Wa
                           }
                       }
                     : built.message
-            return options.publishStatusMessage({
+            const published = await options.publishStatusMessage({
                 message,
                 recipients: input.recipients,
                 statusSetting: input.statusSetting,
                 options: input.options
             })
+            return built.upload ? { ...published, upload: built.upload } : published
         },
         revokeStatus: async (input) => {
             const message: Proto.IMessage = {

--- a/src/client/coordinators/WaStatusCoordinator.ts
+++ b/src/client/coordinators/WaStatusCoordinator.ts
@@ -1,0 +1,86 @@
+import type {
+    WaAppStateMutationCoordinator,
+    WaSetStatusPrivacyInput
+} from '@client/coordinators/WaAppStateMutationCoordinator'
+import type { WaSendMessageOptions } from '@client/types'
+import type { WaMessagePublishResult, WaSendMessageContent } from '@message/types'
+import { proto, type Proto } from '@proto'
+import { WA_DEFAULTS } from '@protocol/defaults'
+import type { WaStatusDistributionSetting } from '@protocol/status'
+
+export interface WaStatusCoordinatorOptions {
+    readonly appStateMutations: WaAppStateMutationCoordinator
+    readonly buildMessageContent: (content: WaSendMessageContent) => Promise<{
+        readonly message: Proto.IMessage
+        readonly upload?: unknown
+    }>
+    readonly publishStatusMessage: (input: {
+        readonly message: Proto.IMessage
+        readonly recipients: readonly string[]
+        readonly statusSetting?: WaStatusDistributionSetting
+        readonly options?: WaSendMessageOptions
+    }) => Promise<WaMessagePublishResult>
+}
+
+export interface WaSendStatusInput {
+    readonly content: WaSendMessageContent
+    readonly recipients: readonly string[]
+    readonly statusSetting?: WaStatusDistributionSetting
+    readonly options?: WaSendMessageOptions
+}
+
+export interface WaStatusCoordinator {
+    readonly setPrivacy: (input: WaSetStatusPrivacyInput) => Promise<void>
+    readonly setUserMuted: (jid: string, muted: boolean) => Promise<void>
+    readonly sendStatus: (input: WaSendStatusInput) => Promise<WaMessagePublishResult>
+    readonly revokeStatus: (input: {
+        readonly messageId: string
+        readonly recipients: readonly string[]
+        readonly statusSetting?: WaStatusDistributionSetting
+        readonly options?: WaSendMessageOptions
+    }) => Promise<WaMessagePublishResult>
+}
+
+export function createStatusCoordinator(options: WaStatusCoordinatorOptions): WaStatusCoordinator {
+    return {
+        setPrivacy: (input) => options.appStateMutations.setStatusPrivacy(input),
+        setUserMuted: (jid, muted) => options.appStateMutations.setUserStatusMute(jid, muted),
+        sendStatus: async (input) => {
+            const built = await options.buildMessageContent(input.content)
+            const message =
+                built.message.conversation && !built.message.extendedTextMessage
+                    ? {
+                          ...built.message,
+                          conversation: null,
+                          extendedTextMessage: {
+                              text: built.message.conversation
+                          }
+                      }
+                    : built.message
+            return options.publishStatusMessage({
+                message,
+                recipients: input.recipients,
+                statusSetting: input.statusSetting,
+                options: input.options
+            })
+        },
+        revokeStatus: async (input) => {
+            const message: Proto.IMessage = {
+                protocolMessage: {
+                    type: proto.Message.ProtocolMessage.Type.REVOKE,
+                    key: {
+                        remoteJid: WA_DEFAULTS.STATUS_BROADCAST_JID,
+                        fromMe: true,
+                        id: input.messageId
+                    }
+                }
+            }
+            return options.publishStatusMessage({
+                message,
+                recipients: input.recipients,
+                statusSetting: input.statusSetting,
+                options: input.options
+            })
+        }
+    }
+}

--- a/src/client/coordinators/__tests__/broadcast-list-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/broadcast-list-coordinator.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type {
+    WaAppStateMutationCoordinator,
+    WaSetBroadcastListInput
+} from '@client/coordinators/WaAppStateMutationCoordinator'
+import { createBroadcastListCoordinator } from '@client/coordinators/WaBroadcastListCoordinator'
+import type { WaMessagePublishResult } from '@message/types'
+import type { Proto } from '@proto'
+
+interface FakeAppStateMutations {
+    readonly setBroadcastListCalls: WaSetBroadcastListInput[]
+    readonly removeBroadcastListCalls: string[]
+}
+
+function createFakeAppStateMutations(): WaAppStateMutationCoordinator & FakeAppStateMutations {
+    const setBroadcastListCalls: WaSetBroadcastListInput[] = []
+    const removeBroadcastListCalls: string[] = []
+    const fake = {
+        setBroadcastListCalls,
+        removeBroadcastListCalls,
+        setBroadcastList: async (input: WaSetBroadcastListInput) => {
+            setBroadcastListCalls.push(input)
+        },
+        removeBroadcastList: async (id: string) => {
+            removeBroadcastListCalls.push(id)
+        }
+    }
+    return fake as unknown as WaAppStateMutationCoordinator & FakeAppStateMutations
+}
+
+function fakePublishResult(id: string): WaMessagePublishResult {
+    return {
+        id,
+        ack: { error: undefined, code: 200, phash: undefined, addressingMode: undefined }
+    } as unknown as WaMessagePublishResult
+}
+
+test('broadcast list coordinator setList delegates to app state mutations', async () => {
+    const appStateMutations = createFakeAppStateMutations()
+    const coordinator = createBroadcastListCoordinator({
+        appStateMutations,
+        buildMessageContent: async () => ({ message: {} }),
+        publishBroadcastListMessage: async () => fakePublishResult('unused')
+    })
+
+    const input: WaSetBroadcastListInput = {
+        id: 'list-1',
+        listName: 'Friends',
+        participants: [{ lidJid: 'a@lid', pnJid: 'a@s.whatsapp.net' }, { lidJid: 'b@lid' }],
+        labelIds: ['L1']
+    }
+    await coordinator.setList(input)
+    assert.deepEqual(appStateMutations.setBroadcastListCalls, [input])
+})
+
+test('broadcast list coordinator removeList delegates to app state mutations', async () => {
+    const appStateMutations = createFakeAppStateMutations()
+    const coordinator = createBroadcastListCoordinator({
+        appStateMutations,
+        buildMessageContent: async () => ({ message: {} }),
+        publishBroadcastListMessage: async () => fakePublishResult('unused')
+    })
+
+    await coordinator.removeList('list-1')
+    assert.deepEqual(appStateMutations.removeBroadcastListCalls, ['list-1'])
+})
+
+test('broadcast list coordinator sendMessage forwards built message + recipients', async () => {
+    const sends: Array<{
+        listJid: string
+        message: Proto.IMessage
+        recipients: readonly string[]
+    }> = []
+    const coordinator = createBroadcastListCoordinator({
+        appStateMutations: createFakeAppStateMutations(),
+        buildMessageContent: async (content) => {
+            assert.equal(content, 'hello list')
+            return { message: { conversation: 'hello list' } }
+        },
+        publishBroadcastListMessage: async (input) => {
+            sends.push({
+                listJid: input.listJid,
+                message: input.message,
+                recipients: input.recipients
+            })
+            return fakePublishResult('msg-1')
+        }
+    })
+
+    const result = await coordinator.sendMessage({
+        listJid: 'list-1@broadcast',
+        content: 'hello list',
+        recipients: ['a@lid', 'b@lid']
+    })
+    assert.equal(result.id, 'msg-1')
+    assert.equal(sends.length, 1)
+    assert.equal(sends[0].listJid, 'list-1@broadcast')
+    assert.equal(sends[0].message.conversation, 'hello list')
+    assert.deepEqual(sends[0].recipients, ['a@lid', 'b@lid'])
+})

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -1097,6 +1097,103 @@ test('app-state mutation coordinator emits delete-message-for-me mutation and va
     )
 })
 
+test('app-state mutation coordinator emits status_privacy account mutation', async () => {
+    const messageStore = new WaMessageMemoryStore()
+    const syncCalls: (readonly WaAppStateMutationInput[])[] = []
+    const coordinator = new WaAppStateMutationCoordinator({
+        logger: createLogger(),
+        messageStore,
+        syncAppState: async (options = {}) => {
+            const pendingMutations = options.pendingMutations ?? []
+            syncCalls.push(pendingMutations)
+            return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
+        }
+    })
+
+    await coordinator.setStatusPrivacy({
+        mode: 'CONTACTS',
+        shareToFB: true
+    })
+
+    assert.equal(syncCalls.length, 1)
+    assert.equal(syncCalls[0].length, 1)
+    const mutation = syncCalls[0][0]
+    assert.equal(mutation.collection, 'regular_high')
+    assert.equal(mutation.operation, 'set')
+    assert.deepEqual(JSON.parse(mutation.index), ['status_privacy'])
+    if (mutation.operation !== 'set') throw new Error('status_privacy must be set')
+    assert.equal(typeof mutation.value.statusPrivacy?.mode, 'number')
+    assert.equal(mutation.value.statusPrivacy?.shareToFB, true)
+    assert.deepEqual(mutation.value.statusPrivacy?.userJid, [])
+})
+
+test('app-state mutation coordinator emits userStatusMute mutation with target jid', async () => {
+    const messageStore = new WaMessageMemoryStore()
+    const syncCalls: (readonly WaAppStateMutationInput[])[] = []
+    const coordinator = new WaAppStateMutationCoordinator({
+        logger: createLogger(),
+        messageStore,
+        syncAppState: async (options = {}) => {
+            const pendingMutations = options.pendingMutations ?? []
+            syncCalls.push(pendingMutations)
+            return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
+        }
+    })
+
+    await coordinator.setUserStatusMute('5511000000000:3@s.whatsapp.net', true)
+
+    assert.equal(syncCalls.length, 1)
+    const mutation = syncCalls[0][0]
+    assert.equal(mutation.collection, 'regular_high')
+    assert.deepEqual(JSON.parse(mutation.index), ['userStatusMute', '5511000000000@s.whatsapp.net'])
+    if (mutation.operation !== 'set') throw new Error('userStatusMute must be set')
+    assert.equal(mutation.value.userStatusMuteAction?.muted, true)
+})
+
+test('app-state mutation coordinator emits business_broadcast_list set/remove pair', async () => {
+    const messageStore = new WaMessageMemoryStore()
+    const syncCalls: (readonly WaAppStateMutationInput[])[] = []
+    const coordinator = new WaAppStateMutationCoordinator({
+        logger: createLogger(),
+        messageStore,
+        syncAppState: async (options = {}) => {
+            const pendingMutations = options.pendingMutations ?? []
+            syncCalls.push(pendingMutations)
+            return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
+        }
+    })
+
+    await coordinator.setBroadcastList({
+        id: 'list-1',
+        listName: 'Friends',
+        participants: [{ lidJid: 'a@lid', pnJid: 'a@s.whatsapp.net' }, { lidJid: 'b@lid' }],
+        labelIds: ['L1']
+    })
+
+    assert.equal(syncCalls.length, 1)
+    const setMutation = syncCalls[0][0]
+    assert.equal(setMutation.collection, 'regular')
+    assert.deepEqual(JSON.parse(setMutation.index), ['business_broadcast_list', 'list-1'])
+    if (setMutation.operation !== 'set') {
+        throw new Error('business_broadcast_list must be set on create')
+    }
+    const action = setMutation.value.businessBroadcastListAction
+    assert.equal(action?.listName, 'Friends')
+    assert.equal(action?.participants?.length, 2)
+    assert.equal(action?.participants?.[0]?.lidJid, 'a@lid')
+    assert.equal(action?.participants?.[0]?.pnJid, 'a@s.whatsapp.net')
+    assert.equal(action?.participants?.[1]?.lidJid, 'b@lid')
+    assert.equal(action?.participants?.[1]?.pnJid, undefined)
+    assert.deepEqual(action?.labelIds, ['L1'])
+
+    await coordinator.removeBroadcastList('list-1')
+
+    assert.equal(syncCalls.length, 2)
+    const removeMutation = syncCalls[1][0]
+    assert.equal(removeMutation.operation, 'remove')
+    assert.deepEqual(JSON.parse(removeMutation.index), ['business_broadcast_list', 'list-1'])
+})
+
 function createPassiveTasksCoordinator(overrides: {
     readonly takeDanglingReceipts: () => BinaryNode[]
     readonly sendNodeDirect: (node: BinaryNode) => Promise<void>

--- a/src/client/coordinators/__tests__/status-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/status-coordinator.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type {
+    WaAppStateMutationCoordinator,
+    WaSetStatusPrivacyInput
+} from '@client/coordinators/WaAppStateMutationCoordinator'
+import { createStatusCoordinator } from '@client/coordinators/WaStatusCoordinator'
+import type { WaMessagePublishResult } from '@message/types'
+import { proto, type Proto } from '@proto'
+
+interface FakeAppStateMutations {
+    readonly setStatusPrivacyCalls: WaSetStatusPrivacyInput[]
+    readonly setUserStatusMuteCalls: { jid: string; muted: boolean }[]
+}
+
+function createFakeAppStateMutations(): WaAppStateMutationCoordinator & FakeAppStateMutations {
+    const setStatusPrivacyCalls: WaSetStatusPrivacyInput[] = []
+    const setUserStatusMuteCalls: { jid: string; muted: boolean }[] = []
+    const fake = {
+        setStatusPrivacyCalls,
+        setUserStatusMuteCalls,
+        setStatusPrivacy: async (input: WaSetStatusPrivacyInput) => {
+            setStatusPrivacyCalls.push(input)
+        },
+        setUserStatusMute: async (jid: string, muted: boolean) => {
+            setUserStatusMuteCalls.push({ jid, muted })
+        }
+    }
+    return fake as unknown as WaAppStateMutationCoordinator & FakeAppStateMutations
+}
+
+function fakePublishResult(id: string): WaMessagePublishResult {
+    return {
+        id,
+        ack: { error: undefined, code: 200, phash: undefined, addressingMode: undefined }
+    } as unknown as WaMessagePublishResult
+}
+
+test('status coordinator setPrivacy delegates to app state mutations', async () => {
+    const appStateMutations = createFakeAppStateMutations()
+    const coordinator = createStatusCoordinator({
+        appStateMutations,
+        buildMessageContent: async () => ({ message: {} }),
+        publishStatusMessage: async () => fakePublishResult('unused')
+    })
+
+    await coordinator.setPrivacy({ mode: 'CONTACTS' })
+    assert.deepEqual(appStateMutations.setStatusPrivacyCalls, [{ mode: 'CONTACTS' }])
+})
+
+test('status coordinator setUserMuted delegates to app state mutations', async () => {
+    const appStateMutations = createFakeAppStateMutations()
+    const coordinator = createStatusCoordinator({
+        appStateMutations,
+        buildMessageContent: async () => ({ message: {} }),
+        publishStatusMessage: async () => fakePublishResult('unused')
+    })
+
+    await coordinator.setUserMuted('5511000000000@s.whatsapp.net', true)
+    assert.deepEqual(appStateMutations.setUserStatusMuteCalls, [
+        { jid: '5511000000000@s.whatsapp.net', muted: true }
+    ])
+})
+
+test('status coordinator sendStatus converts conversation to extendedTextMessage', async () => {
+    const publishes: Array<{
+        message: Proto.IMessage
+        recipients: readonly string[]
+        statusSetting?: string
+    }> = []
+    const coordinator = createStatusCoordinator({
+        appStateMutations: createFakeAppStateMutations(),
+        buildMessageContent: async (content) => {
+            assert.equal(content, 'hi status')
+            return { message: { conversation: 'hi status' } }
+        },
+        publishStatusMessage: async (input) => {
+            publishes.push({
+                message: input.message,
+                recipients: input.recipients,
+                statusSetting: input.statusSetting
+            })
+            return fakePublishResult('status-1')
+        }
+    })
+
+    const result = await coordinator.sendStatus({
+        content: 'hi status',
+        recipients: ['5511000000000@lid'],
+        statusSetting: 'denylist'
+    })
+    assert.equal(result.id, 'status-1')
+    assert.equal(publishes.length, 1)
+    assert.equal(publishes[0].statusSetting, 'denylist')
+    assert.deepEqual(publishes[0].recipients, ['5511000000000@lid'])
+    assert.equal(publishes[0].message.extendedTextMessage?.text, 'hi status')
+    assert.equal(publishes[0].message.conversation, null)
+})
+
+test('status coordinator sendStatus passes a pre-built proto unchanged', async () => {
+    let captured: Proto.IMessage | undefined
+    const coordinator = createStatusCoordinator({
+        appStateMutations: createFakeAppStateMutations(),
+        buildMessageContent: async (content) => ({ message: content as Proto.IMessage }),
+        publishStatusMessage: async (input) => {
+            captured = input.message
+            return fakePublishResult('status-2')
+        }
+    })
+
+    const proto1: Proto.IMessage = {
+        extendedTextMessage: { text: 'already wrapped' }
+    }
+    await coordinator.sendStatus({ content: proto1, recipients: ['5511000000000@lid'] })
+    assert.equal(captured?.extendedTextMessage?.text, 'already wrapped')
+})
+
+test('status coordinator revokeStatus emits a REVOKE protocolMessage for status@broadcast', async () => {
+    let captured: Proto.IMessage | undefined
+    const coordinator = createStatusCoordinator({
+        appStateMutations: createFakeAppStateMutations(),
+        buildMessageContent: async () => ({ message: {} }),
+        publishStatusMessage: async (input) => {
+            captured = input.message
+            return fakePublishResult('revoke-1')
+        }
+    })
+
+    await coordinator.revokeStatus({
+        messageId: 'MSG_ID',
+        recipients: ['5511000000000@lid']
+    })
+    assert.ok(captured?.protocolMessage)
+    assert.equal(captured.protocolMessage?.type, proto.Message.ProtocolMessage.Type.REVOKE)
+    assert.equal(captured.protocolMessage?.key?.id, 'MSG_ID')
+    assert.equal(captured.protocolMessage?.key?.fromMe, true)
+    assert.equal(captured.protocolMessage?.key?.remoteJid, 'status@broadcast')
+})

--- a/src/client/events/__tests__/events.test.ts
+++ b/src/client/events/__tests__/events.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
+import { parseAccountEventFromAppStateMutation } from '@client/events/account'
 import { parseBusinessNotificationEvents } from '@client/events/business'
 import { parseChatEventFromAppStateMutation } from '@client/events/chat'
 import { parseChatstateNode } from '@client/events/chatstate'
@@ -40,6 +41,90 @@ test('chat event parser maps app-state mutation to chat actions', () => {
     assert.equal(parsed?.action, 'mute')
     assert.equal(parsed?.chatJid, '5511@s.whatsapp.net')
     assert.equal(parsed?.muted, true)
+})
+
+test('account event parser maps statusPrivacy / userStatusMute / business broadcast list', () => {
+    const privacy = parseAccountEventFromAppStateMutation({
+        collection: 'regular_high',
+        operation: 'set',
+        source: 'patch',
+        index: JSON.stringify(['status_privacy']),
+        value: {
+            statusPrivacy: { mode: 1, userJid: ['a@lid', 'b@lid'], shareToFB: true }
+        },
+        version: 7,
+        indexMac: new Uint8Array(),
+        valueMac: new Uint8Array(),
+        keyId: new Uint8Array(),
+        timestamp: 1
+    })
+    assert.equal(privacy?.action, 'status_privacy')
+    if (privacy?.action === 'status_privacy') {
+        assert.equal(privacy.settings.mode, 1)
+        assert.deepEqual(privacy.settings.userJids, ['a@lid', 'b@lid'])
+        assert.equal(privacy.settings.shareToFB, true)
+    }
+
+    const mute = parseAccountEventFromAppStateMutation({
+        collection: 'regular_high',
+        operation: 'set',
+        source: 'patch',
+        index: JSON.stringify(['userStatusMute', 'someone@lid']),
+        value: { userStatusMuteAction: { muted: true } },
+        version: 7,
+        indexMac: new Uint8Array(),
+        valueMac: new Uint8Array(),
+        keyId: new Uint8Array(),
+        timestamp: 2
+    })
+    assert.equal(mute?.action, 'user_status_mute')
+    if (mute?.action === 'user_status_mute') {
+        assert.equal(mute.targetJid, 'someone@lid')
+        assert.equal(mute.muted, true)
+    }
+
+    const listSet = parseAccountEventFromAppStateMutation({
+        collection: 'regular',
+        operation: 'set',
+        source: 'patch',
+        index: JSON.stringify(['business_broadcast_list', 'list-1']),
+        value: {
+            businessBroadcastListAction: {
+                listName: 'List One',
+                participants: [{ lidJid: 'x@lid', pnJid: 'x@s.whatsapp.net' }],
+                labelIds: ['L1']
+            }
+        },
+        version: 1,
+        indexMac: new Uint8Array(),
+        valueMac: new Uint8Array(),
+        keyId: new Uint8Array(),
+        timestamp: 3
+    })
+    assert.equal(listSet?.action, 'business_broadcast_list_set')
+    if (listSet?.action === 'business_broadcast_list_set') {
+        assert.equal(listSet.listId, 'list-1')
+        assert.equal(listSet.listName, 'List One')
+        assert.equal(listSet.participants.length, 1)
+        assert.deepEqual(listSet.labelIds, ['L1'])
+    }
+
+    const listRemove = parseAccountEventFromAppStateMutation({
+        collection: 'regular',
+        operation: 'remove',
+        source: 'patch',
+        index: JSON.stringify(['business_broadcast_list', 'list-2']),
+        value: null,
+        version: 1,
+        indexMac: new Uint8Array(),
+        valueMac: new Uint8Array(),
+        keyId: new Uint8Array(),
+        timestamp: 4
+    })
+    assert.equal(listRemove?.action, 'business_broadcast_list_remove')
+    if (listRemove?.action === 'business_broadcast_list_remove') {
+        assert.equal(listRemove.listId, 'list-2')
+    }
 })
 
 test('group notification parser handles supported and unsupported actions', () => {

--- a/src/client/events/account.ts
+++ b/src/client/events/account.ts
@@ -30,7 +30,7 @@ export function parseAccountEventFromAppStateMutation(
         version: mutation.version
     } as const
 
-    if (value?.statusPrivacy) {
+    if (parsedIndex.action === 'status_privacy' && value?.statusPrivacy) {
         const settings = value.statusPrivacy
         const userJid = Array.isArray(settings.userJid) ? [...settings.userJid] : []
         const entry: WaStatusPrivacyEntry = {
@@ -46,7 +46,7 @@ export function parseAccountEventFromAppStateMutation(
         return { ...base, action: 'status_privacy', settings: entry }
     }
 
-    if (value?.userStatusMuteAction) {
+    if (parsedIndex.action === 'userStatusMute' && value?.userStatusMuteAction) {
         const targetJid = parsedIndex.parts[1]
         if (!targetJid) {
             return null
@@ -71,12 +71,15 @@ export function parseAccountEventFromAppStateMutation(
         if (!action) {
             return null
         }
-        const participants: WaBroadcastListMembershipEntry[] = (action.participants ?? []).map(
-            (entry) => ({
-                lidJid: entry.lidJid ?? '',
+        const participants: WaBroadcastListMembershipEntry[] = (action.participants ?? [])
+            .filter(
+                (entry): entry is { readonly lidJid: string; readonly pnJid?: string } =>
+                    typeof entry.lidJid === 'string' && entry.lidJid.length > 0
+            )
+            .map((entry) => ({
+                lidJid: entry.lidJid,
                 ...(entry.pnJid ? { pnJid: entry.pnJid } : {})
-            })
-        )
+            }))
         return {
             ...base,
             action: 'business_broadcast_list_set',

--- a/src/client/events/account.ts
+++ b/src/client/events/account.ts
@@ -1,0 +1,116 @@
+import type { WaAppStateMutation } from '@appstate/types'
+import type {
+    WaAccountEvent,
+    WaBroadcastListMembershipEntry,
+    WaStatusPrivacyEntry
+} from '@client/types'
+
+interface ParsedAccountIndex {
+    readonly action: string
+    readonly parts: readonly string[]
+}
+
+export function parseAccountEventFromAppStateMutation(
+    mutation: WaAppStateMutation
+): WaAccountEvent | null {
+    const parsedIndex = parseAccountIndex(mutation.index)
+    if (!parsedIndex) {
+        return null
+    }
+
+    const value = mutation.value
+    const base = {
+        source: mutation.source,
+        collection: mutation.collection,
+        operation: mutation.operation,
+        mutationIndex: mutation.index,
+        indexAction: parsedIndex.action,
+        indexParts: parsedIndex.parts,
+        timestamp: mutation.timestamp,
+        version: mutation.version
+    } as const
+
+    if (value?.statusPrivacy) {
+        const settings = value.statusPrivacy
+        const userJid = Array.isArray(settings.userJid) ? [...settings.userJid] : []
+        const entry: WaStatusPrivacyEntry = {
+            mode: typeof settings.mode === 'number' ? settings.mode : null,
+            userJids: userJid,
+            ...(settings.shareToFB !== null && settings.shareToFB !== undefined
+                ? { shareToFB: settings.shareToFB }
+                : {}),
+            ...(settings.shareToIG !== null && settings.shareToIG !== undefined
+                ? { shareToIG: settings.shareToIG }
+                : {})
+        }
+        return { ...base, action: 'status_privacy', settings: entry }
+    }
+
+    if (value?.userStatusMuteAction) {
+        const targetJid = parsedIndex.parts[1]
+        if (!targetJid) {
+            return null
+        }
+        return {
+            ...base,
+            action: 'user_status_mute',
+            targetJid,
+            muted: value.userStatusMuteAction.muted ?? null
+        }
+    }
+
+    if (parsedIndex.action === 'business_broadcast_list') {
+        const listId = parsedIndex.parts[1]
+        if (!listId) {
+            return null
+        }
+        if (mutation.operation === 'remove') {
+            return { ...base, action: 'business_broadcast_list_remove', listId }
+        }
+        const action = value?.businessBroadcastListAction
+        if (!action) {
+            return null
+        }
+        const participants: WaBroadcastListMembershipEntry[] = (action.participants ?? []).map(
+            (entry) => ({
+                lidJid: entry.lidJid ?? '',
+                ...(entry.pnJid ? { pnJid: entry.pnJid } : {})
+            })
+        )
+        return {
+            ...base,
+            action: 'business_broadcast_list_set',
+            listId,
+            listName: action.listName ?? '',
+            participants,
+            labelIds: Array.isArray(action.labelIds) ? [...action.labelIds] : []
+        }
+    }
+
+    return null
+}
+
+function parseAccountIndex(index: string): ParsedAccountIndex | null {
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(index)
+    } catch {
+        return null
+    }
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+        return null
+    }
+    const parts: string[] = []
+    for (const item of parsed) {
+        if (typeof item === 'string') {
+            parts.push(item)
+            continue
+        }
+        if (typeof item === 'number' || typeof item === 'boolean') {
+            parts.push(String(item))
+            continue
+        }
+        return null
+    }
+    return { action: parts[0], parts }
+}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -558,6 +558,51 @@ export interface WaChatEvent {
     readonly deviceAgentId?: string
 }
 
+export interface WaStatusPrivacyEntry {
+    readonly mode: number | null
+    readonly userJids: readonly string[]
+    readonly shareToFB?: boolean
+    readonly shareToIG?: boolean
+}
+
+export interface WaBroadcastListMembershipEntry {
+    readonly lidJid: string
+    readonly pnJid?: string
+}
+
+interface WaAccountEventBase {
+    readonly source: WaChatEventSource
+    readonly collection: AppStateCollectionName
+    readonly operation: 'set' | 'remove'
+    readonly mutationIndex: string
+    readonly indexAction: string
+    readonly indexParts: readonly string[]
+    readonly timestamp: number
+    readonly version: number
+}
+
+export type WaAccountEvent =
+    | (WaAccountEventBase & {
+          readonly action: 'status_privacy'
+          readonly settings: WaStatusPrivacyEntry
+      })
+    | (WaAccountEventBase & {
+          readonly action: 'user_status_mute'
+          readonly targetJid: string
+          readonly muted: boolean | null
+      })
+    | (WaAccountEventBase & {
+          readonly action: 'business_broadcast_list_set'
+          readonly listId: string
+          readonly listName: string
+          readonly participants: readonly WaBroadcastListMembershipEntry[]
+          readonly labelIds: readonly string[]
+      })
+    | (WaAccountEventBase & {
+          readonly action: 'business_broadcast_list_remove'
+          readonly listId: string
+      })
+
 export type WaConnectionEvent =
     | {
           readonly status: 'open'
@@ -615,6 +660,7 @@ export interface WaClientEventMap {
     readonly group_event: (event: WaGroupEvent) => void
     readonly business_event: (event: WaBusinessEvent) => void
     readonly chat_event: (event: WaChatEvent) => void
+    readonly account_event: (event: WaAccountEvent) => void
     readonly history_sync_chunk: (event: WaHistorySyncChunkEvent) => void
     readonly privacy_token_update: (event: WaPrivacyTokenUpdateEvent) => void
     readonly offline_resume: (event: WaOfflineResumeEvent) => void

--- a/src/protocol/__tests__/protocol.test.ts
+++ b/src/protocol/__tests__/protocol.test.ts
@@ -29,6 +29,7 @@ import {
     isHostedDeviceJid,
     isHostedServer,
     isNewsletterJid,
+    isStatusBroadcastJid,
     normalizeDeviceJid,
     normalizeRecipientJid,
     parsePhoneJid,
@@ -64,6 +65,9 @@ test('jid type detection and device handling', () => {
     assert.equal(isNewsletterJid('120363025343298869@newsletter'), true)
     assert.equal(isNewsletterJid('120363025343298869@s.whatsapp.net'), false)
     assert.equal(isNewsletterJid('@newsletter'), false)
+    assert.equal(isStatusBroadcastJid('status@broadcast'), true)
+    assert.equal(isStatusBroadcastJid('120@broadcast'), false)
+    assert.equal(isStatusBroadcastJid('status@s.whatsapp.net'), false)
 
     assert.deepEqual(parseSignalAddressFromJid('5511:3@s.whatsapp.net'), {
         user: '5511',

--- a/src/protocol/appstate.ts
+++ b/src/protocol/appstate.ts
@@ -65,3 +65,21 @@ export const WA_APP_STATE_CHAT_MUTATION_SPECS = Object.freeze({
     },
     LOCK_CHAT: { collection: WA_APP_STATE_COLLECTIONS.REGULAR_LOW, action: 'lock', version: 7 }
 } as const)
+
+export const WA_APP_STATE_ACCOUNT_MUTATION_SPECS = Object.freeze({
+    STATUS_PRIVACY: {
+        collection: WA_APP_STATE_COLLECTIONS.REGULAR_HIGH,
+        action: 'status_privacy',
+        version: 7
+    },
+    USER_STATUS_MUTE: {
+        collection: WA_APP_STATE_COLLECTIONS.REGULAR_HIGH,
+        action: 'userStatusMute',
+        version: 7
+    },
+    BUSINESS_BROADCAST_LIST: {
+        collection: WA_APP_STATE_COLLECTIONS.REGULAR,
+        action: 'business_broadcast_list',
+        version: 1
+    }
+} as const)

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -28,6 +28,7 @@ export {
 } from '@protocol/message'
 export type { WaOutboundReceiptType } from '@protocol/message'
 export {
+    WA_APP_STATE_ACCOUNT_MUTATION_SPECS,
     WA_APP_STATE_COLLECTIONS,
     WA_APP_STATE_COLLECTION_STATES,
     WA_APP_STATE_CHAT_MUTATION_SPECS,
@@ -84,6 +85,8 @@ export {
     WA_META_NODE_ATTRS_BOT
 } from '@protocol/bot'
 export type { WaBizBotType, WaBotMsgBodyType, WaBotMsgEditType } from '@protocol/bot'
+export { WA_STATUS_DISTRIBUTION_SETTINGS } from '@protocol/status'
+export type { WaStatusDistributionSetting } from '@protocol/status'
 export {
     WA_EMAIL_CONTEXTS,
     WA_EMAIL_ERROR_CODES,

--- a/src/protocol/defaults.ts
+++ b/src/protocol/defaults.ts
@@ -12,6 +12,7 @@ export const WA_DEFAULTS = Object.freeze({
     INTEROP_SERVER: 'interop',
     NEWSLETTER_SERVER: 'newsletter',
     BOT_SERVER: 'bot',
+    STATUS_BROADCAST_JID: 'status@broadcast',
     DEVICE_BROWSER: WA_BROWSERS.FIREFOX,
     DEVICE_PLATFORM: getWaCompanionPlatformId(WA_BROWSERS.FIREFOX),
     CHAT_SOCKET_URLS: ['wss://web.whatsapp.com/ws/chat', 'wss://web.whatsapp.com:5222/ws/chat'],

--- a/src/protocol/jid.ts
+++ b/src/protocol/jid.ts
@@ -86,6 +86,10 @@ export function isBroadcastJid(jid: string): boolean {
     return isJidType(jid, WA_DEFAULTS.BROADCAST_SERVER)
 }
 
+export function isStatusBroadcastJid(jid: string): boolean {
+    return jid === WA_DEFAULTS.STATUS_BROADCAST_JID
+}
+
 export function isNewsletterJid(jid: string): boolean {
     return isJidType(jid, WA_DEFAULTS.NEWSLETTER_SERVER)
 }

--- a/src/protocol/status.ts
+++ b/src/protocol/status.ts
@@ -1,0 +1,9 @@
+export const WA_STATUS_DISTRIBUTION_SETTINGS = Object.freeze({
+    CONTACTS: 'contacts',
+    ALLOWLIST: 'allowlist',
+    DENYLIST: 'denylist',
+    CLOSE_FRIENDS: 'close_friends'
+} as const)
+
+export type WaStatusDistributionSetting =
+    (typeof WA_STATUS_DISTRIBUTION_SETTINGS)[keyof typeof WA_STATUS_DISTRIBUTION_SETTINGS]

--- a/src/retry/__tests__/retry.test.ts
+++ b/src/retry/__tests__/retry.test.ts
@@ -358,6 +358,59 @@ test('retry replay service handles group plaintext retries and pkmsg identity gu
     assert.equal(sendNodeCalls[0].content[0].attrs.count, '1')
 })
 
+test('retry replay service emits status@broadcast retry with meta and no addressing_mode', async () => {
+    const sendNodeCalls: BinaryNode[] = []
+    const service = new WaRetryReplayService({
+        logger: createLogger(),
+        messageClient: {
+            sendEncrypted: async () => undefined,
+            sendMessageNode: async (node: BinaryNode) => {
+                sendNodeCalls.push(node)
+            }
+        } as unknown as WaMessageClient,
+        signalProtocol: {
+            encryptMessage: async () => ({
+                type: 'msg' as const,
+                ciphertext: new Uint8Array([1, 2, 3])
+            })
+        } as unknown as SignalProtocol,
+        getCurrentMeJid: () => null,
+        getCurrentMeLid: () => null,
+        getCurrentSignedIdentity: () => null
+    })
+
+    const now = Date.now()
+    const outbound: WaRetryOutboundMessageRecord = {
+        messageId: 'm-status-1',
+        toJid: 'status@broadcast',
+        messageType: 'text',
+        replayMode: 'plaintext',
+        replayPayload: {
+            mode: 'plaintext',
+            to: 'status@broadcast',
+            type: 'text',
+            plaintext: new Uint8Array([1, 2, 3, 4]),
+            statusSetting: 'denylist'
+        },
+        state: 'pending',
+        createdAtMs: now,
+        updatedAtMs: now,
+        expiresAtMs: now + 60_000
+    }
+    const result = await service.resendOutboundMessage(outbound, '5511:43@lid', 1)
+    assert.equal(result, 'resent')
+    assert.equal(sendNodeCalls.length, 1)
+    const node = sendNodeCalls[0]
+    assert.equal(node.attrs.to, 'status@broadcast')
+    assert.equal(node.attrs.participant, '5511:43@lid')
+    assert.equal(node.attrs.addressing_mode, undefined)
+    assert.ok(Array.isArray(node.content))
+    assert.equal(node.content[0].tag, 'meta')
+    assert.equal(node.content[0].attrs.status_setting, 'denylist')
+    assert.equal(node.content[1].tag, 'enc')
+    assert.equal(node.content[1].attrs.count, '1')
+})
+
 test('retry replay service handles encrypted mode eligibility', async () => {
     const sendEncryptedCalls: Array<Record<string, unknown>> = []
     const service = new WaRetryReplayService({

--- a/src/retry/replay.ts
+++ b/src/retry/replay.ts
@@ -5,6 +5,7 @@ import type { WaMessageClient } from '@message/WaMessageClient'
 import { proto, type Proto } from '@proto'
 import {
     isGroupOrBroadcastJid,
+    isStatusBroadcastJid,
     normalizeDeviceJid,
     parseJidFull,
     type parseSignalAddressFromJid,
@@ -19,7 +20,7 @@ import type {
 } from '@retry/types'
 import type { SignalProtocol } from '@signal/session/SignalProtocol'
 import { decodeBinaryNode } from '@transport/binary'
-import { buildGroupRetryMessageNode } from '@transport/node/builders/message'
+import { buildGroupRetryMessageNode, buildMetaNode } from '@transport/node/builders/message'
 import { findNodeChild } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
 import { toError } from '@util/primitives'
@@ -145,18 +146,21 @@ export class WaRetryReplayService {
             deviceIdentity = proto.ADVSignedDeviceIdentity.encode(signedIdentity).finish()
         }
 
+        // status retries echo `<meta status_setting>` and omit `addressing_mode`.
+        const isStatus = isStatusBroadcastJid(payload.to)
+        const metaNode = isStatus ? buildMetaNode({ status_setting: 'contacts' }) : undefined
         const retryNode = buildGroupRetryMessageNode({
             to: payload.to,
             type: payload.type,
             id: outbound.messageId,
             requesterJid,
-            addressingMode: requesterAddress.server === 'lid' ? 'lid' : 'pn',
+            addressingMode: isStatus ? undefined : requesterAddress.server === 'lid' ? 'lid' : 'pn',
             encType: encrypted.type,
             ciphertext: encrypted.ciphertext,
             retryCount,
-            deviceIdentity
+            deviceIdentity,
+            metaNode
         })
-
         await this.options.messageClient.sendMessageNode(retryNode)
         return 'resent'
     }

--- a/src/retry/replay.ts
+++ b/src/retry/replay.ts
@@ -148,7 +148,9 @@ export class WaRetryReplayService {
 
         // status retries echo `<meta status_setting>` and omit `addressing_mode`.
         const isStatus = isStatusBroadcastJid(payload.to)
-        const metaNode = isStatus ? buildMetaNode({ status_setting: 'contacts' }) : undefined
+        const metaNode = isStatus
+            ? buildMetaNode({ status_setting: payload.statusSetting ?? 'contacts' })
+            : undefined
         const retryNode = buildGroupRetryMessageNode({
             to: payload.to,
             type: payload.type,

--- a/src/retry/types.ts
+++ b/src/retry/types.ts
@@ -49,6 +49,9 @@ export interface WaRetryPlaintextReplayPayload {
     readonly to: string
     readonly type: string
     readonly plaintext: Uint8Array
+    // status@broadcast routing metadata to echo on retry; preserves the
+    // original audience (contacts / allowlist / denylist / close_friends).
+    readonly statusSetting?: string
 }
 
 export interface WaRetryEncryptedReplayPayload {

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -557,6 +557,25 @@ test('message builders create fanout nodes and validate participant requirements
     assert.equal(retryNode.content[0].attrs.type, 'msg')
     assert.equal(retryNode.content[0].attrs.count, '2')
 
+    const statusRetry = buildGroupRetryMessageNode({
+        to: 'status@broadcast',
+        type: 'text',
+        id: 'id-status',
+        requesterJid: '5511:3@lid',
+        encType: 'pkmsg',
+        ciphertext: new Uint8Array([1]),
+        retryCount: 1,
+        metaNode: buildMetaNode({ status_setting: 'denylist' })
+    })
+    // status@broadcast retries omit `addressing_mode`
+    assert.equal(statusRetry.attrs.addressing_mode, undefined)
+    if (!Array.isArray(statusRetry.content)) {
+        throw new Error('expected status retry content array')
+    }
+    assert.equal(statusRetry.content[0].tag, 'meta')
+    assert.equal(statusRetry.content[0].attrs.status_setting, 'denylist')
+    assert.equal(statusRetry.content[1].tag, 'enc')
+
     const inboundRetry = buildReceiptNode({
         kind: 'retry',
         node: {

--- a/src/transport/node/builders/message.ts
+++ b/src/transport/node/builders/message.ts
@@ -4,8 +4,8 @@ import type { BinaryNode } from '@transport/types'
 
 interface EncryptedParticipant {
     readonly jid: string
-    readonly encType: 'msg' | 'pkmsg'
-    readonly ciphertext: Uint8Array
+    readonly encType?: 'msg' | 'pkmsg'
+    readonly ciphertext?: Uint8Array
 }
 
 type DirectMessageFanoutInput = {
@@ -39,12 +39,14 @@ type GroupRetryMessageInput = {
     readonly type: string
     readonly id: string
     readonly requesterJid: string
-    readonly addressingMode: 'pn' | 'lid'
+    // omit `addressing_mode` for status@broadcast retries.
+    readonly addressingMode?: 'pn' | 'lid'
     readonly encType: 'msg' | 'pkmsg'
     readonly ciphertext: Uint8Array
     readonly retryCount: number
     readonly deviceIdentity?: Uint8Array
     readonly mediatype?: string
+    readonly metaNode?: BinaryNode
 }
 
 function buildEncAttrs(
@@ -93,6 +95,10 @@ function buildMessageAttrs(input: {
 }
 
 function buildEncryptedToNode(p: EncryptedParticipant, mediatype?: string): BinaryNode {
+    // Status broadcast viewers without ciphertext get a bare `<to jid>`.
+    if (!p.encType || !p.ciphertext) {
+        return { tag: 'to', attrs: { jid: p.jid } }
+    }
     return {
         tag: 'to',
         attrs: { jid: p.jid },
@@ -220,13 +226,15 @@ export function buildGroupSenderKeyMessageNode(input: GroupSenderKeyMessageInput
 }
 
 export function buildGroupRetryMessageNode(input: GroupRetryMessageInput): BinaryNode {
-    const content: BinaryNode[] = [
-        {
-            tag: WA_MESSAGE_TAGS.ENC,
-            attrs: buildEncAttrs(input.encType, input.mediatype, input.retryCount),
-            content: input.ciphertext
-        }
-    ]
+    const content: BinaryNode[] = []
+    if (input.metaNode) {
+        content.push(input.metaNode)
+    }
+    content.push({
+        tag: WA_MESSAGE_TAGS.ENC,
+        attrs: buildEncAttrs(input.encType, input.mediatype, input.retryCount),
+        content: input.ciphertext
+    })
     if (input.deviceIdentity) {
         content.push({
             tag: WA_NODE_TAGS.DEVICE_IDENTITY,
@@ -235,15 +243,18 @@ export function buildGroupRetryMessageNode(input: GroupRetryMessageInput): Binar
         })
     }
 
+    const attrs: Record<string, string> = {
+        to: input.to,
+        type: input.type,
+        id: input.id,
+        participant: input.requesterJid
+    }
+    if (input.addressingMode) {
+        attrs.addressing_mode = input.addressingMode
+    }
     return {
         tag: WA_MESSAGE_TAGS.MESSAGE,
-        attrs: {
-            to: input.to,
-            type: input.type,
-            id: input.id,
-            participant: input.requesterJid,
-            addressing_mode: input.addressingMode
-        },
+        attrs,
         content
     }
 }

--- a/src/transport/node/builders/message.ts
+++ b/src/transport/node/builders/message.ts
@@ -95,9 +95,12 @@ function buildMessageAttrs(input: {
 }
 
 function buildEncryptedToNode(p: EncryptedParticipant, mediatype?: string): BinaryNode {
-    // Status broadcast viewers without ciphertext get a bare `<to jid>`.
-    if (!p.encType || !p.ciphertext) {
+    // Status broadcast viewers without an encrypted payload get a bare `<to jid>`.
+    if (!p.encType && !p.ciphertext) {
         return { tag: 'to', attrs: { jid: p.jid } }
+    }
+    if (!p.encType || !p.ciphertext) {
+        throw new Error(`invalid encrypted participant payload for ${p.jid}`)
     }
     return {
         tag: 'to',


### PR DESCRIPTION
New `client.status.*` API for WhatsApp status (story) flows:

- `client.status.setPrivacy(input)` — change who can see your status: CONTACTS / ALLOWLIST / DENYLIST / CLOSE_FRIENDS, plus optional userJids list and shareToFB / shareToIG flags. Syncs to all linked devices.

- `client.status.setUserMuted(jid, muted)` — mute / unmute a contact's status from your timeline. Syncs to all linked devices.

- `client.status.sendStatus(input)` — post a text or media status to a list of recipients (LIDs). Pass any `WaSendMessageContent`: string, styled text (extendedTextMessage with `backgroundArgb`/`textArgb`/ `font`), image, video, audio (incl. PTT with `backgroundArgb`), sticker, or a pre-built `Proto.IMessage`. `statusSetting` controls the meta attribute the server uses to route the broadcast (defaults to `contacts`).

- `client.status.revokeStatus(input)` — emit a REVOKE protocolMessage targeting an earlier status by id.

Reading status receipts uses the standard `client.sendReceipt('status@broadcast', stanzaId, { type: 'read' | 'played', recipient: senderLid })` — no dedicated method needed.

New `client.broadcastList.*` API for business broadcast lists:

- `setList({ id, listName, participants, labelIds })`, `removeList(id)`, and `sendMessage({ listJid, content, recipients, options? })` for fan-out messaging to a stored business broadcast list.

New `account_event` event in the WaClientEventMap:

App-state mutations applied on this device (typically pushed from another device of the same account) now emit a typed `account_event` with one of four actions:

- `status_privacy` — privacy setting changed elsewhere (new mode, userJids, FB/IG share flags)
- `user_status_mute` — a contact's status was muted / unmuted on another device
- `business_broadcast_list_set` — broadcast list created or updated
- `business_broadcast_list_remove` — broadcast list deleted

Useful for bots / backends that mirror account-level preferences in real time.

Status retry parity with wa-mob:

Status@broadcast retry stanzas now match the wa-mob shape exactly: they echo `<meta status_setting>`, omit `addressing_mode`, and use the standard direct retry envelope (pairwise-encrypted plaintext via Signal). Routes through the standard group-retry replay path. Drops the previous sender-key republish flow that the receiver never picked up because the stanza shape was wrong.

Other internals:

- New `WA_STATUS_DISTRIBUTION_SETTINGS` constant and `WaStatusDistributionSetting` type so the setting strings are typed end-to-end.
- `isStatusBroadcastJid` JID helper.
- Dispatch extracts a `publishSenderKeyFanout` private helper that centralizes the encrypt → distribute → publish → mark-distributed pipeline shared by status and broadcast lists.
- `buildGroupRetryMessageNode` gains optional `metaNode` and optional `addressingMode` (omitted for status).
- `buildEncryptedToNode` emits a bare `<to jid>` for status broadcast viewers that don't receive ciphertext.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status messaging capabilities: send and revoke status messages with privacy controls
  * Added status privacy management to control who can view your status
  * Added user status mute functionality
  * Added broadcast list management and messaging: create, manage, and send messages to broadcast lists
  * Added account event notifications for status and broadcast list changes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/65)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->