### PR TITLE
feat(message): peer data operation requester

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -58,6 +58,7 @@ import {
 } from '@message/addon-crypto'
 import { decryptBotChunk } from '@message/bot'
 import { unwrapMessage } from '@message/content'
+import type { PeerDataOperationRequester } from '@message/peer-data-operation'
 import type {
     WaMessagePublishResult,
     WaSendMessageContent,
@@ -162,6 +163,7 @@ export class WaClient extends EventEmitter {
     private readonly receiptQueue!: WaReceiptQueue
     private readonly connectionManager!: WaConnectionManager
     private readonly trustedContactToken!: WaTrustedContactTokenCoordinator
+    private readonly peerDataOperation!: PeerDataOperationRequester
     private readonly writeBehind!: WriteBehindPersistence
     private connectPromise: Promise<void> | null = null
     private acceptingIncomingEvents = true
@@ -226,6 +228,12 @@ export class WaClient extends EventEmitter {
                 clearStoredState: this.clearStoredState.bind(this),
                 resumeIncomingEvents: () => {
                     this.acceptingIncomingEvents = true
+                },
+                subscribeProtocolMessage: (handler) => {
+                    this.on('message_protocol', handler)
+                    return () => {
+                        this.off('message_protocol', handler)
+                    }
                 }
             }
         })

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -64,6 +64,7 @@ import type {
     WaClientEventMap,
     WaClientOptions,
     WaIncomingMessageEvent,
+    WaIncomingProtocolMessageEvent,
     WaIncomingUnhandledStanzaEvent,
     WaNewsletterEventAction
 } from '@client/types'
@@ -71,6 +72,10 @@ import type { Logger } from '@infra/log/types'
 import type { WaMediaConn } from '@media/types'
 import { WaMediaTransferClient } from '@media/WaMediaTransferClient'
 import { handleIncomingMessageAck } from '@message/incoming'
