### PR TITLE
feat(client): add registerIncomingStanzaFilter for dropping inbound stanzas

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -25,7 +25,7 @@
         "typecheck": "tsc --noEmit",
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\"",
         "start": "node --import tsx src/bin.ts",
-        "dev": "cross-env MCP_TRANSPORT=http MCP_LOG_LEVEL=trace MCP_AUTH_PATH=../../.auth/state.sqlite node --watch --import tsx src/bin.ts"
+        "dev": "cross-env MCP_TRANSPORT=http MCP_EVAL_ENABLED=1 MCP_LOG_LEVEL=trace MCP_AUTH_PATH=../../.auth/state.sqlite node --watch --import tsx src/bin.ts"
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -430,49 +430,93 @@ test('restart tool rejects invalid mode', async () => {
     await assert.rejects(() => tool.handler({ mode: 'hard' }, runtime), /soft \| process_exit/)
 })
 
+const withEvalEnabled = async (run: () => Promise<void>): Promise<void> => {
+    const prev = process.env.MCP_EVAL_ENABLED
+    process.env.MCP_EVAL_ENABLED = '1'
+    try {
+        await run()
+    } finally {
+        if (prev === undefined) {
+            delete process.env.MCP_EVAL_ENABLED
+        } else {
+            process.env.MCP_EVAL_ENABLED = prev
+        }
+    }
+}
+
 test('eval tool runs source with client + lib in scope and encodes result', async () => {
-    const runtime = buildFakeRuntime(new FakeClient())
-    const tool = findTool('eval')
-    const result = (await tool.handler(
-        { source: 'return await client.multiply(6, 7)' },
-        runtime
-    )) as { kind: string; result: unknown }
-    assert.equal(result.kind, 'eval')
-    assert.equal(result.result, 42)
+    await withEvalEnabled(async () => {
+        const runtime = buildFakeRuntime(new FakeClient())
+        const tool = findTool('eval')
+        const result = (await tool.handler(
+            { source: 'return await client.multiply(6, 7)' },
+            runtime
+        )) as { kind: string; result: unknown }
+        assert.equal(result.kind, 'eval')
+        assert.equal(result.result, 42)
 
-    const libResult = (await tool.handler(
-        { source: 'return typeof lib.parsePhoneJid' },
-        runtime
-    )) as { result: unknown }
-    assert.equal(libResult.result, 'function')
+        const libResult = (await tool.handler(
+            { source: 'return typeof lib.parsePhoneJid' },
+            runtime
+        )) as { result: unknown }
+        assert.equal(libResult.result, 'function')
 
-    const bytesResult = (await tool.handler(
-        { source: 'return await client.roundtrip(new Uint8Array([1,2,3]))' },
-        runtime
-    )) as { result: { $bytes: string } }
-    assert.equal(bytesResult.result.$bytes, 'AQID')
+        const bytesResult = (await tool.handler(
+            { source: 'return await client.roundtrip(new Uint8Array([1,2,3]))' },
+            runtime
+        )) as { result: { $bytes: string } }
+        assert.equal(bytesResult.result.$bytes, 'AQID')
+    })
 })
 
 test('eval tool rejects empty source', async () => {
-    const runtime = buildFakeRuntime(new FakeClient())
-    const tool = findTool('eval')
-    await assert.rejects(() => tool.handler({ source: '' }, runtime), /non-empty string/)
-    await assert.rejects(() => tool.handler({}, runtime), /non-empty string/)
+    await withEvalEnabled(async () => {
+        const runtime = buildFakeRuntime(new FakeClient())
+        const tool = findTool('eval')
+        await assert.rejects(() => tool.handler({ source: '' }, runtime), /non-empty string/)
+        await assert.rejects(() => tool.handler({}, runtime), /non-empty string/)
+    })
 })
 
 test('eval tool fires async source without awaiting when noAwait is set', async () => {
-    const runtime = buildFakeRuntime(new FakeClient())
-    const tool = findTool('eval')
-    const result = (await tool.handler(
-        { source: 'globalThis.__evalStash = await client.multiply(3, 4)', noAwait: true },
-        runtime
-    )) as { kind: string; noAwait: boolean; fired: boolean }
-    assert.equal(result.kind, 'eval')
-    assert.equal(result.noAwait, true)
-    assert.equal(result.fired, true)
-    // Allow the microtask queue to drain so the noAwait promise can mutate globalThis.
-    await new Promise((resolve) => setImmediate(resolve))
-    const stashed = (globalThis as Record<string, unknown>).__evalStash
-    assert.equal(stashed, 12)
-    delete (globalThis as Record<string, unknown>).__evalStash
+    await withEvalEnabled(async () => {
+        const runtime = buildFakeRuntime(new FakeClient())
+        const tool = findTool('eval')
+        const result = (await tool.handler(
+            { source: 'globalThis.__evalStash = await client.multiply(3, 4)', noAwait: true },
+            runtime
+        )) as { kind: string; noAwait: boolean; fired: boolean }
+        assert.equal(result.kind, 'eval')
+        assert.equal(result.noAwait, true)
+        assert.equal(result.fired, true)
+        // Allow the microtask queue to drain so the noAwait promise can mutate globalThis.
+        await new Promise((resolve) => setImmediate(resolve))
+        const stashed = (globalThis as Record<string, unknown>).__evalStash
+        assert.equal(stashed, 12)
+        delete (globalThis as Record<string, unknown>).__evalStash
+    })
+})
+
+test('eval tool is disabled unless MCP_EVAL_ENABLED=1', async () => {
+    const prev = process.env.MCP_EVAL_ENABLED
+    delete process.env.MCP_EVAL_ENABLED
+    try {
+        const runtime = buildFakeRuntime(new FakeClient())
+        const tool = findTool('eval')
+        await assert.rejects(
+            () => tool.handler({ source: 'return 1' }, runtime),
+            /MCP_EVAL_ENABLED/
+        )
+        process.env.MCP_EVAL_ENABLED = '0'
+        await assert.rejects(
+            () => tool.handler({ source: 'return 1' }, runtime),
+            /MCP_EVAL_ENABLED/
+        )
+    } finally {
+        if (prev === undefined) {
+            delete process.env.MCP_EVAL_ENABLED
+        } else {
+            process.env.MCP_EVAL_ENABLED = prev
+        }
+    }
 })

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -429,3 +429,50 @@ test('restart tool rejects invalid mode', async () => {
     const tool = findTool('restart')
     await assert.rejects(() => tool.handler({ mode: 'hard' }, runtime), /soft \| process_exit/)
 })
