### PR TITLE
refactor(protocol): replace hardcoded literals with WA_* constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ coverage
 .claude
 *.log
 ___*
-**/___*

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ coverage
 /test/
 .claude
 *.log
+___*
+**/___*

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -1043,8 +1043,8 @@ export function buildWaClientDependencies(input: {
                     rawNode: node,
                     stanzaId: parsed.stanzaId,
                     chatJid: parsed.fromJid,
-                    stanzaType: 'encrypt',
-                    notificationType: 'encrypt',
+                    stanzaType: WA_NOTIFICATION_TYPES.ENCRYPT,
+                    notificationType: WA_NOTIFICATION_TYPES.ENCRYPT,
                     classification: 'core',
                     details: {
                         kind: 'identity_change',
@@ -1118,8 +1118,8 @@ export function buildWaClientDependencies(input: {
                 rawNode: node,
                 stanzaId: parsed.stanzaId,
                 chatJid: parsed.fromJid,
-                stanzaType: 'devices',
-                notificationType: 'devices',
+                stanzaType: WA_NOTIFICATION_TYPES.DEVICES,
+                notificationType: WA_NOTIFICATION_TYPES.DEVICES,
                 classification: 'core',
                 details: {
                     kind: 'device_list_change',

--- a/src/client/coordinators/WaBusinessCoordinator.ts
+++ b/src/client/coordinators/WaBusinessCoordinator.ts
@@ -10,6 +10,7 @@ import type { Logger } from '@infra/log/types'
 import { PPS_UPLOAD_PATHS } from '@media/constants'
 import type { WaMediaConn } from '@media/types'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
+import { WA_BUSINESS_NOTIFICATION_TAGS } from '@protocol/notification'
 import {
     buildDeleteCoverPhotoIq,
     buildEditBusinessProfileIq,
@@ -63,7 +64,7 @@ function parseBusinessProfiles(result: BinaryNode): readonly WaBusinessProfileRe
 }
 
 function parseVerifiedName(result: BinaryNode): WaVerifiedNameResult | null {
-    const vnNode = findNodeChild(result, 'verified_name')
+    const vnNode = findNodeChild(result, WA_BUSINESS_NOTIFICATION_TAGS.VERIFIED_NAME)
     if (!vnNode) return null
     return parseVerifiedNameNode(vnNode)
 }

--- a/src/client/coordinators/WaGroupCoordinator.ts
+++ b/src/client/coordinators/WaGroupCoordinator.ts
@@ -1,7 +1,8 @@
 import { parseParticipants as parseGroupEventParticipants } from '@client/events/group'
 import { WA_DEFAULTS } from '@protocol/defaults'
 import { WA_GROUP_PARTICIPANT_TYPES, type WaGroupSetting } from '@protocol/group'
-import { WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
+import { WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
+import { WA_GROUP_NOTIFICATION_TAGS } from '@protocol/notification'
 import {
     buildDeactivateCommunityIq,
     buildLinkedGroupsParticipantsIq,
@@ -394,13 +395,22 @@ function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
 const SETTING_TAGS: Readonly<
     Record<WaGroupSetting, { readonly on: string; readonly off: string }>
 > = {
-    announcement: { on: 'announcement', off: 'not_announcement' },
-    restrict: { on: 'locked', off: 'unlocked' },
-    ephemeral: { on: 'ephemeral', off: 'not_ephemeral' },
-    membership_approval_mode: { on: 'membership_approval_mode', off: 'membership_approval_mode' },
+    announcement: {
+        on: WA_GROUP_NOTIFICATION_TAGS.ANNOUNCEMENT,
+        off: WA_GROUP_NOTIFICATION_TAGS.NOT_ANNOUNCEMENT
+    },
+    restrict: { on: WA_GROUP_NOTIFICATION_TAGS.LOCKED, off: WA_GROUP_NOTIFICATION_TAGS.UNLOCKED },
+    ephemeral: {
+        on: WA_GROUP_NOTIFICATION_TAGS.EPHEMERAL,
+        off: WA_GROUP_NOTIFICATION_TAGS.NOT_EPHEMERAL
+    },
+    membership_approval_mode: {
+        on: WA_GROUP_NOTIFICATION_TAGS.MEMBERSHIP_APPROVAL_MODE,
+        off: WA_GROUP_NOTIFICATION_TAGS.MEMBERSHIP_APPROVAL_MODE
+    },
     allow_non_admin_sub_group_creation: {
-        on: 'allow_non_admin_sub_group_creation',
-        off: 'not_allow_non_admin_sub_group_creation'
+        on: WA_GROUP_NOTIFICATION_TAGS.ALLOW_NON_ADMIN_SUB_GROUP_CREATION,
+        off: WA_GROUP_NOTIFICATION_TAGS.NOT_ALLOW_NON_ADMIN_SUB_GROUP_CREATION
     }
 }
 
@@ -458,7 +468,7 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
 
     return {
         queryGroupMetadata: async (groupJid) => {
-            const node = buildIqNode('get', groupJid, WA_XMLNS.GROUPS, [
+            const node = buildIqNode(WA_IQ_TYPES.GET, groupJid, WA_XMLNS.GROUPS, [
                 {
                     tag: WA_NODE_TAGS.QUERY,
                     attrs: {}
@@ -470,7 +480,7 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
         },
 
         queryAllGroups: async () => {
-            const node = buildIqNode('get', WA_DEFAULTS.GROUP_SERVER, WA_XMLNS.GROUPS, [
+            const node = buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.GROUP_SERVER, WA_XMLNS.GROUPS, [
                 {
                     tag: WA_NODE_TAGS.PARTICIPATING,
                     attrs: {},
@@ -491,7 +501,7 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
         },
 
         queryGroupInviteInfo: async (code) => {
-            const node = buildIqNode('get', WA_DEFAULTS.GROUP_SERVER, WA_XMLNS.GROUPS, [
+            const node = buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.GROUP_SERVER, WA_XMLNS.GROUPS, [
                 { tag: WA_NODE_TAGS.INVITE, attrs: { code } }
             ])
             const result = await queryWithContext('group.invite.info', node)
@@ -512,7 +522,7 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
         },
 
         setSubject: async (groupJid, subject) => {
-            const node = buildIqNode('set', groupJid, WA_XMLNS.GROUPS, [
+            const node = buildIqNode(WA_IQ_TYPES.SET, groupJid, WA_XMLNS.GROUPS, [
                 { tag: WA_NODE_TAGS.SUBJECT, attrs: {}, content: subject }
             ])
             const result = await queryWithContext('group.setSubject', node)
@@ -531,7 +541,7 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
                 content = [{ tag: WA_NODE_TAGS.BODY, attrs: {}, content: description }]
             }
 
-            const node = buildIqNode('set', groupJid, WA_XMLNS.GROUPS, [
+            const node = buildIqNode(WA_IQ_TYPES.SET, groupJid, WA_XMLNS.GROUPS, [
                 { tag: WA_NODE_TAGS.DESCRIPTION, attrs, content }
             ])
             const result = await queryWithContext('group.setDescription', node)
@@ -552,7 +562,7 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
                 ]
             }
 
-            const node = buildIqNode('set', groupJid, WA_XMLNS.GROUPS, [
+            const node = buildIqNode(WA_IQ_TYPES.SET, groupJid, WA_XMLNS.GROUPS, [
                 { tag, attrs: {}, ...(content ? { content } : {}) }
             ])
             const result = await queryWithContext('group.setSetting', node)
@@ -579,7 +589,7 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
         },
 
         revokeInvite: async (groupJid) => {
-            const node = buildIqNode('set', groupJid, WA_XMLNS.GROUPS, [
+            const node = buildIqNode(WA_IQ_TYPES.SET, groupJid, WA_XMLNS.GROUPS, [
                 { tag: WA_NODE_TAGS.INVITE, attrs: {} }
             ])
             const result = await queryWithContext('group.revokeInvite', node)
@@ -588,7 +598,7 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
         },
 
         joinGroupViaInvite: async (code) => {
-            const node = buildIqNode('set', WA_DEFAULTS.GROUP_SERVER, WA_XMLNS.GROUPS, [
+            const node = buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.GROUP_SERVER, WA_XMLNS.GROUPS, [
                 { tag: WA_NODE_TAGS.INVITE, attrs: { code } }
             ])
             const result = await queryWithContext('group.joinViaInvite', node)
@@ -629,13 +639,13 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
 
             const linksNode = findNodeChild(result, 'links')
             const linkNode = linksNode ? findNodeChild(linksNode, 'link') : undefined
-            const groupNodes = linkNode ? getNodeChildrenByTag(linkNode, 'group') : []
+            const groupNodes = linkNode ? getNodeChildrenByTag(linkNode, WA_NODE_TAGS.GROUP) : []
             const linkedJids: string[] = []
             const failed: WaCommunitySubGroupResult[] = []
             for (const groupNode of groupNodes) {
                 const jid = groupNode.attrs.jid
                 if (!jid) continue
-                const errorAttr = findNodeChild(groupNode, 'error')?.attrs.code
+                const errorAttr = findNodeChild(groupNode, WA_NODE_TAGS.ERROR)?.attrs.code
                 if (errorAttr !== undefined) {
                     failed.push({ jid, error: Number(errorAttr) })
                 } else {
@@ -655,13 +665,15 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
             assertIqResult(result, 'community.unlinkSubGroups')
 
             const unlinkNode = findNodeChild(result, 'unlink')
-            const groupNodes = unlinkNode ? getNodeChildrenByTag(unlinkNode, 'group') : []
+            const groupNodes = unlinkNode
+                ? getNodeChildrenByTag(unlinkNode, WA_NODE_TAGS.GROUP)
+                : []
             const unlinkedJids: string[] = []
             const failed: WaCommunitySubGroupResult[] = []
             for (const groupNode of groupNodes) {
                 const jid = groupNode.attrs.jid
                 if (!jid) continue
-                const errorAttr = findNodeChild(groupNode, 'error')?.attrs.code
+                const errorAttr = findNodeChild(groupNode, WA_NODE_TAGS.ERROR)?.attrs.code
                 if (errorAttr !== undefined) {
                     failed.push({ jid, error: Number(errorAttr) })
                 } else {

--- a/src/client/coordinators/WaPassiveTasksCoordinator.ts
+++ b/src/client/coordinators/WaPassiveTasksCoordinator.ts
@@ -1,7 +1,7 @@
 import type { WaAppStateSyncClient } from '@appstate/WaAppStateSyncClient'
 import type { WaAuthCredentials } from '@auth/types'
 import type { Logger } from '@infra/log/types'
-import { WA_DEFAULTS } from '@protocol/constants'
+import { WA_DEFAULTS, WA_IQ_TYPES } from '@protocol/constants'
 import {
     SIGNAL_SIGNED_PREKEY_ROTATION_INTERVAL_MS,
     SIGNAL_SIGNED_PREKEY_SERVER_ERROR_BACKOFF_MS,
@@ -224,7 +224,7 @@ export class WaPassiveTasksCoordinator {
             },
             this.mobilePrimary ? { useSystemId: true } : undefined
         )
-        if (response.attrs.type === 'result') {
+        if (response.attrs.type === WA_IQ_TYPES.RESULT) {
             // Mark uploaded key first so the serverHasPreKeys flag never commits ahead of local key progress.
             await this.preKeyStore.markKeyAsUploaded(lastPreKeyId)
             await Promise.all([

--- a/src/client/coordinators/WaPrivacyCoordinator.ts
+++ b/src/client/coordinators/WaPrivacyCoordinator.ts
@@ -1,3 +1,4 @@
+import { WA_NODE_TAGS } from '@protocol/nodes'
 import {
     WA_PRIVACY_CATEGORY_TO_SETTING,
     WA_PRIVACY_SETTING_TO_CATEGORY,
@@ -75,7 +76,7 @@ function isValidPrivacyValue(value: string): value is WaPrivacyValue {
 }
 
 function parsePrivacySettings(result: BinaryNode): WaPrivacySettings {
-    const privacyNode = findNodeChild(result, 'privacy')
+    const privacyNode = findNodeChild(result, WA_NODE_TAGS.PRIVACY)
     if (!privacyNode) {
         return {}
     }
@@ -110,7 +111,7 @@ function parsePrivacySettings(result: BinaryNode): WaPrivacySettings {
 }
 
 function parseDisallowedList(result: BinaryNode): WaPrivacyDisallowedListResult {
-    const privacyNode = findNodeChild(result, 'privacy')
+    const privacyNode = findNodeChild(result, WA_NODE_TAGS.PRIVACY)
     if (!privacyNode) {
         return { jids: [] }
     }
@@ -138,7 +139,7 @@ function parseDisallowedList(result: BinaryNode): WaPrivacyDisallowedListResult 
 }
 
 function parseBlocklist(result: BinaryNode): WaBlocklistResult {
-    const listNode = findNodeChild(result, 'list')
+    const listNode = findNodeChild(result, WA_NODE_TAGS.LIST)
     if (!listNode) {
         return { jids: [] }
     }

--- a/src/client/coordinators/WaProfileCoordinator.ts
+++ b/src/client/coordinators/WaProfileCoordinator.ts
@@ -1,3 +1,4 @@
+import { WA_NODE_TAGS } from '@protocol/nodes'
 import {
     buildDeleteProfilePictureIq,
     buildGetDisappearingModeUsyncQueryNode,
@@ -67,7 +68,7 @@ interface WaProfileCoordinatorOptions {
 }
 
 function parseProfilePicture(result: BinaryNode): WaProfilePictureResult {
-    const pictureNode = findNodeChild(result, 'picture')
+    const pictureNode = findNodeChild(result, WA_NODE_TAGS.PICTURE)
     if (!pictureNode) {
         return {}
     }
@@ -80,16 +81,16 @@ function parseProfilePicture(result: BinaryNode): WaProfilePictureResult {
 }
 
 function parseSetPictureResult(result: BinaryNode): string | null {
-    const pictureNode = findNodeChild(result, 'picture')
+    const pictureNode = findNodeChild(result, WA_NODE_TAGS.PICTURE)
     return pictureNode?.attrs.id ?? null
 }
 
 function parseUsyncProfiles(result: BinaryNode): readonly WaProfileInfo[] {
-    const usyncNode = findNodeChild(result, 'usync')
+    const usyncNode = findNodeChild(result, WA_NODE_TAGS.USYNC)
     if (!usyncNode) {
         return []
     }
-    const listNode = findNodeChild(usyncNode, 'list')
+    const listNode = findNodeChild(usyncNode, WA_NODE_TAGS.LIST)
     if (!listNode) {
         return []
     }
@@ -100,7 +101,7 @@ function parseUsyncProfiles(result: BinaryNode): readonly WaProfileInfo[] {
 
     for (let i = 0; i < userNodes.length; i += 1) {
         const userNode = userNodes[i]
-        if (userNode.tag !== 'user') {
+        if (userNode.tag !== WA_NODE_TAGS.USER) {
             continue
         }
         const jid = userNode.attrs.jid as string | undefined
@@ -118,7 +119,7 @@ function parseUsyncProfiles(result: BinaryNode): readonly WaProfileInfo[] {
 
         for (let j = 0; j < userContent.length; j += 1) {
             const child = userContent[j]
-            if (child.tag === 'picture') {
+            if (child.tag === WA_NODE_TAGS.PICTURE) {
                 const idAttr = child.attrs.id as string | undefined
                 if (idAttr) {
                     const parsed = Number.parseInt(idAttr, 10)
@@ -152,9 +153,9 @@ function parseUsyncProfiles(result: BinaryNode): readonly WaProfileInfo[] {
 }
 
 function parseUsyncDisappearingModes(result: BinaryNode): readonly WaDisappearingModeResult[] {
-    const usyncNode = findNodeChild(result, 'usync')
+    const usyncNode = findNodeChild(result, WA_NODE_TAGS.USYNC)
     if (!usyncNode) return []
-    const listNode = findNodeChild(usyncNode, 'list')
+    const listNode = findNodeChild(usyncNode, WA_NODE_TAGS.LIST)
     if (!listNode) return []
 
     const userNodes = getNodeChildren(listNode)
@@ -163,7 +164,7 @@ function parseUsyncDisappearingModes(result: BinaryNode): readonly WaDisappearin
 
     for (let i = 0; i < userNodes.length; i += 1) {
         const userNode = userNodes[i]
-        if (userNode.tag !== 'user') continue
+        if (userNode.tag !== WA_NODE_TAGS.USER) continue
         const userContent = userNode.content
         if (!Array.isArray(userContent)) continue
 
@@ -171,7 +172,7 @@ function parseUsyncDisappearingModes(result: BinaryNode): readonly WaDisappearin
             const child = userContent[j]
             if (child.tag !== 'disappearing_mode') continue
 
-            const errorNode = findNodeChild(child, 'error')
+            const errorNode = findNodeChild(child, WA_NODE_TAGS.ERROR)
             if (errorNode) continue
 
             const duration = Number.parseInt((child.attrs.duration as string) ?? '0', 10)

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -1,7 +1,7 @@
 import type { Logger } from '@infra/log/types'
 import type { WaMessageClient } from '@message/WaMessageClient'
 import { proto, type Proto } from '@proto'
-import { WA_MESSAGE_TAGS } from '@protocol/constants'
+import { WA_MESSAGE_TAGS, WA_MESSAGE_TYPES } from '@protocol/constants'
 import {
     isGroupOrBroadcastJid,
     normalizeDeviceJid,
@@ -223,7 +223,8 @@ export class WaRetryCoordinator {
     private isRetryReceiptNode(node: BinaryNode): boolean {
         return (
             node.tag === WA_MESSAGE_TAGS.RECEIPT &&
-            (node.attrs.type === 'retry' || node.attrs.type === 'enc_rekey_retry')
+            (node.attrs.type === WA_MESSAGE_TYPES.RECEIPT_TYPE_RETRY ||
+                node.attrs.type === 'enc_rekey_retry')
         )
     }
 
@@ -870,19 +871,19 @@ export class WaRetryCoordinator {
     }
 
     private mapOutboundStateFromReceiptType(type: string | undefined): WaRetryOutboundState | null {
-        if (type === 'read') {
+        if (type === WA_MESSAGE_TYPES.RECEIPT_TYPE_READ) {
             return 'read'
         }
-        if (type === 'played') {
+        if (type === WA_MESSAGE_TYPES.RECEIPT_TYPE_PLAYED) {
             return 'played'
         }
         if (
             type === undefined ||
             type === '' ||
-            type === 'delivery' ||
-            type === 'sender' ||
-            type === 'inactive' ||
-            type === 'peer_msg'
+            type === WA_MESSAGE_TYPES.RECEIPT_TYPE_DELIVERY ||
+            type === WA_MESSAGE_TYPES.RECEIPT_TYPE_SENDER ||
+            type === WA_MESSAGE_TYPES.RECEIPT_TYPE_INACTIVE ||
+            type === WA_MESSAGE_TYPES.RECEIPT_TYPE_PEER
         ) {
             return 'delivered'
         }

--- a/src/client/coordinators/WaStreamControlCoordinator.ts
+++ b/src/client/coordinators/WaStreamControlCoordinator.ts
@@ -136,7 +136,7 @@ export function createStreamControlHandler(
     return {
         handleStreamControlResult: async (result: WaStreamControlNodeResult) => {
             switch (result.kind) {
-                case 'xmlstreamend':
+                case WA_STREAM_SIGNALING.XML_STREAM_END_TAG:
                     logger.info('received xmlstreamend stanza')
                     return
                 case 'stream_error_code':
@@ -157,14 +157,14 @@ export function createStreamControlHandler(
                     }
                     await resumeSocketDueToStreamError(`stream_error_code_${result.code}`)
                     return
-                case 'stream_error_replaced':
+                case WA_DISCONNECT_REASONS.STREAM_ERROR_REPLACED:
                     logger.warn('received stream:error replaced, stopping client')
                     await disconnectDueToStreamError(
                         WA_DISCONNECT_REASONS.STREAM_ERROR_REPLACED,
                         null
                     )
                     return
-                case 'stream_error_device_removed':
+                case WA_DISCONNECT_REASONS.STREAM_ERROR_DEVICE_REMOVED:
                     logger.warn('received stream:error device removed, logging out')
                     await logoutDueToStreamError(
                         WA_DISCONNECT_REASONS.STREAM_ERROR_DEVICE_REMOVED,
@@ -172,17 +172,17 @@ export function createStreamControlHandler(
                         false
                     )
                     return
-                case 'stream_error_ack':
+                case WA_DISCONNECT_REASONS.STREAM_ERROR_ACK:
                     logger.warn('received stream:error ack', { id: result.id })
                     await resumeSocketDueToStreamError(WA_DISCONNECT_REASONS.STREAM_ERROR_ACK)
                     return
-                case 'stream_error_xml_not_well_formed':
+                case WA_DISCONNECT_REASONS.STREAM_ERROR_XML_NOT_WELL_FORMED:
                     logger.warn('received stream:error xml-not-well-formed')
                     await resumeSocketDueToStreamError(
                         WA_DISCONNECT_REASONS.STREAM_ERROR_XML_NOT_WELL_FORMED
                     )
                     return
-                case 'stream_error_other':
+                case WA_DISCONNECT_REASONS.STREAM_ERROR_OTHER:
                     logger.warn('received stream:error other')
                     await resumeSocketDueToStreamError(WA_DISCONNECT_REASONS.STREAM_ERROR_OTHER)
                     return

--- a/src/client/dirty.ts
+++ b/src/client/dirty.ts
@@ -6,6 +6,7 @@ import {
     WA_DIRTY_PROTOCOLS,
     WA_DIRTY_TYPES,
     WA_IQ_TYPES,
+    WA_NODE_TAGS,
     WA_SUPPORTED_DIRTY_TYPES
 } from '@protocol/constants'
 import { toUserJid } from '@protocol/jid'
@@ -269,7 +270,7 @@ async function syncAccountPictureDirtyBit(runtime: WaDirtySyncRuntime): Promise<
         { meJid, target: targetJid }
     )
 
-    if (response.tag !== 'iq') {
+    if (response.tag !== WA_NODE_TAGS.IQ) {
         throw new Error(`account_sync.picture returned non-iq node (${response.tag})`)
     }
     if (response.attrs.type === WA_IQ_TYPES.RESULT) {

--- a/src/client/events/business.ts
+++ b/src/client/events/business.ts
@@ -257,7 +257,7 @@ function parseFeatureFlagsList(node: BinaryNode): readonly WaBusinessFeatureFlag
 function parseProductIds(catalogNode: BinaryNode): readonly string[] {
     const ids: string[] = []
     for (const product of getNodeChildrenByTag(catalogNode, 'product')) {
-        const idNode = findNodeChild(product, 'id')
+        const idNode = findNodeChild(product, WA_NODE_TAGS.ID)
         if (!idNode) continue
         const text = getNodeTextContent(idNode)
         if (text) ids.push(text)

--- a/src/client/events/devices.ts
+++ b/src/client/events/devices.ts
@@ -1,4 +1,5 @@
 import { parseSignalAddressFromJid } from '@protocol/jid'
+import { WA_NODE_TAGS } from '@protocol/nodes'
 import { findNodeChild, getNodeChildrenByTag } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
 
@@ -51,7 +52,7 @@ export function parseDeviceNotification(node: BinaryNode): DeviceNotification | 
     const devices: DeviceNotificationDevice[] = []
 
     if (action !== DEVICE_NOTIFICATION_ACTIONS.UPDATE && actionNode) {
-        const deviceNodes = getNodeChildrenByTag(actionNode, 'device')
+        const deviceNodes = getNodeChildrenByTag(actionNode, WA_NODE_TAGS.DEVICE)
         for (let index = 0; index < deviceNodes.length; index += 1) {
             const deviceNode = deviceNodes[index]
             const jidAttr = deviceNode.attrs.jid

--- a/src/client/events/group.ts
+++ b/src/client/events/group.ts
@@ -173,7 +173,9 @@ function parseCreateGroupAction(
             defaultSubgroup: findNodeChild(groupNode, 'default_sub_group') !== undefined,
             generalSubgroup: findNodeChild(groupNode, 'general_chat') !== undefined,
             hiddenSubgroup: findNodeChild(groupNode, 'hidden_group') !== undefined,
-            groupSafetyCheck: findNodeChild(groupNode, 'group_safety_check') !== undefined,
+            groupSafetyCheck:
+                findNodeChild(groupNode, WA_GROUP_NOTIFICATION_TAGS.GROUP_SAFETY_CHECK) !==
+                undefined,
             hasCapi: findNodeChild(groupNode, 'capi') !== undefined,
             limitSharingEnabled:
                 findNodeChild(groupNode, WA_GROUP_NOTIFICATION_TAGS.LIMIT_SHARING_ENABLED) !==
@@ -269,7 +271,8 @@ function parseGroupActionNode(
                 }
             }
         case WA_GROUP_NOTIFICATION_TAGS.DESCRIPTION: {
-            const hasDeleteChild = findNodeChild(actionNode, 'delete') !== undefined
+            const hasDeleteChild =
+                findNodeChild(actionNode, WA_GROUP_NOTIFICATION_TAGS.DELETE) !== undefined
             const bodyNode = findNodeChild(actionNode, WA_NODE_TAGS.BODY)
             return {
                 ...baseEvent,

--- a/src/client/events/identity.ts
+++ b/src/client/events/identity.ts
@@ -1,3 +1,4 @@
+import { WA_NODE_TAGS } from '@protocol/nodes'
 import { getFirstNodeChild } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
 
@@ -13,7 +14,7 @@ export function parseIdentityChangeNotification(
     node: BinaryNode
 ): IdentityChangeNotification | null {
     const child = getFirstNodeChild(node)
-    if (!child || child.tag !== 'identity') {
+    if (!child || child.tag !== WA_NODE_TAGS.IDENTITY) {
         return null
     }
     const fromJid = node.attrs.from

--- a/src/client/incoming.ts
+++ b/src/client/incoming.ts
@@ -13,7 +13,12 @@ import type {
     WaRegistrationCodeEvent
 } from '@client/types'
 import type { Logger } from '@infra/log/types'
-import { WA_DISCONNECT_REASONS, WA_NODE_TAGS, WA_NOTIFICATION_TYPES } from '@protocol/constants'
+import {
+    WA_DISCONNECT_REASONS,
+    WA_MESSAGE_TYPES,
+    WA_NODE_TAGS,
+    WA_NOTIFICATION_TYPES
+} from '@protocol/constants'
 import type { WaConnectionCode, WaDisconnectReason } from '@protocol/stream'
 import { buildAckNode } from '@transport/node/builders/global'
 import { getFirstNodeChild, getNodeChildrenNonEmptyAttrValuesByTag } from '@transport/node/helpers'
@@ -217,7 +222,7 @@ export function createIncomingReceiptHandler(
             buildAckNode({
                 kind: 'receipt',
                 node,
-                includeParticipant: receiptType !== 'server-error'
+                includeParticipant: receiptType !== WA_MESSAGE_TYPES.RECEIPT_TYPE_SERVER_ERROR
             })
         )
         return true

--- a/src/client/newsletter/content.ts
+++ b/src/client/newsletter/content.ts
@@ -124,13 +124,15 @@ function resolveSendMediaKind(content: WaSendMediaMessage): NewsletterMediaKind 
 }
 
 function pickMediaTypeFromMessage(message: Proto.IMessage): string | null {
-    if (message.imageMessage) return 'image'
-    if (message.videoMessage) return message.videoMessage.gifPlayback ? 'gif' : 'video'
-    if (message.audioMessage) return message.audioMessage.ptt ? 'ptt' : 'audio'
-    if (message.documentMessage) return 'document'
-    if (message.stickerMessage) return 'sticker'
+    if (message.imageMessage) return WA_ENC_MEDIA_TYPES.IMAGE
+    if (message.videoMessage)
+        return message.videoMessage.gifPlayback ? WA_ENC_MEDIA_TYPES.GIF : WA_ENC_MEDIA_TYPES.VIDEO
+    if (message.audioMessage)
+        return message.audioMessage.ptt ? WA_ENC_MEDIA_TYPES.PTT : WA_ENC_MEDIA_TYPES.AUDIO
+    if (message.documentMessage) return WA_ENC_MEDIA_TYPES.DOCUMENT
+    if (message.stickerMessage) return WA_ENC_MEDIA_TYPES.STICKER
     if (message.stickerPackMessage) return WA_ENC_MEDIA_TYPES.STICKER_PACK
-    if (message.ptvMessage) return 'ptv'
+    if (message.ptvMessage) return WA_ENC_MEDIA_TYPES.PTV
     return null
 }
 

--- a/src/client/newsletter/messaging.ts
+++ b/src/client/newsletter/messaging.ts
@@ -22,6 +22,7 @@ import type {
     WaSendMessageContent
 } from '@message/types'
 import { WA_NEWSLETTER_MUTE_TYPES, WA_NEWSLETTER_MUTE_VALUES } from '@protocol/newsletter'
+import { WA_NEWSLETTER_NOTIFICATION_TAGS } from '@protocol/notification'
 import {
     buildNewsletterMessageNode,
     buildNewsletterMessagesIq,
@@ -277,7 +278,10 @@ export function createMessagingOps(deps: WaNewsletterMessagingDeps): WaNewslette
                 'newsletter.subscribe_live_updates',
                 buildNewsletterSubscribeLiveUpdatesIq(newsletterJid)
             )
-            const liveUpdates = findNodeChild(response, 'live_updates')
+            const liveUpdates = findNodeChild(
+                response,
+                WA_NEWSLETTER_NOTIFICATION_TAGS.LIVE_UPDATES
+            )
             const durationAttr = liveUpdates?.attrs.duration
             const parsed = durationAttr ? Number.parseInt(durationAttr, 10) : NaN
             if (!Number.isFinite(parsed) || parsed < 30 || parsed > 600) {

--- a/src/client/newsletter/parse.ts
+++ b/src/client/newsletter/parse.ts
@@ -17,6 +17,7 @@ import type {
 import {
     WA_NEWSLETTER_MUTE_TYPES,
     WA_NEWSLETTER_MUTE_VALUES,
+    WA_NEWSLETTER_STATE_TYPES,
     type WaNewsletterRole,
     type WaNewsletterStateType
 } from '@protocol/newsletter'
@@ -127,7 +128,7 @@ export function parseNewsletterMetadata(envelope: MexNewsletterEnvelope): WaNews
 
     return {
         jid: envelope.id ?? '',
-        state: envelope.state?.type ?? 'ACTIVE',
+        state: envelope.state?.type ?? WA_NEWSLETTER_STATE_TYPES.ACTIVE,
         creationTime: toNumber(meta?.creation_time),
         name: meta?.name?.text,
         nameUpdateTime: toNumber(meta?.name?.update_time),

--- a/src/message/WaMessageClient.ts
+++ b/src/message/WaMessageClient.ts
@@ -224,7 +224,7 @@ export class WaMessageClient {
             kind: 'outbound',
             to: input.to,
             id: input.id,
-            type: input.type ?? 'read',
+            type: input.type ?? WA_MESSAGE_TYPES.RECEIPT_TYPE_READ,
             participant: input.participant,
             recipient: input.recipient,
             category: input.category,

--- a/src/retry/parse.ts
+++ b/src/retry/parse.ts
@@ -1,4 +1,4 @@
-import { WA_MESSAGE_TAGS, WA_NODE_TAGS } from '@protocol/constants'
+import { WA_MESSAGE_TAGS, WA_MESSAGE_TYPES, WA_NODE_TAGS } from '@protocol/constants'
 import { normalizeDeviceJid } from '@protocol/jid'
 import type { WaParsedRetryRequest, WaRetryKeyBundle, WaRetryOutboundState } from '@retry/types'
 import { decodeExactLength, parseUint } from '@signal/api/codec'
@@ -144,7 +144,8 @@ export function parseRetryReceiptRequest(
         return null
     }
     const receiptType =
-        node.attrs.type === 'retry' || node.attrs.type === 'enc_rekey_retry'
+        node.attrs.type === WA_MESSAGE_TYPES.RECEIPT_TYPE_RETRY ||
+        node.attrs.type === 'enc_rekey_retry'
             ? node.attrs.type
             : null
     if (!receiptType) {

--- a/src/retry/replay.ts
+++ b/src/retry/replay.ts
@@ -3,6 +3,7 @@ import { wrapDeviceSentMessage } from '@message/device-sent'
 import { unpadPkcs7, writeRandomPadMax16 } from '@message/padding'
 import type { WaMessageClient } from '@message/WaMessageClient'
 import { proto, type Proto } from '@proto'
+import { WA_DEFAULTS, WA_NODE_TAGS } from '@protocol/constants'
 import {
     isGroupOrBroadcastJid,
     isStatusBroadcastJid,
@@ -156,7 +157,11 @@ export class WaRetryReplayService {
             type: payload.type,
             id: outbound.messageId,
             requesterJid,
-            addressingMode: isStatus ? undefined : requesterAddress.server === 'lid' ? 'lid' : 'pn',
+            addressingMode: isStatus
+                ? undefined
+                : requesterAddress.server === WA_DEFAULTS.LID_SERVER
+                  ? 'lid'
+                  : 'pn',
             encType: encrypted.type,
             ciphertext: encrypted.ciphertext,
             retryCount,
@@ -254,7 +259,7 @@ export class WaRetryReplayService {
     }
 
     private isOpaqueReplayCompatible(node: BinaryNode, normalizedRequesterJid: string): boolean {
-        const participantsNode = findNodeChild(node, 'participants')
+        const participantsNode = findNodeChild(node, WA_NODE_TAGS.PARTICIPANTS)
         if (participantsNode) {
             const participantsContent = Array.isArray(participantsNode.content)
                 ? participantsNode.content

--- a/src/signal/api/SignalDeviceSyncApi.ts
+++ b/src/signal/api/SignalDeviceSyncApi.ts
@@ -470,7 +470,7 @@ export class SignalDeviceSyncApi {
                 ? rawUserJid.slice(rawAtIndex + 1)
                 : parsedNormalizedUser.server
         const dedup = new Set<string>()
-        for (const deviceNode of getNodeChildrenByTag(deviceListNode, 'device')) {
+        for (const deviceNode of getNodeChildrenByTag(deviceListNode, WA_NODE_TAGS.DEVICE)) {
             const parsedId = deviceNode.attrs.id
                 ? Number.parseInt(deviceNode.attrs.id, 10)
                 : Number.NaN

--- a/src/transport/__tests__/transport.test.ts
+++ b/src/transport/__tests__/transport.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import type { Logger } from '@infra/log/types'
+import { WA_IQ_TYPES } from '@protocol/nodes'
 import { buildIqNode, parseIqError, queryWithContext } from '@transport'
 
 function createLogger(): Logger {
@@ -16,7 +17,7 @@ function createLogger(): Logger {
 }
 
 test('transport barrel exports iq helpers with expected behavior', async () => {
-    const iq = buildIqNode('get', 's.whatsapp.net', 'w:test')
+    const iq = buildIqNode(WA_IQ_TYPES.GET, 's.whatsapp.net', 'w:test')
     assert.equal(iq.tag, 'iq')
 
     const parsed = parseIqError({

--- a/src/transport/__tests__/transport.test.ts
+++ b/src/transport/__tests__/transport.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import type { Logger } from '@infra/log/types'
-import { WA_IQ_TYPES } from '@protocol/nodes'
+import { WA_IQ_TYPES } from '@protocol/constants'
 import { buildIqNode, parseIqError, queryWithContext } from '@transport'
 
 function createLogger(): Logger {

--- a/src/transport/binary/decoder.ts
+++ b/src/transport/binary/decoder.ts
@@ -31,9 +31,6 @@ const JID_U_DOMAIN_TYPE_LID = 0x01
 const JID_U_DOMAIN_TYPE_HOSTED_LID = 0x81
 const JID_U_DOMAIN_TYPE_HOSTED_MASK = 0x80
 const JID_U_DOMAIN_TYPE_LID_MASK = 0x01
-const JID_U_DOMAIN_LID = 'lid'
-const JID_U_DOMAIN_HOSTED = 'hosted'
-const JID_U_DOMAIN_HOSTED_LID = 'hosted.lid'
 
 class ByteReader {
     private readonly data: Uint8Array
@@ -184,14 +181,14 @@ function decodeJidU(reader: ByteReader): string {
 
     let domain: string = WA_DEFAULTS.HOST_DOMAIN
     if (domainType === JID_U_DOMAIN_TYPE_LID) {
-        domain = JID_U_DOMAIN_LID
+        domain = WA_DEFAULTS.LID_SERVER
     } else if (domainType === JID_U_DOMAIN_TYPE_HOSTED_LID) {
-        domain = JID_U_DOMAIN_HOSTED_LID
+        domain = WA_DEFAULTS.HOSTED_LID_SERVER
     } else if (
         (domainType & JID_U_DOMAIN_TYPE_HOSTED_MASK) !== 0 &&
         (domainType & JID_U_DOMAIN_TYPE_LID_MASK) === 0
     ) {
-        domain = JID_U_DOMAIN_HOSTED
+        domain = WA_DEFAULTS.HOSTED_SERVER
     }
 
     if (device > 0) {

--- a/src/transport/node/__tests__/node.test.ts
+++ b/src/transport/node/__tests__/node.test.ts
@@ -94,9 +94,11 @@ test('node helpers parse child collections and binary payloads', () => {
 })
 
 test('iq helper functions build, parse and assert response results', async () => {
-    const iq = buildIqNode('get', 'server', 'w:test', [{ tag: 'x', attrs: {} }], { id: '1' })
+    const iq = buildIqNode(WA_IQ_TYPES.GET, 'server', 'w:test', [{ tag: 'x', attrs: {} }], {
+        id: '1'
+    })
     assert.equal(iq.tag, WA_NODE_TAGS.IQ)
-    assert.equal(iq.attrs.type, 'get')
+    assert.equal(iq.attrs.type, WA_IQ_TYPES.GET)
     assert.equal(iq.attrs.id, '1')
 
     const ok: BinaryNode = { tag: 'iq', attrs: { type: WA_IQ_TYPES.RESULT } }

--- a/src/transport/node/builders/abprops.ts
+++ b/src/transport/node/builders/abprops.ts
@@ -1,5 +1,5 @@
 import { WA_ABPROPS_PROTOCOL_VERSION } from '@protocol/abprops'
-import { WA_DEFAULTS, WA_XMLNS } from '@protocol/constants'
+import { WA_DEFAULTS, WA_IQ_TYPES, WA_XMLNS } from '@protocol/constants'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
@@ -16,7 +16,7 @@ export function buildGetAbPropsIq(options?: {
     if (options?.refreshId !== undefined && options.refreshId !== null) {
         propsAttrs.refresh_id = `${options.refreshId}`
     }
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.ABPROPS, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.ABPROPS, [
         {
             tag: 'props',
             attrs: propsAttrs

--- a/src/transport/node/builders/account-sync.ts
+++ b/src/transport/node/builders/account-sync.ts
@@ -1,4 +1,10 @@
-import { WA_DEFAULTS, WA_NODE_TAGS, WA_USYNC_CONTEXTS, WA_XMLNS } from '@protocol/constants'
+import {
+    WA_DEFAULTS,
+    WA_IQ_TYPES,
+    WA_NODE_TAGS,
+    WA_USYNC_CONTEXTS,
+    WA_XMLNS
+} from '@protocol/constants'
 import { buildUsyncIq } from '@transport/node/builders/usync'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
@@ -23,7 +29,7 @@ export function buildAccountDevicesSyncIq(userJids: readonly string[], sid: stri
 
 export function buildAccountPictureSyncIq(meJid: string): BinaryNode {
     return buildIqNode(
-        'get',
+        WA_IQ_TYPES.GET,
         WA_DEFAULTS.HOST_DOMAIN,
         WA_XMLNS.PROFILE_PICTURE,
         [
@@ -42,7 +48,7 @@ export function buildAccountPictureSyncIq(meJid: string): BinaryNode {
 }
 
 export function buildAccountPrivacySyncIq(): BinaryNode {
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PRIVACY, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PRIVACY, [
         {
             tag: WA_NODE_TAGS.PRIVACY,
             attrs: {}
@@ -51,11 +57,11 @@ export function buildAccountPrivacySyncIq(): BinaryNode {
 }
 
 export function buildAccountBlocklistSyncIq(): BinaryNode {
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BLOCKLIST)
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BLOCKLIST)
 }
 
 export function buildGroupsDirtySyncIq(): BinaryNode {
-    return buildIqNode('get', WA_DEFAULTS.GROUP_SERVER, WA_XMLNS.GROUPS, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.GROUP_SERVER, WA_XMLNS.GROUPS, [
         {
             tag: WA_NODE_TAGS.PARTICIPATING,
             attrs: {},
@@ -74,7 +80,7 @@ export function buildGroupsDirtySyncIq(): BinaryNode {
 }
 
 export function buildNewsletterMetadataSyncIq(): BinaryNode {
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.NEWSLETTER, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.NEWSLETTER, [
         {
             tag: WA_NODE_TAGS.MY_ADDONS,
             attrs: {
@@ -91,7 +97,7 @@ export function buildClearDirtyBitsIq(
     }[]
 ): BinaryNode {
     return buildIqNode(
-        'set',
+        WA_IQ_TYPES.SET,
         WA_DEFAULTS.HOST_DOMAIN,
         WA_XMLNS.DIRTY_BITS,
         dirtyBits.map((dirtyBit) => ({

--- a/src/transport/node/builders/bot.ts
+++ b/src/transport/node/builders/bot.ts
@@ -1,12 +1,12 @@
 import { WA_DEFAULTS } from '@protocol/defaults'
-import { WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
+import { WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
 const BOT_LIST_VERSION = '2'
 
 export function buildBotListIq(version: string = BOT_LIST_VERSION): BinaryNode {
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BOT, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BOT, [
         {
             tag: WA_NODE_TAGS.BOT,
             attrs: { v: version }

--- a/src/transport/node/builders/business.ts
+++ b/src/transport/node/builders/business.ts
@@ -1,4 +1,4 @@
-import { WA_DEFAULTS, WA_XMLNS } from '@protocol/constants'
+import { WA_DEFAULTS, WA_IQ_TYPES, WA_XMLNS } from '@protocol/constants'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
@@ -27,7 +27,7 @@ export function buildGetBusinessProfileIq(
     jids: readonly string[],
     version: number = WA_BUSINESS_PROFILE_VERSION
 ): BinaryNode {
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BUSINESS, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BUSINESS, [
         {
             tag: 'business_profile',
             attrs: { v: `${version}` },
@@ -84,7 +84,7 @@ export function buildEditBusinessProfileIq(input: WaEditBusinessProfileInput): B
         children.push(buildBusinessHoursNode(input.businessHours))
     }
 
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BUSINESS, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BUSINESS, [
         {
             tag: 'business_profile',
             attrs: { v: '3', mutation_type: 'delta' },
@@ -125,7 +125,7 @@ function buildBusinessHoursNode(
 }
 
 export function buildGetVerifiedNameIq(jid: string): BinaryNode {
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BUSINESS, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BUSINESS, [
         {
             tag: 'verified_name',
             attrs: { jid }
@@ -134,7 +134,7 @@ export function buildGetVerifiedNameIq(jid: string): BinaryNode {
 }
 
 export function buildUpdateCoverPhotoIq(id: string, timestamp: string, token: string): BinaryNode {
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BUSINESS, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BUSINESS, [
         {
             tag: 'business_profile',
             attrs: { v: '3', mutation_type: 'delta' },
@@ -149,7 +149,7 @@ export function buildUpdateCoverPhotoIq(id: string, timestamp: string, token: st
 }
 
 export function buildDeleteCoverPhotoIq(id: string): BinaryNode {
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BUSINESS, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BUSINESS, [
         {
             tag: 'business_profile',
             attrs: { v: '3', mutation_type: 'delta' },

--- a/src/transport/node/builders/community.ts
+++ b/src/transport/node/builders/community.ts
@@ -1,4 +1,4 @@
-import { WA_XMLNS } from '@protocol/nodes'
+import { WA_IQ_TYPES, WA_XMLNS } from '@protocol/nodes'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
@@ -11,7 +11,7 @@ export function buildLinkSubGroupsIq(input: BuildLinkSubGroupsIqInput): BinaryNo
     if (input.subGroups.length === 0) {
         throw new Error('linkSubGroups requires at least one subgroup')
     }
-    return buildIqNode('set', input.communityJid, WA_XMLNS.GROUPS, [
+    return buildIqNode(WA_IQ_TYPES.SET, input.communityJid, WA_XMLNS.GROUPS, [
         {
             tag: 'links',
             attrs: {},
@@ -44,7 +44,7 @@ export function buildUnlinkSubGroupsIq(input: BuildUnlinkSubGroupsIqInput): Bina
     if (input.removeOrphanedMembers) {
         groupAttrs.remove_orphaned_members = 'true'
     }
-    return buildIqNode('set', input.communityJid, WA_XMLNS.GROUPS, [
+    return buildIqNode(WA_IQ_TYPES.SET, input.communityJid, WA_XMLNS.GROUPS, [
         {
             tag: 'unlink',
             attrs: { unlink_type: 'sub_group' },
@@ -57,11 +57,13 @@ export function buildUnlinkSubGroupsIq(input: BuildUnlinkSubGroupsIqInput): Bina
 }
 
 export function buildDeactivateCommunityIq(communityJid: string): BinaryNode {
-    return buildIqNode('set', communityJid, WA_XMLNS.GROUPS, [{ tag: 'delete_parent', attrs: {} }])
+    return buildIqNode(WA_IQ_TYPES.SET, communityJid, WA_XMLNS.GROUPS, [
+        { tag: 'delete_parent', attrs: {} }
+    ])
 }
 
 export function buildLinkedGroupsParticipantsIq(communityJid: string): BinaryNode {
-    return buildIqNode('get', communityJid, WA_XMLNS.GROUPS, [
+    return buildIqNode(WA_IQ_TYPES.GET, communityJid, WA_XMLNS.GROUPS, [
         { tag: 'linked_groups_participants', attrs: {} }
     ])
 }

--- a/src/transport/node/builders/device.ts
+++ b/src/transport/node/builders/device.ts
@@ -1,10 +1,10 @@
 import { WA_DEFAULTS } from '@protocol/defaults'
-import { WA_XMLNS } from '@protocol/nodes'
+import { WA_IQ_TYPES, WA_XMLNS } from '@protocol/nodes'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
 export function buildRemoveCompanionDeviceIq(deviceJid: string, reason: string): BinaryNode {
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.MD, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.MD, [
         {
             tag: 'remove-companion-device',
             attrs: { jid: deviceJid, reason }

--- a/src/transport/node/builders/email.ts
+++ b/src/transport/node/builders/email.ts
@@ -5,11 +5,12 @@ import {
     WA_EMAIL_XMLNS,
     type WaEmailContext
 } from '@protocol/email'
+import { WA_IQ_TYPES } from '@protocol/nodes'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
 export function buildGetEmailIq(): BinaryNode {
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
         { tag: WA_EMAIL_TAGS.EMAIL, attrs: {} }
     ])
 }
@@ -25,7 +26,7 @@ export function buildSetEmailIq(email: string, context?: WaEmailContext): Binary
         emailChildren.push({ tag: WA_EMAIL_TAGS.CONTEXT, attrs: {}, content: context })
     }
     emailChildren.push({ tag: WA_EMAIL_TAGS.EMAIL_ADDRESS, attrs: {}, content: email })
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
         { tag: WA_EMAIL_TAGS.EMAIL, attrs: {}, content: emailChildren }
     ])
 }
@@ -40,7 +41,7 @@ export function buildRequestEmailVerificationCodeIq(
 ): BinaryNode {
     assertLocaleField('languageCode', input.languageCode)
     assertLocaleField('localeCode', input.localeCode)
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
         {
             tag: WA_EMAIL_TAGS.VERIFY_EMAIL,
             attrs: {},
@@ -56,7 +57,7 @@ export function buildVerifyEmailCodeIq(code: string): BinaryNode {
     if (code.length !== WA_EMAIL_LIMITS.CODE_LENGTH) {
         throw new Error(`verification code must be exactly ${WA_EMAIL_LIMITS.CODE_LENGTH} chars`)
     }
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
         {
             tag: WA_EMAIL_TAGS.VERIFY_EMAIL,
             attrs: {},
@@ -70,7 +71,7 @@ export function buildConfirmEmailIq(context?: WaEmailContext): BinaryNode {
         context !== undefined
             ? [{ tag: WA_EMAIL_TAGS.CONTEXT, attrs: {}, content: context }]
             : undefined
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_EMAIL_XMLNS, [
         {
             tag: WA_EMAIL_TAGS.CONFIRM_EMAIL,
             attrs: {},

--- a/src/transport/node/builders/global.ts
+++ b/src/transport/node/builders/global.ts
@@ -232,7 +232,7 @@ export function buildAckNode(input: BuildAckNodeInput): BinaryNode {
     }
 
     const attrs: Record<string, string> = {
-        class: 'receipt'
+        class: WA_MESSAGE_TAGS.RECEIPT
     }
     if (input.retryType) {
         attrs.type = input.typeOverride ?? WA_MESSAGE_TYPES.RECEIPT_TYPE_RETRY

--- a/src/transport/node/builders/group.ts
+++ b/src/transport/node/builders/group.ts
@@ -1,5 +1,5 @@
 import { WA_DEFAULTS } from '@protocol/defaults'
-import { WA_XMLNS } from '@protocol/nodes'
+import { WA_IQ_TYPES, WA_XMLNS } from '@protocol/nodes'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
@@ -52,7 +52,7 @@ export function buildCreateGroupIq(input: BuildCreateGroupIqInput): BinaryNode {
         children.push({ tag: 'create_general_chat', attrs: {} })
     }
 
-    return buildIqNode('set', WA_DEFAULTS.GROUP_SERVER, WA_XMLNS.GROUPS, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.GROUP_SERVER, WA_XMLNS.GROUPS, [
         {
             tag: 'create',
             attrs: { subject: input.subject },
@@ -68,7 +68,7 @@ export function buildGroupParticipantChangeIq(input: {
     readonly action: GroupParticipantAction
     readonly participants: readonly string[]
 }): BinaryNode {
-    return buildIqNode('set', input.groupJid, WA_XMLNS.GROUPS, [
+    return buildIqNode(WA_IQ_TYPES.SET, input.groupJid, WA_XMLNS.GROUPS, [
         {
             tag: input.action,
             attrs: {},
@@ -81,7 +81,7 @@ export function buildGroupParticipantChangeIq(input: {
 }
 
 export function buildLeaveGroupIq(groupJids: readonly string[]): BinaryNode {
-    return buildIqNode('set', WA_DEFAULTS.GROUP_SERVER, WA_XMLNS.GROUPS, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.GROUP_SERVER, WA_XMLNS.GROUPS, [
         {
             tag: 'leave',
             attrs: {},
@@ -94,7 +94,7 @@ export function buildLeaveGroupIq(groupJids: readonly string[]): BinaryNode {
 }
 
 export function buildGetMembershipApprovalRequestsIq(groupJid: string): BinaryNode {
-    return buildIqNode('get', groupJid, WA_XMLNS.GROUPS, [
+    return buildIqNode(WA_IQ_TYPES.GET, groupJid, WA_XMLNS.GROUPS, [
         { tag: 'membership_approval_requests', attrs: {} }
     ])
 }
@@ -124,7 +124,7 @@ export function buildMembershipRequestsActionIq(input: {
             content: reject.map((jid) => ({ tag: 'participant', attrs: { jid } }))
         })
     }
-    return buildIqNode('set', input.groupJid, WA_XMLNS.GROUPS, [
+    return buildIqNode(WA_IQ_TYPES.SET, input.groupJid, WA_XMLNS.GROUPS, [
         { tag: 'membership_requests_action', attrs: {}, content: children }
     ])
 }
@@ -136,7 +136,7 @@ export function buildCancelMembershipRequestsIq(input: {
     if (input.participantJids.length === 0) {
         throw new Error('cancel_membership_requests requires at least one participant')
     }
-    return buildIqNode('set', input.groupJid, WA_XMLNS.GROUPS, [
+    return buildIqNode(WA_IQ_TYPES.SET, input.groupJid, WA_XMLNS.GROUPS, [
         {
             tag: 'cancel_membership_requests',
             attrs: {},
@@ -157,7 +157,7 @@ export function buildJoinLinkedGroupIq(input: {
     if (input.type) {
         attrs.type = input.type
     }
-    return buildIqNode('set', input.groupJid, WA_XMLNS.GROUPS, [
+    return buildIqNode(WA_IQ_TYPES.SET, input.groupJid, WA_XMLNS.GROUPS, [
         { tag: 'join_linked_group', attrs }
     ])
 }

--- a/src/transport/node/builders/media.ts
+++ b/src/transport/node/builders/media.ts
@@ -1,9 +1,9 @@
-import { WA_DEFAULTS, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
+import { WA_DEFAULTS, WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
 export function buildMediaConnIq(): BinaryNode {
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.MEDIA, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.MEDIA, [
         {
             tag: WA_NODE_TAGS.MEDIA_CONN,
             attrs: {}

--- a/src/transport/node/builders/newsletter.ts
+++ b/src/transport/node/builders/newsletter.ts
@@ -1,6 +1,6 @@
 import { WA_DEFAULTS } from '@protocol/defaults'
 import { WA_EDIT_ATTRS } from '@protocol/message'
-import { WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
+import { WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
@@ -187,7 +187,7 @@ export function buildNewsletterViewReceiptNode(input: BuildNewsletterViewReceipt
 }
 
 export function buildNewsletterMetadataIq(): BinaryNode {
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.NEWSLETTER, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.NEWSLETTER, [
         {
             tag: WA_NODE_TAGS.MY_ADDONS,
             attrs: {
@@ -198,7 +198,7 @@ export function buildNewsletterMetadataIq(): BinaryNode {
 }
 
 export function buildNewsletterSubscribeLiveUpdatesIq(newsletterJid: string): BinaryNode {
-    return buildIqNode('set', newsletterJid, WA_XMLNS.NEWSLETTER, [
+    return buildIqNode(WA_IQ_TYPES.SET, newsletterJid, WA_XMLNS.NEWSLETTER, [
         {
             tag: 'live_updates',
             attrs: {}
@@ -228,7 +228,7 @@ export function buildNewsletterMessagesIq(input: BuildNewsletterMessagesIqInput)
     if (input.viewRole) {
         attrs.view_role = input.viewRole
     }
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.NEWSLETTER, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.NEWSLETTER, [
         {
             tag: 'messages',
             attrs
@@ -261,7 +261,7 @@ export function buildNewsletterMessageUpdatesIq(
     } else if (input.after !== undefined) {
         attrs.after = String(input.after)
     }
-    return buildIqNode('get', input.newsletterJid, WA_XMLNS.NEWSLETTER, [
+    return buildIqNode(WA_IQ_TYPES.GET, input.newsletterJid, WA_XMLNS.NEWSLETTER, [
         {
             tag: 'message_updates',
             attrs

--- a/src/transport/node/builders/prekeys.ts
+++ b/src/transport/node/builders/prekeys.ts
@@ -1,5 +1,5 @@
 import { toRawPubKey } from '@crypto/core/keys'
-import { WA_DEFAULTS, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
+import { WA_DEFAULTS, WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
 import { SIGNAL_KEY_BUNDLE_TYPE_BYTES } from '@signal/api/constants'
 import type { SignalMissingPreKeysTarget } from '@signal/api/SignalMissingPreKeysSyncApi'
 import type { PreKeyRecord, RegistrationInfo, SignedPreKeyRecord } from '@signal/types'
@@ -75,11 +75,11 @@ export function buildPreKeyUploadIq(
         },
         buildSignedPreKeyNode(signedPreKey)
     )
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.SIGNAL, children)
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.SIGNAL, children)
 }
 
 export function buildSignedPreKeyRotateIq(signedPreKey: SignedPreKeyRecord) {
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.SIGNAL, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.SIGNAL, [
         {
             tag: WA_NODE_TAGS.ROTATE,
             attrs: {},
@@ -89,7 +89,7 @@ export function buildSignedPreKeyRotateIq(signedPreKey: SignedPreKeyRecord) {
 }
 
 export function buildMissingPreKeysFetchIq(users: readonly SignalMissingPreKeysTarget[]) {
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.SIGNAL, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.SIGNAL, [
         {
             tag: WA_NODE_TAGS.KEY_FETCH,
             attrs: {},

--- a/src/transport/node/builders/privacy-token.ts
+++ b/src/transport/node/builders/privacy-token.ts
@@ -1,6 +1,6 @@
 import { WA_DEFAULTS } from '@protocol/defaults'
 import { toUserJid } from '@protocol/jid'
-import { WA_XMLNS } from '@protocol/nodes'
+import { WA_IQ_TYPES, WA_XMLNS } from '@protocol/nodes'
 import { WA_PRIVACY_TOKEN_TAGS, WA_PRIVACY_TOKEN_TYPES } from '@protocol/privacy-token'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
@@ -12,7 +12,7 @@ export interface BuildPrivacyTokenIqInput {
 }
 
 export function buildPrivacyTokenIqNode(input: BuildPrivacyTokenIqInput): BinaryNode {
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PRIVACY, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PRIVACY, [
         {
             tag: WA_PRIVACY_TOKEN_TAGS.TOKENS,
             attrs: {},

--- a/src/transport/node/builders/privacy.ts
+++ b/src/transport/node/builders/privacy.ts
@@ -1,11 +1,11 @@
 import { WA_DEFAULTS } from '@protocol/defaults'
-import { WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
+import { WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
 import { WA_PRIVACY_TAGS, type WaPrivacyCategory, type WaPrivacyValue } from '@protocol/privacy'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
 export function buildGetPrivacySettingsIq(): BinaryNode {
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PRIVACY, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PRIVACY, [
         { tag: WA_NODE_TAGS.PRIVACY, attrs: {} }
     ])
 }
@@ -14,7 +14,7 @@ export function buildSetPrivacyCategoryIq(
     category: WaPrivacyCategory,
     value: WaPrivacyValue
 ): BinaryNode {
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PRIVACY, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PRIVACY, [
         {
             tag: WA_NODE_TAGS.PRIVACY,
             attrs: {},
@@ -29,7 +29,7 @@ export function buildSetPrivacyCategoryIq(
 }
 
 export function buildGetPrivacyDisallowedListIq(category: WaPrivacyCategory): BinaryNode {
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PRIVACY, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PRIVACY, [
         {
             tag: WA_NODE_TAGS.PRIVACY,
             attrs: {},
@@ -44,11 +44,11 @@ export function buildGetPrivacyDisallowedListIq(category: WaPrivacyCategory): Bi
 }
 
 export function buildGetBlocklistIq(): BinaryNode {
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BLOCKLIST)
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BLOCKLIST)
 }
 
 export function buildBlocklistChangeIq(jid: string, action: 'block' | 'unblock'): BinaryNode {
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BLOCKLIST, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BLOCKLIST, [
         {
             tag: 'item',
             attrs: { jid, action }

--- a/src/transport/node/builders/profile.ts
+++ b/src/transport/node/builders/profile.ts
@@ -1,4 +1,4 @@
-import { WA_DEFAULTS, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
+import { WA_DEFAULTS, WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
@@ -17,7 +17,7 @@ export function buildGetProfilePictureIq(
         pictureAttrs.id = existingId
     }
     return buildIqNode(
-        'get',
+        WA_IQ_TYPES.GET,
         WA_DEFAULTS.HOST_DOMAIN,
         WA_XMLNS.PROFILE_PICTURE,
         [
@@ -38,7 +38,7 @@ export function buildSetProfilePictureIq(imageBytes: Uint8Array, targetJid?: str
         attrs.target = targetJid
     }
     return buildIqNode(
-        'set',
+        WA_IQ_TYPES.SET,
         WA_DEFAULTS.HOST_DOMAIN,
         WA_XMLNS.PROFILE_PICTURE,
         [
@@ -57,11 +57,17 @@ export function buildDeleteProfilePictureIq(targetJid?: string): BinaryNode {
     if (targetJid) {
         attrs.target = targetJid
     }
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PROFILE_PICTURE, undefined, attrs)
+    return buildIqNode(
+        WA_IQ_TYPES.SET,
+        WA_DEFAULTS.HOST_DOMAIN,
+        WA_XMLNS.PROFILE_PICTURE,
+        undefined,
+        attrs
+    )
 }
 
 export function buildSetStatusIq(text: string): BinaryNode {
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.STATUS, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.STATUS, [
         {
             tag: 'status',
             attrs: {},

--- a/src/transport/node/builders/tos.ts
+++ b/src/transport/node/builders/tos.ts
@@ -1,5 +1,5 @@
 import { WA_DEFAULTS } from '@protocol/defaults'
-import { WA_XMLNS } from '@protocol/nodes'
+import { WA_IQ_TYPES, WA_XMLNS } from '@protocol/nodes'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
@@ -14,7 +14,7 @@ export function buildTosQueryIq(noticeIds: readonly string[]): BinaryNode {
     if (noticeIds.length === 0) {
         throw new Error('tos query requires at least one notice id')
     }
-    return buildIqNode('get', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.TOS, [
+    return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.TOS, [
         {
             tag: 'request',
             attrs: {},
@@ -27,7 +27,7 @@ export function buildTosUpdateIq(noticeIds: readonly string[]): BinaryNode {
     if (noticeIds.length === 0) {
         throw new Error('tos update requires at least one notice id')
     }
-    return buildIqNode('set', WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.TOS, [
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.TOS, [
         {
             tag: 'request',
             attrs: { type: 'session_update' },

--- a/src/transport/node/builders/usync.ts
+++ b/src/transport/node/builders/usync.ts
@@ -1,5 +1,6 @@
 import {
     WA_DEFAULTS,
+    WA_IQ_TYPES,
     WA_NODE_TAGS,
     WA_USYNC_CONTEXTS,
     WA_USYNC_DEFAULTS,
@@ -49,28 +50,33 @@ export function buildUsyncIq(input: BuildUsyncIqInput): BinaryNode {
         users[index] = buildUsyncUserNode(input.users[index])
     }
 
-    return buildIqNode('get', input.hostDomain ?? WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.USYNC, [
-        {
-            tag: WA_NODE_TAGS.USYNC,
-            attrs: {
-                sid: input.sid,
-                index: input.index ?? WA_USYNC_DEFAULTS.INDEX,
-                last: input.last ?? WA_USYNC_DEFAULTS.LAST,
-                mode: input.mode ?? WA_USYNC_MODES.QUERY,
-                context: input.context ?? WA_USYNC_CONTEXTS.INTERACTIVE
-            },
-            content: [
-                {
-                    tag: WA_NODE_TAGS.QUERY,
-                    attrs: {},
-                    content: input.queryProtocolNodes
+    return buildIqNode(
+        WA_IQ_TYPES.GET,
+        input.hostDomain ?? WA_DEFAULTS.HOST_DOMAIN,
+        WA_XMLNS.USYNC,
+        [
+            {
+                tag: WA_NODE_TAGS.USYNC,
+                attrs: {
+                    sid: input.sid,
+                    index: input.index ?? WA_USYNC_DEFAULTS.INDEX,
+                    last: input.last ?? WA_USYNC_DEFAULTS.LAST,
+                    mode: input.mode ?? WA_USYNC_MODES.QUERY,
+                    context: input.context ?? WA_USYNC_CONTEXTS.INTERACTIVE
                 },
-                {
-                    tag: WA_NODE_TAGS.LIST,
-                    attrs: {},
-                    content: users
-                }
-            ]
-        }
-    ])
+                content: [
+                    {
+                        tag: WA_NODE_TAGS.QUERY,
+                        attrs: {},
+                        content: input.queryProtocolNodes
+                    },
+                    {
+                        tag: WA_NODE_TAGS.LIST,
+                        attrs: {},
+                        content: users
+                    }
+                ]
+            }
+        ]
+    )
 }

--- a/src/transport/node/query.ts
+++ b/src/transport/node/query.ts
@@ -5,7 +5,7 @@ import type { BinaryNode } from '@transport/types'
 import { toError } from '@util/primitives'
 
 export function buildIqNode(
-    type: 'get' | 'set',
+    type: typeof WA_IQ_TYPES.GET | typeof WA_IQ_TYPES.SET,
     to: string,
     xmlns: string,
     content?: BinaryNode['content'],


### PR DESCRIPTION
Migrate ~80 literal strings duplicating values already defined in src/protocol/* to use the named constants directly. Touches IQ types, node tags, message tags/types, notification tags, stream signaling, disconnect reasons, newsletter state, business/privacy/profile tags across builders, coordinators, events, and incoming handlers.

Also tighten buildIqNode signature to accept only WA_IQ_TYPES.GET/SET and ignore ___* paths in .gitignore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal code standardization and maintainability improvements across the codebase with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/72)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->