### PR TITLE
feat(message): add sticker pack send for direct chats and newsletters

### DIFF
--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -1,5 +1,5 @@
 import { createReadStream } from 'node:fs'
-import type { Readable } from 'node:stream'
+import { Readable } from 'node:stream'
 
 import {
     assertMediaUploadStatus,
@@ -18,19 +18,28 @@ import type { WaMediaOptions } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import { parseMediaConnResponse } from '@media/conn'
 import { MEDIA_CONN_CACHE_GRACE_MS, MEDIA_UPLOAD_PATHS } from '@media/constants'
+import { createStickerPackZipStream } from '@media/sticker-pack'
 import type { MediaCryptoType, WaMediaConn } from '@media/types'
 import { WaMediaCrypto } from '@media/WaMediaCrypto'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
 import { isSendMediaMessage, isSendTextMessage } from '@message/content'
+import {
+    toStickerPackProtoStickers,
+    toStickerPackZipEntries,
+    validateStickerPackInput
+} from '@message/sticker-pack'
 import type {
     WaMessageBuildResult,
     WaMessageUploadInfo,
     WaSendMediaMessage,
-    WaSendMessageContent
+    WaSendMessageContent,
+    WaSendStickerPackMessage
 } from '@message/types'
+import { proto } from '@proto'
 import { WA_DEFAULTS } from '@protocol/constants'
 import { buildMediaConnIq } from '@transport/node/builders/media'
 import type { BinaryNode } from '@transport/types'
+import { bytesToBase64 } from '@util/bytes'
 
 export interface WaMediaMessageOptions {
     readonly logger: Logger
@@ -85,17 +94,19 @@ export async function getMediaConn(
     return mediaConn
 }
 
-function needsSidecar(content: WaSendMediaMessage): boolean {
+function needsSidecar(content: Exclude<WaSendMediaMessage, WaSendStickerPackMessage>): boolean {
     return content.type === 'video' || content.type === 'ptv' || content.type === 'audio'
 }
 
-function resolveUploadType(content: WaSendMediaMessage): MediaCryptoType {
+function resolveUploadType(
+    content: Exclude<WaSendMediaMessage, WaSendStickerPackMessage>
+): MediaCryptoType {
     if (content.type === 'video' && content.gifPlayback) return 'gif'
     if (content.type === 'audio' && content.ptt) return 'ptt'
     return content.type as MediaCryptoType
 }
 
-function resolveMimetype(content: WaSendMediaMessage): string {
+function resolveMimetype(content: Exclude<WaSendMediaMessage, WaSendStickerPackMessage>): string {
     if (content.mimetype) return content.mimetype
     if (content.type === 'sticker') return 'image/webp'
     throw new Error(`mimetype is required for ${content.type} messages`)
@@ -105,6 +116,9 @@ async function buildMediaMessage(
     options: WaMediaMessageOptions,
     content: WaSendMediaMessage
 ): Promise<WaMessageBuildResult> {
+    if (content.type === 'sticker-pack') {
+        return buildStickerPackMediaMessage(options, content)
+    }
     const needsTempFile =
         hasMediaProcessingTasks(options.media, content) ||
         (content.type === 'sticker' && content.firstFrameLength === undefined)
@@ -329,7 +343,7 @@ function parseUploadResponse(
 
 async function uploadMediaBytes(
     options: WaMediaMessageOptions,
-    content: WaSendMediaMessage,
+    content: Exclude<WaSendMediaMessage, WaSendStickerPackMessage>,
     mediaBytes: Uint8Array,
     firstFrameLength?: number
 ): Promise<UploadResult> {
@@ -376,33 +390,42 @@ async function uploadMediaBytes(
     }
 }
 
-async function uploadMediaStream(
+interface EncryptedStreamUploadInput {
+    readonly plaintext: Readable
+    readonly mediaKey: Uint8Array
+    readonly cryptoType: MediaCryptoType
+    readonly uploadPath: string
+    readonly contentType: string
+    readonly logLabel: string
+    readonly sidecar: boolean
+    readonly firstFrameLength?: number
+}
+
+async function uploadEncryptedStream(
     options: WaMediaMessageOptions,
-    content: WaSendMediaMessage,
-    stream: Readable,
-    firstFrameLength?: number
+    input: EncryptedStreamUploadInput
 ): Promise<UploadResult> {
-    const uploadType = resolveUploadType(content)
-    const mediaKey = await WaMediaCrypto.generateMediaKey()
-    const encResult = await WaMediaCrypto.encryptToFile(uploadType, mediaKey, stream, {
-        sidecar: needsSidecar(content),
-        firstFrameLength
-    })
+    const encResult = await WaMediaCrypto.encryptToFile(
+        input.cryptoType,
+        input.mediaKey,
+        input.plaintext,
+        { sidecar: input.sidecar, firstFrameLength: input.firstFrameLength }
+    )
     let readStream: ReturnType<typeof createReadStream> | undefined
     try {
         const mediaConn = await getMediaConn(options)
         const selectedHost = selectMediaUploadHost(mediaConn)
         const uploadUrl = buildMediaUploadUrl(
             selectedHost,
-            resolveUploadPath(uploadType),
+            input.uploadPath,
             mediaConn.auth,
             encResult.fileEncSha256
         )
 
-        options.logger.debug('sending media stream upload request', {
-            mediaType: content.type,
-            uploadType,
+        options.logger.debug(input.logLabel, {
             host: selectedHost,
+            uploadPath: input.uploadPath,
+            plaintextLength: encResult.plaintextLength,
             encryptedSize: encResult.fileSize
         })
         readStream = createReadStream(encResult.filePath)
@@ -411,19 +434,19 @@ async function uploadMediaStream(
             method: 'POST',
             body: readStream,
             contentLength: encResult.fileSize,
-            contentType: resolveMimetype(content)
+            contentType: input.contentType
         })
         const responseBody = await options.mediaTransfer.readResponseBytes(uploadResponse)
         const parsed = parseUploadResponse(responseBody, uploadResponse.status)
         return {
             ...parsed,
-            mediaKey,
+            mediaKey: input.mediaKey,
             fileSha256: encResult.fileSha256,
             fileEncSha256: encResult.fileEncSha256,
             fileLength: encResult.plaintextLength,
             streamingSidecar: encResult.streamingSidecar,
             firstFrameSidecar: encResult.firstFrameSidecar,
-            firstFrameLength
+            firstFrameLength: input.firstFrameLength
         }
     } finally {
         if (readStream && !readStream.closed) {
@@ -433,5 +456,94 @@ async function uploadMediaStream(
             })
         }
         await WaMediaCrypto.cleanupEncryptedFile(encResult.filePath)
+    }
+}
+
+async function uploadMediaStream(
+    options: WaMediaMessageOptions,
+    content: Exclude<WaSendMediaMessage, WaSendStickerPackMessage>,
+    stream: Readable,
+    firstFrameLength?: number
+): Promise<UploadResult> {
+    const cryptoType = resolveUploadType(content)
+    return uploadEncryptedStream(options, {
+        plaintext: stream,
+        mediaKey: await WaMediaCrypto.generateMediaKey(),
+        cryptoType,
+        uploadPath: resolveUploadPath(cryptoType),
+        contentType: resolveMimetype(content),
+        logLabel: 'sending media stream upload request',
+        sidecar: needsSidecar(content),
+        firstFrameLength
+    })
+}
+
+function openStickerPackInputStream(media: Uint8Array | string): Readable {
+    return typeof media === 'string' ? createReadStream(media) : Readable.from([media])
+}
+
+async function buildStickerPackMediaMessage(
+    options: WaMediaMessageOptions,
+    content: WaSendStickerPackMessage
+): Promise<WaMessageBuildResult> {
+    validateStickerPackInput(content)
+
+    const mediaKey = await WaMediaCrypto.generateMediaKey()
+    const [bundle, cover] = await Promise.all([
+        uploadEncryptedStream(options, {
+            plaintext: createStickerPackZipStream(toStickerPackZipEntries(content)),
+            mediaKey,
+            cryptoType: 'sticker-pack',
+            uploadPath: MEDIA_UPLOAD_PATHS['sticker-pack'],
+            contentType: 'application/zip',
+            logLabel: 'sending sticker pack bundle upload',
+            sidecar: false
+        }),
+        uploadEncryptedStream(options, {
+            plaintext: openStickerPackInputStream(content.coverThumbnail),
+            mediaKey,
+            cryptoType: 'thumbnail-sticker-pack',
+            uploadPath: MEDIA_UPLOAD_PATHS['thumbnail-sticker-pack'],
+            contentType: 'image/jpeg',
+            logLabel: 'sending sticker pack thumbnail upload',
+            sidecar: false
+        })
+    ])
+    if (cover.fileLength === 0) {
+        throw new Error('sticker pack coverThumbnail is empty')
+    }
+
+    return {
+        upload: {
+            url: bundle.url,
+            directPath: bundle.directPath,
+            fileSha256: bundle.fileSha256,
+            fileLength: bundle.fileLength
+        },
+        message: {
+            stickerPackMessage: {
+                stickerPackId: content.stickerPackId,
+                name: content.name,
+                publisher: content.publisher,
+                stickers: toStickerPackProtoStickers(content),
+                fileLength: bundle.fileLength,
+                fileSha256: bundle.fileSha256,
+                fileEncSha256: bundle.fileEncSha256,
+                mediaKey,
+                mediaKeyTimestamp: Math.floor(Date.now() / 1000),
+                directPath: bundle.directPath,
+                thumbnailDirectPath: cover.directPath,
+                thumbnailSha256: cover.fileSha256,
+                thumbnailEncSha256: cover.fileEncSha256,
+                thumbnailWidth: content.thumbnailWidth ?? 252,
+                thumbnailHeight: content.thumbnailHeight ?? 252,
+                trayIconFileName: content.trayIcon.fileName,
+                stickerPackSize: bundle.fileLength,
+                stickerPackOrigin: proto.Message.StickerPackMessage.StickerPackOrigin.USER_CREATED,
+                imageDataHash: bytesToBase64(cover.fileSha256),
+                caption: content.caption,
+                packDescription: content.packDescription
+            }
+        }
     }
 }

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -487,6 +487,10 @@ async function buildStickerPackMediaMessage(
     content: WaSendStickerPackMessage
 ): Promise<WaMessageBuildResult> {
     validateStickerPackInput(content)
+    if (content.coverThumbnail === undefined) {
+        throw new Error('sticker pack send requires coverThumbnail for non-newsletter recipients')
+    }
+    const coverThumbnail = content.coverThumbnail
 
     const mediaKey = await WaMediaCrypto.generateMediaKey()
     const [bundle, cover] = await Promise.all([
@@ -500,7 +504,7 @@ async function buildStickerPackMediaMessage(
             sidecar: false
         }),
         uploadEncryptedStream(options, {
-            plaintext: openStickerPackInputStream(content.coverThumbnail),
+            plaintext: openStickerPackInputStream(coverThumbnail),
             mediaKey,
             cryptoType: 'thumbnail-sticker-pack',
             uploadPath: MEDIA_UPLOAD_PATHS['thumbnail-sticker-pack'],

--- a/src/client/newsletter/content.ts
+++ b/src/client/newsletter/content.ts
@@ -8,12 +8,23 @@ import {
 } from '@client/media'
 import type { Logger } from '@infra/log/types'
 import { NEWSLETTER_MEDIA_UPLOAD_PATHS, type NewsletterMediaKind } from '@media/constants'
+import { createStickerPackZipStream } from '@media/sticker-pack'
 import type { WaMediaConn } from '@media/types'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
 import { isSendMediaMessage, isSendTextMessage, resolveMessageTypeAttr } from '@message/content'
 import { applyContextInfo, type WaSendContextInfo } from '@message/context-info'
-import type { WaSendMediaMessage, WaSendMessageContent } from '@message/types'
+import {
+    toStickerPackProtoStickers,
+    toStickerPackZipEntries,
+    validateStickerPackInput
+} from '@message/sticker-pack'
+import type {
+    WaSendMediaMessage,
+    WaSendMessageContent,
+    WaSendStickerPackMessage
+} from '@message/types'
 import { proto, type Proto } from '@proto'
+import { WA_ENC_MEDIA_TYPES } from '@protocol/message'
 import { base64ToBytes } from '@util/bytes'
 
 export type WaNewsletterUploadMedia = WaUploadMediaSource
@@ -118,12 +129,13 @@ function pickMediaTypeFromMessage(message: Proto.IMessage): string | null {
     if (message.audioMessage) return message.audioMessage.ptt ? 'ptt' : 'audio'
     if (message.documentMessage) return 'document'
     if (message.stickerMessage) return 'sticker'
+    if (message.stickerPackMessage) return WA_ENC_MEDIA_TYPES.STICKER_PACK
     if (message.ptvMessage) return 'ptv'
     return null
 }
 
 function buildMediaProtoMessage(
-    content: WaSendMediaMessage,
+    content: Exclude<WaSendMediaMessage, WaSendStickerPackMessage>,
     upload: WaNewsletterUploadResult
 ): Proto.IMessage {
     const common = {
@@ -192,7 +204,9 @@ function buildMediaProtoMessage(
     }
 }
 
-function toUploadMedia(media: WaSendMediaMessage['media']): Uint8Array | string | Readable {
+function toUploadMedia(
+    media: Uint8Array | ArrayBuffer | Readable | string
+): Uint8Array | string | Readable {
     if (media instanceof Uint8Array) return media
     if (media instanceof ArrayBuffer) return new Uint8Array(media)
     return media
@@ -230,6 +244,39 @@ export async function buildNewsletterMessageContent(
             )
         }
         const mediaConn = await options.getMediaConn()
+        if (content.type === 'sticker-pack') {
+            validateStickerPackInput(content)
+            const upload = await uploadNewsletterMedia(
+                { mediaTransfer: options.mediaTransfer, logger: options.logger },
+                {
+                    mediaKind: 'sticker-pack',
+                    media: createStickerPackZipStream(toStickerPackZipEntries(content)),
+                    mimetype: 'application/zip',
+                    mediaConn
+                }
+            )
+            const stickerPackMessage: Proto.Message.IStickerPackMessage = {
+                stickerPackId: content.stickerPackId,
+                name: content.name,
+                publisher: content.publisher,
+                stickers: toStickerPackProtoStickers(content),
+                fileLength: upload.fileLength,
+                fileSha256: upload.fileSha256,
+                directPath: upload.directPath,
+                trayIconFileName: content.trayIcon.fileName,
+                stickerPackSize: upload.fileLength,
+                stickerPackOrigin: proto.Message.StickerPackMessage.StickerPackOrigin.USER_CREATED,
+                caption: content.caption,
+                packDescription: content.packDescription
+            }
+            const message = applyContextInfo({ stickerPackMessage }, ctx)
+            return {
+                kind: 'media',
+                plaintext: proto.Message.encode(message).finish(),
+                mediaType: WA_ENC_MEDIA_TYPES.STICKER_PACK,
+                upload
+            }
+        }
         const explicitMimetype = 'mimetype' in content && content.mimetype ? content.mimetype : null
         const resolvedMimetype =
             explicitMimetype ?? (content.type === 'sticker' ? 'image/webp' : null)

--- a/src/media/__tests__/sticker-pack.test.ts
+++ b/src/media/__tests__/sticker-pack.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict'
+import { type Readable } from 'node:stream'
+import test from 'node:test'
+
+import { createStickerPackZipStream, type StickerPackZipEntry } from '@media/sticker-pack'
+import { concatBytes } from '@util/bytes'
+
+const ZIP_LOCAL_FILE = 0x04034b50
+const ZIP_CENTRAL_DIR = 0x02014b50
+const ZIP_EOCD = 0x06054b50
+
+function readUint32LE(bytes: Uint8Array, offset: number): number {
+    return (
+        (bytes[offset] |
+            (bytes[offset + 1] << 8) |
+            (bytes[offset + 2] << 16) |
+            (bytes[offset + 3] << 24)) >>>
+        0
+    )
+}
+
+function readUint16LE(bytes: Uint8Array, offset: number): number {
+    return bytes[offset] | (bytes[offset + 1] << 8)
+}
+
+function findEocd(zip: Uint8Array): number {
+    for (let i = zip.byteLength - 22; i >= 0; i -= 1) {
+        if (readUint32LE(zip, i) === ZIP_EOCD) return i
+    }
+    throw new Error('EOCD not found')
+}
+
+interface ParsedEntry {
+    readonly fileName: string
+    readonly bytes: Uint8Array
+}
+
+function parseZip(zip: Uint8Array): readonly ParsedEntry[] {
+    const eocd = findEocd(zip)
+    const entryCount = readUint16LE(zip, eocd + 10)
+    const centralDirSize = readUint32LE(zip, eocd + 12)
+    const centralDirOffset = readUint32LE(zip, eocd + 16)
+    assert.equal(centralDirOffset + centralDirSize, eocd, 'central dir abuts EOCD')
+
+    const entries: ParsedEntry[] = []
+    let cursor = centralDirOffset
+    for (let i = 0; i < entryCount; i += 1) {
+        assert.equal(readUint32LE(zip, cursor), ZIP_CENTRAL_DIR, 'central dir signature')
+        const compressedSize = readUint32LE(zip, cursor + 20)
+        const nameLen = readUint16LE(zip, cursor + 28)
+        const extraLen = readUint16LE(zip, cursor + 30)
+        const commentLen = readUint16LE(zip, cursor + 32)
+        const localOffset = readUint32LE(zip, cursor + 42)
+        const fileName = new TextDecoder().decode(zip.subarray(cursor + 46, cursor + 46 + nameLen))
+
+        assert.equal(readUint32LE(zip, localOffset), ZIP_LOCAL_FILE, 'local file signature')
+        const localNameLen = readUint16LE(zip, localOffset + 26)
+        const localExtraLen = readUint16LE(zip, localOffset + 28)
+        const dataStart = localOffset + 30 + localNameLen + localExtraLen
+        entries.push({
+            fileName,
+            bytes: zip.subarray(dataStart, dataStart + compressedSize)
+        })
+        cursor += 46 + nameLen + extraLen + commentLen
+    }
+    return entries
+}
+
+async function drainZip(entries: readonly StickerPackZipEntry[]): Promise<Uint8Array> {
+    const stream = createStickerPackZipStream(entries)
+    return concatBytes(await collectChunks(stream))
+}
+
+async function collectChunks(stream: Readable): Promise<readonly Uint8Array[]> {
+    const chunks: Uint8Array[] = []
+    for await (const chunk of stream) {
+        chunks.push(chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk as Buffer))
+    }
+    return chunks
+}
+
+test('createStickerPackZipStream round-trips entries and produces a valid EOCD', async () => {
+    const stickers: StickerPackZipEntry[] = [
+        { fileName: 'sticker0.webp', source: new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 1, 2, 3]) },
+        { fileName: 'sticker1.webp', source: new Uint8Array([0x52, 0x49, 0x46, 0x46, 9, 8, 7, 6]) }
+    ]
+    const zip = await drainZip(stickers)
+    const parsed = parseZip(zip)
+    assert.equal(parsed.length, stickers.length)
+    for (let i = 0; i < stickers.length; i += 1) {
+        assert.equal(parsed[i].fileName, stickers[i].fileName)
+        assert.deepEqual(parsed[i].bytes, stickers[i].source)
+    }
+})
+
+test('createStickerPackZipStream rejects empty input, duplicate names, and empty names', () => {
+    assert.throws(() => createStickerPackZipStream([]), /at least one entry/)
+    assert.throws(
+        () =>
+            createStickerPackZipStream([
+                { fileName: 'a.webp', source: new Uint8Array([1]) },
+                { fileName: 'a.webp', source: new Uint8Array([2]) }
+            ]),
+        /duplicate fileName/
+    )
+    assert.throws(
+        () => createStickerPackZipStream([{ fileName: '', source: new Uint8Array([1]) }]),
+        /non-empty fileName/
+    )
+})
+
+test('createStickerPackZipStream writes uncompressed (stored) entries so bytes survive verbatim', async () => {
+    const original = new Uint8Array(2_048)
+    for (let i = 0; i < original.length; i += 1) original[i] = (i * 7) & 0xff
+
+    const zip = await drainZip([{ fileName: 'big.webp', source: original }])
+    const parsed = parseZip(zip)
+    assert.equal(parsed.length, 1)
+    assert.deepEqual(parsed[0].bytes, original)
+})

--- a/src/media/sticker-pack.ts
+++ b/src/media/sticker-pack.ts
@@ -1,0 +1,159 @@
+import { readFile } from 'node:fs/promises'
+import { Readable } from 'node:stream'
+
+import { TEXT_ENCODER } from '@util/bytes'
+
+const SIGNATURE_LOCAL_FILE = 0x04034b50
+const SIGNATURE_CENTRAL_DIR = 0x02014b50
+const SIGNATURE_END_OF_CENTRAL_DIR = 0x06054b50
+const COMPRESSION_STORED = 0
+const VERSION_NEEDED = 20
+const LOCAL_HEADER_SIZE = 30
+const CENTRAL_HEADER_SIZE = 46
+const EOCD_SIZE = 22
+
+const CRC32_TABLE: ReadonlyArray<number> = (() => {
+    const table = new Array<number>(256)
+    for (let i = 0; i < 256; i += 1) {
+        let c = i
+        for (let k = 0; k < 8; k += 1) {
+            c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+        }
+        table[i] = c >>> 0
+    }
+    return table
+})()
+
+function crc32(bytes: Uint8Array): number {
+    let crc = 0xffffffff
+    for (let i = 0; i < bytes.byteLength; i += 1) {
+        crc = CRC32_TABLE[(crc ^ bytes[i]) & 0xff] ^ (crc >>> 8)
+    }
+    return (crc ^ 0xffffffff) >>> 0
+}
+
+export interface StickerPackZipEntry {
+    readonly fileName: string
+    readonly source: Uint8Array | string
+}
+
+function validateEntries(entries: readonly StickerPackZipEntry[]): void {
+    if (entries.length === 0) {
+        throw new Error('sticker pack zip requires at least one entry')
+    }
+    const seen = new Set<string>()
+    for (const entry of entries) {
+        if (!entry.fileName) {
+            throw new Error('sticker pack zip entry requires a non-empty fileName')
+        }
+        if (seen.has(entry.fileName)) {
+            throw new Error(`sticker pack zip has duplicate fileName: ${entry.fileName}`)
+        }
+        seen.add(entry.fileName)
+    }
+}
+
+async function loadEntryBytes(source: Uint8Array | string): Promise<Uint8Array> {
+    if (typeof source === 'string') {
+        const buf = await readFile(source)
+        return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+    }
+    return source
+}
+
+function buildLocalHeader(name: Uint8Array, crc: number, dataLength: number): Uint8Array {
+    const out = new Uint8Array(LOCAL_HEADER_SIZE + name.byteLength)
+    const view = new DataView(out.buffer, out.byteOffset, out.byteLength)
+    view.setUint32(0, SIGNATURE_LOCAL_FILE, true)
+    view.setUint16(4, VERSION_NEEDED, true)
+    view.setUint16(6, 0, true)
+    view.setUint16(8, COMPRESSION_STORED, true)
+    view.setUint16(10, 0, true)
+    view.setUint16(12, 0, true)
+    view.setUint32(14, crc, true)
+    view.setUint32(18, dataLength, true)
+    view.setUint32(22, dataLength, true)
+    view.setUint16(26, name.byteLength, true)
+    view.setUint16(28, 0, true)
+    out.set(name, LOCAL_HEADER_SIZE)
+    return out
+}
+
+interface CentralEntry {
+    readonly name: Uint8Array
+    readonly crc: number
+    readonly dataLength: number
+    readonly localOffset: number
+}
+
+function buildCentralDirectory(entries: readonly CentralEntry[]): Uint8Array {
+    let totalSize = 0
+    for (const entry of entries) totalSize += CENTRAL_HEADER_SIZE + entry.name.byteLength
+    const out = new Uint8Array(totalSize)
+    const view = new DataView(out.buffer, out.byteOffset, out.byteLength)
+    let offset = 0
+    for (const entry of entries) {
+        view.setUint32(offset, SIGNATURE_CENTRAL_DIR, true)
+        view.setUint16(offset + 4, VERSION_NEEDED, true)
+        view.setUint16(offset + 6, VERSION_NEEDED, true)
+        view.setUint16(offset + 8, 0, true)
+        view.setUint16(offset + 10, COMPRESSION_STORED, true)
+        view.setUint16(offset + 12, 0, true)
+        view.setUint16(offset + 14, 0, true)
+        view.setUint32(offset + 16, entry.crc, true)
+        view.setUint32(offset + 20, entry.dataLength, true)
+        view.setUint32(offset + 24, entry.dataLength, true)
+        view.setUint16(offset + 28, entry.name.byteLength, true)
+        view.setUint16(offset + 30, 0, true)
+        view.setUint16(offset + 32, 0, true)
+        view.setUint16(offset + 34, 0, true)
+        view.setUint16(offset + 36, 0, true)
+        view.setUint32(offset + 38, 0, true)
+        view.setUint32(offset + 42, entry.localOffset, true)
+        offset += CENTRAL_HEADER_SIZE
+        out.set(entry.name, offset)
+        offset += entry.name.byteLength
+    }
+    return out
+}
+
+function buildEocd(
+    entryCount: number,
+    centralDirSize: number,
+    centralDirOffset: number
+): Uint8Array {
+    const out = new Uint8Array(EOCD_SIZE)
+    const view = new DataView(out.buffer, out.byteOffset, out.byteLength)
+    view.setUint32(0, SIGNATURE_END_OF_CENTRAL_DIR, true)
+    view.setUint16(4, 0, true)
+    view.setUint16(6, 0, true)
+    view.setUint16(8, entryCount, true)
+    view.setUint16(10, entryCount, true)
+    view.setUint32(12, centralDirSize, true)
+    view.setUint32(16, centralDirOffset, true)
+    view.setUint16(20, 0, true)
+    return out
+}
+
+export function createStickerPackZipStream(entries: readonly StickerPackZipEntry[]): Readable {
+    validateEntries(entries)
+    return Readable.from(zipChunks(entries))
+}
+
+async function* zipChunks(entries: readonly StickerPackZipEntry[]): AsyncGenerator<Uint8Array> {
+    const central: CentralEntry[] = []
+    let offset = 0
+    for (const entry of entries) {
+        const data = await loadEntryBytes(entry.source)
+        const name = TEXT_ENCODER.encode(entry.fileName)
+        const crc = crc32(data)
+        const header = buildLocalHeader(name, crc, data.byteLength)
+        yield header
+        yield data
+        central.push({ name, crc, dataLength: data.byteLength, localOffset: offset })
+        offset += header.byteLength + data.byteLength
+    }
+    const centralDir = buildCentralDirectory(central)
+    yield centralDir
+    yield buildEocd(central.length, centralDir.byteLength, offset)
+}

--- a/src/media/types.ts
+++ b/src/media/types.ts
@@ -12,6 +12,8 @@ export type MediaCryptoType =
     | 'md-app-state'
     | 'md-msg-hist'
     | 'xma-image'
+    | 'sticker-pack'
+    | 'thumbnail-sticker-pack'
 
 export interface WaMediaConnHost {
     readonly hostname: string

--- a/src/message/content.ts
+++ b/src/message/content.ts
@@ -9,7 +9,13 @@ import {
 } from '@protocol/constants'
 
 export function isSendMediaMessage(content: unknown): content is WaSendMediaMessage {
-    return !!content && typeof content === 'object' && 'type' in content && 'media' in content
+    if (!content || typeof content !== 'object' || !('type' in content)) {
+        return false
+    }
+    if ('media' in content) {
+        return true
+    }
+    return (content as { type: unknown }).type === 'sticker-pack' && 'stickers' in content
 }
 
 export function isSendTextMessage(content: unknown): content is WaSendTextMessage {
@@ -176,6 +182,7 @@ export function resolveEncMediaType(message: Proto.IMessage): string | null {
 
     if (msg.imageMessage) return WA_ENC_MEDIA_TYPES.IMAGE
     if (msg.stickerMessage) return WA_ENC_MEDIA_TYPES.STICKER
+    if (msg.stickerPackMessage) return WA_ENC_MEDIA_TYPES.STICKER_PACK
     if (msg.locationMessage) {
         return msg.locationMessage.isLive
             ? WA_ENC_MEDIA_TYPES.LIVE_LOCATION

--- a/src/message/sticker-pack.ts
+++ b/src/message/sticker-pack.ts
@@ -1,0 +1,39 @@
+import { type StickerPackZipEntry } from '@media/sticker-pack'
+import type { WaSendStickerPackMessage } from '@message/types'
+import type { Proto } from '@proto'
+
+export function validateStickerPackInput(content: WaSendStickerPackMessage): void {
+    if (content.stickers.length === 0) {
+        throw new Error('sticker pack requires at least one sticker')
+    }
+    if (!content.trayIcon.fileName) {
+        throw new Error('sticker pack trayIcon requires a non-empty fileName')
+    }
+    if (content.stickers.some((sticker) => sticker.fileName === content.trayIcon.fileName)) {
+        throw new Error(
+            `sticker pack trayIcon.fileName ${content.trayIcon.fileName} collides with a sticker fileName; the tray icon must be a separate ZIP entry`
+        )
+    }
+}
+
+export function toStickerPackZipEntries(content: WaSendStickerPackMessage): StickerPackZipEntry[] {
+    return [
+        ...content.stickers.map((sticker) => ({
+            fileName: sticker.fileName,
+            source: sticker.media
+        })),
+        { fileName: content.trayIcon.fileName, source: content.trayIcon.media }
+    ]
+}
+
+export function toStickerPackProtoStickers(
+    content: WaSendStickerPackMessage
+): Proto.Message.StickerPackMessage.ISticker[] {
+    return content.stickers.map((sticker) => ({
+        fileName: sticker.fileName,
+        emojis: [...sticker.emojis],
+        isAnimated: sticker.isAnimated,
+        isLottie: sticker.isLottie,
+        mimetype: sticker.mimetype ?? 'image/webp'
+    }))
+}

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -143,7 +143,7 @@ export interface WaSendStickerPackMessage extends UserMediaFields<
     readonly publisher: string
     readonly stickers: readonly WaSendStickerPackStickerInput[]
     readonly trayIcon: WaSendStickerPackTrayIcon
-    readonly coverThumbnail: Uint8Array | string
+    readonly coverThumbnail?: Uint8Array | string
     readonly contextInfo?: WaSendContextInfo
 }
 

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -107,6 +107,46 @@ interface WaSendStickerMessage
     readonly type: 'sticker'
 }
 
+export interface WaSendStickerPackStickerInput {
+    readonly media: Uint8Array | string
+    readonly fileName: string
+    readonly emojis: readonly string[]
+    readonly isAnimated?: boolean
+    readonly isLottie?: boolean
+    readonly mimetype?: string
+}
+
+export interface WaSendStickerPackTrayIcon {
+    readonly media: Uint8Array | string
+    readonly fileName: string
+}
+
+type StickerPackBuilderFilled =
+    | 'stickers'
+    | 'trayIconFileName'
+    | 'thumbnailDirectPath'
+    | 'thumbnailSha256'
+    | 'thumbnailEncSha256'
+    | 'stickerPackSize'
+    | 'imageDataHash'
+    | 'stickerPackOrigin'
+
+export interface WaSendStickerPackMessage extends UserMediaFields<
+    Omit<
+        Proto.Message.IStickerPackMessage,
+        StickerPackBuilderFilled | 'stickerPackId' | 'name' | 'publisher'
+    >
+> {
+    readonly type: 'sticker-pack'
+    readonly stickerPackId: string
+    readonly name: string
+    readonly publisher: string
+    readonly stickers: readonly WaSendStickerPackStickerInput[]
+    readonly trayIcon: WaSendStickerPackTrayIcon
+    readonly coverThumbnail: Uint8Array | string
+    readonly contextInfo?: WaSendContextInfo
+}
+
 export type WaSendMediaMessage =
     | WaSendImageMessage
     | WaSendVideoMessage
@@ -114,6 +154,7 @@ export type WaSendMediaMessage =
     | WaSendAudioMessage
     | WaSendDocumentMessage
     | WaSendStickerMessage
+    | WaSendStickerPackMessage
 
 export type WaSendMessageContent = string | WaSendTextMessage | Proto.IMessage | WaSendMediaMessage
 

--- a/src/protocol/media.ts
+++ b/src/protocol/media.ts
@@ -9,7 +9,9 @@ export const WA_MEDIA_HKDF_INFO = Object.freeze({
     ptt: 'WhatsApp Audio Keys',
     'md-app-state': 'WhatsApp App State Keys',
     'md-msg-hist': 'WhatsApp History Keys',
-    history: 'WhatsApp History Keys'
+    history: 'WhatsApp History Keys',
+    'sticker-pack': 'WhatsApp Sticker Pack Keys',
+    'thumbnail-sticker-pack': 'WhatsApp Sticker Pack Thumbnail Keys'
 } as const)
 
 export const WA_PREVIEW_MEDIA_HKDF_INFO = 'Messenger Preview Keys'


### PR DESCRIPTION
Bundle the pack as a STORED ZIP (one entry per sticker plus the tray icon, streamed to a temp file via WaMediaCrypto.encryptToFile), upload encrypted to /mms/sticker-pack and the cover JPEG to /mms/thumbnail-sticker-pack sharing the same mediaKey with HKDF info "WhatsApp Sticker Pack Keys" and "WhatsApp Sticker Pack Thumbnail Keys". For newsletter recipients the same ZIP is uploaded plaintext to /newsletter/newsletter-sticker-pack (no encryption, no cover) and wired with mediatype="sticker_pack".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sticker-pack media message support, enabling delivery of collections of stickers with customizable tray icons
  * Sticker-pack messages now available for newsletter content
  * Refactored encrypted media upload system for improved reusability

* **Tests**
  * Added test coverage for sticker-pack ZIP stream creation and validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/71)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->