+
+test('eval tool runs source with client + lib in scope and encodes result', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('eval')
+    const result = (await tool.handler(
+        { source: 'return await client.multiply(6, 7)' },
+        runtime
+    )) as { kind: string; result: unknown }
+    assert.equal(result.kind, 'eval')
+    assert.equal(result.result, 42)
+
+    const libResult = (await tool.handler(
+        { source: 'return typeof lib.parsePhoneJid' },
+        runtime
+    )) as { result: unknown }
+    assert.equal(libResult.result, 'function')
+
+    const bytesResult = (await tool.handler(
+        { source: 'return await client.roundtrip(new Uint8Array([1,2,3]))' },
+        runtime
+    )) as { result: { $bytes: string } }
+    assert.equal(bytesResult.result.$bytes, 'AQID')
+})
+
+test('eval tool rejects empty source', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('eval')
+    await assert.rejects(() => tool.handler({ source: '' }, runtime), /non-empty string/)
+    await assert.rejects(() => tool.handler({}, runtime), /non-empty string/)
+})
+
+test('eval tool fires async source without awaiting when noAwait is set', async () => {
+    const runtime = buildFakeRuntime(new FakeClient())
+    const tool = findTool('eval')
+    const result = (await tool.handler(
+        { source: 'globalThis.__evalStash = await client.multiply(3, 4)', noAwait: true },
+        runtime
+    )) as { kind: string; noAwait: boolean; fired: boolean }
+    assert.equal(result.kind, 'eval')
+    assert.equal(result.noAwait, true)
+    assert.equal(result.fired, true)
+    // Allow the microtask queue to drain so the noAwait promise can mutate globalThis.
+    await new Promise((resolve) => setImmediate(resolve))
+    const stashed = (globalThis as Record<string, unknown>).__evalStash
+    assert.equal(stashed, 12)
+    delete (globalThis as Record<string, unknown>).__evalStash
+})

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -420,6 +420,54 @@ const lifecycleTool: ToolDefinition = {
     }
 }
 
