### PR TITLE
feat(client): add link preview generation for text messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@types/node": "^22.13.14",
                 "@types/ws": "^8.18.1",
                 "@typescript-eslint/parser": "^8.56.1",
-                "@vinikjkkj/eslint-config": "^1.0.0",
+                "@vinikjkkj/eslint-config": "1.0.2",
                 "argo-codec": "^0.2.1",
                 "better-sqlite3": "^12.6.2",
                 "c8": "^11.0.0",
@@ -2508,9 +2508,9 @@
             ]
         },
         "node_modules/@vinikjkkj/eslint-config": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@vinikjkkj/eslint-config/-/eslint-config-1.0.1.tgz",
-            "integrity": "sha512-B3cvxy15ilLaWZuFTVxpZNxop9isxTL2VezHE9WtvnILXTqmaHhTkyVnO1U6D861zbI2/FH5Fu/yTqipGCLveQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@vinikjkkj/eslint-config/-/eslint-config-1.0.2.tgz",
+            "integrity": "sha512-/QHdo4jnHt0leR0gYmT1r4nPo3DLgejzhY86pn9zanIc81u++2P4cQa1LqFsTdq6Dr5YvvW2buC0g0O651WDlg==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -9069,9 +9069,7 @@
             "name": "@zapo-js/mcp-server",
             "version": "0.0.0",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.29.0",
-                "@zapo-js/store-sqlite": ">=0.1.0",
-                "zapo-js": ">=0.1.0"
+                "@modelcontextprotocol/sdk": "^1.29.0"
             },
             "bin": {
                 "zapo-mcp-server": "dist/bin.js"
@@ -9087,7 +9085,9 @@
                 "node": ">=20.9.0"
             },
             "peerDependencies": {
-                "better-sqlite3": ">=11.0.0"
+                "@zapo-js/store-sqlite": ">=0.1.0",
+                "better-sqlite3": ">=11.0.0",
+                "zapo-js": ">=0.1.0"
             },
             "peerDependenciesMeta": {
                 "better-sqlite3": {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
         "@types/node": "^22.13.14",
         "@types/ws": "^8.18.1",
         "@typescript-eslint/parser": "^8.56.1",
-        "@vinikjkkj/eslint-config": "^1.0.0",
+        "@vinikjkkj/eslint-config": "1.0.2",
         "argo-codec": "^0.2.1",
         "better-sqlite3": "^12.6.2",
         "c8": "^11.0.0",

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -52,6 +52,7 @@ import { handleDirtyBits, parseDirtyBits } from '@client/dirty'
 import { DEVICE_NOTIFICATION_ACTIONS, parseDeviceNotification } from '@client/events/devices'
 import { parseIdentityChangeNotification } from '@client/events/identity'
 import { parsePrivacyTokenNotification } from '@client/events/privacy-token'
+import { resolveLinkPreview } from '@client/link-preview'
 import {
     buildMediaMessageContent,
     getMediaConn as getClientMediaConn,
@@ -72,6 +73,7 @@ import type { Logger } from '@infra/log/types'
 import type { WaMediaConn } from '@media/types'
 import { WaMediaTransferClient } from '@media/WaMediaTransferClient'
 import { handleIncomingMessageAck } from '@message/incoming'
+import { createDefaultLinkPreviewFetcher } from '@message/link-preview/fetcher'
 import {
     createPeerDataOperationRequester,
     type PeerDataOperationRequester
@@ -448,6 +450,18 @@ export function buildWaClientDependencies(input: {
         defaultDownloadAgent: toProxyAgent(options.proxy?.mediaDownload),
         skipMacVerification: options.dangerous?.disableMediaMacVerification
     })
+    const linkPreviewOptions = options.linkPreview ?? {}
+    const linkPreviewFetcher =
+        linkPreviewOptions.fetcher ??
+        createDefaultLinkPreviewFetcher({
+            mediaTransfer,
+            userAgent: linkPreviewOptions.userAgent,
+            fetchTimeoutMs: linkPreviewOptions.fetchTimeoutMs,
+            maxHtmlBytes: linkPreviewOptions.maxHtmlBytes,
+            maxThumbnailBytes: linkPreviewOptions.maxThumbnailBytes,
+            allowPrivateHosts: linkPreviewOptions.allowPrivateHosts,
+            proxy: linkPreviewOptions.proxy ?? options.proxy?.linkPreview
+        })
     const mediaMessageBuildOptions: WaMediaMessageOptions = {
         logger,
         mediaTransfer,
@@ -463,7 +477,15 @@ export function buildWaClientDependencies(input: {
             mediaConnCacheFallback = mediaConn
             connectionManager?.setMediaConnCache(mediaConn)
         },
-        media: options.media
+        media: options.media,
+        linkPreviewResolver: (content) =>
+            resolveLinkPreview(content.text, content.linkPreview, {
+                logger,
+                mediaTransfer,
+                getMediaConn: () => getClientMediaConn(mediaMessageBuildOptions),
+                fetcher: linkPreviewFetcher,
+                options: linkPreviewOptions
+            })
     }
 
     const messageClient = new WaMessageClient({

--- a/src/client/__tests__/link-preview.test.ts
+++ b/src/client/__tests__/link-preview.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import { resolveLinkPreview } from '@client/link-preview'
+import { buildMediaMessageContent, type WaMediaMessageOptions } from '@client/messages'
 import { createNoopLogger } from '@infra/log/types'
 import type { WaMediaConn } from '@media/types'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
@@ -227,4 +228,45 @@ test('resolveLinkPreview drops thumbnail on upload failure', async () => {
     assert.equal(r?.resolved.matchedText, 'https://example.com')
     assert.equal(r?.thumbnailFields.thumbnailDirectPath, undefined)
     assert.equal(r?.thumbnailFields.jpegThumbnail, undefined)
+})
+
+function makeBuildOptions(
+    resolver: WaMediaMessageOptions['linkPreviewResolver']
+): WaMediaMessageOptions {
+    return {
+        logger: createNoopLogger(),
+        mediaTransfer: undefined as unknown as WaMediaTransferClient,
+        queryWithContext: async () => ({ tag: 'noop', attrs: {} }),
+        getMediaConnCache: () => null,
+        setMediaConnCache: () => {},
+        linkPreviewResolver: resolver
+    }
+}
+
+test('buildMediaMessageContent falls back to plain extendedTextMessage when resolver throws', async () => {
+    const result = await buildMediaMessageContent(
+        makeBuildOptions(() => {
+            throw new Error('resolver crashed')
+        }),
+        { type: 'text', text: 'see https://example.com' }
+    )
+    assert.deepEqual(result, {
+        message: { extendedTextMessage: { text: 'see https://example.com' } }
+    })
+})
+
+test('buildMediaMessageContent uses resolver output when it returns a preview', async () => {
+    const result = await buildMediaMessageContent(
+        makeBuildOptions(async () => ({
+            resolved: {
+                matchedText: 'https://example.com',
+                title: 'Resolved',
+                previewType: proto.Message.ExtendedTextMessage.PreviewType.NONE
+            },
+            thumbnailFields: {}
+        })),
+        { type: 'text', text: 'see https://example.com' }
+    )
+    assert.equal(result.message.extendedTextMessage?.title, 'Resolved')
+    assert.equal(result.message.extendedTextMessage?.matchedText, 'https://example.com')
 })

--- a/src/client/__tests__/link-preview.test.ts
+++ b/src/client/__tests__/link-preview.test.ts
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resolveLinkPreview } from '@client/link-preview'
+import { createNoopLogger } from '@infra/log/types'
+import type { WaMediaConn } from '@media/types'
+import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
+import type { WaLinkPreviewFetcher, WaLinkPreviewResolved } from '@message/link-preview/types'
+import { proto } from '@proto'
+import { TEXT_ENCODER } from '@util/bytes'
+
+const fakeMediaConn: WaMediaConn = {
+    auth: 'auth-token',
+    expiresAtMs: Date.now() + 60_000,
+    hosts: [{ hostname: 'mmg.whatsapp.net', isFallback: false }]
+}
+
+function noopFetcher(result: WaLinkPreviewResolved | null = null): WaLinkPreviewFetcher {
+    return {
+        async fetch() {
+            return result
+        }
+    }
+}
+
+function recordingFetcher(): {
+    readonly fetcher: WaLinkPreviewFetcher
+    readonly calls: { matchedText: string }[]
+} {
+    const calls: { matchedText: string }[] = []
+    return {
+        fetcher: {
+            async fetch(input) {
+                calls.push({ matchedText: input.matchedText })
+                return {
+                    matchedText: input.matchedText,
+                    title: 'Auto Title',
+                    previewType: proto.Message.ExtendedTextMessage.PreviewType.NONE
+                }
+            }
+        },
+        calls
+    }
+}
+
+function uploadStubMediaTransfer(directPath: string): {
+    readonly transfer: WaMediaTransferClient
+    readonly uploads: number
+} {
+    let uploads = 0
+    const stub = {
+        async uploadStream(): Promise<{ status: number; url: string }> {
+            uploads++
+            return { status: 200, url: 'https://mmg.whatsapp.net/x' }
+        },
+        async readResponseBytes(): Promise<Uint8Array> {
+            return TEXT_ENCODER.encode(
+                JSON.stringify({ direct_path: directPath, url: 'https://mmg.whatsapp.net/x' })
+            )
+        }
+    }
+    return {
+        transfer: stub as unknown as WaMediaTransferClient,
+        get uploads() {
+            return uploads
+        }
+    }
+}
+
+test('resolveLinkPreview returns null when perMessage=false', async () => {
+    const r = await resolveLinkPreview('see https://example.com', false, {
+        logger: createNoopLogger(),
+        mediaTransfer: uploadStubMediaTransfer('').transfer,
+        getMediaConn: () => Promise.resolve(fakeMediaConn),
+        fetcher: noopFetcher({
+            matchedText: 'https://example.com',
+            title: 'x',
+            previewType: proto.Message.ExtendedTextMessage.PreviewType.NONE
+        }),
+        options: {}
+    })
+    assert.equal(r, null)
+})
+
+test('resolveLinkPreview returns null when text has no url', async () => {
+    const r = await resolveLinkPreview('hello world', undefined, {
+        logger: createNoopLogger(),
+        mediaTransfer: uploadStubMediaTransfer('').transfer,
+        getMediaConn: () => Promise.resolve(fakeMediaConn),
+        fetcher: noopFetcher(),
+        options: {}
+    })
+    assert.equal(r, null)
+})
+
+test('resolveLinkPreview returns null when global disabled and perMessage undefined', async () => {
+    const r = await resolveLinkPreview('see https://example.com', undefined, {
+        logger: createNoopLogger(),
+        mediaTransfer: uploadStubMediaTransfer('').transfer,
+        getMediaConn: () => Promise.resolve(fakeMediaConn),
+        fetcher: noopFetcher({
+            matchedText: 'https://example.com',
+            title: 'x',
+            previewType: proto.Message.ExtendedTextMessage.PreviewType.NONE
+        }),
+        options: { enabled: false }
+    })
+    assert.equal(r, null)
+})
+
+test('resolveLinkPreview allows opt-in when global disabled', async () => {
+    const { fetcher, calls } = recordingFetcher()
+    const r = await resolveLinkPreview('see https://example.com', true, {
+        logger: createNoopLogger(),
+        mediaTransfer: uploadStubMediaTransfer('').transfer,
+        getMediaConn: () => Promise.resolve(fakeMediaConn),
+        fetcher,
+        options: { enabled: false }
+    })
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0]?.matchedText, 'https://example.com')
+    assert.equal(r?.resolved.title, 'Auto Title')
+})
+
+test('resolveLinkPreview uses override without invoking fetcher', async () => {
+    const { fetcher, calls } = recordingFetcher()
+    const r = await resolveLinkPreview(
+        'see https://example.com',
+        {
+            title: 'Custom',
+            description: 'Custom desc',
+            previewType: proto.Message.ExtendedTextMessage.PreviewType.VIDEO
+        },
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: uploadStubMediaTransfer('').transfer,
+            getMediaConn: () => Promise.resolve(fakeMediaConn),
+            fetcher,
+            options: {}
+        }
+    )
+    assert.equal(calls.length, 0)
+    assert.equal(r?.resolved.title, 'Custom')
+    assert.equal(r?.resolved.description, 'Custom desc')
+    assert.equal(r?.resolved.previewType, proto.Message.ExtendedTextMessage.PreviewType.VIDEO)
+    assert.equal(r?.resolved.matchedText, 'https://example.com')
+})
+
+test('resolveLinkPreview inlines thumbnails ≤ 64KB', async () => {
+    const small = new Uint8Array(1024)
+    const r = await resolveLinkPreview(
+        'see https://example.com',
+        { thumbnail: { bytes: small } },
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: uploadStubMediaTransfer('').transfer,
+            getMediaConn: () => Promise.resolve(fakeMediaConn),
+            fetcher: noopFetcher(),
+            options: {}
+        }
+    )
+    assert.equal(r?.thumbnailFields.jpegThumbnail, small)
+    assert.equal(r?.thumbnailFields.thumbnailDirectPath, undefined)
+})
+
+test('resolveLinkPreview drops oversized thumbnail when uploadHqThumbnail=false', async () => {
+    const big = new Uint8Array(100_000)
+    const r = await resolveLinkPreview(
+        'see https://example.com',
+        { thumbnail: { bytes: big } },
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: uploadStubMediaTransfer('').transfer,
+            getMediaConn: () => Promise.resolve(fakeMediaConn),
+            fetcher: noopFetcher(),
+            options: { uploadHqThumbnail: false }
+        }
+    )
+    assert.equal(r?.thumbnailFields.jpegThumbnail, undefined)
+    assert.equal(r?.thumbnailFields.thumbnailDirectPath, undefined)
+})
+
+test('resolveLinkPreview uploads HQ thumbnail when oversize and upload enabled', async () => {
+    const stub = uploadStubMediaTransfer('/v/abc')
+    const big = new Uint8Array(100_000)
+    const r = await resolveLinkPreview(
+        'see https://example.com',
+        { thumbnail: { bytes: big, width: 200, height: 100 } },
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: stub.transfer,
+            getMediaConn: () => Promise.resolve(fakeMediaConn),
+            fetcher: noopFetcher(),
+            options: { uploadHqThumbnail: true }
+        }
+    )
+    assert.equal(stub.uploads, 1)
+    assert.equal(r?.thumbnailFields.thumbnailDirectPath, '/v/abc')
+    assert.equal(r?.thumbnailFields.thumbnailSha256?.byteLength, 32)
+    assert.equal(r?.thumbnailFields.thumbnailEncSha256?.byteLength, 32)
+    assert.equal(r?.thumbnailFields.mediaKey?.byteLength, 32)
+    assert.equal(r?.thumbnailFields.thumbnailWidth, 200)
+    assert.equal(r?.thumbnailFields.thumbnailHeight, 100)
+})
+
+test('resolveLinkPreview drops thumbnail on upload failure', async () => {
+    const failingTransfer = {
+        async uploadStream(): Promise<{ status: number; url: string }> {
+            return { status: 500, url: 'x' }
+        },
+        async readResponseBytes(): Promise<Uint8Array> {
+            return new Uint8Array()
+        }
+    } as unknown as WaMediaTransferClient
+    const big = new Uint8Array(100_000)
+    const r = await resolveLinkPreview(
+        'see https://example.com',
+        { thumbnail: { bytes: big } },
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: failingTransfer,
+            getMediaConn: () => Promise.resolve(fakeMediaConn),
+            fetcher: noopFetcher(),
+            options: { uploadHqThumbnail: true }
+        }
+    )
+    assert.equal(r?.resolved.matchedText, 'https://example.com')
+    assert.equal(r?.thumbnailFields.thumbnailDirectPath, undefined)
+    assert.equal(r?.thumbnailFields.jpegThumbnail, undefined)
+})

