### PR TITLE
feat(transport): resync clock skew on keepalive ping with half-RTT compensation

### DIFF
--- a/src/appstate/WaAppStateSyncClient.ts
+++ b/src/appstate/WaAppStateSyncClient.ts
@@ -35,6 +35,7 @@ import type {
 import { assertIqResult } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 import { bytesToHex, decodeProtoBytes, uint8Equal } from '@util/bytes'
+import type { ServerClock } from '@util/clock'
 import { longToNumber } from '@util/primitives'
 
 interface OutgoingPatchContext {
@@ -56,6 +57,7 @@ interface WaAppStateSyncClientOptions {
     readonly logger: Logger
     readonly query: (node: BinaryNode, timeoutMs: number) => Promise<BinaryNode>
     readonly store: WaAppStateStore
+    readonly serverClock: ServerClock
     readonly getCurrentMeJid?: () => string | null | undefined
     readonly hostDomain?: string
     readonly defaultTimeoutMs?: number
@@ -84,6 +86,7 @@ export class WaAppStateSyncClient {
     private readonly logger: Logger
     private readonly query: (node: BinaryNode, timeoutMs: number) => Promise<BinaryNode>
     private readonly store: WaAppStateStore
+    private readonly serverClock: ServerClock
     private readonly getCurrentMeJid?: () => string | null | undefined
     private readonly hostDomain: string
     private readonly defaultTimeoutMs: number
@@ -101,6 +104,7 @@ export class WaAppStateSyncClient {
         this.logger = options.logger
         this.query = options.query
         this.store = options.store
+        this.serverClock = options.serverClock
         this.getCurrentMeJid = options.getCurrentMeJid
         this.hostDomain = options.hostDomain ?? WA_DEFAULTS.HOST_DOMAIN
         this.defaultTimeoutMs = options.defaultTimeoutMs ?? WA_DEFAULTS.APP_STATE_SYNC_TIMEOUT_MS
@@ -128,7 +132,7 @@ export class WaAppStateSyncClient {
         const key: WaAppStateSyncKey = {
             keyId: keyIdBytes,
             keyData,
-            timestamp: Date.now(),
+            timestamp: this.serverClock.nowMs(),
             fingerprint: { rawId, currentIndex: 0, deviceIndexes: [0] }
         }
         await this.store.upsertSyncKeys([key])
@@ -172,7 +176,7 @@ export class WaAppStateSyncClient {
                 keyData,
                 timestamp:
                     item.keyData?.timestamp === null || item.keyData?.timestamp === undefined
-                        ? Date.now()
+                        ? this.serverClock.nowMs()
                         : this.normalizeProtoLong(
                               item.keyData?.timestamp,
                               'appStateSyncKeyShare.keys[].keyData.timestamp'

--- a/src/appstate/__tests__/appstate.test.ts
+++ b/src/appstate/__tests__/appstate.test.ts
@@ -288,6 +288,7 @@ test('appstate sync client builds outgoing patch without inline version field', 
     const logger = createNoopLogger()
 
     const client = new WaAppStateSyncClient({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger,
         query,
         store,
@@ -372,6 +373,7 @@ test('appstate sync client uploads mutation for persisted empty version zero sta
     const logger = createNoopLogger()
 
     const client = new WaAppStateSyncClient({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger,
         query,
         store,
@@ -445,6 +447,7 @@ test('appstate sync client marks empty successful bootstrap as initialized for n
     const logger = createNoopLogger()
 
     const client = new WaAppStateSyncClient({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger,
         query,
         store,
@@ -477,6 +480,7 @@ test('appstate sync client marks empty successful bootstrap as initialized for n
 test('ensureInitialSyncKey mints a 32-byte key with fingerprint when store is empty', async () => {
     const store = new WaAppStateMemoryStore()
     const client = new WaAppStateSyncClient({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         query: async () => ({ tag: 'iq', attrs: {} }),
         store

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -108,6 +108,7 @@ import { WaNodeOrchestrator } from '@transport/node/WaNodeOrchestrator'
 import { WaNodeTransport } from '@transport/node/WaNodeTransport'
 import { isProxyTransport, toProxyAgent } from '@transport/proxy'
 import type { BinaryNode } from '@transport/types'
+import { createServerClock } from '@util/clock'
 import { toError } from '@util/primitives'
 import { getRuntimeOsDisplayName } from '@util/runtime'
 
@@ -414,6 +415,8 @@ export function buildWaClientDependencies(input: {
     let mediaConnCacheFallback: WaMediaConn | null = null
     let scheduleReconnectAfterPairing: () => void = () => undefined
 
+    const serverClock = createServerClock(() => connectionManager?.getClockSkewMs() ?? null)
+
     const nodeTransport = new WaNodeTransport(logger)
     const nodeOrchestrator = new WaNodeOrchestrator({
         sendNode: async (node) => nodeTransport.sendNode(node),
@@ -430,7 +433,8 @@ export function buildWaClientDependencies(input: {
         getIntervalMs: () =>
             abPropsCoordinator.getConfigValue<number>('heartbeat_interval_s') * 1_000,
         timeoutMs: options.deadSocketTimeoutMs,
-        hostDomain: WA_DEFAULTS.HOST_DOMAIN
+        hostDomain: WA_DEFAULTS.HOST_DOMAIN,
+        onClockSkewMs: (clockSkewMs) => connectionManager?.setClockSkewMs(clockSkewMs, 'keepalive')
     })
 
     const mediaTransfer = new WaMediaTransferClient({
@@ -635,6 +639,7 @@ export function buildWaClientDependencies(input: {
             emitEvent: runtime.emitEvent,
             getCurrentMeLid: () => getCurrentMeLid() ?? null
         },
+        serverClock,
         durationS: options.privacyToken?.tcTokenDurationS,
         numBuckets: options.privacyToken?.tcTokenNumBuckets,
         senderDurationS: options.privacyToken?.tcTokenSenderDurationS,
@@ -738,6 +743,7 @@ export function buildWaClientDependencies(input: {
         getCurrentMeJid,
         defaultTimeoutMs: options.appStateSyncTimeoutMs,
         store: sessionStore.appState,
+        serverClock,
         onMissingKeys: async ({ keyIds }) => {
             await messageDispatch.requestAppStateSyncKeys(keyIds)
         },
@@ -748,7 +754,8 @@ export function buildWaClientDependencies(input: {
     const appStateMutations = new WaAppStateMutationCoordinator({
         logger,
         messageStore: sessionStore.messages,
-        syncAppState: runtime.syncAppStateWithOptions
+        syncAppState: runtime.syncAppStateWithOptions,
+        serverClock
     })
 
     const statusCoordinator = createStatusCoordinator({

--- a/src/client/connection/WaConnectionManager.ts
+++ b/src/client/connection/WaConnectionManager.ts
@@ -142,6 +142,17 @@ export class WaConnectionManager {
         })
     }
 
+    public setClockSkewMs(clockSkewMs: number, source: string): void {
+        if (!Number.isFinite(clockSkewMs)) {
+            return
+        }
+        const previous = this.clockSkewMs
+        this.clockSkewMs = clockSkewMs
+        if (previous === null || Math.abs(previous - clockSkewMs) >= 1_000) {
+            this.logger.debug('clock skew updated', { source, clockSkewMs, previous })
+        }
+    }
+
     private async connectInternal(
         frameHandler: (frame: Uint8Array) => Promise<void>,
         lifecycleGeneration: number

--- a/src/client/connection/__tests__/connection.test.ts
+++ b/src/client/connection/__tests__/connection.test.ts
@@ -93,6 +93,18 @@ test('connection manager exposes media cache and clock skew helpers', async () =
     assert.notEqual(manager.getClockSkewMs(), null)
     assert.equal(manager.isConnected(), false)
 
+    manager.setClockSkewMs(1_234, 'test')
+    assert.equal(manager.getClockSkewMs(), 1_234)
+
+    manager.setClockSkewMs(Number.NaN, 'test')
+    assert.equal(manager.getClockSkewMs(), 1_234)
+
+    manager.setClockSkewMs(Number.POSITIVE_INFINITY, 'test')
+    assert.equal(manager.getClockSkewMs(), 1_234)
+
+    manager.setClockSkewMs(-500, 'test')
+    assert.equal(manager.getClockSkewMs(), -500)
+
     await manager.clearStoredCredentials()
     assert.equal(clearedCredentialsCalls, 1)
 })

--- a/src/client/coordinators/WaAppStateMutationCoordinator.ts
+++ b/src/client/coordinators/WaAppStateMutationCoordinator.ts
@@ -25,6 +25,7 @@ import {
     toUserJid
 } from '@protocol/jid'
 import type { WaMessageStore, WaStoredMessageRecord } from '@store/contracts/message.store'
+import type { ServerClock } from '@util/clock'
 import { resolvePositive } from '@util/coercion'
 import { toError } from '@util/primitives'
 
@@ -43,6 +44,7 @@ interface WaAppStateMutationCoordinatorOptions {
     readonly logger: Logger
     readonly messageStore: WaMessageStore
     readonly syncAppState: (options?: WaAppStateSyncOptions) => Promise<WaAppStateSyncResult>
+    readonly serverClock: ServerClock
     readonly archiveRangeLimit?: number
 }
 
@@ -77,6 +79,7 @@ export class WaAppStateMutationCoordinator {
     private readonly syncAppState: (
         options?: WaAppStateSyncOptions
     ) => Promise<WaAppStateSyncResult>
+    private readonly serverClock: ServerClock
     private readonly archiveRangeLimit: number
     private readonly pendingMutations: Map<string, WaAppStateMutationInput>
     private flushPromise: Promise<void> | null
@@ -85,6 +88,7 @@ export class WaAppStateMutationCoordinator {
         this.logger = options.logger
         this.messageStore = options.messageStore
         this.syncAppState = options.syncAppState
+        this.serverClock = options.serverClock
         this.archiveRangeLimit = resolvePositive(
             options.archiveRangeLimit,
             WA_APP_STATE_ARCHIVE_RANGE_DEFAULT_LIMIT,
@@ -100,7 +104,7 @@ export class WaAppStateMutationCoordinator {
         muteEndTimestampMs?: number
     ): Promise<void> {
         const chatIndexJid = this.normalizeChatMutationJid(chatJid)
-        const timestamp = Date.now()
+        const timestamp = this.serverClock.nowMs()
         const normalizedMuteEnd = muteEndTimestampMs
         if (
             normalizedMuteEnd !== undefined &&
@@ -132,7 +136,7 @@ export class WaAppStateMutationCoordinator {
 
     public async setMessageStar(message: WaAppStateMessageKey, starred: boolean): Promise<void> {
         const messageIndex = this.buildMessageMutationIndex(message)
-        const timestamp = Date.now()
+        const timestamp = this.serverClock.nowMs()
         const mutation = this.createSetMutation({
             spec: WA_APP_STATE_CHAT_MUTATION_SPECS.STAR,
             chatIndexJid: messageIndex.chatIndexJid,
@@ -149,7 +153,7 @@ export class WaAppStateMutationCoordinator {
 
     public async setChatRead(chatJid: string, read: boolean): Promise<void> {
         const chatIndexJid = this.normalizeChatMutationJid(chatJid)
-        const timestamp = Date.now()
+        const timestamp = this.serverClock.nowMs()
         const messageRange = await this.buildChatMessageRange(chatIndexJid)
         const mutation = this.createSetMutation({
             spec: WA_APP_STATE_CHAT_MUTATION_SPECS.MARK_CHAT_AS_READ,
@@ -167,7 +171,7 @@ export class WaAppStateMutationCoordinator {
 
     public async setChatPin(chatJid: string, pinned: boolean): Promise<void> {
         const chatIndexJid = this.normalizeChatMutationJid(chatJid)
-        const timestamp = Date.now()
+        const timestamp = this.serverClock.nowMs()
         const pending: WaAppStateMutationInput[] = [
             this.createSetMutation({
                 spec: WA_APP_STATE_CHAT_MUTATION_SPECS.PIN,
@@ -190,7 +194,7 @@ export class WaAppStateMutationCoordinator {
 
     public async setChatArchive(chatJid: string, archived: boolean): Promise<void> {
         const chatIndexJid = this.normalizeChatMutationJid(chatJid)
-        const timestamp = Date.now()
+        const timestamp = this.serverClock.nowMs()
         const pending: WaAppStateMutationInput[] = [
             await this.createArchiveMutation(chatIndexJid, archived, timestamp)
         ]
@@ -215,7 +219,7 @@ export class WaAppStateMutationCoordinator {
 
     public async clearChat(chatJid: string, options: WaClearChatOptions = {}): Promise<void> {
         const chatIndexJid = this.normalizeChatMutationJid(chatJid)
-        const timestamp = Date.now()
+        const timestamp = this.serverClock.nowMs()
         const deleteStarred = options.deleteStarred === true
         const deleteMedia = options.deleteMedia === true
         const messageRange = await this.buildChatMessageRange(chatIndexJid)
@@ -235,7 +239,7 @@ export class WaAppStateMutationCoordinator {
 
     public async deleteChat(chatJid: string, options: WaDeleteChatOptions = {}): Promise<void> {
         const chatIndexJid = this.normalizeChatMutationJid(chatJid)
-        const timestamp = Date.now()
+        const timestamp = this.serverClock.nowMs()
         const deleteMedia = options.deleteMedia === true
         const messageRange = await this.buildChatMessageRange(chatIndexJid)
         const mutation = this.createSetMutation({
@@ -257,7 +261,7 @@ export class WaAppStateMutationCoordinator {
         options: WaDeleteMessageForMeOptions = {}
     ): Promise<void> {
         const messageIndex = this.buildMessageMutationIndex(message)
-        const timestamp = Date.now()
+        const timestamp = this.serverClock.nowMs()
         const deleteMedia = options.deleteMedia === true
         const messageTimestampMs = options.messageTimestampMs
         let messageTimestamp: number | undefined
@@ -288,7 +292,7 @@ export class WaAppStateMutationCoordinator {
 
     public async setChatLock(chatJid: string, locked: boolean): Promise<void> {
         const chatIndexJid = this.normalizeChatMutationJid(chatJid)
-        const timestamp = Date.now()
+        const timestamp = this.serverClock.nowMs()
         const pending: WaAppStateMutationInput[] = []
         if (locked) {
             pending.push(await this.createArchiveMutation(chatIndexJid, false, timestamp))
@@ -486,7 +490,7 @@ export class WaAppStateMutationCoordinator {
                 ...(input.shareToIG === undefined ? {} : { shareToIG: input.shareToIG })
             }
         }
-        const timestamp = Date.now()
+        const timestamp = this.serverClock.nowMs()
         await this.enqueueAndFlush([
             this.createAccountSetMutation({
                 spec: WA_APP_STATE_ACCOUNT_MUTATION_SPECS.STATUS_PRIVACY,
@@ -502,7 +506,7 @@ export class WaAppStateMutationCoordinator {
         if (isGroupOrBroadcastJid(indexJid)) {
             throw new Error(`setUserStatusMute requires a user jid, got ${jid}`)
         }
-        const timestamp = Date.now()
+        const timestamp = this.serverClock.nowMs()
         await this.enqueueAndFlush([
             this.createAccountSetMutation({
                 spec: WA_APP_STATE_ACCOUNT_MUTATION_SPECS.USER_STATUS_MUTE,
@@ -525,7 +529,7 @@ export class WaAppStateMutationCoordinator {
                 labelIds: input.labelIds ? [...input.labelIds] : []
             }
         }
-        const timestamp = Date.now()
+        const timestamp = this.serverClock.nowMs()
         await this.enqueueAndFlush([
             this.createAccountSetMutation({
                 spec: WA_APP_STATE_ACCOUNT_MUTATION_SPECS.BUSINESS_BROADCAST_LIST,
@@ -537,7 +541,7 @@ export class WaAppStateMutationCoordinator {
     }
 
     public async removeBroadcastList(id: string): Promise<void> {
-        const timestamp = Date.now()
+        const timestamp = this.serverClock.nowMs()
         await this.enqueueAndFlush([
             this.createAccountRemoveMutation({
                 spec: WA_APP_STATE_ACCOUNT_MUTATION_SPECS.BUSINESS_BROADCAST_LIST,

--- a/src/client/coordinators/WaTrustedContactTokenCoordinator.ts
+++ b/src/client/coordinators/WaTrustedContactTokenCoordinator.ts
@@ -12,6 +12,7 @@ import {
     buildTcTokenMessageNode
 } from '@transport/node/builders/privacy-token'
 import type { BinaryNode } from '@transport/types'
+import type { ServerClock } from '@util/clock'
 import { toError } from '@util/primitives'
 
 const NCT_SALT_SENTINEL_JID = '__nct_salt__'
@@ -42,6 +43,7 @@ export class WaTrustedContactTokenCoordinator {
     private readonly logger: Logger
     private readonly store: WaPrivacyTokenStore
     private readonly runtime: WaTrustedContactTokenRuntime
+    private readonly serverClock: ServerClock
     private readonly baseConfig: WaTrustedContactTokenConfig
     private readonly getConfigOverrides: (() => Partial<WaTrustedContactTokenConfig>) | undefined
     private readonly csTokenGenerator: CsTokenGenerator
@@ -53,6 +55,7 @@ export class WaTrustedContactTokenCoordinator {
         readonly logger: Logger
         readonly store: WaPrivacyTokenStore
         readonly runtime: WaTrustedContactTokenRuntime
+        readonly serverClock: ServerClock
         readonly durationS?: number
         readonly numBuckets?: number
         readonly senderDurationS?: number
@@ -63,6 +66,7 @@ export class WaTrustedContactTokenCoordinator {
         this.logger = options.logger
         this.store = options.store
         this.runtime = options.runtime
+        this.serverClock = options.serverClock
         const maxDurationS = options.maxDurationS ?? WA_TC_TOKEN_DEFAULTS.MAX_DURATION_S
         this.baseConfig = {
             durationS: clampDuration(
@@ -107,7 +111,7 @@ export class WaTrustedContactTokenCoordinator {
 
     public async resolveTokenForMessage(recipientJid: string): Promise<BinaryNode | null> {
         const record = await this.store.getByJid(recipientJid)
-        const nowS = Math.floor(Date.now() / 1000)
+        const nowS = this.serverClock.nowSeconds()
 
         const config = this.resolveConfig()
         if (
@@ -160,7 +164,7 @@ export class WaTrustedContactTokenCoordinator {
 
     public async maybeIssueSenderToken(recipientJid: string): Promise<void> {
         return this.senderTokenDedup.run(recipientJid, async () => {
-            const nowS = Math.floor(Date.now() / 1000)
+            const nowS = this.serverClock.nowSeconds()
             const record = await this.store.getByJid(recipientJid)
             const senderTimestampS = record?.tcTokenSenderTimestamp
 
@@ -186,7 +190,7 @@ export class WaTrustedContactTokenCoordinator {
             return
         }
 
-        const nowS = Math.floor(Date.now() / 1000)
+        const nowS = this.serverClock.nowSeconds()
         const config = this.resolveConfig()
         if (
             isTokenExpired(

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -669,6 +669,7 @@ test('app-state mutation coordinator flushes queued mutations while sync is in-f
     })
 
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {
@@ -710,6 +711,7 @@ test('app-state mutation coordinator emits pin + archive mutations when pinning 
 
     const syncCalls: (readonly WaAppStateMutationInput[])[] = []
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {
@@ -749,6 +751,7 @@ test('app-state mutation coordinator flushes only targeted collections for queue
 
     const syncCalls: { readonly collections: readonly string[]; readonly pending: number }[] = []
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {
@@ -788,6 +791,7 @@ test('app-state mutation coordinator includes message range and auto-unpin on ar
 
     const syncCalls: (readonly WaAppStateMutationInput[])[] = []
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {
@@ -833,6 +837,7 @@ test('app-state mutation coordinator preserves device participant jid in archive
 
     const syncCalls: (readonly WaAppStateMutationInput[])[] = []
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {
@@ -873,6 +878,7 @@ test('app-state mutation coordinator skips incoming group messages without parti
 
     const syncCalls: (readonly WaAppStateMutationInput[])[] = []
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {
@@ -903,6 +909,7 @@ test('app-state mutation coordinator keeps pending mutations after blocked flush
     let flushAttempt = 0
 
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {
@@ -938,6 +945,7 @@ test('app-state mutation coordinator emits read/clear/delete mutations with expe
 
     const syncCalls: (readonly WaAppStateMutationInput[])[] = []
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {
@@ -982,6 +990,7 @@ test('app-state mutation coordinator emits archive and unpin before lock mutatio
 
     const syncCalls: (readonly WaAppStateMutationInput[])[] = []
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {
@@ -1008,6 +1017,7 @@ test('app-state mutation coordinator emits star mutation with message-key index'
     const messageStore = new WaMessageMemoryStore()
     const syncCalls: (readonly WaAppStateMutationInput[])[] = []
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {
@@ -1047,6 +1057,7 @@ test('app-state mutation coordinator emits delete-message-for-me mutation and va
     const messageStore = new WaMessageMemoryStore()
     const syncCalls: (readonly WaAppStateMutationInput[])[] = []
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {
@@ -1101,6 +1112,7 @@ test('app-state mutation coordinator emits status_privacy account mutation', asy
     const messageStore = new WaMessageMemoryStore()
     const syncCalls: (readonly WaAppStateMutationInput[])[] = []
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {
@@ -1131,6 +1143,7 @@ test('app-state mutation coordinator emits userStatusMute mutation with target j
     const messageStore = new WaMessageMemoryStore()
     const syncCalls: (readonly WaAppStateMutationInput[])[] = []
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {
@@ -1154,6 +1167,7 @@ test('app-state mutation coordinator emits business_broadcast_list set/remove pa
     const messageStore = new WaMessageMemoryStore()
     const syncCalls: (readonly WaAppStateMutationInput[])[] = []
     const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         messageStore,
         syncAppState: async (options = {}) => {

--- a/src/client/coordinators/__tests__/trusted-contact-token-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/trusted-contact-token-coordinator.test.ts
@@ -55,6 +55,7 @@ test('trusted contact token coordinator uses fresh tc token for message fanout',
     const store = new WaPrivacyTokenMemoryStore()
     const { runtime, queries } = createRuntime()
     const coordinator = new WaTrustedContactTokenCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         store,
         runtime,
@@ -80,6 +81,7 @@ test('trusted contact token coordinator falls back to cs token when tc token is 
     const store = new WaPrivacyTokenMemoryStore()
     const { runtime } = createRuntime()
     const coordinator = new WaTrustedContactTokenCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         store,
         runtime,
@@ -109,6 +111,7 @@ test('trusted contact token coordinator persists incoming trusted tokens and emi
     const store = new WaPrivacyTokenMemoryStore()
     const { runtime, emitted } = createRuntime()
     const coordinator = new WaTrustedContactTokenCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: {
             ...createLogger(),
             warn: (...args) => {
@@ -147,6 +150,7 @@ test('trusted contact token coordinator deduplicates sender token issue and resp
     const store = new WaPrivacyTokenMemoryStore()
     const { runtime, queries } = createRuntime({ queryDelayMs: 20 })
     const coordinator = new WaTrustedContactTokenCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         store,
         runtime,
@@ -170,6 +174,7 @@ test('trusted contact token coordinator reissues token on identity change when s
     const store = new WaPrivacyTokenMemoryStore()
     const { runtime, queries } = createRuntime()
     const coordinator = new WaTrustedContactTokenCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createLogger(),
         store,
         runtime,

--- a/src/transport/keepalive/WaKeepAlive.ts
+++ b/src/transport/keepalive/WaKeepAlive.ts
@@ -21,6 +21,7 @@ interface WaKeepAliveOptions {
     readonly hostDomain?: string
     readonly jitterRatio?: number
     readonly minJitterMs?: number
+    readonly onClockSkewMs?: (clockSkewMs: number) => void
 }
 
 export class WaKeepAlive {
@@ -33,6 +34,7 @@ export class WaKeepAlive {
     private readonly hostDomain: string
     private readonly jitterRatio: number
     private readonly minJitterMs: number
+    private readonly onClockSkewMs: ((clockSkewMs: number) => void) | undefined
     private timer: NodeJS.Timeout | null
     private generation: number
     private inFlight: boolean
@@ -50,6 +52,7 @@ export class WaKeepAlive {
             options.minJitterMs,
             KEEPALIVE_DEFAULT_MIN_JITTER_MS
         )
+        this.onClockSkewMs = options.onClockSkewMs
         this.timer = null
         this.generation = 0
         this.inFlight = false
@@ -124,10 +127,18 @@ export class WaKeepAlive {
                     xmlns: WA_XMLNS.WHATSAPP_PING
                 }
             }
-            await this.nodeOrchestrator.query(pingNode, this.timeoutMs)
-            this.logger.debug('keepalive ping success', {
-                latencyMs: Date.now() - startedAt
-            })
+            const response = await this.nodeOrchestrator.query(pingNode, this.timeoutMs)
+            const receivedAt = Date.now()
+            const latencyMs = receivedAt - startedAt
+            this.logger.debug('keepalive ping success', { latencyMs })
+            if (this.onClockSkewMs) {
+                const serverT = response.attrs.t ? Number(response.attrs.t) : NaN
+                if (Number.isFinite(serverT) && serverT > 0) {
+                    const halfRttMs = Math.round(latencyMs / 2)
+                    const clockSkewMs = serverT * 1000 - (startedAt + halfRttMs)
+                    this.onClockSkewMs(clockSkewMs)
+                }
+            }
         } catch (error) {
             this.logger.warn('keepalive ping failed, reconnecting socket', {
                 message: toError(error).message

--- a/src/transport/keepalive/__tests__/keepalive.test.ts
+++ b/src/transport/keepalive/__tests__/keepalive.test.ts
@@ -80,3 +80,116 @@ test('keepalive asks comms to resume when ping fails', async (t) => {
 
     assert.ok(resumed >= 1)
 })
+
+test('keepalive reports clock skew from ping response with half-RTT compensation', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    const skewUpdates: number[] = []
+    let nowMs = 1_700_000_000_000
+    const originalNow = Date.now
+    Date.now = () => nowMs
+    t.after(() => {
+        Date.now = originalNow
+    })
+
+    const serverTSeconds = 1_700_000_001
+    const latencyMs = 200
+
+    const keepAlive = new WaKeepAlive({
+        logger: createLogger(),
+        nodeOrchestrator: {
+            hasPending: () => false,
+            query: async () => {
+                nowMs += latencyMs
+                return {
+                    tag: 'iq',
+                    attrs: { type: 'result', t: String(serverTSeconds) }
+                }
+            }
+        },
+        getComms: () =>
+            ({
+                getCommsState: () => ({ connected: true })
+            }) as never,
+        intervalMs: 5,
+        timeoutMs: 5,
+        jitterRatio: 0,
+        minJitterMs: 0,
+        onClockSkewMs: (value) => skewUpdates.push(value)
+    })
+
+    keepAlive.start()
+    t.mock.timers.tick(5)
+    await Promise.resolve()
+    await Promise.resolve()
+    keepAlive.stop()
+
+    assert.equal(skewUpdates.length, 1)
+    const sentMs = 1_700_000_000_000
+    const halfRtt = latencyMs / 2
+    const expected = serverTSeconds * 1_000 - (sentMs + halfRtt)
+    assert.equal(skewUpdates[0], expected)
+})
+
+test('keepalive skips clock skew update when ping response has no t', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    const skewUpdates: number[] = []
+    const keepAlive = new WaKeepAlive({
+        logger: createLogger(),
+        nodeOrchestrator: {
+            hasPending: () => false,
+            query: async () => ({ tag: 'iq', attrs: { type: 'result' } })
+        },
+        getComms: () =>
+            ({
+                getCommsState: () => ({ connected: true })
+            }) as never,
+        intervalMs: 5,
+        timeoutMs: 5,
+        jitterRatio: 0,
+        minJitterMs: 0,
+        onClockSkewMs: (value) => skewUpdates.push(value)
+    })
+
+    keepAlive.start()
+    t.mock.timers.tick(5)
+    await Promise.resolve()
+    await Promise.resolve()
+    keepAlive.stop()
+
+    assert.equal(skewUpdates.length, 0)
+})
+
+test('keepalive ignores invalid t attribute', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    const skewUpdates: number[] = []
+    const keepAlive = new WaKeepAlive({
+        logger: createLogger(),
+        nodeOrchestrator: {
+            hasPending: () => false,
+            query: async () => ({
+                tag: 'iq',
+                attrs: { type: 'result', t: 'not-a-number' }
+            })
+        },
+        getComms: () =>
+            ({
+                getCommsState: () => ({ connected: true })
+            }) as never,
+        intervalMs: 5,
+        timeoutMs: 5,
+        jitterRatio: 0,
+        minJitterMs: 0,
+        onClockSkewMs: (value) => skewUpdates.push(value)
+    })
+
+    keepAlive.start()
+    t.mock.timers.tick(5)
+    await Promise.resolve()
+    await Promise.resolve()
+    keepAlive.stop()
+
+    assert.equal(skewUpdates.length, 0)
+})

--- a/src/util/__tests__/clock.test.ts
+++ b/src/util/__tests__/clock.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createServerClock } from '@util/clock'
+
+test('createServerClock adds the skew to Date.now() for nowMs', () => {
+    const clock = createServerClock(() => 5_000)
+    const before = Date.now()
+    const observed = clock.nowMs()
+    const after = Date.now()
+    assert.ok(observed - before >= 5_000)
+    assert.ok(observed - after <= 5_001)
+})
+
+test('createServerClock floors corrected millis for nowSeconds', () => {
+    const clock = createServerClock(() => 3_500)
+    const localMs = Date.now()
+    const expected = Math.floor((localMs + 3_500) / 1_000)
+    const observed = clock.nowSeconds()
+    assert.ok(Math.abs(observed - expected) <= 1)
+})
+
+test('createServerClock falls back to Date.now() when skew is null/undefined/NaN', () => {
+    const candidates: (number | null | undefined)[] = [null, undefined, Number.NaN]
+    for (const skew of candidates) {
+        const clock = createServerClock(() => skew)
+        const before = Date.now()
+        const observed = clock.nowMs()
+        const after = Date.now()
+        assert.ok(
+            observed >= before && observed <= after,
+            `nowMs(${String(skew)}) = ${observed} should be between ${before} and ${after}`
+        )
+    }
+})
+
+test('createServerClock accepts negative skew (local clock ahead of server)', () => {
+    const clock = createServerClock(() => -2_000)
+    const before = Date.now()
+    const observed = clock.nowMs()
+    assert.ok(observed <= before - 1_999)
+})
+
+test('createServerClock reads the skew getter on every call', () => {
+    let current: number | null = null
+    const clock = createServerClock(() => current)
+    const baseline = clock.nowMs()
+    current = 10_000
+    const skewed = clock.nowMs()
+    assert.ok(skewed - baseline >= 9_000)
+})

--- a/src/util/clock.ts
+++ b/src/util/clock.ts
@@ -1,0 +1,22 @@
+export type GetClockSkewMs = () => number | null | undefined
+
+export interface ServerClock {
+    nowMs(): number
+    nowSeconds(): number
+}
+
+export function createServerClock(getClockSkewMs: GetClockSkewMs): ServerClock {
+    return {
+        nowMs() {
+            const skewMs = getClockSkewMs()
+            const nowMs = Date.now()
+            return Number.isFinite(skewMs) ? nowMs + (skewMs as number) : nowMs
+        },
+        nowSeconds() {
+            const skewMs = getClockSkewMs()
+            const nowMs = Date.now()
+            const correctedMs = Number.isFinite(skewMs) ? nowMs + (skewMs as number) : nowMs
+            return Math.floor(correctedMs / 1_000)
+        }
+    }
+}


### PR DESCRIPTION
WaKeepAlive now extracts the server `t` attribute from each ping response and propagates `serverMs - (sentMs + halfRttMs)` to a new WaConnectionManager.setClockSkewMs hook. Mirrors wa-web's WAComms.sendPing which uses the half-RTT compensated formula to track server time over long sessions instead of only at <success>.

Wire-bound timestamps now route through a ServerClock util that adds the current skew to Date.now(). Migrated callsites:

- WaAppStateMutationCoordinator: 13 SyncActionValue.timestamp emissions (mute, star, read, pin, archive, clear, delete, message-for-me, chat-lock, status-privacy, status-mute, broadcast-list, delete-message)
- WaAppStateSyncClient: 2 fallback timestamps when ensuring/importing sync keys
- WaTrustedContactTokenCoordinator: 3 nowSeconds comparisons against server-issued tcToken/tcTokenSender timestamps

Local-only timestamps (updatedAtMs metadata, retry expiration TTLs, passive task scheduling, log/trace lines) keep using Date.now().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented server clock synchronization to ensure accurate timestamps across the application.
  * The system now automatically measures and compensates for differences between device and server time during keepalive communications.
  * All time-dependent operations (messaging, token issuance, state mutations) now use server-synchronized time instead of local device time for improved consistency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/69)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->