### PR TITLE
feat(mcp-server): q/regex search on events and logs tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,29 @@ jobs:
             - name: run sqlite tests
               run: npm test -w packages/store-sqlite
 
+    test-mcp-server:
+        runs-on: ubuntu-latest
+        needs: test-core
+
+        steps:
+            - name: checkout repository
+              uses: actions/checkout@v4
+
+            - name: setup node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: npm
+
+            - name: install dependencies
+              run: npm ci
+
+            - name: build
+              run: npm run build && npx turbo run build --filter=@zapo-js/fake-server --filter=@zapo-js/store-sqlite --filter=@zapo-js/mcp-server
+
+            - name: run mcp-server tests
+              run: npm test -w packages/mcp-server
+
     test-mysql:
         runs-on: ubuntu-latest
         needs: test-core

--- a/packages/mcp-server/src/__tests__/runtime-logger.test.ts
+++ b/packages/mcp-server/src/__tests__/runtime-logger.test.ts
@@ -88,6 +88,60 @@ test('listLogs supports case-insensitive regex via q + regex flag', () => {
     assert.equal(malformed.length, 0)
 })
 
+interface RecordEventCapable {
+    recordEvent: (type: string, payload: unknown) => void
+}
+
+const recordEvent = (runtime: McpRuntime, type: string, payload: unknown): void => {
+    ;(runtime as unknown as RecordEventCapable).recordEvent(type, payload)
+}
+
+test('listEvents filters by q substring across type + payload', () => {
+    const runtime = new McpRuntime(baseConfig())
+    recordEvent(runtime, 'connection', { status: 'open' })
+    recordEvent(runtime, 'message', { chatJid: '120363@g.us', text: 'hi' })
+    recordEvent(runtime, 'message', { chatJid: '5511@s.whatsapp.net', text: 'yo' })
+    recordEvent(runtime, 'group_event', { action: 'add', participants: ['120363@g.us'] })
+
+    const byType = runtime.listEvents({ q: 'CONNECTION' })
+    assert.equal(byType.length, 1)
+    assert.equal(byType[0].type, 'connection')
+
+    const byPayloadJid = runtime.listEvents({ q: '120363' })
+    assert.equal(byPayloadJid.length, 2)
+    assert.deepStrictEqual(
+        byPayloadJid.map((e) => e.type),
+        ['message', 'group_event']
+    )
+
+    const none = runtime.listEvents({ q: 'no-such-thing' })
+    assert.equal(none.length, 0)
+})
+
+test('listEvents supports case-insensitive regex via q + regex flag', () => {
+    const runtime = new McpRuntime(baseConfig())
+    recordEvent(runtime, 'message', { id: '3EB001' })
+    recordEvent(runtime, 'message', { id: '3EB002' })
+    recordEvent(runtime, 'message', { id: 'OTHER' })
+
+    const matches = runtime.listEvents({ q: '3eb0\\d{2}', regex: true })
+    assert.equal(matches.length, 2)
+
+    const malformed = runtime.listEvents({ q: '(unclosed', regex: true })
+    assert.equal(malformed.length, 0)
+})
+
+test('listEvents q combines with types filter', () => {
+    const runtime = new McpRuntime(baseConfig())
+    recordEvent(runtime, 'message', { id: 'AAA-match' })
+    recordEvent(runtime, 'group_event', { id: 'AAA-match' })
+    recordEvent(runtime, 'message', { id: 'BBB' })
+
+    const matches = runtime.listEvents({ types: ['message'], q: 'aaa' })
+    assert.equal(matches.length, 1)
+    assert.equal(matches[0].type, 'message')
+})
+
 test('BufferedTeeLogger mirrors entries to the configured log file as JSONL', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'mcp-log-'))
     const logFilePath = join(dir, 'out.log')

--- a/packages/mcp-server/src/__tests__/runtime-logger.test.ts
+++ b/packages/mcp-server/src/__tests__/runtime-logger.test.ts
@@ -55,6 +55,39 @@ test('BufferedTeeLogger respects bufferLimit by dropping oldest entries', () => 
     )
 })
 