--- a/src/client/link-preview.ts
+++ b/src/client/link-preview.ts
@@ -1,0 +1,244 @@
+import { createReadStream } from 'node:fs'
+
+import {
+    assertMediaUploadStatus,
+    buildMediaUploadUrl,
+    parseMediaUploadJsonBody,
+    selectMediaUploadHost
+} from '@client/media'
+import type { Logger } from '@infra/log/types'
+import { MEDIA_UPLOAD_PATHS } from '@media/constants'
+import type { WaMediaConn } from '@media/types'
+import { WaMediaCrypto } from '@media/WaMediaCrypto'
+import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
+import type { WaLinkPreviewThumbnailFields } from '@message/link-preview/builder'
+import { findFirstLink } from '@message/link-preview/detect'
+import type {
+    WaLinkPreviewFetcher,
+    WaLinkPreviewOptions,
+    WaLinkPreviewOverride,
+    WaLinkPreviewResolved,
+    WaLinkPreviewThumbnailBytes,
+    WaLinkPreviewThumbnailInput,
+    WaLinkPreviewThumbnailStream
+} from '@message/link-preview/types'
+import { proto } from '@proto'
+import { toError } from '@util/primitives'
+
+const INLINE_THUMBNAIL_MAX_BYTES = 64 * 1024
+
+export interface ResolveLinkPreviewDeps {
+    readonly logger: Logger
+    readonly mediaTransfer: WaMediaTransferClient
+    readonly getMediaConn: () => Promise<WaMediaConn>
+    readonly fetcher: WaLinkPreviewFetcher
+    readonly options: WaLinkPreviewOptions
+}
+
+export interface ResolvedLinkPreviewResult {
+    readonly resolved: WaLinkPreviewResolved
+    readonly thumbnailFields: WaLinkPreviewThumbnailFields
+}
+
+export async function resolveLinkPreview(
+    text: string,
+    perMessage: boolean | WaLinkPreviewOverride | undefined,
+    deps: ResolveLinkPreviewDeps
+): Promise<ResolvedLinkPreviewResult | null> {
+    if (perMessage === false) return null
+    const globalEnabled = deps.options.enabled !== false
+    if (!globalEnabled && perMessage === undefined) return null
+
+    let resolved: WaLinkPreviewResolved | null
+    if (typeof perMessage === 'object' && perMessage !== null) {
+        resolved = applyOverride(text, perMessage)
+        if (resolved === null) return null
+    } else {
+        const detected = findFirstLink(text)
+        if (detected === null) return null
+        resolved = await deps.fetcher.fetch({
+            url: detected.url,
+            matchedText: detected.matchedText,
+            logger: deps.logger
+        })
+        if (resolved === null) return null
+    }
+
+    const thumbnailFields = await resolveThumbnailFields(deps, resolved.thumbnail)
+    return { resolved, thumbnailFields }
+}
+
+function applyOverride(
+    text: string,
+    override: WaLinkPreviewOverride
+): WaLinkPreviewResolved | null {
+    const matchedText = override.matchedText ?? findFirstLink(text)?.matchedText
+    if (matchedText === undefined || matchedText.length === 0) return null
+    return {
+        matchedText,
+        previewType: override.previewType ?? proto.Message.ExtendedTextMessage.PreviewType.NONE,
+        ...(override.title !== undefined ? { title: override.title } : {}),
+        ...(override.description !== undefined ? { description: override.description } : {}),
+        ...(override.thumbnail !== undefined ? { thumbnail: override.thumbnail } : {})
+    }
+}
+
+async function resolveThumbnailFields(
+    deps: ResolveLinkPreviewDeps,
+    thumbnail: WaLinkPreviewThumbnailInput | undefined
+): Promise<WaLinkPreviewThumbnailFields> {
+    if (thumbnail === undefined) return {}
+    if ('bytes' in thumbnail) {
+        return resolveBytesThumbnailFields(deps, thumbnail)
+    }
+    return resolveStreamThumbnailFields(deps, thumbnail)
+}
+
+async function resolveBytesThumbnailFields(
+    deps: ResolveLinkPreviewDeps,
+    thumbnail: WaLinkPreviewThumbnailBytes
+): Promise<WaLinkPreviewThumbnailFields> {
+    const fitsInline = thumbnail.bytes.byteLength <= INLINE_THUMBNAIL_MAX_BYTES
+    const inlineFields = fitsInline ? buildInlineFields(thumbnail) : {}
+    if (deps.options.uploadHqThumbnail === false) {
+        return inlineFields
+    }
+    try {
+        const hqFields = await uploadHqFromBytes(deps, thumbnail)
+        return { ...inlineFields, ...hqFields }
+    } catch (error) {
+        deps.logger.warn('link preview thumbnail upload failed', {
+            message: toError(error).message
+        })
+        return inlineFields
+    }
+}
+
+async function resolveStreamThumbnailFields(
+    deps: ResolveLinkPreviewDeps,
+    thumbnail: WaLinkPreviewThumbnailStream
+): Promise<WaLinkPreviewThumbnailFields> {
+    if (deps.options.uploadHqThumbnail === false) {
+        thumbnail.stream.destroy()
+        return {}
+    }
+    try {
+        return await uploadHqFromStream(deps, thumbnail)
+    } catch (error) {
+        deps.logger.warn('link preview thumbnail upload failed', {
+            message: toError(error).message
+        })
+        thumbnail.stream.destroy()
+        return {}
+    }
+}
+
+function buildInlineFields(thumbnail: WaLinkPreviewThumbnailBytes): WaLinkPreviewThumbnailFields {
+    return {
+        jpegThumbnail: thumbnail.bytes,
+        ...(thumbnail.width !== undefined ? { thumbnailWidth: thumbnail.width } : {}),
+        ...(thumbnail.height !== undefined ? { thumbnailHeight: thumbnail.height } : {})
+    }
+}
+
+async function uploadHqFromBytes(
+    deps: ResolveLinkPreviewDeps,
+    thumbnail: WaLinkPreviewThumbnailBytes
+): Promise<WaLinkPreviewThumbnailFields> {
+    const mediaKey = await WaMediaCrypto.generateMediaKey()
+    const encrypted = await WaMediaCrypto.encryptBytes(
+        'thumbnail-link',
+        mediaKey,
+        thumbnail.bytes,
+        { sidecar: false }
+    )
+    const directPath = await dispatchUpload(
+        deps,
+        encrypted.ciphertextHmac,
+        encrypted.ciphertextHmac.byteLength,
+        encrypted.fileEncSha256
+    )
+    return {
+        thumbnailDirectPath: directPath,
+        thumbnailSha256: encrypted.fileSha256,
+        thumbnailEncSha256: encrypted.fileEncSha256,
+        mediaKey,
+        mediaKeyTimestamp: Math.floor(Date.now() / 1000),
+        ...(thumbnail.width !== undefined ? { thumbnailWidth: thumbnail.width } : {}),
+        ...(thumbnail.height !== undefined ? { thumbnailHeight: thumbnail.height } : {})
+    }
+}
+
+async function uploadHqFromStream(
+    deps: ResolveLinkPreviewDeps,
+    thumbnail: WaLinkPreviewThumbnailStream
+): Promise<WaLinkPreviewThumbnailFields> {
+    const mediaKey = await WaMediaCrypto.generateMediaKey()
+    const encrypted = await WaMediaCrypto.encryptToFile(
+        'thumbnail-link',
+        mediaKey,
+        thumbnail.stream,
+        { sidecar: false, expectedFileSize: thumbnail.contentLength }
+    )
+    let readStream: ReturnType<typeof createReadStream> | undefined
+    try {
+        readStream = createReadStream(encrypted.filePath)
+        const directPath = await dispatchUpload(
+            deps,
+            readStream,
+            encrypted.fileSize,
+            encrypted.fileEncSha256
+        )
+        return {
+            thumbnailDirectPath: directPath,
+            thumbnailSha256: encrypted.fileSha256,
+            thumbnailEncSha256: encrypted.fileEncSha256,
+            mediaKey,
+            mediaKeyTimestamp: Math.floor(Date.now() / 1000),
+            ...(thumbnail.width !== undefined ? { thumbnailWidth: thumbnail.width } : {}),
+            ...(thumbnail.height !== undefined ? { thumbnailHeight: thumbnail.height } : {})
+        }
+    } finally {
+        if (readStream && !readStream.closed) {
+            await new Promise<void>((resolve) => {
+                readStream!.once('close', resolve)
+                readStream!.destroy()
+            })
+        }
+        await WaMediaCrypto.cleanupEncryptedFile(encrypted.filePath)
+    }
+}
+
+async function dispatchUpload(
+    deps: ResolveLinkPreviewDeps,
+    body: Uint8Array | ReturnType<typeof createReadStream>,
+    contentLength: number,
+    fileEncSha256: Uint8Array
+): Promise<string> {
+    const mediaConn = await deps.getMediaConn()
+    const host = selectMediaUploadHost(mediaConn)
+    const uploadUrl = buildMediaUploadUrl(
+        host,
+        MEDIA_UPLOAD_PATHS['thumbnail-link'],
+        mediaConn.auth,
+        fileEncSha256
+    )
+    deps.logger.debug('uploading link preview thumbnail', { host, contentLength })
+    const response = await deps.mediaTransfer.uploadStream({
+        url: uploadUrl,
+        method: 'POST',
+        body,
+        contentLength,
+        contentType: 'image/jpeg'
+    })
+    const responseBody = await deps.mediaTransfer.readResponseBytes(response)
+    assertMediaUploadStatus(response.status, 'thumbnail-link upload')
+    const parsed = parseMediaUploadJsonBody<{ readonly direct_path?: string }>(
+        responseBody,
+        'thumbnail-link upload'
+    )
+    if (!parsed.direct_path) {
+        throw new Error('thumbnail-link upload response missing direct_path')
+    }
+    return parsed.direct_path
+}

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -43,6 +43,7 @@ import { WA_DEFAULTS } from '@protocol/constants'
 import { buildMediaConnIq } from '@transport/node/builders/media'
 import type { BinaryNode } from '@transport/types'
 import { bytesToBase64 } from '@util/bytes'
