### PR TITLE
fix(appstate): drop REMOVE previousValue, omit clientDebugData, mark 405/406 fatal

### DIFF
--- a/src/appstate/WaAppStateSyncClient.ts
+++ b/src/appstate/WaAppStateSyncClient.ts
@@ -1166,7 +1166,7 @@ export class WaAppStateSyncClient {
 
         const encryptedResults = await Promise.all(
             pendingMutations.map(async (mutation) => {
-                const value = mutation.operation === 'set' ? mutation.value : mutation.previousValue
+                const value = mutation.operation === 'set' ? mutation.value : null
                 const operationCode =
                     mutation.operation === 'remove'
                         ? proto.SyncdMutation.SyncdOperation.REMOVE
@@ -1225,15 +1225,13 @@ export class WaAppStateSyncClient {
             collection
         )
         const deviceIndex = this.resolveDeviceIndex()
-        const clientDebugData = this.buildPatchClientDebugData()
 
         const encodedPatch = proto.SyncdPatch.encode({
             mutations: encryptedMutations,
             snapshotMac,
             patchMac,
             keyId: { id: activeKey.keyId },
-            ...(deviceIndex === undefined ? {} : { deviceIndex }),
-            clientDebugData
+            ...(deviceIndex === undefined ? {} : { deviceIndex })
         }).finish()
 
         return {
@@ -1261,13 +1259,6 @@ export class WaAppStateSyncClient {
             void error
             return undefined
         }
-    }
-
-    private buildPatchClientDebugData(): Uint8Array {
-        return proto.PatchDebugData.encode({
-            isSenderPrimary: false,
-            senderPlatform: proto.PatchDebugData.Platform.WEB
-        }).finish()
     }
 
     private async computeNextCollectionState(

--- a/src/appstate/__tests__/appstate.test.ts
+++ b/src/appstate/__tests__/appstate.test.ts
@@ -320,7 +320,7 @@ test('appstate sync client builds outgoing patch without inline version field', 
         bytesToHex(key.keyId)
     )
     assert.equal(patch.deviceIndex, 3)
-    assert.equal((patch.clientDebugData as Uint8Array)?.length > 0, true)
+    assert.equal(patch.clientDebugData ?? null, null)
 })
 
 test('appstate sync client uploads mutation for persisted empty version zero state', async () => {

--- a/src/appstate/response-parser.ts
+++ b/src/appstate/response-parser.ts
@@ -108,7 +108,9 @@ export function parseCollectionState(node: BinaryNode): AppStateCollectionState 
     }
     if (
         code === WA_APP_STATE_ERROR_CODES.BAD_REQUEST ||
-        code === WA_APP_STATE_ERROR_CODES.NOT_FOUND
+        code === WA_APP_STATE_ERROR_CODES.NOT_FOUND ||
+        code === WA_APP_STATE_ERROR_CODES.NOT_ALLOWED ||
+        code === WA_APP_STATE_ERROR_CODES.NOT_ACCEPTABLE
     ) {
         return WA_APP_STATE_COLLECTION_STATES.ERROR_FATAL
     }

--- a/src/protocol/appstate.ts
+++ b/src/protocol/appstate.ts
@@ -19,7 +19,9 @@ export const WA_APP_STATE_COLLECTION_STATES = Object.freeze({
 export const WA_APP_STATE_ERROR_CODES = Object.freeze({
     CONFLICT: '409',
     BAD_REQUEST: '400',
-    NOT_FOUND: '404'
+    NOT_FOUND: '404',
+    NOT_ALLOWED: '405',
+    NOT_ACCEPTABLE: '406'
 } as const)
 
 export const WA_APP_STATE_SYNC_DATA_TYPE = Object.freeze({


### PR DESCRIPTION
REMOVE outgoing patches now carry an empty SyncActionValue rather than re-encrypting the previousValue, matching wa-mob KmpSyncdEncryptor.A00. The previousValue stays local for the LTHash subtract lookup via baseMap.

The clientDebugData field is no longer emitted; wa-mob only attaches it when its diagnostic AB flag is on, and the server treats it as opaque.

405 NOT_ALLOWED and 406 NOT_ACCEPTABLE now resolve to ERROR_FATAL in parseCollectionState alongside 400/404, so the retry loop bails out instead of spinning on a permanent server-side rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended error detection to properly handle additional HTTP error response codes, improving system robustness and fault tolerance during edge-case failures.
  * Refined data synchronization with optimized encryption and improved patch management, ensuring more reliable and consistent app state updates across sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/68)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->