+import {
+    createPeerDataOperationRequester,
+    type PeerDataOperationRequester
+} from '@message/peer-data-operation'
 import { WaMessageClient } from '@message/WaMessageClient'
 import {
     getWaCompanionPlatformId,
@@ -139,6 +144,9 @@ interface WaClientBuildRuntime {
     readonly handleIncomingFrame: (frame: Uint8Array) => Promise<void>
     readonly clearStoredState: () => Promise<void>
     readonly resumeIncomingEvents: () => void
+    readonly subscribeProtocolMessage: (
+        handler: (event: WaIncomingProtocolMessageEvent) => void
+    ) => () => void
 }
 
 interface WaClientDependencies {
@@ -177,6 +185,7 @@ interface WaClientDependencies {
     readonly connectionManager: WaConnectionManager
     readonly trustedContactToken: WaTrustedContactTokenCoordinator
     readonly abPropsCoordinator: WaAbPropsCoordinator
+    readonly peerDataOperation: PeerDataOperationRequester
 }
 
 function assertProxyTransport(value: unknown, path: string): void {
@@ -651,8 +660,8 @@ export function buildWaClientDependencies(input: {
     let messageDispatch!: WaMessageDispatchCoordinator
 
     const appStateSyncKeyProtocol = createAppStateSyncKeyProtocol({
-        publishSignalMessage: (signalInput, publishOptions) =>
-            messageDispatch.publishSignalMessage(signalInput, publishOptions),
+        publishProtocolMessageToDevice: (deviceJid, protocolMessage, opts) =>
+            messageDispatch.publishProtocolMessageToDevice(deviceJid, protocolMessage, opts),
         fanoutResolver,
         getCurrentMeJid,
         getCurrentMeLid,
@@ -1161,6 +1170,15 @@ export function buildWaClientDependencies(input: {
         }
     })
 
+    const peerDataOperation = createPeerDataOperationRequester({
+        logger,
+        publishProtocolMessageToDevice: (deviceJid, protocolMessage, opts) =>
+            messageDispatch.publishProtocolMessageToDevice(deviceJid, protocolMessage, opts),
+        getCurrentMeJid,
+        generateOutgoingMessageId: () => messageDispatch.generateOutgoingMessageId(),
+        subscribeToProtocolMessage: runtime.subscribeProtocolMessage
+    })
+
     passiveTasks = new WaPassiveTasksCoordinator({
         logger,
         signalStore: sessionStore.signal,
@@ -1214,6 +1232,7 @@ export function buildWaClientDependencies(input: {
         receiptQueue,
         connectionManager,
         trustedContactToken,
-        abPropsCoordinator
+        abPropsCoordinator,
+        peerDataOperation
     }
 }

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -356,7 +356,8 @@ test('buildWaClientDependencies wires privacy coordinator', () => {
         handleError: (_error: Error) => undefined,
         handleIncomingFrame: async (_frame: Uint8Array) => undefined,
         clearStoredState: async () => undefined,
-        resumeIncomingEvents: () => undefined
+        resumeIncomingEvents: () => undefined,
+        subscribeProtocolMessage: () => () => undefined
     }
 
     const dependencies = buildWaClientDependencies({ base, runtime })
@@ -398,7 +399,8 @@ test('buildWaClientDependencies wires trusted contact token AB prop overrides', 
         handleError: (_error: Error) => undefined,
         handleIncomingFrame: async (_frame: Uint8Array) => undefined,
         clearStoredState: async () => undefined,
-        resumeIncomingEvents: () => undefined
+        resumeIncomingEvents: () => undefined,
+        subscribeProtocolMessage: () => () => undefined
     }
 
     const dependencies = buildWaClientDependencies({ base, runtime })

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -435,6 +435,21 @@ export class WaMessageDispatchCoordinator {
         await this.messageClient.sendReceipt(input)
     }
 
+    public async publishProtocolMessageToDevice(
+        deviceJid: string,
+        protocolMessage: Proto.Message.IProtocolMessage,
+        options?: { readonly id?: string }
+    ): Promise<WaMessagePublishResult> {
+        return this.publishSignalMessage({
+            to: deviceJid,
+            plaintext: proto.Message.encode({ protocolMessage }).finish(),
+            id: options?.id,
+            type: 'text',
+            category: 'peer',
+            pushPriority: 'high'
+        })
+    }
+
     public async publishStatusMessage(input: {
         readonly message: Proto.IMessage
         readonly recipients: readonly string[]

--- a/src/client/messaging/__tests__/messaging.test.ts
+++ b/src/client/messaging/__tests__/messaging.test.ts
@@ -6,6 +6,7 @@ import { createAppStateSyncKeyProtocol } from '@client/messaging/key-protocol'
 import { createGroupParticipantsCache } from '@client/messaging/participants'
 import type { WaGroupEvent, WaGroupEventAction } from '@client/types'
 import type { Logger } from '@infra/log/types'
+import { proto } from '@proto'
 import { WaParticipantsMemoryStore } from '@store/providers/memory/participants.store'
 
 function createLogger(): Logger {
@@ -167,13 +168,13 @@ test('group participants cache mutates membership from events', async () => {
 })
 
 test('app-state sync key protocol requests keys from peer devices and dedupes key ids', async () => {
-    const published: { readonly to: string; readonly type?: string }[] = []
+    const published: { readonly to: string; readonly protocolType?: number | null }[] = []
 
     const protocol = createAppStateSyncKeyProtocol({
-        publishSignalMessage: async (input) => {
+        publishProtocolMessageToDevice: async (deviceJid, protocolMessage) => {
             published.push({
-                to: input.to,
-                type: input.type
+                to: deviceJid,
+                protocolType: protocolMessage.type
             })
             return {
                 id: 'msg-id',
@@ -209,5 +210,10 @@ test('app-state sync key protocol requests keys from peer devices and dedupes ke
         '551100000000:3@s.whatsapp.net'
     ])
     assert.equal(published.length, 2)
-    assert.ok(published.every((entry) => entry.type === 'protocol'))
+    assert.ok(
+        published.every(
+            (entry) =>
+                entry.protocolType === proto.Message.ProtocolMessage.Type.APP_STATE_SYNC_KEY_REQUEST
+        )
+    )
 })

--- a/src/client/messaging/key-protocol.ts
+++ b/src/client/messaging/key-protocol.ts
@@ -1,16 +1,15 @@
 import type { WaAppStateSyncKey } from '@appstate/types'
 import type { DeviceFanoutResolver } from '@client/messaging/fanout'
-import type { WaSignalMessagePublishInput } from '@client/types'
 import type { Logger } from '@infra/log/types'
-import { writeRandomPadMax16 } from '@message/padding'
-import type { WaMessagePublishOptions, WaMessagePublishResult } from '@message/types'
+import type { WaMessagePublishResult } from '@message/types'
 import { type Proto, proto } from '@proto'
 import { normalizeDeviceJid } from '@protocol/jid'
 import { bytesToHex } from '@util/bytes'
 
-type PublishSignalMessageFn = (
-    input: WaSignalMessagePublishInput,
-    options?: WaMessagePublishOptions
+export type PublishProtocolMessageToDeviceFn = (
+    deviceJid: string,
+    protocolMessage: Proto.Message.IProtocolMessage,
+    options?: { readonly id?: string }
 ) => Promise<WaMessagePublishResult>
 
 export type AppStateSyncKeyProtocol = {
@@ -23,14 +22,19 @@ export type AppStateSyncKeyProtocol = {
 }
 
 export function createAppStateSyncKeyProtocol(options: {
-    readonly publishSignalMessage: PublishSignalMessageFn
+    readonly publishProtocolMessageToDevice: PublishProtocolMessageToDeviceFn
     readonly fanoutResolver: DeviceFanoutResolver
     readonly getCurrentMeJid: () => string | null | undefined
     readonly getCurrentMeLid: () => string | null | undefined
     readonly logger: Logger
 }): AppStateSyncKeyProtocol {
-    const { publishSignalMessage, fanoutResolver, getCurrentMeJid, getCurrentMeLid, logger } =
-        options
+    const {
+        publishProtocolMessageToDevice,
+        fanoutResolver,
+        getCurrentMeJid,
+        getCurrentMeLid,
+        logger
+    } = options
 
     const requireCurrentIdentity = (context: string): void => {
         const meJid = getCurrentMeJid()
@@ -39,24 +43,6 @@ export function createAppStateSyncKeyProtocol(options: {
             return
         }
         throw new Error(`${context} requires registered identity`)
-    }
-
-    const publishProtocolMessageToDevice = async (
-        deviceJid: string,
-        protocolMessage: proto.Message.IProtocolMessage
-    ): Promise<void> => {
-        const plaintext = await writeRandomPadMax16(
-            proto.Message.encode({
-                protocolMessage
-            }).finish()
-        )
-        await publishSignalMessage({
-            to: deviceJid,
-            plaintext,
-            type: 'protocol',
-            category: 'peer',
-            pushPriority: 'high'
-        })
     }
 
     const requestKeys = async (keyIds: readonly Uint8Array[]): Promise<readonly string[]> => {

--- a/src/message/__tests__/peer-data-operation.test.ts
+++ b/src/message/__tests__/peer-data-operation.test.ts
@@ -1,0 +1,259 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { WaIncomingProtocolMessageEvent } from '@client/types'
+import type { Logger } from '@infra/log/types'
+import { createPeerDataOperationRequester } from '@message/peer-data-operation'
+import type { WaMessagePublishResult } from '@message/types'
+import { proto, type Proto } from '@proto'
+
+function createLogger(): Logger {
+    return {
+        level: 'trace',
+        trace: () => undefined,
+        debug: () => undefined,
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined
+    }
+}
+
+interface PublishedRequest {
+    readonly deviceJid: string
+    readonly protocolMessage: Proto.Message.IProtocolMessage
+    readonly id: string
+}
+
+interface RequesterHarness {
+    readonly requester: ReturnType<typeof createPeerDataOperationRequester>
+    readonly published: PublishedRequest[]
+    readonly emitResponse: (
+        stanzaId: string | undefined | null,
+        results?: readonly Proto.Message.PeerDataOperationRequestResponseMessage.IPeerDataOperationResult[]
+    ) => void
+    readonly emitProtocol: (event: WaIncomingProtocolMessageEvent) => void
+    readonly listeners: Set<(event: WaIncomingProtocolMessageEvent) => void>
+}
+
+function createHarness(opts?: {
+    readonly defaultTimeoutMs?: number
+    readonly maxPending?: number
+}): RequesterHarness {
+    const published: PublishedRequest[] = []
+    const listeners = new Set<(event: WaIncomingProtocolMessageEvent) => void>()
+    let counter = 0
+
+    const requester = createPeerDataOperationRequester({
+        logger: createLogger(),
+        publishProtocolMessageToDevice: async (deviceJid, protocolMessage, options) => {
+            const id = options?.id ?? `auto-${counter}`
+            counter += 1
+            published.push({ deviceJid, protocolMessage, id })
+            return { id } as WaMessagePublishResult
+        },
+        getCurrentMeJid: () => '5511920387975:0@s.whatsapp.net',
+        generateOutgoingMessageId: async () => {
+            const id = `msg-${counter}`
+            counter += 1
+            return id
+        },
+        subscribeToProtocolMessage: (handler) => {
+            listeners.add(handler)
+            return () => {
+                listeners.delete(handler)
+            }
+        },
+        defaultTimeoutMs: opts?.defaultTimeoutMs ?? 5_000,
+        maxPending: opts?.maxPending
+    })
+
+    const emitProtocol = (event: WaIncomingProtocolMessageEvent): void => {
+        for (const listener of listeners) {
+            listener(event)
+        }
+    }
+
+    const emitResponse: RequesterHarness['emitResponse'] = (stanzaId, results = []) => {
+        emitProtocol({
+            rawNode: { tag: 'message', attrs: {} },
+            isGroupChat: false,
+            isBroadcastChat: false,
+            protocolMessage: {
+                type: proto.Message.ProtocolMessage.Type
+                    .PEER_DATA_OPERATION_REQUEST_RESPONSE_MESSAGE,
+                peerDataOperationRequestResponseMessage: {
+                    stanzaId: stanzaId ?? undefined,
+                    peerDataOperationResult: [...results]
+                }
+            }
+        })
+    }
+
+    return { requester, published, emitResponse, emitProtocol, listeners }
+}
+
+async function flushMicrotasks(): Promise<void> {
+    await new Promise<void>((resolve) => setImmediate(resolve))
+}
+
+test('request publishes a PDO request to self user lid and resolves on matching response', async () => {
+    const harness = createHarness()
+
+    const promise = harness.requester.request(
+        proto.Message.PeerDataOperationRequestType.PLACEHOLDER_MESSAGE_RESEND,
+        {
+            placeholderMessageResendRequest: [
+                {
+                    messageKey: {
+                        remoteJid: '123@s.whatsapp.net',
+                        fromMe: false,
+                        id: 'orig-1'
+                    }
+                }
+            ]
+        }
+    )
+    await flushMicrotasks()
+
+    assert.equal(harness.published.length, 1)
+    const sent = harness.published[0]
+    assert.equal(sent.deviceJid, '5511920387975@s.whatsapp.net')
+    assert.equal(
+        sent.protocolMessage.type,
+        proto.Message.ProtocolMessage.Type.PEER_DATA_OPERATION_REQUEST_MESSAGE
+    )
+    const reqMsg = sent.protocolMessage.peerDataOperationRequestMessage
+    assert.equal(
+        reqMsg?.peerDataOperationRequestType,
+        proto.Message.PeerDataOperationRequestType.PLACEHOLDER_MESSAGE_RESEND
+    )
+    assert.equal(reqMsg?.placeholderMessageResendRequest?.length, 1)
+
+    harness.emitResponse(sent.id, [
+        {
+            placeholderMessageResendResponse: { webMessageInfoBytes: new Uint8Array([1, 2, 3]) }
+        }
+    ])
+
+    const results = await promise
+    assert.equal(results.length, 1)
+    assert.deepEqual(
+        results[0].placeholderMessageResendResponse?.webMessageInfoBytes,
+        new Uint8Array([1, 2, 3])
+    )
+})
+
+test('request rejects with timeout error after configured timeout', async () => {
+    const harness = createHarness({ defaultTimeoutMs: 20 })
+
+    await assert.rejects(
+        harness.requester.request(
+            proto.Message.PeerDataOperationRequestType.HISTORY_SYNC_ON_DEMAND,
+            { historySyncOnDemandRequest: { chatJid: 'a@s.whatsapp.net' } }
+        ),
+        /timed out/
+    )
+})
+
+test('request honours per-call timeout override', async () => {
+    const harness = createHarness({ defaultTimeoutMs: 5_000 })
+
+    const start = Date.now()
+    await assert.rejects(
+        harness.requester.request(
+            proto.Message.PeerDataOperationRequestType.UPLOAD_STICKER,
+            { requestStickerReupload: [{ fileSha256: 'abc' }] },
+            { timeoutMs: 25 }
+        ),
+        /timed out/
+    )
+    assert.ok(Date.now() - start < 1_000, 'should not wait for default timeout')
+})
+
+test('irrelevant or unmatched protocol messages do not resolve pending requests', async () => {
+    const harness = createHarness({ defaultTimeoutMs: 40 })
+
+    const promise = harness.requester.request(
+        proto.Message.PeerDataOperationRequestType.GENERATE_LINK_PREVIEW,
+        { requestUrlPreview: [{ url: 'https://example.com' }] }
+    )
+    harness.emitProtocol({
+        rawNode: { tag: 'message', attrs: {} },
+        isGroupChat: false,
+        isBroadcastChat: false,
+        protocolMessage: {
+            type: proto.Message.ProtocolMessage.Type.APP_STATE_SYNC_KEY_REQUEST
+        }
+    })
+    harness.emitResponse(undefined, [])
+    harness.emitResponse('unrelated-id', [])
+
+    await assert.rejects(promise, /timed out/)
+})
+
+test('multiple concurrent requests correlate independently by stanzaId', async () => {
+    const harness = createHarness()
+
+    const promiseA = harness.requester.request(
+        proto.Message.PeerDataOperationRequestType.UPLOAD_STICKER,
+        { requestStickerReupload: [{ fileSha256: 'a' }] }
+    )
+    const promiseB = harness.requester.request(
+        proto.Message.PeerDataOperationRequestType.UPLOAD_STICKER,
+        { requestStickerReupload: [{ fileSha256: 'b' }] }
+    )
+    await flushMicrotasks()
+
+    assert.notEqual(harness.published[0].id, harness.published[1].id)
+
+    harness.emitResponse(harness.published[1].id, [
+        { stickerMessage: { fileSha256: new Uint8Array([0xbb]) } }
+    ])
+    harness.emitResponse(harness.published[0].id, [
+        { stickerMessage: { fileSha256: new Uint8Array([0xaa]) } }
+    ])
+
+    const [resA, resB] = await Promise.all([promiseA, promiseB])
+    assert.deepEqual(resA[0].stickerMessage?.fileSha256, new Uint8Array([0xaa]))
+    assert.deepEqual(resB[0].stickerMessage?.fileSha256, new Uint8Array([0xbb]))
+})
+
+test('send returns published message id without registering pending entry', async () => {
+    const harness = createHarness()
+
+    const result = await harness.requester.send(
+        proto.Message.PeerDataOperationRequestType.PLACEHOLDER_MESSAGE_RESEND,
+        {
+            placeholderMessageResendRequest: [
+                { messageKey: { remoteJid: '1@s.whatsapp.net', fromMe: false, id: 'x' } }
+            ]
+        }
+    )
+    assert.equal(result.messageId, harness.published[0].id)
+})
+
+test('bounded pending map evicts oldest entry when full', async () => {
+    const harness = createHarness({ defaultTimeoutMs: 5_000, maxPending: 2 })
+
+    const promiseA = harness.requester.request(
+        proto.Message.PeerDataOperationRequestType.UPLOAD_STICKER,
+        { requestStickerReupload: [{ fileSha256: 'a' }] }
+    )
+    const promiseB = harness.requester.request(
+        proto.Message.PeerDataOperationRequestType.UPLOAD_STICKER,
+        { requestStickerReupload: [{ fileSha256: 'b' }] }
+    )
+    const promiseC = harness.requester.request(
+        proto.Message.PeerDataOperationRequestType.UPLOAD_STICKER,
+        { requestStickerReupload: [{ fileSha256: 'c' }] }
+    )
+
+    await assert.rejects(promiseA, /evicted/i)
+
+    harness.emitResponse(harness.published[1].id, [])
+    harness.emitResponse(harness.published[2].id, [])
+
+    const [resB, resC] = await Promise.all([promiseB, promiseC])
+    assert.equal(resB.length, 0)
+    assert.equal(resC.length, 0)
+})

--- a/src/message/ack.ts
+++ b/src/message/ack.ts
@@ -12,6 +12,9 @@ export function isNegativeAckNode(node: BinaryNode): boolean {
     if (node.tag !== WA_MESSAGE_TAGS.ACK) {
         return false
     }
+    if (node.attrs.error) {
+        return true
+    }
     const ackType = node.attrs.type
     const ackClass = node.attrs.class
     return (
@@ -37,6 +40,7 @@ export function describeAckNode(node: BinaryNode): string {
     const type = node.attrs.type
     const ackClass = node.attrs.class
     const code = node.attrs.code
+    const error = node.attrs.error
     if (id) {
         description += ` id=${id}`
     }
@@ -48,6 +52,9 @@ export function describeAckNode(node: BinaryNode): string {
     }
     if (code) {
         description += ` code=${code}`
+    }
+    if (error) {
+        description += ` error=${error}`
     }
     return description
 }

--- a/src/message/peer-data-operation.ts
+++ b/src/message/peer-data-operation.ts
@@ -105,13 +105,13 @@ export function createPeerDataOperationRequester(
 
     const publish = async (
         type: Proto.Message.PeerDataOperationRequestType,
-        body: Proto.Message.IPeerDataOperationRequestMessage
+        body: Proto.Message.IPeerDataOperationRequestMessage,
+        id: string
     ): Promise<string> => {
         const meJid = getCurrentMeJid()
         if (!meJid) {
             throw new Error('peer data operation requires current me jid')
         }
-        const id = await generateOutgoingMessageId()
         const result = await publishProtocolMessageToDevice(
             toUserJid(meJid),
             buildRequestProtocolMessage(type, body),
@@ -122,9 +122,11 @@ export function createPeerDataOperationRequester(
 
     return {
         request: async (type, body, requestOptions) => {
-            const messageId = await publish(type, body)
+            const messageId = await generateOutgoingMessageId()
             const timeoutMs = requestOptions?.timeoutMs ?? defaultTimeoutMs
-            return new Promise((resolve, reject) => {
+            return new Promise<
+                readonly Proto.Message.PeerDataOperationRequestResponseMessage.IPeerDataOperationResult[]
+            >((resolve, reject) => {
                 const timeout = setTimeout(() => {
                     if (!pending.delete(messageId)) {
                         return
@@ -138,9 +140,6 @@ export function createPeerDataOperationRequester(
                 }, timeoutMs)
                 const entry: PendingPdo = { resolve, reject, timeout }
                 setBoundedMapEntry(pending, messageId, entry, maxPending, (evictedKey, evicted) => {
-                    if (evictedKey === messageId) {
-                        return
-                    }
                     clearTimeout(evicted.timeout)
                     logger.warn('pdo pending entry evicted: capacity reached', {
                         evictedId: evictedKey,
@@ -152,8 +151,17 @@ export function createPeerDataOperationRequester(
                         )
                     )
                 })
+                publish(type, body, messageId).catch((error) => {
+                    clearTimeout(timeout)
+                    if (pending.delete(messageId)) {
+                        reject(error instanceof Error ? error : new Error(String(error)))
+                    }
+                })
             })
         },
-        send: async (type, body) => ({ messageId: await publish(type, body) })
+        send: async (type, body) => {
+            const messageId = await generateOutgoingMessageId()
+            return { messageId: await publish(type, body, messageId) }
+        }
     }
 }

--- a/src/message/peer-data-operation.ts
+++ b/src/message/peer-data-operation.ts
@@ -1,0 +1,159 @@
+import type { PublishProtocolMessageToDeviceFn } from '@client/messaging/key-protocol'
+import type { WaIncomingProtocolMessageEvent } from '@client/types'
+import type { Logger } from '@infra/log/types'
+import { proto, type Proto } from '@proto'
+import { toUserJid } from '@protocol/jid'
+import { setBoundedMapEntry } from '@util/collections'
+
+export interface PeerDataOperationRequesterOptions {
+    readonly logger: Logger
+    readonly publishProtocolMessageToDevice: PublishProtocolMessageToDeviceFn
+    readonly getCurrentMeJid: () => string | null | undefined
+    readonly generateOutgoingMessageId: () => Promise<string>
+    readonly subscribeToProtocolMessage: (
+        handler: (event: WaIncomingProtocolMessageEvent) => void
+    ) => () => void
+    readonly defaultTimeoutMs?: number
+    readonly maxPending?: number
+}
+
+export interface PeerDataOperationRequester {
+    readonly request: (
+        type: Proto.Message.PeerDataOperationRequestType,
+        body: Proto.Message.IPeerDataOperationRequestMessage,
+        options?: { readonly timeoutMs?: number }
+    ) => Promise<
+        readonly Proto.Message.PeerDataOperationRequestResponseMessage.IPeerDataOperationResult[]
+    >
+    readonly send: (
+        type: Proto.Message.PeerDataOperationRequestType,
+        body: Proto.Message.IPeerDataOperationRequestMessage
+    ) => Promise<{ readonly messageId: string }>
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000
+const DEFAULT_MAX_PENDING = 256
+
+interface PendingPdo {
+    readonly resolve: (
+        results: readonly Proto.Message.PeerDataOperationRequestResponseMessage.IPeerDataOperationResult[]
+    ) => void
+    readonly reject: (error: Error) => void
+    readonly timeout: ReturnType<typeof setTimeout>
+}
+
+function buildRequestProtocolMessage(
+    type: Proto.Message.PeerDataOperationRequestType,
+    body: Proto.Message.IPeerDataOperationRequestMessage
+): Proto.Message.IProtocolMessage {
+    return {
+        type: proto.Message.ProtocolMessage.Type.PEER_DATA_OPERATION_REQUEST_MESSAGE,
+        peerDataOperationRequestMessage: {
+            ...body,
+            peerDataOperationRequestType: type
+        }
+    }
+}
+
+export function createPeerDataOperationRequester(
+    options: PeerDataOperationRequesterOptions
+): PeerDataOperationRequester {
+    const {
+        logger,
+        publishProtocolMessageToDevice,
+        getCurrentMeJid,
+        generateOutgoingMessageId,
+        subscribeToProtocolMessage
+    } = options
+    const defaultTimeoutMs = options.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS
+    const maxPending = options.maxPending ?? DEFAULT_MAX_PENDING
+    const pending = new Map<string, PendingPdo>()
+
+    subscribeToProtocolMessage((event) => {
+        const protocolMessage = event.protocolMessage
+        if (
+            protocolMessage.type !==
+            proto.Message.ProtocolMessage.Type.PEER_DATA_OPERATION_REQUEST_RESPONSE_MESSAGE
+        ) {
+            return
+        }
+        const response = protocolMessage.peerDataOperationRequestResponseMessage
+        if (!response) {
+            return
+        }
+        const stanzaId = response.stanzaId
+        const results = response.peerDataOperationResult ?? []
+        if (!stanzaId) {
+            logger.debug('pdo response without stanzaId', {
+                from: event.chatJid,
+                resultCount: results.length
+            })
+            return
+        }
+        const entry = pending.get(stanzaId)
+        if (!entry) {
+            logger.debug('pdo response for unknown stanzaId', {
+                stanzaId,
+                resultCount: results.length
+            })
+            return
+        }
+        clearTimeout(entry.timeout)
+        pending.delete(stanzaId)
+        entry.resolve(results)
+    })
+
+    const publish = async (
+        type: Proto.Message.PeerDataOperationRequestType,
+        body: Proto.Message.IPeerDataOperationRequestMessage
+    ): Promise<string> => {
+        const meJid = getCurrentMeJid()
+        if (!meJid) {
+            throw new Error('peer data operation requires current me jid')
+        }
+        const id = await generateOutgoingMessageId()
+        const result = await publishProtocolMessageToDevice(
+            toUserJid(meJid),
+            buildRequestProtocolMessage(type, body),
+            { id }
+        )
+        return result.id
+    }
+
+    return {
+        request: async (type, body, requestOptions) => {
+            const messageId = await publish(type, body)
+            const timeoutMs = requestOptions?.timeoutMs ?? defaultTimeoutMs
+            return new Promise((resolve, reject) => {
+                const timeout = setTimeout(() => {
+                    if (!pending.delete(messageId)) {
+                        return
+                    }
+                    logger.debug('pdo request timed out', { messageId, timeoutMs, type })
+                    reject(
+                        new Error(
+                            `peer data operation timed out after ${timeoutMs}ms (id=${messageId})`
+                        )
+                    )
+                }, timeoutMs)
+                const entry: PendingPdo = { resolve, reject, timeout }
+                setBoundedMapEntry(pending, messageId, entry, maxPending, (evictedKey, evicted) => {
+                    if (evictedKey === messageId) {
+                        return
+                    }
+                    clearTimeout(evicted.timeout)
+                    logger.warn('pdo pending entry evicted: capacity reached', {
+                        evictedId: evictedKey,
+                        maxPending
+                    })
+                    evicted.reject(
+                        new Error(
+                            `peer data operation evicted from pending map (id=${String(evictedKey)})`
+                        )
+                    )
+                })
+            })
+        },
+        send: async (type, body) => ({ messageId: await publish(type, body) })
+    }
+}


### PR DESCRIPTION
Adds createPeerDataOperationRequester for sending PDO requests to the primary device and correlating responses by stanzaId. Supports both awaitable request (placeholder resend, history sync, link preview, syncd recovery) and fire-and-forget send (galaxy flow).

Extracts publishProtocolMessageToDevice onto WaMessageDispatchCoordinator so key-protocol and PDO share one peer publish trail (type=text, category=peer, push_priority=high, target=meJid PN form).

Validated end-to-end via MCP: link preview returned full metadata, syncd snapshot recovery returned real app-state data, placeholder resend recovered an actual message from primary.

Also fixes isNegativeAckNode to treat attrs.error as a negative ack (previously ack with error='479' was logged as positive, masking real publish rejections), and surfaces the error code in describeAckNode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added support for peer-data operation requests and responses.
  - Improved protocol-message routing and device-targeted protocol delivery.
  - App-state sync key protocol now uses the unified protocol-message publisher.

* **Bug Fixes**
  - Enhanced acknowledgement/receipt handling to detect and include error states.

* **Tests**
  - Added comprehensive peer-data-operation tests and updated protocol message tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/66)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->