+import { toError } from '@util/primitives'
 
 export interface WaMediaMessageOptions {
     readonly logger: Logger
@@ -71,15 +72,21 @@ export async function buildMediaMessageContent(
     }
     if (isSendTextMessage(content)) {
         if (options.linkPreviewResolver) {
-            const preview = await options.linkPreviewResolver(content)
-            if (preview !== null) {
-                return {
-                    message: buildExtendedTextWithPreview(
-                        content.text,
-                        preview.resolved,
-                        preview.thumbnailFields
-                    )
+            try {
+                const preview = await options.linkPreviewResolver(content)
+                if (preview !== null) {
+                    return {
+                        message: buildExtendedTextWithPreview(
+                            content.text,
+                            preview.resolved,
+                            preview.thumbnailFields
+                        )
+                    }
                 }
+            } catch (error) {
+                options.logger.warn('link preview resolver failed, sending plain text', {
+                    message: toError(error).message
+                })
             }
         }
         return { message: { extendedTextMessage: { text: content.text } } }

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -1,6 +1,7 @@
 import { createReadStream } from 'node:fs'
 import { Readable } from 'node:stream'
 
+import type { ResolvedLinkPreviewResult } from '@client/link-preview'
 import {
     assertMediaUploadStatus,
     buildMediaUploadUrl,
@@ -23,6 +24,7 @@ import type { MediaCryptoType, WaMediaConn } from '@media/types'
 import { WaMediaCrypto } from '@media/WaMediaCrypto'
 import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
 import { isSendMediaMessage, isSendTextMessage } from '@message/content'
+import { buildExtendedTextWithPreview } from '@message/link-preview/builder'
 import {
     toStickerPackProtoStickers,
     toStickerPackZipEntries,
@@ -33,7 +35,8 @@ import type {
     WaMessageUploadInfo,
     WaSendMediaMessage,
     WaSendMessageContent,
-    WaSendStickerPackMessage
+    WaSendStickerPackMessage,
+    WaSendTextMessage
 } from '@message/types'
 import { proto } from '@proto'
 import { WA_DEFAULTS } from '@protocol/constants'
@@ -54,6 +57,9 @@ export interface WaMediaMessageOptions {
     readonly getMediaConnCache: () => WaMediaConn | null
     readonly setMediaConnCache: (mediaConn: WaMediaConn | null) => void
     readonly media?: WaMediaOptions
+    readonly linkPreviewResolver?: (
+        content: WaSendTextMessage
+    ) => Promise<ResolvedLinkPreviewResult | null>
 }
 
 export async function buildMediaMessageContent(
@@ -64,6 +70,18 @@ export async function buildMediaMessageContent(
         return { message: { conversation: content } }
     }
     if (isSendTextMessage(content)) {
+        if (options.linkPreviewResolver) {
+            const preview = await options.linkPreviewResolver(content)
+            if (preview !== null) {
+                return {
+                    message: buildExtendedTextWithPreview(
+                        content.text,
+                        preview.resolved,
+                        preview.thumbnailFields
+                    )
+                }
+            }
+        }
         return { message: { extendedTextMessage: { text: content.text } } }
     }
     if (isSendMediaMessage(content)) {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -9,6 +9,7 @@ import type { IncomingPresenceType, PresenceLastSeen } from '@client/events/pres
 import type { WaMediaProcessor } from '@media/processor'
 import type { WaDecodedAddon } from '@message/addon-crypto'
 import type { WaQuoteRef, WaSendContextInfo } from '@message/context-info'
+import type { WaLinkPreviewOptions } from '@message/link-preview/types'
 import type { WaMessagePublishOptions } from '@message/types'
 import type { Proto } from '@proto'
 import type { WaBotMsgEditType } from '@protocol/bot'
@@ -22,6 +23,13 @@ export interface WaClientProxyOptions {
     readonly ws?: WaProxyTransport
     readonly mediaUpload?: WaProxyTransport
     readonly mediaDownload?: WaProxyTransport
+    /**
+     * Proxy used by the default link preview fetcher when fetching the page
+     * HTML and the og:image bytes. Must be a `WaProxyDispatcher` (e.g. an
+     * undici `ProxyAgent`); the global `fetch` does not consume `http.Agent`.
+     * HQ thumbnail upload reuses `mediaUpload`.
+     */
+    readonly linkPreview?: WaProxyTransport
 }
 
 export interface WaLogoutStoreClearOptions {
@@ -75,6 +83,7 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
     readonly addons?: WaAddonOptions
     readonly logoutStoreClear?: WaLogoutStoreClearOptions
     readonly media?: WaMediaOptions
+    readonly linkPreview?: WaLinkPreviewOptions
     /**
      * Test-only overrides intended for running against a fake server.
      *

--- a/src/media/types.ts
+++ b/src/media/types.ts
@@ -14,6 +14,7 @@ export type MediaCryptoType =
     | 'xma-image'
     | 'sticker-pack'
     | 'thumbnail-sticker-pack'
+    | 'thumbnail-link'
 
 export interface WaMediaConnHost {
     readonly hostname: string

--- a/src/message/link-preview/__tests__/builder.test.ts
+++ b/src/message/link-preview/__tests__/builder.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildExtendedTextWithPreview } from '@message/link-preview/builder'
+import { proto } from '@proto'
+
+test('buildExtendedTextWithPreview sets matchedText, title, description, previewType', () => {
+    const msg = buildExtendedTextWithPreview(
+        'check https://example.com',
+        {
+            matchedText: 'https://example.com',
+            title: 'Example',
+            description: 'An example site',
+            previewType: proto.Message.ExtendedTextMessage.PreviewType.NONE
+        },
+        {}
+    )
+    assert.equal(msg.extendedTextMessage?.text, 'check https://example.com')
+    assert.equal(msg.extendedTextMessage?.matchedText, 'https://example.com')
+    assert.equal(msg.extendedTextMessage?.title, 'Example')
+    assert.equal(msg.extendedTextMessage?.description, 'An example site')
+    assert.equal(
+        msg.extendedTextMessage?.previewType,
+        proto.Message.ExtendedTextMessage.PreviewType.NONE
+    )
+})
+
+test('buildExtendedTextWithPreview inlines jpegThumbnail bytes', () => {
+    const thumb = new Uint8Array([1, 2, 3])
+    const msg = buildExtendedTextWithPreview(
+        'x https://example.com',
+        {
+            matchedText: 'https://example.com',
+            previewType: proto.Message.ExtendedTextMessage.PreviewType.NONE
+        },
+        { jpegThumbnail: thumb }
+    )
+    assert.equal(msg.extendedTextMessage?.jpegThumbnail, thumb)
+    assert.equal(msg.extendedTextMessage?.thumbnailDirectPath, undefined)
+})
+
+test('buildExtendedTextWithPreview maps HQ thumbnail fields and VIDEO previewType', () => {
+    const sha = new Uint8Array(32).fill(7)
+    const encSha = new Uint8Array(32).fill(8)
+    const mediaKey = new Uint8Array(32).fill(9)
+    const msg = buildExtendedTextWithPreview(
+        'x https://example.com',
+        {
+            matchedText: 'https://example.com',
+            previewType: proto.Message.ExtendedTextMessage.PreviewType.VIDEO
+        },
+        {
+            thumbnailDirectPath: '/v/x',
+            thumbnailSha256: sha,
+            thumbnailEncSha256: encSha,
+            mediaKey,
+            mediaKeyTimestamp: 1234,
+            thumbnailWidth: 100,
+            thumbnailHeight: 200
+        }
+    )
+    assert.equal(msg.extendedTextMessage?.thumbnailDirectPath, '/v/x')
+    assert.equal(msg.extendedTextMessage?.thumbnailSha256, sha)
+    assert.equal(msg.extendedTextMessage?.thumbnailEncSha256, encSha)
+    assert.equal(msg.extendedTextMessage?.mediaKey, mediaKey)
+    assert.equal(msg.extendedTextMessage?.mediaKeyTimestamp, 1234)
+    assert.equal(msg.extendedTextMessage?.thumbnailWidth, 100)
+    assert.equal(msg.extendedTextMessage?.thumbnailHeight, 200)
+    assert.equal(
+        msg.extendedTextMessage?.previewType,
+        proto.Message.ExtendedTextMessage.PreviewType.VIDEO
+    )
+})
+
+test('buildExtendedTextWithPreview omits unset optional fields', () => {
+    const msg = buildExtendedTextWithPreview(
+        'x https://example.com',
+        {
+            matchedText: 'https://example.com',
+            previewType: proto.Message.ExtendedTextMessage.PreviewType.NONE
+        },
+        {}
+    )
+    assert.equal(msg.extendedTextMessage?.title, undefined)
+    assert.equal(msg.extendedTextMessage?.description, undefined)
+    assert.equal(msg.extendedTextMessage?.jpegThumbnail, undefined)
+    assert.equal(msg.extendedTextMessage?.thumbnailDirectPath, undefined)
+    assert.equal(msg.extendedTextMessage?.mediaKey, undefined)
+})

--- a/src/message/link-preview/__tests__/detect.test.ts
+++ b/src/message/link-preview/__tests__/detect.test.ts
@@ -19,9 +19,25 @@ test('findFirstLink strips trailing sentence punctuation', () => {
     assert.equal(r?.matchedText, 'https://example.com/path')
 })
 
-test('findFirstLink strips closing paren', () => {
+test('findFirstLink strips unbalanced closing paren', () => {
     const r = findFirstLink('(see https://example.com)')
     assert.equal(r?.matchedText, 'https://example.com')
+})
+
+test('findFirstLink preserves balanced parens inside url', () => {
+    const r = findFirstLink('check https://example.com/a_(b)')
+    assert.equal(r?.matchedText, 'https://example.com/a_(b)')
+})
+
+test('findFirstLink preserves balanced brackets and braces', () => {
+    assert.equal(
+        findFirstLink('https://example.com/path[0]')?.matchedText,
+        'https://example.com/path[0]'
+    )
+    assert.equal(
+        findFirstLink('https://example.com/{x}/y')?.matchedText,
+        'https://example.com/{x}/y'
+    )
 })
 
 test('findFirstLink returns null when no url present', () => {

--- a/src/message/link-preview/__tests__/detect.test.ts
+++ b/src/message/link-preview/__tests__/detect.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { findFirstLink } from '@message/link-preview/detect'
+
+test('findFirstLink picks the first http url', () => {
+    const r = findFirstLink('see https://example.com/foo for details')
+    assert.equal(r?.matchedText, 'https://example.com/foo')
+    assert.equal(r?.url.hostname, 'example.com')
+})
+
+test('findFirstLink picks the link at the start of the text', () => {
+    const r = findFirstLink('https://example.com')
+    assert.equal(r?.matchedText, 'https://example.com')
+})
+
+test('findFirstLink strips trailing sentence punctuation', () => {
+    const r = findFirstLink('check https://example.com/path.')
+    assert.equal(r?.matchedText, 'https://example.com/path')
+})
+
+test('findFirstLink strips closing paren', () => {
+    const r = findFirstLink('(see https://example.com)')
+    assert.equal(r?.matchedText, 'https://example.com')
+})
+
+test('findFirstLink returns null when no url present', () => {
+    assert.equal(findFirstLink('hello world'), null)
+})
+
+test('findFirstLink ignores non http/https schemes', () => {
+    assert.equal(findFirstLink('ftp://example.com/file'), null)
+    assert.equal(findFirstLink('javascript:alert(1)'), null)
+})
+
+test('findFirstLink does not match urls glued to a word boundary', () => {
+    assert.equal(findFirstLink('xhttp://example.com'), null)
+})
+
+test('findFirstLink picks first when multiple urls in text', () => {
+    const r = findFirstLink('a https://one.example b https://two.example')
+    assert.equal(r?.matchedText, 'https://one.example')
+})

--- a/src/message/link-preview/__tests__/fetcher.test.ts
+++ b/src/message/link-preview/__tests__/fetcher.test.ts
@@ -220,6 +220,69 @@ test('default fetcher blocks private host', async () => {
     assert.equal(result, null)
 })
 
+test('default fetcher blocks .localhost subdomains (RFC 6761)', async () => {
+    const fetcher = createDefaultLinkPreviewFetcher({
+        mediaTransfer: mockMediaTransfer(() => ({ status: 200 }))
+    })
+    const result = await fetcher.fetch({
+        url: new URL('http://internal.localhost/secret'),
+        matchedText: 'http://internal.localhost/secret',
+        logger: createNoopLogger()
+    })
+    assert.equal(result, null)
+})
+
+test('default fetcher blocks IPv6 link-local addresses without brackets', async () => {
+    const fetcher = createDefaultLinkPreviewFetcher({
+        mediaTransfer: mockMediaTransfer(() => ({ status: 200 }))
+    })
+    const result = await fetcher.fetch({
+        url: new URL('http://[fe80::1]/'),
+        matchedText: 'http://[fe80::1]/',
+        logger: createNoopLogger()
+    })
+    assert.equal(result, null)
+})
+
+test('default fetcher blocks IPv6 unique-local (fc00::/7) addresses', async () => {
+    const fetcher = createDefaultLinkPreviewFetcher({
+        mediaTransfer: mockMediaTransfer(() => ({ status: 200 }))
+    })
+    const result = await fetcher.fetch({
+        url: new URL('http://[fd00::1]/'),
+        matchedText: 'http://[fd00::1]/',
+        logger: createNoopLogger()
+    })
+    assert.equal(result, null)
+})
+
+test('default fetcher drops thumbnail truncated without content-length', async () => {
+    const transfer = mockMediaTransfer((url): MockResponse => {
+        if (url.pathname === '/img.jpg') {
+            return {
+                status: 200,
+                headers: { 'content-type': 'image/jpeg' },
+                body: new Uint8Array(20_000)
+            }
+        }
+        return {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+            body: '<html><head><meta property="og:image" content="https://example.com/img.jpg"></head></html>'
+        }
+    })
+    const fetcher = createDefaultLinkPreviewFetcher({
+        mediaTransfer: transfer,
+        maxThumbnailBytes: 1024
+    })
+    const result = await fetcher.fetch({
+        url: new URL('https://example.com'),
+        matchedText: 'https://example.com',
+        logger: createNoopLogger()
+    })
+    assert.equal(result?.thumbnail, undefined)
+})
+
 test('default fetcher with allowPrivateHosts permits loopback', async () => {
     const transfer = mockMediaTransfer(() => ({ status: 500 }))
     const fetcher = createDefaultLinkPreviewFetcher({

--- a/src/message/link-preview/__tests__/fetcher.test.ts
+++ b/src/message/link-preview/__tests__/fetcher.test.ts
@@ -1,0 +1,340 @@
+import assert from 'node:assert/strict'
+import { Readable } from 'node:stream'
+import test from 'node:test'
+
+import { createNoopLogger } from '@infra/log/types'
+import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
+import { createDefaultLinkPreviewFetcher } from '@message/link-preview/fetcher'
+import { proto } from '@proto'
+import { TEXT_ENCODER } from '@util/bytes'
+
+interface MockResponse {
+    readonly status: number
+    readonly headers?: Readonly<Record<string, string>>
+    readonly body?: Uint8Array | string
+}
+
+type Handler = (url: URL) => MockResponse
+
+function mockMediaTransfer(handler: Handler): WaMediaTransferClient {
+    return {
+        async downloadStream(request: { url?: string }) {
+            const target = new URL(request.url ?? '')
+            const r = handler(target)
+            const bodyBytes =
+                typeof r.body === 'string'
+                    ? TEXT_ENCODER.encode(r.body)
+                    : r.body instanceof Uint8Array
+                      ? r.body
+                      : null
+            const body = bodyBytes === null ? null : Readable.from([bodyBytes])
+            return {
+                url: request.url,
+                status: r.status,
+                ok: r.status >= 200 && r.status < 300,
+                headers: r.headers ?? {},
+                body
+            }
+        }
+    } as unknown as WaMediaTransferClient
+}
+
+const fullHtml = `<!doctype html>
+<html><head>
+<title>Title Tag</title>
+<meta property="og:title" content="OG Title">
+<meta property="og:description" content="OG Description">
+<meta property="og:image" content="https://cdn.example.com/img.jpg">
+</head><body>...</body></html>`
+
+test('default fetcher parses og:title/og:description and fetches thumbnail', async () => {
+    const imageBytes = new Uint8Array([1, 2, 3, 4])
+    const transfer = mockMediaTransfer((url) => {
+        if (url.hostname === 'example.com') {
+            return {
+                status: 200,
+                headers: { 'content-type': 'text/html; charset=utf-8' },
+                body: fullHtml
+            }
+        }
+        if (url.hostname === 'cdn.example.com') {
+            return {
+                status: 200,
+                headers: { 'content-type': 'image/jpeg' },
+                body: imageBytes
+            }
+        }
+        return { status: 404 }
+    })
+    const fetcher = createDefaultLinkPreviewFetcher({ mediaTransfer: transfer })
+    const result = await fetcher.fetch({
+        url: new URL('https://example.com'),
+        matchedText: 'https://example.com',
+        logger: createNoopLogger()
+    })
+    assert.equal(result?.title, 'OG Title')
+    assert.equal(result?.description, 'OG Description')
+    assert.equal(result?.previewType, proto.Message.ExtendedTextMessage.PreviewType.NONE)
+    assert.equal(result?.matchedText, 'https://example.com')
+    assert.ok(result?.thumbnail && 'bytes' in result.thumbnail)
+    assert.equal(result.thumbnail.bytes.byteLength, 4)
+})
+
+test('default fetcher returns minimal preview on http error', async () => {
+    const transfer = mockMediaTransfer(() => ({ status: 500 }))
+    const fetcher = createDefaultLinkPreviewFetcher({ mediaTransfer: transfer })
+    const result = await fetcher.fetch({
+        url: new URL('https://example.com'),
+        matchedText: 'https://example.com',
+        logger: createNoopLogger()
+    })
+    assert.equal(result?.matchedText, 'https://example.com')
+    assert.equal(result?.title, 'example.com')
+    assert.equal(result?.previewType, proto.Message.ExtendedTextMessage.PreviewType.NONE)
+    assert.equal(result?.thumbnail, undefined)
+})
+
+test('default fetcher sets previewType=VIDEO when og:video present', async () => {
+    const transfer = mockMediaTransfer((url) => {
+        if (url.pathname === '/img.jpg') {
+            return {
+                status: 200,
+                headers: { 'content-type': 'image/jpeg' },
+                body: new Uint8Array([0])
+            }
+        }
+        return {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+            body: `<html><head>
+<meta property="og:title" content="V">
+<meta property="og:image" content="https://example.com/img.jpg">
+<meta property="og:video" content="https://example.com/v.mp4">
+</head></html>`
+        }
+    })
+    const fetcher = createDefaultLinkPreviewFetcher({ mediaTransfer: transfer })
+    const result = await fetcher.fetch({
+        url: new URL('https://example.com'),
+        matchedText: 'https://example.com',
+        logger: createNoopLogger()
+    })
+    assert.equal(result?.previewType, proto.Message.ExtendedTextMessage.PreviewType.VIDEO)
+})
+
+test('default fetcher falls back to <title> tag when no og:title', async () => {
+    const transfer = mockMediaTransfer(() => ({
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+        body: '<html><head><title>Bare Title</title></head></html>'
+    }))
+    const fetcher = createDefaultLinkPreviewFetcher({ mediaTransfer: transfer })
+    const result = await fetcher.fetch({
+        url: new URL('https://example.com'),
+        matchedText: 'https://example.com',
+        logger: createNoopLogger()
+    })
+    assert.equal(result?.title, 'Bare Title')
+})
+
+test('default fetcher decodes html entities in title', async () => {
+    const transfer = mockMediaTransfer(() => ({
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+        body: '<html><head><title>Foo &amp; Bar</title></head></html>'
+    }))
+    const fetcher = createDefaultLinkPreviewFetcher({ mediaTransfer: transfer })
+    const result = await fetcher.fetch({
+        url: new URL('https://example.com'),
+        matchedText: 'https://example.com',
+        logger: createNoopLogger()
+    })
+    assert.equal(result?.title, 'Foo & Bar')
+})
+
+test('default fetcher resolves relative og:image against base url', async () => {
+    let imageRequested: URL | null = null
+    const transfer = mockMediaTransfer((url) => {
+        if (url.hostname === 'example.com' && url.pathname === '/img.jpg') {
+            imageRequested = url
+            return {
+                status: 200,
+                headers: { 'content-type': 'image/jpeg' },
+                body: new Uint8Array([1])
+            }
+        }
+        return {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+            body: '<html><head><meta property="og:image" content="/img.jpg"></head></html>'
+        }
+    })
+    const fetcher = createDefaultLinkPreviewFetcher({ mediaTransfer: transfer })
+    const result = await fetcher.fetch({
+        url: new URL('https://example.com/page'),
+        matchedText: 'https://example.com/page',
+        logger: createNoopLogger()
+    })
+    assert.ok(result?.thumbnail)
+    assert.equal((imageRequested as unknown as URL)?.toString(), 'https://example.com/img.jpg')
+})
+
+test('default fetcher accepts png/webp og:image as raw bytes', async () => {
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+    const transfer = mockMediaTransfer((url) => {
+        if (url.pathname === '/img.png') {
+            return {
+                status: 200,
+                headers: { 'content-type': 'image/png' },
+                body: pngBytes
+            }
+        }
+        return {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+            body: `<html><head>
+<meta property="og:title" content="X">
+<meta property="og:image" content="https://example.com/img.png">
+</head></html>`
+        }
+    })
+    const fetcher = createDefaultLinkPreviewFetcher({ mediaTransfer: transfer })
+    const result = await fetcher.fetch({
+        url: new URL('https://example.com'),
+        matchedText: 'https://example.com',
+        logger: createNoopLogger()
+    })
+    assert.equal(result?.title, 'X')
+    assert.ok(result?.thumbnail && 'bytes' in result.thumbnail)
+    assert.equal(result.thumbnail.bytes.byteLength, 4)
+})
+
+test('default fetcher blocks private host', async () => {
+    const transfer = mockMediaTransfer(() => ({ status: 200 }))
+    const fetcher = createDefaultLinkPreviewFetcher({ mediaTransfer: transfer })
+    const result = await fetcher.fetch({
+        url: new URL('http://127.0.0.1'),
+        matchedText: 'http://127.0.0.1',
+        logger: createNoopLogger()
+    })
+    assert.equal(result, null)
+})
+
+test('default fetcher with allowPrivateHosts permits loopback', async () => {
+    const transfer = mockMediaTransfer(() => ({ status: 500 }))
+    const fetcher = createDefaultLinkPreviewFetcher({
+        mediaTransfer: transfer,
+        allowPrivateHosts: true
+    })
+    const result = await fetcher.fetch({
+        url: new URL('http://127.0.0.1'),
+        matchedText: 'http://127.0.0.1',
+        logger: createNoopLogger()
+    })
+    assert.equal(result?.title, '127.0.0.1')
+})
+
+test('default fetcher caps html bytes', async () => {
+    const huge = 'x'.repeat(200_000) + '<title>NeverReached</title>'
+    const transfer = mockMediaTransfer(() => ({
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+        body: huge
+    }))
+    const fetcher = createDefaultLinkPreviewFetcher({ mediaTransfer: transfer, maxHtmlBytes: 1024 })
+    const result = await fetcher.fetch({
+        url: new URL('https://example.com'),
+        matchedText: 'https://example.com',
+        logger: createNoopLogger()
+    })
+    assert.notEqual(result?.title, 'NeverReached')
+})
+
+test('default fetcher returns stream variant when content-length exceeds inline threshold', async () => {
+    const bigBytes = new Uint8Array(80_000)
+    const transfer = mockMediaTransfer((url): MockResponse => {
+        if (url.pathname === '/img.jpg') {
+            return {
+                status: 200,
+                headers: {
+                    'content-type': 'image/jpeg',
+                    'content-length': String(bigBytes.byteLength)
+                },
+                body: bigBytes
+            }
+        }
+        return {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+            body: `<html><head>
+<meta property="og:title" content="Big">
+<meta property="og:image" content="https://example.com/img.jpg">
+</head></html>`
+        }
+    })
+    const fetcher = createDefaultLinkPreviewFetcher({ mediaTransfer: transfer })
+    const result = await fetcher.fetch({
+        url: new URL('https://example.com'),
+        matchedText: 'https://example.com',
+        logger: createNoopLogger()
+    })
+    assert.ok(result?.thumbnail && 'stream' in result.thumbnail)
+    assert.equal(result.thumbnail.contentLength, 80_000)
+    result.thumbnail.stream.destroy()
+})
+
+test('default fetcher drops thumbnail when content-length exceeds maxThumbnailBytes', async () => {
+    const transfer = mockMediaTransfer((url): MockResponse => {
+        if (url.pathname === '/img.jpg') {
+            return {
+                status: 200,
+                headers: {
+                    'content-type': 'image/jpeg',
+                    'content-length': '500000'
+                },
+                body: new Uint8Array(0)
+            }
+        }
+        return {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+            body: `<html><head>
+<meta property="og:title" content="Huge">
+<meta property="og:image" content="https://example.com/img.jpg">
+</head></html>`
+        }
+    })
+    const fetcher = createDefaultLinkPreviewFetcher({
+        mediaTransfer: transfer,
+        maxThumbnailBytes: 262_144
+    })
+    const result = await fetcher.fetch({
+        url: new URL('https://example.com'),
+        matchedText: 'https://example.com',
+        logger: createNoopLogger()
+    })
+    assert.equal(result?.thumbnail, undefined)
+})
+
+test('default fetcher follows 301 redirects', async () => {
+    const transfer = mockMediaTransfer((url): MockResponse => {
+        if (url.hostname === 'short.example.com') {
+            return {
+                status: 301,
+                headers: { location: 'https://full.example.com/page' }
+            }
+        }
+        return {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+            body: '<html><head><title>Redirected</title></head></html>'
+        }
+    })
+    const fetcher = createDefaultLinkPreviewFetcher({ mediaTransfer: transfer })
+    const result = await fetcher.fetch({
+        url: new URL('https://short.example.com'),
+        matchedText: 'https://short.example.com',
+        logger: createNoopLogger()
+    })
+    assert.equal(result?.title, 'Redirected')
+})

--- a/src/message/link-preview/builder.ts
+++ b/src/message/link-preview/builder.ts
@@ -1,0 +1,53 @@
+import type { Proto } from '@proto'
+
+import type { WaLinkPreviewResolved } from './types'
+
+export interface WaLinkPreviewThumbnailFields {
+    readonly jpegThumbnail?: Uint8Array
+    readonly thumbnailDirectPath?: string
+    readonly thumbnailSha256?: Uint8Array
+    readonly thumbnailEncSha256?: Uint8Array
+    readonly mediaKey?: Uint8Array
+    readonly mediaKeyTimestamp?: number
+    readonly thumbnailWidth?: number
+    readonly thumbnailHeight?: number
+}
+
+export function buildExtendedTextWithPreview(
+    text: string,
+    resolved: WaLinkPreviewResolved,
+    thumbnailFields: WaLinkPreviewThumbnailFields
+): Proto.IMessage {
+    const message: Proto.Message.IExtendedTextMessage = {
+        text,
+        matchedText: resolved.matchedText,
+        previewType: resolved.previewType
+    }
+    if (resolved.title !== undefined) message.title = resolved.title
+    if (resolved.description !== undefined) message.description = resolved.description
+    if (thumbnailFields.jpegThumbnail !== undefined) {
+        message.jpegThumbnail = thumbnailFields.jpegThumbnail
+    }
+    if (thumbnailFields.thumbnailDirectPath !== undefined) {
+        message.thumbnailDirectPath = thumbnailFields.thumbnailDirectPath
+    }
+    if (thumbnailFields.thumbnailSha256 !== undefined) {
+        message.thumbnailSha256 = thumbnailFields.thumbnailSha256
+    }
+    if (thumbnailFields.thumbnailEncSha256 !== undefined) {
+        message.thumbnailEncSha256 = thumbnailFields.thumbnailEncSha256
+    }
+    if (thumbnailFields.mediaKey !== undefined) {
+        message.mediaKey = thumbnailFields.mediaKey
+    }
+    if (thumbnailFields.mediaKeyTimestamp !== undefined) {
+        message.mediaKeyTimestamp = thumbnailFields.mediaKeyTimestamp
+    }
+    if (thumbnailFields.thumbnailWidth !== undefined) {
+        message.thumbnailWidth = thumbnailFields.thumbnailWidth
+    }
+    if (thumbnailFields.thumbnailHeight !== undefined) {
+        message.thumbnailHeight = thumbnailFields.thumbnailHeight
+    }
+    return { extendedTextMessage: message }
+}

--- a/src/message/link-preview/detect.ts
+++ b/src/message/link-preview/detect.ts
@@ -1,5 +1,10 @@
 const URL_REGEX = /\bhttps?:\/\/\S+/i
-const TRAILING_PUNCT = '.,;:!?)]}\'"»›>'
+const TRAILING_PUNCT = '.,;:!?\'"»›>'
+const WRAPPER_PAIRS: Readonly<Record<string, string>> = Object.freeze({
+    ')': '(',
+    ']': '[',
+    '}': '{'
+})
 
 export interface WaDetectedLink {
     readonly matchedText: string
@@ -9,10 +14,7 @@ export interface WaDetectedLink {
 export function findFirstLink(text: string): WaDetectedLink | null {
     const match = URL_REGEX.exec(text)
     if (!match) return null
-    let raw = match[0]
-    while (raw.length > 0 && TRAILING_PUNCT.includes(raw[raw.length - 1] ?? '')) {
-        raw = raw.slice(0, -1)
-    }
+    const raw = stripTrailing(match[0])
     if (raw.length === 0) return null
     let url: URL
     try {
@@ -22,4 +24,34 @@ export function findFirstLink(text: string): WaDetectedLink | null {
     }
     if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
     return { matchedText: raw, url }
+}
+
+function stripTrailing(raw: string): string {
+    let s = raw
+    while (s.length > 0) {
+        const last = s[s.length - 1] ?? ''
+        if (TRAILING_PUNCT.includes(last)) {
+            s = s.slice(0, -1)
+            continue
+        }
+        const opener = WRAPPER_PAIRS[last]
+        if (opener === undefined) break
+        // Only strip the closing wrapper if it's unbalanced (no matching opener
+        // inside the candidate URL). Keeps URLs like `/a_(b)` intact while
+        // still trimming `(see https://x.com)` → `https://x.com`.
+        if (countChar(s, last) > countChar(s, opener)) {
+            s = s.slice(0, -1)
+            continue
+        }
+        break
+    }
+    return s
+}
+
+function countChar(s: string, ch: string): number {
+    let n = 0
+    for (let i = 0; i < s.length; i++) {
+        if (s[i] === ch) n++
+    }
+    return n
 }

--- a/src/message/link-preview/detect.ts
+++ b/src/message/link-preview/detect.ts
@@ -1,0 +1,25 @@
+const URL_REGEX = /\bhttps?:\/\/\S+/i
+const TRAILING_PUNCT = '.,;:!?)]}\'"»›>'
+
+export interface WaDetectedLink {
+    readonly matchedText: string
+    readonly url: URL
+}
+
+export function findFirstLink(text: string): WaDetectedLink | null {
+    const match = URL_REGEX.exec(text)
+    if (!match) return null
+    let raw = match[0]
+    while (raw.length > 0 && TRAILING_PUNCT.includes(raw[raw.length - 1] ?? '')) {
+        raw = raw.slice(0, -1)
+    }
+    if (raw.length === 0) return null
+    let url: URL
+    try {
+        url = new URL(raw)
+    } catch {
+        return null
+    }
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+    return { matchedText: raw, url }
+}

--- a/src/message/link-preview/fetcher.ts
+++ b/src/message/link-preview/fetcher.ts
@@ -6,7 +6,7 @@ import { proto } from '@proto'
 import { toProxyAgent } from '@transport/proxy'
 import type { WaProxyTransport } from '@transport/types'
 import { TEXT_DECODER } from '@util/bytes'
-import { toError } from '@util/primitives'
+import { parseOptionalInt, toError } from '@util/primitives'
 
 import type {
     WaLinkPreviewFetcher,
@@ -130,8 +130,8 @@ function parseHtmlMeta(html: string, base: URL): ParsedMeta {
         extractMetaContent(head, 'property', 'og:image:url') ??
         extractMetaContent(head, 'property', 'og:image') ??
         extractMetaContent(head, 'name', 'twitter:image')
-    const ogImageWidth = parsePositiveInt(extractMetaContent(head, 'property', 'og:image:width'))
-    const ogImageHeight = parsePositiveInt(extractMetaContent(head, 'property', 'og:image:height'))
+    const ogImageWidth = parseOptionalInt(extractMetaContent(head, 'property', 'og:image:width'))
+    const ogImageHeight = parseOptionalInt(extractMetaContent(head, 'property', 'og:image:height'))
     const ogVideo =
         extractMetaContent(head, 'property', 'og:video:secure_url') ??
         extractMetaContent(head, 'property', 'og:video:url') ??
@@ -147,11 +147,6 @@ function parseHtmlMeta(html: string, base: URL): ParsedMeta {
     }
 }
 
-function parsePositiveInt(value: string | undefined): number | undefined {
-    if (value === undefined) return undefined
-    const n = Number.parseInt(value, 10)
-    return Number.isFinite(n) && n > 0 ? n : undefined
-}
 
 function extractHeadSection(html: string): string {
     const closeIdx = html.search(/<\/head\s*>/i)
@@ -242,6 +237,8 @@ async function fetchHtml(url: URL, opts: FetchHtmlInput): Promise<string> {
     if (!/text\/html|application\/xhtml/i.test(result.contentType)) {
         return ''
     }
+    // HTML truncation is tolerable: the regex meta parser only needs the
+    // <head> section, which fits well below maxHtmlBytes for realistic pages.
     return TEXT_DECODER.decode(result.bytes)
 }
 
@@ -306,9 +303,17 @@ async function fetchThumbnail(
         ) {
             return { stream: streamResult.body, contentLength: streamResult.contentLength }
         }
-        const bytes = await readBodyCapped(streamResult.body, opts.maxBytes)
-        if (bytes.byteLength === 0) return undefined
-        return { bytes }
+        const capped = await readBodyCapped(streamResult.body, opts.maxBytes)
+        if (capped.bytes.byteLength === 0) return undefined
+        // If we capped without knowing the real size, the bytes are an
+        // arbitrary prefix of the original image (corrupt JPEG/PNG). Drop it.
+        if (capped.truncated && streamResult.contentLength === undefined) {
+            opts.logger.warn('link preview thumbnail dropped: truncated without content-length', {
+                url: parsed.toString()
+            })
+            return undefined
+        }
+        return { bytes: capped.bytes }
     } catch (error) {
         opts.logger.warn('link preview thumbnail fetch failed', {
             url: parsed.toString(),
@@ -347,11 +352,11 @@ async function httpGetWithRedirects(opts: HttpGetWithRedirectsInput): Promise<Ht
         signal: opts.signal,
         allowPrivateHosts: opts.allowPrivateHosts
     })
-    const bytes = await readBodyCapped(streamResult.body, opts.maxBytes)
+    const capped = await readBodyCapped(streamResult.body, opts.maxBytes)
     return {
         status: streamResult.status,
         contentType: streamResult.contentType,
-        bytes
+        bytes: capped.bytes
     }
 }
 
@@ -414,7 +419,7 @@ async function httpGetStreamWithRedirects(opts: HttpGetStreamInput): Promise<Htt
             continue
         }
         const contentLengthHeader = response.headers['content-length']
-        const contentLength = parsePositiveInt(contentLengthHeader)
+        const contentLength = parseOptionalInt(contentLengthHeader)
         return {
             status: response.status,
             contentType,
@@ -425,19 +430,33 @@ async function httpGetStreamWithRedirects(opts: HttpGetStreamInput): Promise<Htt
     throw new Error(`too many redirects (>${MAX_REDIRECTS})`)
 }
 
-async function readBodyCapped(body: Readable | null, maxBytes: number): Promise<Uint8Array> {
-    if (!body) return new Uint8Array(0)
+interface CappedReadResult {
+    readonly bytes: Uint8Array
+    readonly truncated: boolean
+}
+
+async function readBodyCapped(body: Readable | null, maxBytes: number): Promise<CappedReadResult> {
+    if (!body) return { bytes: new Uint8Array(0), truncated: false }
     const chunks: Uint8Array[] = []
     let total = 0
+    let truncated = false
     try {
         for await (const chunk of body) {
             const view = chunk as Uint8Array
             const room = maxBytes - total
-            if (room <= 0) break
-            const slice = view.byteLength <= room ? view : view.subarray(0, room)
-            chunks.push(slice)
-            total += slice.byteLength
-            if (total >= maxBytes) break
+            if (room <= 0) {
+                truncated = true
+                break
+            }
+            if (view.byteLength <= room) {
+                chunks.push(view)
+                total += view.byteLength
+            } else {
+                chunks.push(view.subarray(0, room))
+                total = maxBytes
+                truncated = true
+                break
+            }
         }
     } finally {
         body.destroy()
@@ -448,7 +467,7 @@ async function readBodyCapped(body: Readable | null, maxBytes: number): Promise<
         out.set(chunk, offset)
         offset += chunk.byteLength
     }
-    return out
+    return { bytes: out, truncated }
 }
 
 const PRIVATE_IPV4 = [
@@ -462,18 +481,24 @@ const PRIVATE_IPV4 = [
 
 function isPrivateHost(hostname: string): boolean {
     const lower = hostname.toLowerCase()
-    if (lower === 'localhost' || lower === '::1') return true
-    if (lower.startsWith('::ffff:')) {
-        return isPrivateHost(lower.slice('::ffff:'.length))
+    // RFC 6761 §6.3: any name in the .localhost domain resolves to loopback.
+    if (lower === 'localhost' || lower.endsWith('.localhost')) return true
+    // URL.hostname strips brackets for IPv6, but tolerate either form.
+    const bare = lower.startsWith('[') && lower.endsWith(']') ? lower.slice(1, -1) : lower
+    if (bare === '::1' || bare === '0:0:0:0:0:0:0:1' || bare === '::') return true
+    if (bare.startsWith('::ffff:')) {
+        return isPrivateHost(bare.slice('::ffff:'.length))
     }
-    if (PRIVATE_IPV4.some((re) => re.test(lower))) return true
-    if (lower.startsWith('[') && lower.endsWith(']')) {
-        const inner = lower.slice(1, -1)
+    if (PRIVATE_IPV4.some((re) => re.test(bare))) return true
+    // IPv6: presence of ':' indicates an address. Match link-local (fe80::/10)
+    // and unique-local (fc00::/7) prefixes.
+    if (bare.includes(':')) {
+        if (bare.startsWith('fc') || bare.startsWith('fd')) return true
         if (
-            inner === '::1' ||
-            inner.startsWith('fc') ||
-            inner.startsWith('fd') ||
-            inner.startsWith('fe80')
+            bare.startsWith('fe8') ||
+            bare.startsWith('fe9') ||
+            bare.startsWith('fea') ||
+            bare.startsWith('feb')
         ) {
             return true
         }

--- a/src/message/link-preview/fetcher.ts
+++ b/src/message/link-preview/fetcher.ts
@@ -147,7 +147,6 @@ function parseHtmlMeta(html: string, base: URL): ParsedMeta {
     }
 }
 
-
 function extractHeadSection(html: string): string {
     const closeIdx = html.search(/<\/head\s*>/i)
     if (closeIdx === -1) return html

--- a/src/message/link-preview/fetcher.ts
+++ b/src/message/link-preview/fetcher.ts
@@ -1,0 +1,482 @@
+import type { Readable } from 'node:stream'
+
+import type { Logger } from '@infra/log/types'
+import type { WaMediaTransferClient } from '@media/WaMediaTransferClient'
+import { proto } from '@proto'
+import { toProxyAgent } from '@transport/proxy'
+import type { WaProxyTransport } from '@transport/types'
+import { TEXT_DECODER } from '@util/bytes'
+import { toError } from '@util/primitives'
+
+import type {
+    WaLinkPreviewFetcher,
+    WaLinkPreviewResolved,
+    WaLinkPreviewThumbnailInput
+} from './types'
+
+const DEFAULT_USER_AGENT =
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+const DEFAULT_TIMEOUT_MS = 3_000
+const DEFAULT_HTML_BYTES = 65_536
+const DEFAULT_THUMBNAIL_BYTES = 262_144
+const INLINE_THUMBNAIL_MAX_BYTES = 64 * 1024
+const MAX_REDIRECTS = 5
+
+export interface DefaultLinkPreviewFetcherOptions {
+    readonly mediaTransfer: WaMediaTransferClient
+    readonly userAgent?: string
+    readonly fetchTimeoutMs?: number
+    readonly maxHtmlBytes?: number
+    readonly maxThumbnailBytes?: number
+    readonly allowPrivateHosts?: boolean
+    readonly proxy?: WaProxyTransport
+}
+
+export function createDefaultLinkPreviewFetcher(
+    options: DefaultLinkPreviewFetcherOptions
+): WaLinkPreviewFetcher {
+    const userAgent = options.userAgent ?? DEFAULT_USER_AGENT
+    const fetchTimeoutMs = options.fetchTimeoutMs ?? DEFAULT_TIMEOUT_MS
+    const maxHtmlBytes = options.maxHtmlBytes ?? DEFAULT_HTML_BYTES
+    const maxThumbnailBytes = options.maxThumbnailBytes ?? DEFAULT_THUMBNAIL_BYTES
+    const allowPrivateHosts = options.allowPrivateHosts === true
+    const agent = toProxyAgent(options.proxy)
+    const mediaTransfer = options.mediaTransfer
+    return {
+        async fetch(input) {
+            if (!allowPrivateHosts && isPrivateHost(input.url.hostname)) {
+                input.logger.warn('link preview blocked: private host', {
+                    hostname: input.url.hostname
+                })
+                return null
+            }
+            const minimal: WaLinkPreviewResolved = {
+                matchedText: input.matchedText,
+                title: input.url.hostname,
+                previewType: proto.Message.ExtendedTextMessage.PreviewType.NONE
+            }
+            let html: string
+            try {
+                html = await fetchHtml(input.url, {
+                    mediaTransfer,
+                    agent,
+                    userAgent,
+                    timeoutMs: fetchTimeoutMs,
+                    maxBytes: maxHtmlBytes,
+                    signal: input.signal,
+                    allowPrivateHosts
+                })
+            } catch (error) {
+                input.logger.warn('link preview html fetch failed', {
+                    url: input.url.toString(),
+                    message: toError(error).message
+                })
+                return minimal
+            }
+            if (html.length === 0) return minimal
+            const parsed = parseHtmlMeta(html, input.url)
+            let thumbnail: WaLinkPreviewThumbnailInput | undefined
+            if (parsed.imageUrl !== undefined) {
+                const fetched = await fetchThumbnail(parsed.imageUrl, {
+                    mediaTransfer,
+                    agent,
+                    userAgent,
+                    timeoutMs: fetchTimeoutMs,
+                    maxBytes: maxThumbnailBytes,
+                    allowPrivateHosts,
+                    signal: input.signal,
+                    logger: input.logger
+                })
+                if (fetched !== undefined) {
+                    thumbnail = {
+                        ...fetched,
+                        ...(parsed.imageWidth !== undefined ? { width: parsed.imageWidth } : {}),
+                        ...(parsed.imageHeight !== undefined ? { height: parsed.imageHeight } : {})
+                    }
+                }
+            }
+            return {
+                matchedText: input.matchedText,
+                title: parsed.title ?? input.url.hostname,
+                previewType: parsed.hasVideo
+                    ? proto.Message.ExtendedTextMessage.PreviewType.VIDEO
+                    : proto.Message.ExtendedTextMessage.PreviewType.NONE,
+                ...(parsed.description !== undefined ? { description: parsed.description } : {}),
+                ...(thumbnail !== undefined ? { thumbnail } : {})
+            }
+        }
+    }
+}
+
+interface ParsedMeta {
+    readonly title?: string
+    readonly description?: string
+    readonly imageUrl?: string
+    readonly imageWidth?: number
+    readonly imageHeight?: number
+    readonly hasVideo: boolean
+}
+
+function parseHtmlMeta(html: string, base: URL): ParsedMeta {
+    const head = extractHeadSection(html)
+    const ogTitle = extractMetaContent(head, 'property', 'og:title')
+    const twitterTitle = extractMetaContent(head, 'name', 'twitter:title')
+    const titleTag = extractTitleTag(head)
+    const ogDesc = extractMetaContent(head, 'property', 'og:description')
+    const twitterDesc = extractMetaContent(head, 'name', 'twitter:description')
+    const metaDesc = extractMetaContent(head, 'name', 'description')
+    const ogImage =
+        extractMetaContent(head, 'property', 'og:image:secure_url') ??
+        extractMetaContent(head, 'property', 'og:image:url') ??
+        extractMetaContent(head, 'property', 'og:image') ??
+        extractMetaContent(head, 'name', 'twitter:image')
+    const ogImageWidth = parsePositiveInt(extractMetaContent(head, 'property', 'og:image:width'))
+    const ogImageHeight = parsePositiveInt(extractMetaContent(head, 'property', 'og:image:height'))
+    const ogVideo =
+        extractMetaContent(head, 'property', 'og:video:secure_url') ??
+        extractMetaContent(head, 'property', 'og:video:url') ??
+        extractMetaContent(head, 'property', 'og:video')
+
+    return {
+        title: cleanText(ogTitle ?? twitterTitle ?? titleTag),
+        description: cleanText(ogDesc ?? twitterDesc ?? metaDesc),
+        imageUrl: ogImage ? toAbsoluteUrl(ogImage, base) : undefined,
+        imageWidth: ogImageWidth,
+        imageHeight: ogImageHeight,
+        hasVideo: ogVideo !== undefined
+    }
+}
+
+function parsePositiveInt(value: string | undefined): number | undefined {
+    if (value === undefined) return undefined
+    const n = Number.parseInt(value, 10)
+    return Number.isFinite(n) && n > 0 ? n : undefined
+}
+
+function extractHeadSection(html: string): string {
+    const closeIdx = html.search(/<\/head\s*>/i)
+    if (closeIdx === -1) return html
+    return html.slice(0, closeIdx)
+}
+
+function extractMetaContent(
+    html: string,
+    attr: 'property' | 'name',
+    key: string
+): string | undefined {
+    const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const re1 = new RegExp(
+        `<meta\\b[^>]*?\\b${attr}\\s*=\\s*["']${escaped}["'][^>]*?\\bcontent\\s*=\\s*["']([^"']*)["']`,
+        'i'
+    )
+    const re2 = new RegExp(
+        `<meta\\b[^>]*?\\bcontent\\s*=\\s*["']([^"']*)["'][^>]*?\\b${attr}\\s*=\\s*["']${escaped}["']`,
+        'i'
+    )
+    const m = re1.exec(html) ?? re2.exec(html)
+    return m?.[1]
+}
+
+function extractTitleTag(html: string): string | undefined {
+    const m = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)
+    return m?.[1]
+}
+
+function cleanText(s: string | undefined): string | undefined {
+    if (s === undefined) return undefined
+    const decoded = decodeHtmlEntities(s.replace(/\s+/g, ' ').trim())
+    return decoded.length === 0 ? undefined : decoded
+}
+
+function decodeHtmlEntities(s: string): string {
+    return s
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/&apos;/g, "'")
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&#(\d+);/g, (_, n: string) => safeCodePoint(Number(n)))
+        .replace(/&#x([0-9a-f]+);/gi, (_, hex: string) => safeCodePoint(Number.parseInt(hex, 16)))
+        .replace(/&amp;/g, '&')
+}
+
+function safeCodePoint(cp: number): string {
+    if (!Number.isFinite(cp) || cp < 0 || cp > 0x10ffff) return ''
+    return String.fromCodePoint(cp)
+}
+
+function toAbsoluteUrl(raw: string, base: URL): string | undefined {
+    try {
+        return new URL(raw, base).toString()
+    } catch {
+        return undefined
+    }
+}
+
+interface FetchHtmlInput {
+    readonly mediaTransfer: WaMediaTransferClient
+    readonly agent: ReturnType<typeof toProxyAgent>
+    readonly userAgent: string
+    readonly timeoutMs: number
+    readonly maxBytes: number
+    readonly signal?: AbortSignal
+    readonly allowPrivateHosts: boolean
+}
+
+async function fetchHtml(url: URL, opts: FetchHtmlInput): Promise<string> {
+    const result = await httpGetWithRedirects({
+        url,
+        mediaTransfer: opts.mediaTransfer,
+        agent: opts.agent,
+        userAgent: opts.userAgent,
+        accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        timeoutMs: opts.timeoutMs,
+        maxBytes: opts.maxBytes,
+        signal: opts.signal,
+        allowPrivateHosts: opts.allowPrivateHosts
+    })
+    if (result.status < 200 || result.status >= 300) {
+        throw new Error(`http ${result.status}`)
+    }
+    if (!/text\/html|application\/xhtml/i.test(result.contentType)) {
+        return ''
+    }
+    return TEXT_DECODER.decode(result.bytes)
+}
+
+interface FetchThumbnailInput {
+    readonly mediaTransfer: WaMediaTransferClient
+    readonly agent: ReturnType<typeof toProxyAgent>
+    readonly userAgent: string
+    readonly timeoutMs: number
+    readonly maxBytes: number
+    readonly allowPrivateHosts: boolean
+    readonly signal?: AbortSignal
+    readonly logger: Logger
+}
+
+async function fetchThumbnail(
+    url: string,
+    opts: FetchThumbnailInput
+): Promise<WaLinkPreviewThumbnailInput | undefined> {
+    let parsed: URL
+    try {
+        parsed = new URL(url)
+    } catch {
+        return undefined
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined
+    if (!opts.allowPrivateHosts && isPrivateHost(parsed.hostname)) {
+        opts.logger.warn('link preview thumbnail blocked: private host', {
+            hostname: parsed.hostname
+        })
+        return undefined
+    }
+    try {
+        const streamResult = await httpGetStreamWithRedirects({
+            url: parsed,
+            mediaTransfer: opts.mediaTransfer,
+            agent: opts.agent,
+            userAgent: opts.userAgent,
+            accept: 'image/jpeg,image/*;q=0.8',
+            timeoutMs: opts.timeoutMs,
+            signal: opts.signal,
+            allowPrivateHosts: opts.allowPrivateHosts
+        })
+        if (streamResult.status < 200 || streamResult.status >= 300) {
+            streamResult.body?.destroy()
+            return undefined
+        }
+        if (!/^image\//i.test(streamResult.contentType)) {
+            streamResult.body?.destroy()
+            return undefined
+        }
+        if (!streamResult.body) return undefined
+        if (
+            streamResult.contentLength !== undefined &&
+            streamResult.contentLength > opts.maxBytes
+        ) {
+            streamResult.body.destroy()
+            return undefined
+        }
+        if (
+            streamResult.contentLength !== undefined &&
+            streamResult.contentLength > INLINE_THUMBNAIL_MAX_BYTES
+        ) {
+            return { stream: streamResult.body, contentLength: streamResult.contentLength }
+        }
+        const bytes = await readBodyCapped(streamResult.body, opts.maxBytes)
+        if (bytes.byteLength === 0) return undefined
+        return { bytes }
+    } catch (error) {
+        opts.logger.warn('link preview thumbnail fetch failed', {
+            url: parsed.toString(),
+            message: toError(error).message
+        })
+        return undefined
+    }
+}
+
+interface HttpGetWithRedirectsInput {
+    readonly url: URL
+    readonly mediaTransfer: WaMediaTransferClient
+    readonly agent: ReturnType<typeof toProxyAgent>
+    readonly userAgent: string
+    readonly accept: string
+    readonly timeoutMs: number
+    readonly maxBytes: number
+    readonly signal?: AbortSignal
+    readonly allowPrivateHosts: boolean
+}
+
+interface HttpGetResult {
+    readonly status: number
+    readonly contentType: string
+    readonly bytes: Uint8Array
+}
+
+async function httpGetWithRedirects(opts: HttpGetWithRedirectsInput): Promise<HttpGetResult> {
+    const streamResult = await httpGetStreamWithRedirects({
+        url: opts.url,
+        mediaTransfer: opts.mediaTransfer,
+        agent: opts.agent,
+        userAgent: opts.userAgent,
+        accept: opts.accept,
+        timeoutMs: opts.timeoutMs,
+        signal: opts.signal,
+        allowPrivateHosts: opts.allowPrivateHosts
+    })
+    const bytes = await readBodyCapped(streamResult.body, opts.maxBytes)
+    return {
+        status: streamResult.status,
+        contentType: streamResult.contentType,
+        bytes
+    }
+}
+
+interface HttpGetStreamInput {
+    readonly url: URL
+    readonly mediaTransfer: WaMediaTransferClient
+    readonly agent: ReturnType<typeof toProxyAgent>
+    readonly userAgent: string
+    readonly accept: string
+    readonly timeoutMs: number
+    readonly signal?: AbortSignal
+    readonly allowPrivateHosts: boolean
+}
+
+interface HttpGetStreamResult {
+    readonly status: number
+    readonly contentType: string
+    readonly contentLength: number | undefined
+    readonly body: Readable | null
+}
+
+async function httpGetStreamWithRedirects(opts: HttpGetStreamInput): Promise<HttpGetStreamResult> {
+    let currentUrl = opts.url
+    for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
+        if (!opts.allowPrivateHosts && isPrivateHost(currentUrl.hostname)) {
+            throw new Error(`redirect to private host blocked: ${currentUrl.hostname}`)
+        }
+        const response = await opts.mediaTransfer.downloadStream({
+            url: currentUrl.toString(),
+            agent: opts.agent,
+            headers: {
+                'user-agent': opts.userAgent,
+                accept: opts.accept
+            },
+            timeoutMs: opts.timeoutMs,
+            signal: opts.signal
+        })
+        const contentType = response.headers['content-type'] ?? ''
+        if (response.status >= 300 && response.status < 400) {
+            const location = response.headers['location']
+            response.body?.destroy()
+            if (typeof location !== 'string' || location.length === 0) {
+                return {
+                    status: response.status,
+                    contentType,
+                    contentLength: undefined,
+                    body: null
+                }
+            }
+            try {
+                currentUrl = new URL(location, currentUrl)
+            } catch {
+                return {
+                    status: response.status,
+                    contentType,
+                    contentLength: undefined,
+                    body: null
+                }
+            }
+            continue
+        }
+        const contentLengthHeader = response.headers['content-length']
+        const contentLength = parsePositiveInt(contentLengthHeader)
+        return {
+            status: response.status,
+            contentType,
+            contentLength,
+            body: response.body
+        }
+    }
+    throw new Error(`too many redirects (>${MAX_REDIRECTS})`)
+}
+
+async function readBodyCapped(body: Readable | null, maxBytes: number): Promise<Uint8Array> {
+    if (!body) return new Uint8Array(0)
+    const chunks: Uint8Array[] = []
+    let total = 0
+    try {
+        for await (const chunk of body) {
+            const view = chunk as Uint8Array
+            const room = maxBytes - total
+            if (room <= 0) break
+            const slice = view.byteLength <= room ? view : view.subarray(0, room)
+            chunks.push(slice)
+            total += slice.byteLength
+            if (total >= maxBytes) break
+        }
+    } finally {
+        body.destroy()
+    }
+    const out = new Uint8Array(total)
+    let offset = 0
+    for (const chunk of chunks) {
+        out.set(chunk, offset)
+        offset += chunk.byteLength
+    }
+    return out
+}
+
+const PRIVATE_IPV4 = [
+    /^127\./,
+    /^10\./,
+    /^192\.168\./,
+    /^172\.(1[6-9]|2\d|3[01])\./,
+    /^169\.254\./,
+    /^0\./
+]
+
+function isPrivateHost(hostname: string): boolean {
+    const lower = hostname.toLowerCase()
+    if (lower === 'localhost' || lower === '::1') return true
+    if (lower.startsWith('::ffff:')) {
+        return isPrivateHost(lower.slice('::ffff:'.length))
+    }
+    if (PRIVATE_IPV4.some((re) => re.test(lower))) return true
+    if (lower.startsWith('[') && lower.endsWith(']')) {
+        const inner = lower.slice(1, -1)
+        if (
+            inner === '::1' ||
+            inner.startsWith('fc') ||
+            inner.startsWith('fd') ||
+            inner.startsWith('fe80')
+        ) {
+            return true
+        }
+    }
+    return false
+}

--- a/src/message/link-preview/types.ts
+++ b/src/message/link-preview/types.ts
@@ -1,0 +1,61 @@
+import type { Readable } from 'node:stream'
+
+import type { Logger } from '@infra/log/types'
+import type { proto } from '@proto'
+import type { WaProxyTransport } from '@transport/types'
+
+export type WaLinkPreviewType = proto.Message.ExtendedTextMessage.PreviewType
+
+export interface WaLinkPreviewThumbnailBytes {
+    readonly bytes: Uint8Array
+    readonly width?: number
+    readonly height?: number
+}
+
+export interface WaLinkPreviewThumbnailStream {
+    readonly stream: Readable
+    readonly contentLength: number
+    readonly width?: number
+    readonly height?: number
+}
+
+export type WaLinkPreviewThumbnailInput = WaLinkPreviewThumbnailBytes | WaLinkPreviewThumbnailStream
+
+export interface WaLinkPreviewOverride {
+    readonly matchedText?: string
+    readonly title?: string
+    readonly description?: string
+    readonly previewType?: WaLinkPreviewType
+    readonly thumbnail?: WaLinkPreviewThumbnailInput
+}
+
+export interface WaLinkPreviewResolved {
+    readonly matchedText: string
+    readonly title?: string
+    readonly description?: string
+    readonly previewType: WaLinkPreviewType
+    readonly thumbnail?: WaLinkPreviewThumbnailInput
+}
+
+export interface WaLinkPreviewFetchInput {
+    readonly url: URL
+    readonly matchedText: string
+    readonly logger: Logger
+    readonly signal?: AbortSignal
+}
+
+export interface WaLinkPreviewFetcher {
+    fetch(input: WaLinkPreviewFetchInput): Promise<WaLinkPreviewResolved | null>
+}
+
+export interface WaLinkPreviewOptions {
+    readonly enabled?: boolean
+    readonly fetchTimeoutMs?: number
+    readonly uploadHqThumbnail?: boolean
+    readonly allowPrivateHosts?: boolean
+    readonly maxHtmlBytes?: number
+    readonly maxThumbnailBytes?: number
+    readonly userAgent?: string
+    readonly proxy?: WaProxyTransport
+    readonly fetcher?: WaLinkPreviewFetcher
+}

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -1,6 +1,7 @@
 import type { Readable } from 'node:stream'
 
 import type { WaSendContextInfo } from '@message/context-info'
+import type { WaLinkPreviewOverride } from '@message/link-preview/types'
 import type { Proto } from '@proto'
 import type { WaOutboundReceiptType } from '@protocol/message'
 import type { BinaryNode } from '@transport/types'
@@ -79,6 +80,12 @@ export interface WaSendTextMessage {
     readonly type: 'text'
     readonly text: string
     readonly contextInfo?: WaSendContextInfo
+    /**
+     * Link preview control: `undefined` follows the global `linkPreview.enabled`
+     * default; `false` disables; `true` forces auto-fetch; an object skips the
+     * fetch and uses the provided fields directly.
+     */
+    readonly linkPreview?: boolean | WaLinkPreviewOverride
 }
 
 interface WaSendImageMessage extends WaSendMediaBase, UserMediaFields<Proto.Message.IImageMessage> {

--- a/src/protocol/media.ts
+++ b/src/protocol/media.ts
@@ -18,7 +18,8 @@ export const WA_MEDIA_HKDF_INFO = Object.freeze({
     'md-msg-hist': HISTORY_KEYS,
     history: HISTORY_KEYS,
     'sticker-pack': TEXT_ENCODER.encode('WhatsApp Sticker Pack Keys'),
-    'thumbnail-sticker-pack': TEXT_ENCODER.encode('WhatsApp Sticker Pack Thumbnail Keys')
+    'thumbnail-sticker-pack': TEXT_ENCODER.encode('WhatsApp Sticker Pack Thumbnail Keys'),
+    'thumbnail-link': TEXT_ENCODER.encode('WhatsApp Link Thumbnail Keys')
 } as const)
 
 export const WA_PREVIEW_MEDIA_HKDF_INFO = TEXT_ENCODER.encode('Messenger Preview Keys')


### PR DESCRIPTION
Auto-detects URLs in WaSendTextMessage text, fetches OpenGraph metadata and og:image via WaMediaTransferClient (with redirect follow), and encrypts+uploads the thumbnail as MEDIA_TYPES.THUMBNAIL_LINK so the recipient renders a hi-res preview card. Inline jpegThumbnail is emitted alongside the HQ upload when the image fits in 64KB; larger images are streamed end-to-end (download -> encryptToFile -> uploadStream) to keep peak memory at O(chunk).

Public API: WaSendTextMessage.linkPreview accepts boolean (auto/skip), or an override object that bypasses the fetch. WaClientOptions exposes a linkPreview section with fetcher injection, proxy (WaProxyTransport), SSRF guard, timeout, and byte caps. WaClientProxyOptions.linkPreview follows the same agent/dispatcher pattern as the media proxies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added link preview functionality for text messages with configurable options
  * Support for custom thumbnail handling, including high-quality encrypted uploads
  * Per-message link preview control with override capabilities
  * Configurable privacy controls and size limits for preview fetching

* **Tests**
  * Added comprehensive test coverage for link preview detection, fetching, and message building

* **Chores**
  * Updated development dependency version

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->