### PR TITLE
feat(client): add markOnlineOnConnect option for initial presence on login

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -87,6 +87,7 @@ import {
     WA_PRIVACY_TOKEN_NOTIFICATION_TYPE
 } from '@protocol/constants'
 import { isNewsletterJid, parseSignalAddressFromJid, toUserJid } from '@protocol/jid'
+import { WA_PRESENCE_TYPES } from '@protocol/presence'
 import type { WaConnectionCode, WaConnectionOpenReason, WaDisconnectReason } from '@protocol/stream'
 import { createOutboundRetryTracker } from '@retry/tracker'
 import type { WaRetryDecryptFailureContext } from '@retry/types'
@@ -371,6 +372,7 @@ function createPassiveTasksRuntime(input: {
     readonly receiptQueue: WaReceiptQueue
     readonly getCurrentCredentials: () => ReturnType<WaAuthClient['getCurrentCredentials']>
     readonly abPropsCoordinator: WaAbPropsCoordinator
+    readonly markOnlineOnConnect: boolean
 }): ConstructorParameters<typeof WaPassiveTasksCoordinator>[0]['runtime'] {
     const {
         queryWithContext,
@@ -378,7 +380,8 @@ function createPassiveTasksRuntime(input: {
         nodeOrchestrator,
         receiptQueue,
         getCurrentCredentials,
-        abPropsCoordinator
+        abPropsCoordinator,
+        markOnlineOnConnect
     } = input
 
     return {
@@ -391,12 +394,13 @@ function createPassiveTasksRuntime(input: {
         requeueDanglingReceipt: (node) => receiptQueue.enqueue(node),
         shouldQueueDanglingReceipt: (node, error) => receiptQueue.shouldQueue(node, error),
         syncAbProps: () => abPropsCoordinator.sync(),
-        sendPresenceAvailable: async () => {
+        sendInitialPresence: async () => {
             const credentials = getCurrentCredentials()
-            await nodeOrchestrator.sendNode(
-                buildPresenceNode({ name: credentials?.meDisplayName ?? undefined }),
-                false
-            )
+            const name = credentials?.meDisplayName ?? undefined
+            const node = markOnlineOnConnect
+                ? buildPresenceNode({ name })
+                : buildPresenceNode({ type: WA_PRESENCE_TYPES.UNAVAILABLE, name })
+            await nodeOrchestrator.sendNode(node, false)
         }
     }
 }
@@ -1198,7 +1202,8 @@ export function buildWaClientDependencies(input: {
             nodeOrchestrator,
             receiptQueue,
             getCurrentCredentials,
-            abPropsCoordinator
+            abPropsCoordinator,
+            markOnlineOnConnect: options.markOnlineOnConnect ?? true
         }),
         mobilePrimary: options.mobileTransport !== undefined,
         appStateSync

--- a/src/client/coordinators/WaPassiveTasksCoordinator.ts
+++ b/src/client/coordinators/WaPassiveTasksCoordinator.ts
@@ -34,7 +34,7 @@ type WaPassiveTasksRuntime = {
     readonly requeueDanglingReceipt: (node: BinaryNode) => void
     readonly shouldQueueDanglingReceipt: (node: BinaryNode, error: Error) => boolean
     readonly syncAbProps: () => void
-    readonly sendPresenceAvailable: () => Promise<void>
+    readonly sendInitialPresence: () => Promise<void>
 }
 
 export class WaPassiveTasksCoordinator {
@@ -130,8 +130,8 @@ export class WaPassiveTasksCoordinator {
             })
         }
 
-        await this.runtime.sendPresenceAvailable().catch((error) => {
-            this.logger.warn('presence available send failed', {
+        await this.runtime.sendInitialPresence().catch((error) => {
+            this.logger.warn('initial presence send failed', {
                 message: toError(error).message
             })
         })

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -1255,7 +1255,7 @@ function createPassiveTasksCoordinator(overrides: {
                 overrides.requeueDanglingReceipt ?? ((node) => requeued.push(node)),
             shouldQueueDanglingReceipt: overrides.shouldQueueDanglingReceipt ?? (() => true),
             syncAbProps: () => undefined,
-            sendPresenceAvailable: async () => undefined
+            sendInitialPresence: async () => undefined
         }
     })
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -56,6 +56,15 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
     readonly messageAckTimeoutMs?: number
     readonly messageMaxAttempts?: number
     readonly messageRetryDelayMs?: number
+    /**
+     * Initial presence sent right after the post-connect passive task runs.
+     * - `true` (default): announce the client as online — matches the wa-web
+     *   behavior when the browser tab has focus at login time.
+     * - `false`: announce as unavailable — matches wa-web when the tab is not
+     *   focused (or the Windows app is minimized to tray) at login time. Useful
+     *   for bots/headless sessions that should not appear "online" on connect.
+     */
+    readonly markOnlineOnConnect?: boolean
     readonly writeBehind?: WaWriteBehindOptions
     readonly history?: WaHistorySyncOptions
     readonly chatEvents?: {


### PR DESCRIPTION
Mirrors wa-web behavior where the post-login presence reflects browser tab focus (or Windows minimized-to-tray) state. Default true preserves the current "always online" behavior; setting false emits <presence type="unavailable" name="..."/> right after passive connect.