+test('listLogs filters by q substring across message + context', () => {
+    const runtime = new McpRuntime(baseConfig())
+    const logger = runtime.getLogger()
+    logger.info('boot', { sessionId: 'abc' })
+    logger.warn('publish failed', { id: 'XYZ123' })
+    logger.error('publish failed', { id: 'qqq' })
+
+    const byMessage = runtime.listLogs({ q: 'PUBLISH' })
+    assert.equal(byMessage.length, 2)
+
+    const byContext = runtime.listLogs({ q: 'xyz' })
+    assert.equal(byContext.length, 1)
+    assert.equal(byContext[0].message, 'publish failed')
+
+    const none = runtime.listLogs({ q: 'no-such-thing' })
+    assert.equal(none.length, 0)
+})
+
+test('listLogs supports case-insensitive regex via q + regex flag', () => {
+    const runtime = new McpRuntime(baseConfig())
+    const logger = runtime.getLogger()
+    logger.info('order 42 processed')
+    logger.info('order ab processed')
+    logger.error('boom')
+
+    const matches = runtime.listLogs({ q: 'ORDER \\d+', regex: true })
+    assert.equal(matches.length, 1)
+    assert.equal(matches[0].message, 'order 42 processed')
+
+    const malformed = runtime.listLogs({ q: '(unclosed', regex: true })
+    assert.equal(malformed.length, 0)
+})
+
 test('BufferedTeeLogger mirrors entries to the configured log file as JSONL', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'mcp-log-'))
     const logFilePath = join(dir, 'out.log')

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -39,9 +39,18 @@ class FakeClient {
     }
 }
 
