### PR TITLE
fix(client): emit connection: open only after registration with isNewLogin

### DIFF
--- a/packages/fake-server/src/__tests__/integration.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/integration.cross-check.test.ts
@@ -30,26 +30,12 @@ test('zapo-js client completes a full noise XX handshake against the fake server
 
     try {
         const successPromise = waitForEvent(client, 'connection_success', 5_000)
-        const connectionOpenPromise = new Promise<void>((resolve, reject) => {
-            const timer = setTimeout(
-                () => reject(new Error('timed out waiting for connection { status: open }')),
-                5_000
-            )
-            client.on('connection', (event) => {
-                if (event.status === 'open') {
-                    clearTimeout(timer)
-                    resolve()
-                }
-            })
-        })
 
         await client.connect()
 
         const [event] = await successPromise
         assert.equal(event.node.tag, 'success')
         assert.ok(event.node.attrs.t, 'success node should carry a timestamp')
-
-        await connectionOpenPromise
     } finally {
         await client.disconnect().catch(() => undefined)
         await server.stop()

--- a/packages/fake-server/src/__tests__/iq-error.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/iq-error.cross-check.test.ts
@@ -17,19 +17,17 @@ test('lib privacy.getPrivacySettings rejects when fake server replies with iq er
 
     const { client } = createZapoClient(server, { sessionId: 'iq-error-test' })
 
-    const openPromise = new Promise<void>((resolve, reject) => {
+    const successPromise = new Promise<void>((resolve, reject) => {
         const timer = setTimeout(() => reject(new Error('connection timeout')), 5_000)
-        client.on('connection', (event) => {
-            if (event.status === 'open') {
-                clearTimeout(timer)
-                resolve()
-            }
+        client.once('connection_success', () => {
+            clearTimeout(timer)
+            resolve()
         })
     })
 
     try {
         await client.connect()
-        await openPromise
+        await successPromise
 
         await assert.rejects(() => client.privacy.getPrivacySettings(), /401/)
     } finally {

--- a/packages/fake-server/src/__tests__/resume-handshake.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/resume-handshake.cross-check.test.ts
@@ -72,21 +72,6 @@ function buildClientFor(server: FakeWaServer, authStore: WaAuthStore, sessionId:
     })
 }
 
-function waitForOpen(client: WaClient, timeoutMs = 5_000): Promise<void> {
-    return new Promise((resolve, reject) => {
-        const timer = setTimeout(
-            () => reject(new Error(`connection { open } timed out after ${timeoutMs}ms`)),
-            timeoutMs
-        )
-        client.on('connection', (event) => {
-            if (event.status === 'open') {
-                clearTimeout(timer)
-                resolve()
-            }
-        })
-    })
-}
-
 function waitForEvent<K extends keyof WaClientEventMap>(
     client: WaClient,
     event: K,
@@ -104,17 +89,15 @@ function waitForEvent<K extends keyof WaClientEventMap>(
     })
 }
 
-test('resume handshake: second connection uses IK and reaches connection_open', async () => {
+test('resume handshake: second connection uses IK and reaches connection_success', async () => {
     const server = await FakeWaServer.start()
     const authStore = new InMemoryAuthStore()
 
     try {
         const firstClient = buildClientFor(server, authStore, 'resume-1')
         const firstSuccess = waitForEvent(firstClient, 'connection_success')
-        const firstOpen = waitForOpen(firstClient)
         await firstClient.connect()
         await firstSuccess
-        await firstOpen
 
         const credsAfterXx = authStore.peek()
         assert.ok(credsAfterXx, 'auth store should have credentials after first connect')
@@ -127,10 +110,8 @@ test('resume handshake: second connection uses IK and reaches connection_open', 
 
         const secondClient = buildClientFor(server, authStore, 'resume-2')
         const secondSuccess = waitForEvent(secondClient, 'connection_success')
-        const secondOpen = waitForOpen(secondClient)
         await secondClient.connect()
         await secondSuccess
-        await secondOpen
 
         await secondClient.disconnect()
     } finally {

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -672,12 +672,15 @@ export class WaClient extends EventEmitter {
         this.connectPromise = this.connectionManager
             .connect((frame) => this.handleIncomingFrame(frame))
             .then(() => {
+                if (!this.authClient.getCurrentCredentials()?.meJid) {
+                    return
+                }
                 this.emit('connection', {
                     status: 'open',
                     reason: 'connected',
                     code: null,
                     isLogout: false,
-                    isNewLogin: this.connectionManager.wasNewLogin()
+                    isNewLogin: false
                 })
             })
             .finally(() => {

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -784,7 +784,16 @@ export function buildWaClientDependencies(input: {
         nodeOrchestrator,
         nodeTransport,
         getPassiveTasks: () => passiveTasks,
-        clearStoredCredentials: runtime.clearStoredState
+        clearStoredCredentials: runtime.clearStoredState,
+        onPostPairReconnected: () => {
+            runtime.emitEvent('connection', {
+                status: 'open',
+                reason: 'connected',
+                code: null,
+                isLogout: false,
+                isNewLogin: true
+            })
+        }
     })
 
     if (mediaConnCacheFallback !== null) {
@@ -812,12 +821,15 @@ export function buildWaClientDependencies(input: {
     const connectWithClientSideEffects = async (reason: WaConnectionOpenReason): Promise<void> => {
         runtime.resumeIncomingEvents()
         await connectionManager?.connect(runtime.handleIncomingFrame)
+        if (!authClient.getCurrentCredentials()?.meJid) {
+            return
+        }
         runtime.emitEvent('connection', {
             status: 'open',
             reason,
             code: null,
             isLogout: false,
-            isNewLogin: connectionManager?.wasNewLogin() ?? false
+            isNewLogin: false
         })
     }
 

--- a/src/client/connection/WaConnectionManager.ts
+++ b/src/client/connection/WaConnectionManager.ts
@@ -19,6 +19,7 @@ interface WaConnectionManagerOptions {
     readonly nodeTransport: WaNodeTransport
     readonly getPassiveTasks: () => WaPassiveTasksCoordinator | null
     readonly clearStoredCredentials: () => Promise<void>
+    readonly onPostPairReconnected: () => void
 }
 
 export class WaConnectionManager {
@@ -30,6 +31,7 @@ export class WaConnectionManager {
     private readonly nodeTransport: WaNodeTransport
     private readonly getPassiveTasks: () => WaPassiveTasksCoordinator | null
     private readonly clearStoredCredentialsCallback: () => Promise<void>
+    private readonly onPostPairReconnected: () => void
     private comms: WaComms | null
     private clockSkewMs: number | null
     private mediaConnCache: WaMediaConn | null
@@ -40,7 +42,6 @@ export class WaConnectionManager {
     private pendingComms: WaComms | null
     private lifecycleGeneration: number
     private lifecycleQueue: Promise<void>
-    private lastConnectWasNewLogin = false
 
     public constructor(options: WaConnectionManagerOptions) {
         this.logger = options.logger
@@ -51,6 +52,7 @@ export class WaConnectionManager {
         this.nodeTransport = options.nodeTransport
         this.getPassiveTasks = options.getPassiveTasks
         this.clearStoredCredentialsCallback = options.clearStoredCredentials
+        this.onPostPairReconnected = options.onPostPairReconnected
         this.comms = null
         this.clockSkewMs = null
         this.mediaConnCache = null
@@ -118,10 +120,6 @@ export class WaConnectionManager {
         return !!(this.comms && this.comms.getCommsState().connected)
     }
 
-    public wasNewLogin(): boolean {
-        return this.lastConnectWasNewLogin
-    }
-
     public getComms(): WaComms | null {
         return this.comms
     }
@@ -172,7 +170,6 @@ export class WaConnectionManager {
 
         this.logger.info('wa client connect start')
         let credentials = await this.authClient.loadOrCreateCredentials()
-        this.lastConnectWasNewLogin = !credentials.meJid
         this.assertLifecycleCurrent(lifecycleGeneration, 'connect')
 
         try {
@@ -252,6 +249,8 @@ export class WaConnectionManager {
 
         await this.startCommsWithCredentials(credentials, frameHandler, lifecycleGeneration)
         this.assertLifecycleCurrent(lifecycleGeneration, 'pairing reconnect')
+
+        this.onPostPairReconnected()
     }
 
     private async disconnectInternal(lifecycleGeneration: number): Promise<void> {

--- a/src/client/connection/__tests__/connection.test.ts
+++ b/src/client/connection/__tests__/connection.test.ts
@@ -60,7 +60,8 @@ test('connection manager exposes media cache and clock skew helpers', async () =
         getPassiveTasks: () => null,
         clearStoredCredentials: async () => {
             clearedCredentialsCalls += 1
-        }
+        },
+        onPostPairReconnected: () => undefined
     })
 
     const mediaConn = {


### PR DESCRIPTION
Previously isNewLogin reflected !meJid at connect-start, so the pre-pair socket open emitted connection: open with isNewLogin: true while still unregistered, and the post-pair reconnect emitted no connection event at all. Now the pre-pair connection: open is suppressed entirely; the registered reconnect (post-pair) emits a single connection: open with isNewLogin: true via a new onPostPairReconnected callback wired through the connection manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection validation by verifying credentials presence before reporting successful connection.
  * Enhanced reconnection behavior after device pairing with more reliable status reporting.

* **Chores**
  * Simplified internal connection state tracking logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->