### PR TITLE
feat(media): expand upload paths and simplify AES-CBC streaming

### DIFF
--- a/src/appstate/WaAppStateSyncClient.ts
+++ b/src/appstate/WaAppStateSyncClient.ts
@@ -764,7 +764,8 @@ export class WaAppStateSyncClient {
                     const decodedMutations = proto.SyncdMutations.decode(patchBytes)
                     readyPatch = {
                         ...readyPatch,
-                        mutations: decodedMutations.mutations ?? []
+                        mutations: decodedMutations.mutations ?? [],
+                        externalMutations: undefined
                     }
                 }
                 return this.validatePatch(payload.collection, readyPatch)

--- a/src/appstate/__tests__/appstate.test.ts
+++ b/src/appstate/__tests__/appstate.test.ts
@@ -477,6 +477,95 @@ test('appstate sync client marks empty successful bootstrap as initialized for n
     assert.deepEqual(versionByCall, ['0', '0'])
 })
 
+test('appstate sync client inlines external mutations and clears the external reference for validatePatch', async () => {
+    const store = new WaAppStateMemoryStore()
+    const key = {
+        keyId: new Uint8Array([0, 1, 0, 0, 0, 5]),
+        keyData: new Uint8Array(32).fill(7),
+        timestamp: 5
+    }
+    await store.upsertSyncKeys([key])
+
+    const externalSyncdMutations = proto.SyncdMutations.encode({ mutations: [] }).finish()
+
+    const patchBytes = proto.SyncdPatch.encode({
+        version: { version: 1 },
+        externalMutations: {
+            directPath: '/external/patch/blob',
+            mediaKey: new Uint8Array(32).fill(1),
+            fileSha256: new Uint8Array(32).fill(2),
+            fileEncSha256: new Uint8Array(32).fill(3)
+        },
+        keyId: { id: key.keyId }
+    }).finish()
+
+    const query = async (): Promise<BinaryNode> => ({
+        tag: WA_NODE_TAGS.IQ,
+        attrs: { type: WA_IQ_TYPES.RESULT },
+        content: [
+            {
+                tag: WA_NODE_TAGS.SYNC,
+                attrs: {},
+                content: [
+                    {
+                        tag: WA_NODE_TAGS.COLLECTION,
+                        attrs: {
+                            name: WA_APP_STATE_COLLECTIONS.REGULAR_LOW,
+                            version: '1'
+                        },
+                        content: [
+                            {
+                                tag: WA_NODE_TAGS.PATCHES,
+                                attrs: {},
+                                content: [
+                                    {
+                                        tag: WA_NODE_TAGS.PATCH,
+                                        attrs: {},
+                                        content: patchBytes
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    })
+
+    const client = new WaAppStateSyncClient({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
+        logger: createNoopLogger(),
+        query,
+        store,
+        skipMacVerification: true
+    })
+
+    let downloadCalls = 0
+    let observedKind: string | null = null
+    let observedRef: Proto.IExternalBlobReference | null = null
+    const result = await client.sync({
+        collections: [WA_APP_STATE_COLLECTIONS.REGULAR_LOW],
+        downloadExternalBlob: async (_collection, kind, ref) => {
+            downloadCalls += 1
+            observedKind = kind
+            observedRef = ref
+            return externalSyncdMutations
+        }
+    })
+
+    assert.equal(downloadCalls, 1)
+    assert.equal(observedKind, 'patch')
+    assert.equal(
+        bytesToHex((observedRef!.mediaKey as Uint8Array) ?? new Uint8Array()),
+        bytesToHex(new Uint8Array(32).fill(1))
+    )
+    assert.equal(result.collections.length, 1)
+    assert.equal(result.collections[0].collection, WA_APP_STATE_COLLECTIONS.REGULAR_LOW)
+    assert.equal(result.collections[0].state, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
+    const persisted = await store.getCollectionState(WA_APP_STATE_COLLECTIONS.REGULAR_LOW)
+    assert.equal(persisted.version, 1)
+})
+
 test('ensureInitialSyncKey mints a 32-byte key with fingerprint when store is empty', async () => {
     const store = new WaAppStateMemoryStore()
     const client = new WaAppStateSyncClient({

--- a/src/client/coordinators/WaBusinessCoordinator.ts
+++ b/src/client/coordinators/WaBusinessCoordinator.ts
@@ -7,7 +7,7 @@ import {
 } from '@client/media'
 import type { WaBusinessProfileResult, WaVerifiedNameResult } from '@client/types'
 import type { Logger } from '@infra/log/types'
-import { BIZ_COVER_PHOTO_UPLOAD_PATH } from '@media/constants'
+import { PPS_UPLOAD_PATHS } from '@media/constants'
 import type { WaMediaConn } from '@media/types'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
 import {
@@ -105,7 +105,7 @@ export function createBusinessCoordinator(
                 { mediaTransfer, mediaConn, logger },
                 {
                     source: media,
-                    path: BIZ_COVER_PHOTO_UPLOAD_PATH,
+                    path: PPS_UPLOAD_PATHS['biz-cover-photo'],
                     logLabel: 'sending business cover photo upload'
                 }
             )

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { createReadStream, createWriteStream } from 'node:fs'
-import { open, unlink } from 'node:fs/promises'
+import { open, stat, unlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { type Readable, Transform } from 'node:stream'
@@ -193,6 +193,7 @@ async function preparePlaintextUploadSource(
         return { fileSha256: sha256(media), byteLength: media.byteLength, body: media }
     }
     if (typeof media === 'string') {
+        await assertReadableFile(media)
         const result = await streamToTempFileWithSha256(createReadStream(media))
         return {
             fileSha256: result.fileSha256,
@@ -318,11 +319,27 @@ export interface ResolvedMediaInputs {
     readonly tempFilePath?: string
 }
 
+async function assertReadableFile(filePath: string): Promise<void> {
+    try {
+        const stats = await stat(filePath)
+        if (!stats.isFile()) {
+            throw new Error(`media path is not a regular file: ${filePath}`)
+        }
+    } catch (error) {
+        const err = toError(error)
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+            throw new Error(`media file not found: ${filePath}`)
+        }
+        throw err
+    }
+}
+
 export async function resolveMediaInputs(
     shouldProcess: boolean,
     raw: Uint8Array | ArrayBuffer | Readable | string
 ): Promise<ResolvedMediaInputs> {
     if (typeof raw === 'string') {
+        await assertReadableFile(raw)
         return {
             processorInput: raw,
             uploadMedia: createReadStream(raw)

--- a/src/media/WaMediaCrypto.ts
+++ b/src/media/WaMediaCrypto.ts
@@ -1,5 +1,4 @@
-import { createHash, createHmac } from 'node:crypto'
-import { once } from 'node:events'
+import { createCipheriv, createDecipheriv, createHash, createHmac } from 'node:crypto'
 import { createWriteStream } from 'node:fs'
 import { stat, unlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -43,42 +42,6 @@ import {
 import { toError } from '@util/primitives'
 
 const AES_BLOCK_SIZE = 16
-const PKCS7_FULL_BLOCK = new Uint8Array(AES_BLOCK_SIZE).fill(AES_BLOCK_SIZE)
-
-function aesCbcEncryptChunk(
-    key: Uint8Array,
-    iv: Uint8Array,
-    chunk: Uint8Array,
-    isFinal: boolean
-): { ciphertext: Uint8Array; nextIv: Uint8Array } {
-    const encrypted = aesCbcEncrypt(key, iv, chunk)
-    if (isFinal) {
-        return {
-            ciphertext: encrypted,
-            nextIv: encrypted.subarray(encrypted.byteLength - AES_BLOCK_SIZE)
-        }
-    }
-    const ciphertext = encrypted.subarray(0, encrypted.byteLength - AES_BLOCK_SIZE)
-    return {
-        ciphertext,
-        nextIv: ciphertext.subarray(ciphertext.byteLength - AES_BLOCK_SIZE)
-    }
-}
-
-function aesCbcDecryptChunk(
-    key: Uint8Array,
-    iv: Uint8Array,
-    ciphertext: Uint8Array,
-    isFinal: boolean
-): { plaintext: Uint8Array; nextIv: Uint8Array } {
-    const nextIv = toBytesView(ciphertext.subarray(ciphertext.byteLength - AES_BLOCK_SIZE))
-    if (isFinal) {
-        return { plaintext: aesCbcDecrypt(key, iv, ciphertext), nextIv }
-    }
-    const padBlock = aesCbcEncrypt(key, nextIv, PKCS7_FULL_BLOCK).subarray(0, AES_BLOCK_SIZE)
-    const withPad = concatBytes([ciphertext, padBlock])
-    return { plaintext: aesCbcDecrypt(key, iv, withPad), nextIv }
-}
 
 function computeFirstFrameSidecar(
     macKey: Uint8Array,
@@ -291,7 +254,7 @@ export class WaMediaCrypto {
         )
         const output = createWriteStream(filePath)
         try {
-            const metadata = await pumpEncryptionToWritable(
+            const metadata = await pumpEncryption(
                 plaintext,
                 output,
                 keys,
@@ -332,7 +295,7 @@ export class WaMediaCrypto {
 
 async function pumpEncryption(
     plaintext: Readable,
-    encrypted: PassThrough,
+    output: Writable,
     keys: WaMediaDerivedKeys,
     computeSidecar: boolean,
     firstFrameLength?: number
@@ -343,7 +306,7 @@ async function pumpEncryption(
     readonly streamingSidecar?: Uint8Array
     readonly firstFrameSidecar?: Uint8Array
 }> {
-    const aesKey = keys.encKey
+    const cipher = createCipheriv('aes-256-cbc', keys.encKey, keys.iv)
     const plainHash = createHash('sha256')
     const encHash = createHash('sha256')
     const hmac = createHmac('sha256', keys.macKey)
@@ -352,63 +315,42 @@ async function pumpEncryption(
         firstFrameLength !== undefined
             ? IV_SIZE + Math.ceil(firstFrameLength / AES_BLOCK_SIZE) * AES_BLOCK_SIZE
             : 0
-    let ffCollected = 0
     const ffChunks: Uint8Array[] = ffTarget > 0 ? [keys.iv] : []
-    if (ffTarget > 0) ffCollected = IV_SIZE
+    let ffCollected = ffTarget > 0 ? IV_SIZE : 0
     let plaintextLength = 0
-    let currentIv = keys.iv
-    let pending: Uint8Array = EMPTY_BYTES
 
     hmac.update(keys.iv)
     sidecar?.push(keys.iv)
+
+    const consumeCiphertext = async (raw: Buffer): Promise<void> => {
+        if (raw.byteLength === 0) return
+        const bytes = toBytesView(raw)
+        hmac.update(bytes)
+        encHash.update(bytes)
+        sidecar?.push(bytes)
+        if (ffCollected < ffTarget) {
+            const need = ffTarget - ffCollected
+            ffChunks.push(bytes.subarray(0, Math.min(need, bytes.byteLength)))
+            ffCollected += bytes.byteLength
+        }
+        await writeChunkToWritable(output, bytes)
+    }
+
     try {
         for await (const chunk of plaintext) {
             const plainChunk = toChunkBytes(chunk)
             if (plainChunk.byteLength === 0) continue
             plaintextLength += plainChunk.byteLength
             plainHash.update(plainChunk)
-
-            const combined =
-                pending.byteLength > 0
-                    ? concatBytes([pending, plainChunk])
-                    : toBytesView(plainChunk)
-            const aligned = combined.byteLength - (combined.byteLength % AES_BLOCK_SIZE)
-            if (aligned === 0) {
-                pending = combined
-                continue
-            }
-
-            const toEncrypt = toBytesView(combined.subarray(0, aligned))
-            pending = toBytesView(combined.subarray(aligned))
-
-            const { ciphertext, nextIv } = aesCbcEncryptChunk(aesKey, currentIv, toEncrypt, false)
-            currentIv = nextIv
-            hmac.update(ciphertext)
-            encHash.update(ciphertext)
-            sidecar?.push(ciphertext)
-            if (ffCollected < ffTarget) {
-                const need = ffTarget - ffCollected
-                ffChunks.push(ciphertext.subarray(0, Math.min(need, ciphertext.byteLength)))
-                ffCollected += ciphertext.byteLength
-            }
-            await writeChunk(encrypted, ciphertext)
+            await consumeCiphertext(cipher.update(plainChunk))
         }
-
-        const { ciphertext: finalCiphertext } = aesCbcEncryptChunk(aesKey, currentIv, pending, true)
-        hmac.update(finalCiphertext)
-        encHash.update(finalCiphertext)
-        sidecar?.push(finalCiphertext)
-        if (ffCollected < ffTarget) {
-            const need = ffTarget - ffCollected
-            ffChunks.push(finalCiphertext.subarray(0, Math.min(need, finalCiphertext.byteLength)))
-        }
-        await writeChunk(encrypted, finalCiphertext)
+        await consumeCiphertext(cipher.final())
 
         const signature = toBytesView(hmac.digest().subarray(0, HMAC_TRUNCATED_SIZE))
         encHash.update(signature)
         sidecar?.push(signature)
-        await writeChunk(encrypted, signature)
-        encrypted.end()
+        await writeChunkToWritable(output, signature)
+        await endWritable(output)
 
         let firstFrameSidecar: Uint8Array | undefined
         if (ffTarget > 0) {
@@ -425,7 +367,7 @@ async function pumpEncryption(
         }
     } catch (error) {
         const normalized = toError(error)
-        encrypted.destroy(normalized)
+        output.destroy(normalized)
         throw normalized
     }
 }
@@ -458,122 +400,20 @@ async function endWritable(stream: Writable): Promise<void> {
     })
 }
 
-async function pumpEncryptionToWritable(
-    plaintext: Readable,
-    output: Writable,
-    keys: WaMediaDerivedKeys,
-    computeSidecar: boolean,
-    firstFrameLength?: number
-): Promise<{
-    readonly fileSha256: Uint8Array
-    readonly fileEncSha256: Uint8Array
-    readonly plaintextLength: number
-    readonly streamingSidecar?: Uint8Array
-    readonly firstFrameSidecar?: Uint8Array
-}> {
-    const aesKey = keys.encKey
-    const plainHash = createHash('sha256')
-    const encHash = createHash('sha256')
-    const hmac = createHmac('sha256', keys.macKey)
-    const sidecar = computeSidecar ? new SidecarAccumulator(keys.macKey) : null
-    const ffTarget =
-        firstFrameLength !== undefined
-            ? IV_SIZE + Math.ceil(firstFrameLength / AES_BLOCK_SIZE) * AES_BLOCK_SIZE
-            : 0
-    let ffCollected = 0
-    const ffChunks: Uint8Array[] = ffTarget > 0 ? [keys.iv] : []
-    if (ffTarget > 0) ffCollected = IV_SIZE
-    let plaintextLength = 0
-    let currentIv = keys.iv
-    let pending: Uint8Array = EMPTY_BYTES
-
-    hmac.update(keys.iv)
-    sidecar?.push(keys.iv)
-    try {
-        for await (const chunk of plaintext) {
-            const plainChunk = toChunkBytes(chunk)
-            if (plainChunk.byteLength === 0) continue
-            plaintextLength += plainChunk.byteLength
-            plainHash.update(plainChunk)
-
-            const combined =
-                pending.byteLength > 0
-                    ? concatBytes([pending, plainChunk])
-                    : toBytesView(plainChunk)
-            const aligned = combined.byteLength - (combined.byteLength % AES_BLOCK_SIZE)
-            if (aligned === 0) {
-                pending = combined
-                continue
-            }
-
-            const toEncrypt = toBytesView(combined.subarray(0, aligned))
-            pending = toBytesView(combined.subarray(aligned))
-
-            const { ciphertext, nextIv } = aesCbcEncryptChunk(aesKey, currentIv, toEncrypt, false)
-            currentIv = nextIv
-            hmac.update(ciphertext)
-            encHash.update(ciphertext)
-            sidecar?.push(ciphertext)
-            if (ffCollected < ffTarget) {
-                const need = ffTarget - ffCollected
-                ffChunks.push(ciphertext.subarray(0, Math.min(need, ciphertext.byteLength)))
-                ffCollected += ciphertext.byteLength
-            }
-            await writeChunkToWritable(output, ciphertext)
-        }
-
-        const { ciphertext: finalCiphertext } = aesCbcEncryptChunk(aesKey, currentIv, pending, true)
-        hmac.update(finalCiphertext)
-        encHash.update(finalCiphertext)
-        sidecar?.push(finalCiphertext)
-        if (ffCollected < ffTarget) {
-            const need = ffTarget - ffCollected
-            ffChunks.push(finalCiphertext.subarray(0, Math.min(need, finalCiphertext.byteLength)))
-        }
-        await writeChunkToWritable(output, finalCiphertext)
-
-        const signature = toBytesView(hmac.digest().subarray(0, HMAC_TRUNCATED_SIZE))
-        encHash.update(signature)
-        sidecar?.push(signature)
-        await writeChunkToWritable(output, signature)
-        await endWritable(output)
-
-        let firstFrameSidecar: Uint8Array | undefined
-        if (ffTarget > 0) {
-            const ffDigest = hmacSha256Sign(keys.macKey, ffChunks)
-            firstFrameSidecar = ffDigest.subarray(0, SIDECAR_HMAC_SIZE)
-        }
-
-        return {
-            fileSha256: toBytesView(plainHash.digest()),
-            fileEncSha256: toBytesView(encHash.digest()),
-            plaintextLength,
-            streamingSidecar: sidecar?.finish(),
-            firstFrameSidecar
-        }
-    } catch (error) {
-        const normalized = toError(error)
-        output.destroy(normalized)
-        throw normalized
-    }
-}
-
 async function pumpDecryption(
     encrypted: Readable,
     plaintext: PassThrough,
     keys: WaMediaDerivedKeys,
     options: WaMediaDecryptReadableOptions
 ): Promise<{ readonly fileSha256: Uint8Array; readonly fileEncSha256: Uint8Array }> {
-    const aesKey = keys.encKey
+    const decipher = createDecipheriv('aes-256-cbc', keys.encKey, keys.iv)
     const plainHash = createHash('sha256')
     const encHash = createHash('sha256')
     const hmac = createHmac('sha256', keys.macKey)
-    let currentIv = keys.iv
-    let pending: Uint8Array = EMPTY_BYTES
+    let trailing: Uint8Array = EMPTY_BYTES
 
     hmac.update(keys.iv)
     try {
-        let trailing: Uint8Array = EMPTY_BYTES
         for await (const chunk of encrypted) {
             const bytes = toChunkBytes(chunk)
             if (bytes.byteLength === 0) {
@@ -587,30 +427,14 @@ async function pumpDecryption(
             }
 
             const ciphertextChunk = merged.subarray(0, merged.byteLength - HMAC_TRUNCATED_SIZE)
-            trailing = merged.subarray(merged.byteLength - HMAC_TRUNCATED_SIZE)
+            trailing = toBytesView(merged.subarray(merged.byteLength - HMAC_TRUNCATED_SIZE))
             hmac.update(ciphertextChunk)
 
-            const combined =
-                pending.byteLength > 0
-                    ? concatBytes([pending, ciphertextChunk])
-                    : toBytesView(ciphertextChunk)
-            const aligned = combined.byteLength - (combined.byteLength % AES_BLOCK_SIZE)
-            if (aligned > AES_BLOCK_SIZE) {
-                const toDecrypt = combined.subarray(0, aligned - AES_BLOCK_SIZE)
-                const { plaintext: plainChunk, nextIv } = aesCbcDecryptChunk(
-                    aesKey,
-                    currentIv,
-                    toDecrypt,
-                    false
-                )
-                currentIv = nextIv
-                if (plainChunk.byteLength > 0) {
-                    plainHash.update(plainChunk)
-                    await writeChunk(plaintext, plainChunk)
-                }
-                pending = toBytesView(combined.subarray(aligned - AES_BLOCK_SIZE))
-            } else {
-                pending = combined
+            const dec = decipher.update(ciphertextChunk)
+            if (dec.byteLength > 0) {
+                const decBytes = toBytesView(dec)
+                plainHash.update(decBytes)
+                await writeChunkToWritable(plaintext, decBytes)
             }
         }
 
@@ -625,13 +449,11 @@ async function pumpDecryption(
             }
         }
 
-        if (pending.byteLength < AES_BLOCK_SIZE || pending.byteLength % AES_BLOCK_SIZE !== 0) {
-            throw new Error(`invalid ciphertext length: ${pending.byteLength}`)
-        }
-        const { plaintext: plainFinal } = aesCbcDecryptChunk(aesKey, currentIv, pending, true)
-        if (plainFinal.byteLength > 0) {
-            plainHash.update(plainFinal)
-            await writeChunk(plaintext, plainFinal)
+        const finalDec = decipher.final()
+        if (finalDec.byteLength > 0) {
+            const bytes = toBytesView(finalDec)
+            plainHash.update(bytes)
+            await writeChunkToWritable(plaintext, bytes)
         }
 
         const fileSha256 = toBytesView(plainHash.digest())
@@ -663,14 +485,4 @@ function mediaTypeToHkdfInfo(mediaType: MediaCryptoType): string {
         return getWaMediaHkdfInfo(WA_APP_STATE_KEY_TYPES.MD_MSG_HIST)
     }
     return getWaMediaHkdfInfo(mediaType)
-}
-
-async function writeChunk(stream: PassThrough, chunk: Uint8Array): Promise<void> {
-    if (chunk.byteLength === 0) {
-        return
-    }
-    if (stream.write(chunk)) {
-        return
-    }
-    await once(stream, 'drain')
 }

--- a/src/media/__tests__/media.test.ts
+++ b/src/media/__tests__/media.test.ts
@@ -10,6 +10,14 @@ import { parseWebpAnimation, runMediaProcessor } from '@client/media'
 import { buildMediaMessageContent, getMediaConn } from '@client/messages'
 import type { Logger } from '@infra/log/types'
 import { parseMediaConnResponse } from '@media/conn'
+import {
+    MEDIA_UPLOAD_PATHS,
+    type MediaUploadKind,
+    NEWSLETTER_MEDIA_UPLOAD_PATHS,
+    type NewsletterMediaKind,
+    PPS_UPLOAD_PATHS,
+    type PpsUploadKind
+} from '@media/constants'
 import { WaMediaCrypto } from '@media/WaMediaCrypto'
 import { WaMediaTransferClient } from '@media/WaMediaTransferClient'
 import type { BinaryNode } from '@transport/types'
@@ -1073,5 +1081,69 @@ test('media transfer client uploads readable stream through optional got agent',
         await new Promise<void>((resolve) => {
             server.close(() => resolve())
         })
+    }
+})
+
+test('MEDIA_UPLOAD_PATHS covers all wa-web /mms paths under /mms prefix', () => {
+    const expected: Record<MediaUploadKind, string> = {
+        image: '/mms/image',
+        video: '/mms/video',
+        audio: '/mms/audio',
+        document: '/mms/document',
+        sticker: '/mms/sticker',
+        gif: '/mms/gif',
+        ptt: '/mms/ptt',
+        ptv: '/mms/video',
+        'ads-image': '/mms/ads-image',
+        'ads-video': '/mms/ads-video',
+        'group-history': '/mms/group-history',
+        'md-app-state': '/mms/md-app-state',
+        'md-msg-hist': '/mms/md-msg-hist',
+        'music-artwork': '/mms/music-artwork',
+        'newsletter-music-artwork': '/mms/newsletter-music-artwork',
+        'sticker-pack': '/mms/sticker-pack',
+        'thumbnail-document': '/mms/thumbnail-document',
+        'thumbnail-image': '/mms/thumbnail-image',
+        'thumbnail-link': '/mms/thumbnail-link',
+        'thumbnail-sticker-pack': '/mms/thumbnail-sticker-pack',
+        'thumbnail-video': '/mms/thumbnail-video',
+        'waffle-image': '/mms/waffle-image',
+        'waffle-video': '/mms/waffle-video'
+    }
+    assert.deepEqual(MEDIA_UPLOAD_PATHS, expected)
+    for (const key of Object.keys(MEDIA_UPLOAD_PATHS) as MediaUploadKind[]) {
+        assert.ok(
+            MEDIA_UPLOAD_PATHS[key].startsWith('/mms/'),
+            `${key} should start with /mms/, got ${MEDIA_UPLOAD_PATHS[key]}`
+        )
+    }
+})
+
+test('PPS_UPLOAD_PATHS exposes profile and biz cover photo paths', () => {
+    const expected: Record<PpsUploadKind, string> = {
+        photo: '/pps/photo',
+        'biz-cover-photo': '/pps/biz-cover-photo'
+    }
+    assert.deepEqual(PPS_UPLOAD_PATHS, expected)
+})
+
+test('NEWSLETTER_MEDIA_UPLOAD_PATHS keys are under /newsletter prefix', () => {
+    const kinds: readonly NewsletterMediaKind[] = [
+        'image',
+        'video',
+        'audio',
+        'document',
+        'sticker',
+        'sticker-pack',
+        'gif',
+        'ptt',
+        'ptv',
+        'thumbnail-link'
+    ]
+    for (const kind of kinds) {
+        assert.ok(
+            NEWSLETTER_MEDIA_UPLOAD_PATHS[kind].startsWith('/newsletter/newsletter-'),
+            `${kind} should start with /newsletter/newsletter-, got ${NEWSLETTER_MEDIA_UPLOAD_PATHS[kind]}`
+        )
     }
 })

--- a/src/media/constants.ts
+++ b/src/media/constants.ts
@@ -14,9 +14,32 @@ export const HMAC_TRUNCATED_SIZE = 10
 export const SIDECAR_CHUNK_SIZE = 65_536
 export const SIDECAR_HMAC_SIZE = 10
 
-export const MEDIA_UPLOAD_PATHS: Readonly<
-    Record<'image' | 'video' | 'audio' | 'document' | 'sticker' | 'gif' | 'ptt' | 'ptv', string>
-> = Object.freeze({
+export type MediaUploadKind =
+    | 'image'
+    | 'video'
+    | 'audio'
+    | 'document'
+    | 'sticker'
+    | 'gif'
+    | 'ptt'
+    | 'ptv'
+    | 'ads-image'
+    | 'ads-video'
+    | 'group-history'
+    | 'md-app-state'
+    | 'md-msg-hist'
+    | 'music-artwork'
+    | 'newsletter-music-artwork'
+    | 'sticker-pack'
+    | 'thumbnail-document'
+    | 'thumbnail-image'
+    | 'thumbnail-link'
+    | 'thumbnail-sticker-pack'
+    | 'thumbnail-video'
+    | 'waffle-image'
+    | 'waffle-video'
+
+export const MEDIA_UPLOAD_PATHS: Readonly<Record<MediaUploadKind, string>> = Object.freeze({
     image: '/mms/image',
     video: '/mms/video',
     audio: '/mms/audio',
@@ -24,7 +47,22 @@ export const MEDIA_UPLOAD_PATHS: Readonly<
     sticker: '/mms/sticker',
     gif: '/mms/gif',
     ptt: '/mms/ptt',
-    ptv: '/mms/video'
+    ptv: '/mms/video',
+    'ads-image': '/mms/ads-image',
+    'ads-video': '/mms/ads-video',
+    'group-history': '/mms/group-history',
+    'md-app-state': '/mms/md-app-state',
+    'md-msg-hist': '/mms/md-msg-hist',
+    'music-artwork': '/mms/music-artwork',
+    'newsletter-music-artwork': '/mms/newsletter-music-artwork',
+    'sticker-pack': '/mms/sticker-pack',
+    'thumbnail-document': '/mms/thumbnail-document',
+    'thumbnail-image': '/mms/thumbnail-image',
+    'thumbnail-link': '/mms/thumbnail-link',
+    'thumbnail-sticker-pack': '/mms/thumbnail-sticker-pack',
+    'thumbnail-video': '/mms/thumbnail-video',
+    'waffle-image': '/mms/waffle-image',
+    'waffle-video': '/mms/waffle-video'
 })
 
 export type NewsletterMediaKind =
@@ -39,7 +77,12 @@ export type NewsletterMediaKind =
     | 'ptv'
     | 'thumbnail-link'
 
-export const BIZ_COVER_PHOTO_UPLOAD_PATH = '/pps/biz-cover-photo'
+export type PpsUploadKind = 'photo' | 'biz-cover-photo'
+
+export const PPS_UPLOAD_PATHS: Readonly<Record<PpsUploadKind, string>> = Object.freeze({
+    photo: '/pps/photo',
+    'biz-cover-photo': '/pps/biz-cover-photo'
+})
 
 export const NEWSLETTER_MEDIA_UPLOAD_PATHS: Readonly<Record<NewsletterMediaKind, string>> =
     Object.freeze({

--- a/src/media/index.ts
+++ b/src/media/index.ts
@@ -1,6 +1,13 @@
 export { WaMediaTransferClient } from '@media/WaMediaTransferClient'
 export { parseMediaConnResponse } from '@media/conn'
-export type { WaMediaConn } from '@media/types'
+export {
+    DEFAULT_MEDIA_HOSTS,
+    MEDIA_UPLOAD_PATHS,
+    NEWSLETTER_MEDIA_UPLOAD_PATHS,
+    PPS_UPLOAD_PATHS
+} from '@media/constants'
+export type { MediaUploadKind, NewsletterMediaKind, PpsUploadKind } from '@media/constants'
+export type { MediaCryptoType, MediaKind, WaMediaConn } from '@media/types'
 export { WaMediaCrypto } from '@media/WaMediaCrypto'
 export type {
     WaMediaProcessor,

--- a/src/media/types.ts
+++ b/src/media/types.ts
@@ -4,7 +4,14 @@ import type { Logger } from '@infra/log/types'
 import type { WaProxyAgent } from '@transport/types'
 
 export type MediaKind = 'image' | 'video' | 'audio' | 'document' | 'sticker' | 'ptv'
-export type MediaCryptoType = MediaKind | 'ptt' | 'gif' | 'history' | 'md-app-state'
+export type MediaCryptoType =
+    | MediaKind
+    | 'ptt'
+    | 'gif'
+    | 'history'
+    | 'md-app-state'
+    | 'md-msg-hist'
+    | 'xma-image'
 
 export interface WaMediaConnHost {
     readonly hostname: string

--- a/src/transport/noise/constants.ts
+++ b/src/transport/noise/constants.ts
@@ -1,6 +1,6 @@
 import { TEXT_ENCODER } from '@util/bytes'
 
-export const DEFAULT_VERSION_BASE = '2.3000.1039498983'
+export const DEFAULT_VERSION_BASE = '2.3000.1034748654'
 export const WA_PROTO_HEADER = new Uint8Array([87, 65, 6, 3])
 export const NOISE_XX_NAME = TEXT_ENCODER.encode('Noise_XX_25519_AESGCM_SHA256\0\0\0\0')
 export const NOISE_IK_NAME = TEXT_ENCODER.encode('Noise_IK_25519_AESGCM_SHA256\0\0\0\0')


### PR DESCRIPTION
- MEDIA_UPLOAD_PATHS now covers all 23 /mms paths from wa-web (was 8): adds ads-image/video, group-history, md-app-state, md-msg-hist, music-artwork, newsletter-music-artwork, sticker-pack, all thumbnail-* variants, waffle-image/video. Exports MediaUploadKind union for type-safe routing.
- PPS_UPLOAD_PATHS groups /pps/photo and /pps/biz-cover-photo behind a single map keyed by PpsUploadKind. WaBusinessCoordinator switched to PPS_UPLOAD_PATHS['biz-cover-photo']; the legacy BIZ_COVER_PHOTO_UPLOAD_PATH alias is dropped.
- MediaCryptoType now lists md-msg-hist and xma-image (already had HKDF entries; the type union was lagging).
- WaMediaCrypto streaming encrypt/decrypt now use createCipheriv('aes-256-cbc') and createDecipheriv as native Transform-grade ciphers. Removes the manual IV chain, PKCS7 padding helper, aesCbcEncryptChunk/aesCbcDecryptChunk, and the duplicated pumpEncryptionToWritable. One unified pumpEncryption handles both PassThrough and WriteStream destinations via Writable.
- resolveMediaInputs and preparePlaintextUploadSource now stat the path before creating the read stream so a missing file throws a clean 'media file not found' error instead of crashing the process with an unhandled ENOENT on the stream.
- resolveReadyPatches clears externalMutations after inlining the downloaded blob so validatePatch doesn't reject the patch as having inline+external mutations together (regression that escaped #68).
- Pin DEFAULT_VERSION_BASE back to 2.3000.1034748654 — the bumped 1039498983 caused server-side routing degradation for usync, group metadata, and prekey fetches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Extended media upload support for many additional WhatsApp media kinds and profile/business cover photo uploads
  - Re-exported media path and kind types for clearer media handling

* **Bug Fixes**
  - Fixed patch handling to avoid validation conflicts between inline and external mutations
  - Added file existence and regular-file checks with explicit errors for media uploads
  - Switched cover-photo uploads to use the centralized upload-path mapping

* **Tests**
  - Added tests for media upload path mappings and appstate sync inlining behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/70)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->