-const buildFakeRuntime = (client: FakeClient): McpRuntime => {
+interface SpyableFakeRuntime extends McpRuntime {
+    readonly __lastEventsFilter: { value: Record<string, unknown> | null }
+    readonly __lastLogsFilter: { value: Record<string, unknown> | null }
+    __pushLog(entry: LogEntry): void
+    __pushEvent(entry: BufferedEvent): void
+}
+
+const buildFakeRuntime = (client: FakeClient): SpyableFakeRuntime => {
     const events: BufferedEvent[] = []
     const logs: LogEntry[] = []
+    const lastEventsFilter = { value: null as Record<string, unknown> | null }
+    const lastLogsFilter = { value: null as Record<string, unknown> | null }
     const config: RuntimeConfig = {
         authPath: '/tmp/test.sqlite',
         sessionId: 'test',
@@ -67,7 +76,10 @@ const buildFakeRuntime = (client: FakeClient): McpRuntime => {
         ensureClient: async () => client,
         getClient: () => client,
         async destroyClient() {},
-        listEvents: () => events,
+        listEvents: (filter: Record<string, unknown> = {}) => {
+            lastEventsFilter.value = filter
+            return events
+        },
         clearEvents: () => {
             const n = events.length
             events.length = 0
@@ -80,8 +92,11 @@ const buildFakeRuntime = (client: FakeClient): McpRuntime => {
                 limit?: number
                 levels?: readonly string[]
                 drain?: boolean
+                q?: string
+                regex?: boolean
             } = {}
         ) => {
+            lastLogsFilter.value = filter as Record<string, unknown>
             const lvSet = filter.levels && filter.levels.length > 0 ? new Set(filter.levels) : null
             const since = filter.since ?? 0
             const limit = filter.limit && filter.limit > 0 ? filter.limit : 100
@@ -103,15 +118,17 @@ const buildFakeRuntime = (client: FakeClient): McpRuntime => {
         bufferLogsSize: () => logs.length,
         async closeLogFile() {},
         resetSequences: () => undefined,
-        // test-only helpers: push synthetic entries
+        // test-only helpers: push synthetic entries + read last filter
         __pushLog: (entry: LogEntry) => {
             logs.push(entry)
         },
         __pushEvent: (entry: BufferedEvent) => {
             events.push(entry)
-        }
+        },
+        __lastEventsFilter: lastEventsFilter,
+        __lastLogsFilter: lastLogsFilter
     }
-    return fake as unknown as McpRuntime
+    return fake as unknown as SpyableFakeRuntime
 }
 
 const findTool = (name: string) => {
@@ -328,6 +345,48 @@ test('logs tool rejects invalid levels', async () => {
     const runtime = buildFakeRuntime(new FakeClient())
     const tool = findTool('logs')
     await assert.rejects(() => tool.handler({ levels: ['fatal'] }, runtime), /invalid level/)
+})
+
+test('logs tool forwards q and regex to runtime.listLogs', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('logs')
+    await tool.handler({ q: 'boom', regex: true, limit: 5 }, runtime)
+    const captured = runtime.__lastLogsFilter.value
+    assert.ok(captured, 'logs filter must be captured')
+    assert.equal(captured.q, 'boom')
+    assert.equal(captured.regex, true)
+    assert.equal(captured.limit, 5)
+})
+
+test('logs tool omits q/regex when not provided', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('logs')
+    await tool.handler({}, runtime)
+    const captured = runtime.__lastLogsFilter.value
+    assert.ok(captured)
+    assert.equal(captured.q, undefined)
+    assert.equal(captured.regex, false)
+})
+
+test('events tool forwards q and regex to runtime.listEvents', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('events')
+    await tool.handler({ q: '3EB0', regex: true, types: ['message'] }, runtime)
+    const captured = runtime.__lastEventsFilter.value
+    assert.ok(captured, 'events filter must be captured')
+    assert.equal(captured.q, '3EB0')
+    assert.equal(captured.regex, true)
+    assert.deepStrictEqual(captured.types, ['message'])
+})
+
+test('events tool omits q/regex when not provided', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('events')
+    await tool.handler({}, runtime)
+    const captured = runtime.__lastEventsFilter.value
+    assert.ok(captured)
+    assert.equal(captured.q, undefined)
+    assert.equal(captured.regex, false)
 })
 
 test('logs_clear tool drops every entry', async () => {

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -95,18 +95,15 @@ class BufferedTeeLogger implements Logger {
         const levels = filter.levels && filter.levels.length > 0 ? new Set(filter.levels) : null
         const since = filter.since ?? 0
         const limit = filter.limit && filter.limit > 0 ? filter.limit : 100
-        const q = filter.q ?? ''
-        const isRegex = filter.regex === true
+        const matchQuery = buildQueryMatcher(filter.q ?? '', filter.regex === true)
         const matched: LogEntry[] = []
         for (let i = 0; i < this.buffer.length; i += 1) {
             const entry = this.buffer[i]
             if (entry.seq <= since) continue
             if (levels && !levels.has(entry.level)) continue
-            if (q) {
-                const haystack =
-                    entry.message + (entry.context ? ' ' + safeStringify(entry.context) : '')
-                if (!matchesQuery(haystack, q, isRegex)) continue
-            }
+            const haystack =
+                entry.message + (entry.context ? ' ' + safeStringify(entry.context) : '')
+            if (!matchQuery(haystack)) continue
             matched.push(entry)
         }
         const tail = matched.length > limit ? matched.slice(matched.length - limit) : matched
@@ -194,21 +191,24 @@ const safeStringify = (value: unknown): string => {
 }
 
 /**
- * Case-insensitive substring search by default. With `isRegex: true`, compiles
- * `query` as a JS regex (with the `i` flag) and tests against the haystack.
- * Malformed regex yields no match instead of throwing — the caller is a tool
- * input and we'd rather miss than crash the buffer scan.
+ * Build a predicate for case-insensitive substring search (default) or regex
+ * match (`isRegex: true`, with the `i` flag). Precomputes the lowercased query
+ * or compiles the regex once so the buffer scan does not re-allocate them per
+ * entry. Malformed regex yields a predicate that always returns false instead
+ * of throwing — tool inputs should miss rather than crash the scan.
  */
-const matchesQuery = (haystack: string, query: string, isRegex: boolean): boolean => {
-    if (!query) return true
+const buildQueryMatcher = (query: string, isRegex: boolean): ((haystack: string) => boolean) => {
+    if (!query) return () => true
     if (isRegex) {
         try {
-            return new RegExp(query, 'i').test(haystack)
+            const pattern = new RegExp(query, 'i')
+            return (haystack): boolean => pattern.test(haystack)
         } catch {
-            return false
+            return () => false
         }
     }
-    return haystack.toLowerCase().includes(query.toLowerCase())
+    const lower = query.toLowerCase()
+    return (haystack): boolean => haystack.toLowerCase().includes(lower)
 }
 
 const ALL_EVENT_NAMES = [
@@ -548,14 +548,13 @@ export class McpRuntime {
         const types = filter.types && filter.types.length > 0 ? new Set(filter.types) : null
         const since = filter.since ?? 0
         const limit = filter.limit && filter.limit > 0 ? filter.limit : 50
-        const q = filter.q ?? ''
-        const isRegex = filter.regex === true
+        const matchQuery = buildQueryMatcher(filter.q ?? '', filter.regex === true)
         const matched: BufferedEvent[] = []
         for (let i = 0; i < this.buffer.length; i += 1) {
             const ev = this.buffer[i]
             if (ev.seq <= since) continue
             if (types && !types.has(ev.type)) continue
-            if (q && !matchesQuery(ev.type + ' ' + safeStringify(ev.payload), q, isRegex)) continue
+            if (!matchQuery(ev.type + ' ' + safeStringify(ev.payload))) continue
             matched.push(ev)
         }
         const tail = matched.length > limit ? matched.slice(matched.length - limit) : matched

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -88,16 +88,25 @@ class BufferedTeeLogger implements Logger {
             readonly since?: number
             readonly limit?: number
             readonly drain?: boolean
+            readonly q?: string
+            readonly regex?: boolean
         } = {}
     ): readonly LogEntry[] {
         const levels = filter.levels && filter.levels.length > 0 ? new Set(filter.levels) : null
         const since = filter.since ?? 0
         const limit = filter.limit && filter.limit > 0 ? filter.limit : 100
+        const q = filter.q ?? ''
+        const isRegex = filter.regex === true
         const matched: LogEntry[] = []
         for (let i = 0; i < this.buffer.length; i += 1) {
             const entry = this.buffer[i]
             if (entry.seq <= since) continue
             if (levels && !levels.has(entry.level)) continue
+            if (q) {
+                const haystack =
+                    entry.message + (entry.context ? ' ' + safeStringify(entry.context) : '')
+                if (!matchesQuery(haystack, q, isRegex)) continue
+            }
             matched.push(entry)
         }
         const tail = matched.length > limit ? matched.slice(matched.length - limit) : matched
@@ -182,6 +191,24 @@ const safeStringify = (value: unknown): string => {
     } catch (err) {
         return JSON.stringify({ $stringifyError: toError(err).message })
     }
+}
+
+/**
+ * Case-insensitive substring search by default. With `isRegex: true`, compiles
+ * `query` as a JS regex (with the `i` flag) and tests against the haystack.
+ * Malformed regex yields no match instead of throwing — the caller is a tool
+ * input and we'd rather miss than crash the buffer scan.
+ */
+const matchesQuery = (haystack: string, query: string, isRegex: boolean): boolean => {
+    if (!query) return true
+    if (isRegex) {
+        try {
+            return new RegExp(query, 'i').test(haystack)
+        } catch {
+            return false
+        }
+    }
+    return haystack.toLowerCase().includes(query.toLowerCase())
 }
 
 const ALL_EVENT_NAMES = [
@@ -383,6 +410,8 @@ export class McpRuntime {
             readonly since?: number
             readonly limit?: number
             readonly drain?: boolean
+            readonly q?: string
+            readonly regex?: boolean
         } = {}
     ): readonly LogEntry[] {
         return this.logger.listLogs(filter)
@@ -512,16 +541,21 @@ export class McpRuntime {
             readonly since?: number
             readonly limit?: number
             readonly drain?: boolean
+            readonly q?: string
+            readonly regex?: boolean
         } = {}
     ): readonly BufferedEvent[] {
         const types = filter.types && filter.types.length > 0 ? new Set(filter.types) : null
         const since = filter.since ?? 0
         const limit = filter.limit && filter.limit > 0 ? filter.limit : 50
+        const q = filter.q ?? ''
+        const isRegex = filter.regex === true
         const matched: BufferedEvent[] = []
         for (let i = 0; i < this.buffer.length; i += 1) {
             const ev = this.buffer[i]
             if (ev.seq <= since) continue
             if (types && !types.has(ev.type)) continue
+            if (q && !matchesQuery(ev.type + ' ' + safeStringify(ev.payload), q, isRegex)) continue
             matched.push(ev)
         }
         const tail = matched.length > limit ? matched.slice(matched.length - limit) : matched

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -180,7 +180,9 @@ const eventsTool: ToolDefinition = {
     description:
         'Read recent buffered WaClient events. Filter by types and/or sequence id. ' +
         'Use this to wait for QR codes, pairing codes, incoming messages, group events, etc. ' +
-        'Each event has a monotonic seq — pass `since: <seq>` next call to fetch only newer ones.',
+        'Each event has a monotonic seq — pass `since: <seq>` next call to fetch only newer ones. ' +
+        'Use `q` for case-insensitive substring search across `type + JSON.stringify(payload)`; ' +
+        '`regex: true` to treat `q` as a regex pattern (case-insensitive).',
     inputSchema: {
         type: 'object',
         properties: {
@@ -201,6 +203,15 @@ const eventsTool: ToolDefinition = {
             drain: {
                 type: 'boolean',
                 description: 'If true, returned events are removed from the buffer.'
+            },
+            q: {
+                type: 'string',
+                description:
+                    'Filter by substring (case-insensitive) of the event type + stringified payload.'
+            },
+            regex: {
+                type: 'boolean',
+                description: 'Treat `q` as a regex pattern (case-insensitive).'
             }
         },
         additionalProperties: false
@@ -238,7 +249,9 @@ const logsTool: ToolDefinition = {
         'Read recent buffered log entries from the WaClient/MCP runtime logger. ' +
         'Each entry has a monotonic seq, timestampMs, level, message and optional context object. ' +
         'Pass `since: <seq>` to fetch only newer entries on the next call. ' +
-        'Logs are also written to stderr and (if MCP_LOG_FILE is set) appended to that file as JSONL.',
+        'Logs are also written to stderr and (if MCP_LOG_FILE is set) appended to that file as JSONL. ' +
+        'Use `q` for case-insensitive substring search across the message + stringified context; ' +
+        '`regex: true` to treat `q` as a regex pattern (case-insensitive).',
     inputSchema: {
         type: 'object',
         properties: {
@@ -258,6 +271,15 @@ const logsTool: ToolDefinition = {
             drain: {
                 type: 'boolean',
                 description: 'If true, returned entries are removed from the buffer.'
+            },
+            q: {
+                type: 'string',
+                description:
+                    'Substring (case-insensitive) matched against `message + JSON.stringify(context)`.'
+            },
+            regex: {
+                type: 'boolean',
+                description: 'Treat `q` as a regex pattern (case-insensitive).'
             }
         },
         additionalProperties: false
@@ -437,7 +459,14 @@ const parseInspectInput = (
 
 const parseEventsInput = (
     input: unknown
-): { types?: readonly string[]; since?: number; limit?: number; drain?: boolean } => {
+): {
+    types?: readonly string[]
+    since?: number
+    limit?: number
+    drain?: boolean
+    q?: string
+    regex?: boolean
+} => {
     const obj = (input ?? {}) as Record<string, unknown>
     const types =
         Array.isArray(obj.types) && obj.types.every((t) => typeof t === 'string')
@@ -446,7 +475,9 @@ const parseEventsInput = (
     const since = typeof obj.since === 'number' ? obj.since : undefined
     const limit = typeof obj.limit === 'number' ? obj.limit : undefined
     const drain = obj.drain === true
-    return { types, since, limit, drain }
+    const q = typeof obj.q === 'string' ? obj.q : undefined
+    const regex = obj.regex === true
+    return { types, since, limit, drain, q, regex }
 }
 
 const parseLogsInput = (
@@ -456,6 +487,8 @@ const parseLogsInput = (
     since?: number
     limit?: number
     drain?: boolean
+    q?: string
+    regex?: boolean
 } => {
     const obj = (input ?? {}) as Record<string, unknown>
     let levels: readonly ('trace' | 'debug' | 'info' | 'warn' | 'error')[] | undefined
@@ -479,7 +512,9 @@ const parseLogsInput = (
     const since = typeof obj.since === 'number' ? obj.since : undefined
     const limit = typeof obj.limit === 'number' ? obj.limit : undefined
     const drain = obj.drain === true
-    return { levels, since, limit, drain }
+    const q = typeof obj.q === 'string' ? obj.q : undefined
+    const regex = obj.regex === true
+    return { levels, since, limit, drain, q, regex }
 }
 
 const parseLifecycleInput = (input: unknown): 'status' | 'start' | 'destroy' => {


### PR DESCRIPTION
Adds case-insensitive substring (`q`) and regex (`q + regex: true`) search to the `events` and `logs` MCP tools. Events match against `type + JSON.stringify(payload)`; logs match against `message + JSON.stringify(context)`. Malformed regex returns no matches instead of throwing.

Also adds a `test-mcp-server` job to CI, following the same pattern as the other workspace test jobs (build core + dependent packages via turbo, then run the package tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added query-based filtering (`q`) and regex support to logs and events, enabling substring search and pattern matching capabilities.

* **Tests**
  * Enhanced test coverage for log and event filtering with new query parameter scenarios, including case-insensitive search and regex validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/67)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->