+const AsyncFunctionCtor = Object.getPrototypeOf(async function () {}).constructor as new (
+    ...args: string[]
+) => (client: unknown, lib: unknown) => Promise<unknown>
+
+const evalTool: ToolDefinition = {
+    name: 'eval',
+    description:
+        'Execute arbitrary JS in the MCP runtime with `client` (WaClient instance) and `lib` ' +
+        '(zapo-js module namespace) in scope. The source is wrapped in an async function — ' +
+        'top-level `await` works. Use `return <expr>` to surface a value; the result is encoded ' +
+        'for JSON ($bytes / $bigint markers). Use `globalThis.<key> = ...` to persist state ' +
+        'between eval calls (e.g. stash an unregister callback returned by ' +
+        'registerIncomingStanzaFilter). When `noAwait: true`, fire-and-forget — the call returns ' +
+        'immediately and rejections go to the runtime logger.',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            source: {
+                type: 'string',
+                description:
+                    'JavaScript statements. Wrapped as `async function (client, lib) { <source> }`.'
+            },
+            noAwait: {
+                type: 'boolean',
+                description: 'Fire-and-forget mode. Defaults to false.'
+            }
+        },
+        required: ['source'],
+        additionalProperties: false
+    },
+    handler: async (input, runtime) => {
+        const { source, noAwait } = parseEvalInput(input)
+        const client = await runtime.ensureClient()
+        const fn = new AsyncFunctionCtor('client', 'lib', source)
+        const invoked = fn(client, ZapoLib)
+        if (noAwait) {
+            invoked.catch((error: unknown) => {
+                runtime.getLogger().warn('eval noAwait rejected', {
+                    message: toError(error).message
+                })
+            })
+            return { kind: 'eval', noAwait: true, fired: true }
+        }
+        const result = await invoked
+        return { kind: 'eval', result: encodeForJson(result) }
+    }
+}
+
 export const TOOLS: readonly ToolDefinition[] = Object.freeze([
     callTool,
     inspectTool,
@@ -428,7 +476,8 @@ export const TOOLS: readonly ToolDefinition[] = Object.freeze([
     logsTool,
     logsClearTool,
     lifecycleTool,
-    restartTool
+    restartTool,
+    evalTool
 ])
 
 const parseCallInput = (
@@ -523,6 +572,17 @@ const parseLifecycleInput = (input: unknown): 'status' | 'start' | 'destroy' => 
         return obj.action
     }
     throw new Error('lifecycle: "action" must be "status" | "start" | "destroy"')
+}
+
+const parseEvalInput = (input: unknown): { source: string; noAwait: boolean } => {
+    if (!input || typeof input !== 'object') {
+        throw new Error('eval: input must be an object')
+    }
+    const obj = input as Record<string, unknown>
+    if (typeof obj.source !== 'string' || obj.source.length === 0) {
+        throw new Error('eval: "source" must be a non-empty string')
+    }
+    return { source: obj.source, noAwait: obj.noAwait === true }
 }
 
 const parseRestartInput = (input: unknown): 'soft' | 'process_exit' => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -428,12 +428,14 @@ const evalTool: ToolDefinition = {
     name: 'eval',
     description:
         'Execute arbitrary JS in the MCP runtime with `client` (WaClient instance) and `lib` ' +
-        '(zapo-js module namespace) in scope. The source is wrapped in an async function — ' +
-        'top-level `await` works. Use `return <expr>` to surface a value; the result is encoded ' +
-        'for JSON ($bytes / $bigint markers). Use `globalThis.<key> = ...` to persist state ' +
-        'between eval calls (e.g. stash an unregister callback returned by ' +
-        'registerIncomingStanzaFilter). When `noAwait: true`, fire-and-forget — the call returns ' +
-        'immediately and rejections go to the runtime logger.',
+        '(zapo-js module namespace) in scope. **Disabled by default**: requires ' +
+        '`MCP_EVAL_ENABLED=1` in the MCP process env, otherwise every call is rejected. ' +
+        'The source is wrapped in an async function — top-level `await` works. ' +
+        'Use `return <expr>` to surface a value; the result is encoded for JSON ' +
+        '($bytes / $bigint markers). Use `globalThis.<key> = ...` to persist state between ' +
+        'eval calls (e.g. stash an unregister callback returned by registerIncomingStanzaFilter). ' +
+        'When `noAwait: true`, fire-and-forget — the call returns immediately and rejections ' +
+        'go to the runtime logger.',
     inputSchema: {
         type: 'object',
         properties: {
@@ -451,6 +453,11 @@ const evalTool: ToolDefinition = {
         additionalProperties: false
     },
     handler: async (input, runtime) => {
+        if (process.env.MCP_EVAL_ENABLED !== '1') {
+            throw new Error(
+                'eval tool is disabled; set MCP_EVAL_ENABLED=1 in the MCP process env to enable'
+            )
+        }
         const { source, noAwait } = parseEvalInput(input)
         const client = await runtime.ensureClient()
         const fn = new AsyncFunctionCtor('client', 'lib', source)

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -38,6 +38,7 @@ import type {
     WaIncomingMessageEvent,
     WaIncomingNodeHandlerRegistration,
     WaIncomingProtocolMessageEvent,
+    WaIncomingStanzaFilter,
     WaSendMessageOptions
 } from '@client/types'
 import { buildWaClientDependencies, resolveWaClientBase } from '@client/WaClientFactory'
@@ -344,6 +345,16 @@ export class WaClient extends EventEmitter {
 
     public unregisterIncomingHandler(registration: WaIncomingNodeHandlerRegistration): boolean {
         return this.incomingNode.unregisterIncomingHandler(registration)
+    }
+
+    /**
+     * Registers a predicate that drops inbound stanzas before any handler runs.
+     * Returning `true` blocks the stanza and sends the protocol ack for
+     * `message`/`receipt`/`notification`. `success`/`failure` always bypass
+     * filters to keep the auth flow intact.
+     */
+    public registerIncomingStanzaFilter(filter: WaIncomingStanzaFilter): () => void {
+        return this.incomingNode.registerIncomingStanzaFilter(filter)
     }
 
     private bindNodeTransportEvents(): void {

--- a/src/client/coordinators/WaIncomingNodeCoordinator.ts
+++ b/src/client/coordinators/WaIncomingNodeCoordinator.ts
@@ -4,6 +4,7 @@ import type { WaDirtyBit } from '@client/dirty'
 import { parseChatstateNode } from '@client/events/chatstate'
 import { parsePresenceNode } from '@client/events/presence'
 import {
+    buildInboundAck,
     createIncomingBaseEvent,
     createIncomingBusinessNotificationHandler,
     createIncomingFailureHandler,
@@ -12,7 +13,8 @@ import {
     createIncomingReceiptHandler,
     createIncomingRegistrationNotificationHandler,
     createInfoBulletinNotificationEvent,
-    createUnhandledIncomingNodeEvent
+    createUnhandledIncomingNodeEvent,
+    sendSafeAck
 } from '@client/incoming'
 import type {
     WaAccountTakeoverNoticeEvent,
@@ -27,6 +29,7 @@ import type {
     WaIncomingNotificationEvent,
     WaIncomingPresenceEvent,
     WaIncomingReceiptEvent,
+    WaIncomingStanzaFilter,
     WaIncomingUnhandledStanzaEvent,
     WaRegistrationCodeEvent
 } from '@client/types'
@@ -109,6 +112,8 @@ const INFO_BULLETIN_CHILD_TAGS = new Set<string>([
     'client_expiration'
 ])
 
+const FILTER_PROTECTED_TAGS = new Set<string>([WA_NODE_TAGS.SUCCESS, 'failure'])
+
 export class WaIncomingNodeCoordinator {
     private readonly logger: Logger
     private readonly runtime: WaIncomingNodeRuntime
@@ -117,6 +122,7 @@ export class WaIncomingNodeCoordinator {
         string,
         { readonly subtype?: string; readonly handler: WaIncomingNodeHandler }[]
     >
+    private readonly stanzaFilters: WaIncomingStanzaFilter[]
     private mediaConnWarmupPromise: Promise<void> | null
 
     public constructor(options: WaIncomingNodeCoordinatorOptions) {
@@ -124,6 +130,7 @@ export class WaIncomingNodeCoordinator {
         this.runtime = options.runtime
         this.offlineResume = options.offlineResume
         this.nodeHandlerRegistry = new Map()
+        this.stanzaFilters = []
         this.registerDefaultIncomingHandlers()
         this.mediaConnWarmupPromise = null
     }
@@ -142,6 +149,9 @@ export class WaIncomingNodeCoordinator {
             await this.runtime.handleStreamControlResult(streamControlResult)
             return
         }
+        if (await this.applyStanzaFilters(node)) {
+            return
+        }
         if (await this.handleSuccessNode(node)) {
             return
         }
@@ -153,6 +163,44 @@ export class WaIncomingNodeCoordinator {
             return
         }
         this.runtime.emitUnhandledIncomingNode(createUnhandledIncomingNodeEvent(node))
+    }
+
+    public registerIncomingStanzaFilter(filter: WaIncomingStanzaFilter): () => void {
+        this.stanzaFilters.push(filter)
+        return () => {
+            const index = this.stanzaFilters.indexOf(filter)
+            if (index !== -1) {
+                this.stanzaFilters.splice(index, 1)
+            }
+        }
+    }
+
+    private async applyStanzaFilters(node: BinaryNode): Promise<boolean> {
+        if (this.stanzaFilters.length === 0 || FILTER_PROTECTED_TAGS.has(node.tag)) {
+            return false
+        }
+        for (let i = 0; i < this.stanzaFilters.length; i += 1) {
+            let verdict: boolean
+            try {
+                verdict = await this.stanzaFilters[i](node)
+            } catch (error) {
+                this.logger.warn('incoming stanza filter threw', {
+                    tag: node.tag,
+                    id: node.attrs.id,
+                    message: toError(error).message
+                })
+                continue
+            }
+            if (!verdict) {
+                continue
+            }
+            const ack = buildInboundAck(node)
+            if (ack) {
+                await sendSafeAck(this.logger, this.runtime.sendNode, ack)
+            }
+            return true
+        }
+        return false
     }
 
     public registerIncomingHandler(registration: WaIncomingNodeHandlerRegistration): () => void {

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -177,6 +177,113 @@ test('incoming node coordinator supports dynamic handler registration and unregi
     assert.equal(unhandled.length, 1)
 })
 
+test('incoming node coordinator runs stanza filters and acks blocked tags', async () => {
+    const { runtime: baseRuntime, unhandled } = createIncomingRuntime()
+    const sent: BinaryNode[] = []
+    let dispatched = 0
+    const runtime = {
+        ...baseRuntime,
+        sendNode: async (node: BinaryNode) => {
+            sent.push(node)
+        },
+        handleGenericIncomingNode: async () => {
+            dispatched += 1
+            return false
+        }
+    }
+    const coordinator = new WaIncomingNodeCoordinator({
+        logger: createNoopLogger(),
+        runtime,
+        offlineResume: {
+            trackOfflineStanza() {},
+            handleOfflinePreview() {},
+            handleOfflineComplete() {},
+            reset() {},
+            isComplete: false,
+            isResuming: false
+        } as never
+    })
+
+    const calls: BinaryNode[] = []
+    const unregister = coordinator.registerIncomingStanzaFilter((node) => {
+        calls.push(node)
+        return node.attrs.sender_pn === '5511999990000'
+    })
+
+    await coordinator.handleIncomingNode({
+        tag: 'message',
+        attrs: {
+            id: 'MSG1',
+            from: '5511999990000@s.whatsapp.net',
+            sender_pn: '5511999990000'
+        }
+    })
+    assert.equal(calls.length, 1)
+    assert.equal(dispatched, 0)
+    assert.equal(unhandled.length, 0)
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].tag, 'ack')
+    assert.equal(sent[0].attrs.id, 'MSG1')
+    assert.equal(sent[0].attrs.to, '5511999990000@s.whatsapp.net')
+    assert.equal(sent[0].attrs.class, 'message')
+
+    await coordinator.handleIncomingNode({
+        tag: 'message',
+        attrs: { id: 'MSG2', from: '5511888880000@s.whatsapp.net' }
+    })
+    assert.equal(calls.length, 2)
+    assert.equal(sent.length, 1)
+    assert.equal(unhandled.length, 1)
+
+    unregister()
+    await coordinator.handleIncomingNode({
+        tag: 'message',
+        attrs: { id: 'MSG3', from: '5511999990000@s.whatsapp.net', sender_pn: '5511999990000' }
+    })
+    assert.equal(calls.length, 2)
+    assert.equal(unhandled.length, 2)
+})
+
+test('incoming node coordinator stanza filters skip success and failure tags', async () => {
+    const { runtime: baseRuntime } = createIncomingRuntime()
+    let emittedSuccess = 0
+    let failureEmitted = 0
+    const runtime = {
+        ...baseRuntime,
+        emitSuccessNode: () => {
+            emittedSuccess += 1
+        },
+        emitIncomingFailure: () => {
+            failureEmitted += 1
+        }
+    }
+    const coordinator = new WaIncomingNodeCoordinator({
+        logger: createNoopLogger(),
+        runtime,
+        offlineResume: {
+            trackOfflineStanza() {},
+            handleOfflinePreview() {},
+            handleOfflineComplete() {},
+            reset() {},
+            isComplete: false,
+            isResuming: false
+        } as never
+    })
+
+    let filterCalls = 0
+    coordinator.registerIncomingStanzaFilter(() => {
+        filterCalls += 1
+        return true
+    })
+
+    await coordinator.handleIncomingNode({ tag: 'success', attrs: {} })
+    await coordinator.handleIncomingNode({ tag: 'failure', attrs: {} })
+
+    assert.equal(filterCalls, 0)
+    assert.equal(emittedSuccess, 1)
+    assert.equal(failureEmitted, 1)
+})
+
 test('incoming node coordinator tracks offline stanzas before dispatching handlers', async () => {
     const { runtime, unhandled } = createIncomingRuntime()
     let trackedStanzas = 0

--- a/src/client/incoming.ts
+++ b/src/client/incoming.ts
@@ -106,10 +106,8 @@ const NOTIFICATION_TYPES_WITHOUT_TYPE_ACK = new Set<string>(['encrypt', 'devices
 const RECEIPT_RETRY_TYPES = new Set<string>(['retry', 'enc_rekey_retry'])
 
 /**
- * Single source of truth for the ack shape of an inbound stanza. Used by every
- * regular handler and by short-circuited paths (e.g. a stanza dropped by a
- * user filter). Returns `null` for tags that are not acked in the normal flow
- * (presence, chatstate, call, iq, error, ...).
+ * Builds the inbound ack for `message`/`receipt`/`notification` tags. Returns
+ * `null` for other tags or when required attrs are missing.
  */
 export function buildInboundAck(node: BinaryNode): BinaryNode | null {
     if (node.tag === WA_MESSAGE_TAGS.MESSAGE) {
@@ -121,6 +119,9 @@ export function buildInboundAck(node: BinaryNode): BinaryNode | null {
         return buildAckNode({ kind: 'message', node, id, to: from })
     }
     if (node.tag === WA_MESSAGE_TAGS.RECEIPT) {
+        if (!node.attrs.id || !node.attrs.from) {
+            return null
+        }
         const receiptType = node.attrs.type
         if (receiptType && RECEIPT_RETRY_TYPES.has(receiptType)) {
             return buildAckNode({ kind: 'receipt', node, retryType: true })

--- a/src/client/incoming.ts
+++ b/src/client/incoming.ts
@@ -15,6 +15,7 @@ import type {
 import type { Logger } from '@infra/log/types'
 import {
     WA_DISCONNECT_REASONS,
+    WA_MESSAGE_TAGS,
     WA_MESSAGE_TYPES,
     WA_NODE_TAGS,
     WA_NOTIFICATION_TYPES
@@ -102,6 +103,47 @@ const OUT_OF_SCOPE_NOTIFICATION_TYPES = new Set<string>(['pay', 'psa', 'waffle',
 
 const NOTIFICATION_TYPES_WITH_PARTICIPANT_ACK = new Set<string>(['mediaretry', 'psa'])
 const NOTIFICATION_TYPES_WITHOUT_TYPE_ACK = new Set<string>(['encrypt', 'devices'])
+const RECEIPT_RETRY_TYPES = new Set<string>(['retry', 'enc_rekey_retry'])
+
+/**
+ * Single source of truth for the ack shape of an inbound stanza. Used by every
+ * regular handler and by short-circuited paths (e.g. a stanza dropped by a
+ * user filter). Returns `null` for tags that are not acked in the normal flow
+ * (presence, chatstate, call, iq, error, ...).
+ */
+export function buildInboundAck(node: BinaryNode): BinaryNode | null {
+    if (node.tag === WA_MESSAGE_TAGS.MESSAGE) {
+        const id = node.attrs.id
+        const from = node.attrs.from
+        if (!id || !from) {
+            return null
+        }
+        return buildAckNode({ kind: 'message', node, id, to: from })
+    }
+    if (node.tag === WA_MESSAGE_TAGS.RECEIPT) {
+        const receiptType = node.attrs.type
+        if (receiptType && RECEIPT_RETRY_TYPES.has(receiptType)) {
+            return buildAckNode({ kind: 'receipt', node, retryType: true })
+        }
+        return buildAckNode({
+            kind: 'receipt',
+            node,
+            includeParticipant: receiptType !== WA_MESSAGE_TYPES.RECEIPT_TYPE_SERVER_ERROR
+        })
+    }
+    if (node.tag === WA_NODE_TAGS.NOTIFICATION) {
+        const type = node.attrs.type ?? ''
+        return buildAckNode({
+            kind: 'notification',
+            node,
+            includeParticipant:
+                type === WA_NOTIFICATION_TYPES.GROUP ||
+                NOTIFICATION_TYPES_WITH_PARTICIPANT_ACK.has(type),
+            includeType: !NOTIFICATION_TYPES_WITHOUT_TYPE_ACK.has(type)
+        })
+    }
+    return null
+}
 
 export function createIncomingBaseEvent(node: BinaryNode): WaIncomingBaseEvent {
     return {
@@ -112,7 +154,7 @@ export function createIncomingBaseEvent(node: BinaryNode): WaIncomingBaseEvent {
     }
 }
 
-async function sendSafeAck(
+export async function sendSafeAck(
     logger: Logger,
     sendNode: (node: BinaryNode) => Promise<void>,
     node: BinaryNode
@@ -203,28 +245,18 @@ export function createIncomingReceiptHandler(
             if (options.handleIncomingRetryReceipt) {
                 await options.handleIncomingRetryReceipt(node)
             } else {
-                await sendSafeAck(
-                    options.logger,
-                    options.sendNode,
-                    buildAckNode({
-                        kind: 'receipt',
-                        node,
-                        retryType: true
-                    })
-                )
+                const ack = buildInboundAck(node)
+                if (ack) {
+                    await sendSafeAck(options.logger, options.sendNode, ack)
+                }
             }
             return true
         }
 
-        await sendSafeAck(
-            options.logger,
-            options.sendNode,
-            buildAckNode({
-                kind: 'receipt',
-                node,
-                includeParticipant: receiptType !== WA_MESSAGE_TYPES.RECEIPT_TYPE_SERVER_ERROR
-            })
-        )
+        const ack = buildInboundAck(node)
+        if (ack) {
+            await sendSafeAck(options.logger, options.sendNode, ack)
+        }
         return true
     }
 }
@@ -261,9 +293,6 @@ export function createIncomingNotificationHandler(
 ): (node: BinaryNode) => Promise<boolean> {
     return async (node: BinaryNode): Promise<boolean> => {
         const notificationType = node.attrs.type ?? ''
-        const includeParticipantInAck =
-            NOTIFICATION_TYPES_WITH_PARTICIPANT_ACK.has(notificationType)
-        const includeTypeInAck = !NOTIFICATION_TYPES_WITHOUT_TYPE_ACK.has(notificationType)
         const classification = classifyNotificationType(notificationType)
         const firstChildTag = getFirstNodeChild(node)?.tag
         const baseEvent = createIncomingBaseEvent(node)
@@ -302,16 +331,10 @@ export function createIncomingNotificationHandler(
             })
         }
 
-        await sendSafeAck(
-            options.logger,
-            options.sendNode,
-            buildAckNode({
-                kind: 'notification',
-                node,
-                includeParticipant: includeParticipantInAck,
-                includeType: includeTypeInAck
-            })
-        )
+        const ack = buildInboundAck(node)
+        if (ack) {
+            await sendSafeAck(options.logger, options.sendNode, ack)
+        }
         if (notificationType === 'server_sync' && serverSyncCollections.length > 0) {
             const collectionsCsv = serverSyncCollections.join(',')
             if (!options.syncAppState) {
@@ -366,14 +389,10 @@ export function createIncomingRegistrationNotificationHandler(
             })
         }
 
-        await sendSafeAck(
-            options.logger,
-            options.sendNode,
-            buildAckNode({
-                kind: 'notification',
-                node
-            })
-        )
+        const ack = buildInboundAck(node)
+        if (ack) {
+            await sendSafeAck(options.logger, options.sendNode, ack)
+        }
         return true
     }
 }
@@ -388,7 +407,6 @@ function createIncomingTypedNotificationHandler<TEvent>(opts: {
     }
     readonly emit: (event: TEvent) => void
     readonly emitUnhandledStanza: (event: WaIncomingUnhandledStanzaEvent) => void
-    readonly includeParticipantInAck?: boolean
 }): (node: BinaryNode) => Promise<boolean> {
     return async (node: BinaryNode): Promise<boolean> => {
         if (node.attrs.type !== opts.type) {
@@ -409,15 +427,10 @@ function createIncomingTypedNotificationHandler<TEvent>(opts: {
                 reason: `notification.${opts.type}.empty`
             })
         }
-        await sendSafeAck(
-            opts.logger,
-            opts.sendNode,
-            buildAckNode({
-                kind: 'notification',
-                node,
-                includeParticipant: opts.includeParticipantInAck
-            })
-        )
+        const ack = buildInboundAck(node)
+        if (ack) {
+            await sendSafeAck(opts.logger, opts.sendNode, ack)
+        }
         return true
     }
 }
@@ -444,8 +457,7 @@ export function createIncomingGroupNotificationHandler(
         type: WA_NOTIFICATION_TYPES.GROUP,
         parse: parseGroupNotificationEvents,
         emit: options.emitGroupEvent,
-        emitUnhandledStanza: options.emitUnhandledStanza,
-        includeParticipantInAck: true
+        emitUnhandledStanza: options.emitUnhandledStanza
     })
 }
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -221,6 +221,16 @@ export interface WaIncomingNodeHandlerRegistration {
     readonly prepend?: boolean
 }
 
+/**
+ * Predicate evaluated against every inbound stanza. Return `true` to drop the
+ * stanza before any handler runs — the coordinator still sends the appropriate
+ * ack for `message`/`receipt`/`notification` so the server stops re-delivering.
+ *
+ * Stream-control nodes and the connection-critical `success`/`failure` tags
+ * bypass filters to keep the auth flow intact.
+ */
+export type WaIncomingStanzaFilter = (node: BinaryNode) => boolean | Promise<boolean>
+
 export interface WaIncomingBaseEvent {
     readonly rawNode: BinaryNode
     readonly stanzaId?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export type {
     WaIncomingNotificationEvent,
     WaIncomingPresenceEvent,
     WaIncomingReceiptEvent,
+    WaIncomingStanzaFilter,
     WaIncomingUnhandledStanzaEvent,
     WaWriteBehindOptions
 } from '@client/types'


### PR DESCRIPTION
The filter receives the raw BinaryNode and returns true to drop. The coordinator sends the appropriate ack (message/receipt/notification) via a new buildInboundAck helper so the server stops re-delivering, then skips dispatch entirely so no events propagate. Stream-control tags (success/failure) bypass filters to keep auth intact.

The existing handlers in incoming.ts now share buildInboundAck instead of building acks inline, same source of truth for the regular flow and the filter short-circuit.

Also adds an eval tool to @zapo-js/mcp-server so callers can register filters (and other features that require passing a JS function) at runtime, since call only carries JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a code execution tool that runs JavaScript with access to the client and library context, supporting both standard and fire-and-forget modes.
  * Added the ability to register custom filters for incoming stanzas, allowing interception and selective blocking of inbound messages before handlers process them.

* **Tests**
  * Comprehensive test coverage for the code execution tool and stanza filtering functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->