### PR TITLE
feat(client): add placeholder message resend PDO fallback for decrypt failures

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -738,6 +738,15 @@ export function buildWaClientDependencies(input: {
         mobileMessageIdFormat: options.mobileTransport !== undefined
     })
 
+    const peerDataOperation = createPeerDataOperationRequester({
+        logger,
+        publishProtocolMessageToDevice: (deviceJid, protocolMessage, opts) =>
+            messageDispatch.publishProtocolMessageToDevice(deviceJid, protocolMessage, opts),
+        getCurrentMeJid,
+        generateOutgoingMessageId: () => messageDispatch.generateOutgoingMessageId(),
+        subscribeToProtocolMessage: runtime.subscribeProtocolMessage
+    })
+
     const retryCoordinator = new WaRetryCoordinator({
         logger,
         retryStore: sessionStore.retry,
@@ -752,7 +761,13 @@ export function buildWaClientDependencies(input: {
         sendNode: runtime.sendNode,
         getCurrentMeJid,
         getCurrentMeLid,
-        getCurrentSignedIdentity
+        getCurrentSignedIdentity,
+        peerDataOperation,
+        emitIncomingMessage: (event) => {
+            void runtime
+                .handleIncomingMessageEvent(event)
+                .catch((err) => runtime.handleError(toError(err)))
+        }
     })
 
     const botCoordinator = createBotCoordinator({
@@ -1208,15 +1223,6 @@ export function buildWaClientDependencies(input: {
             abPropsCoordinator.sync()
             return true
         }
-    })
-
-    const peerDataOperation = createPeerDataOperationRequester({
-        logger,
-        publishProtocolMessageToDevice: (deviceJid, protocolMessage, opts) =>
-            messageDispatch.publishProtocolMessageToDevice(deviceJid, protocolMessage, opts),
-        getCurrentMeJid,
-        generateOutgoingMessageId: () => messageDispatch.generateOutgoingMessageId(),
-        subscribeToProtocolMessage: runtime.subscribeProtocolMessage
     })
 
     passiveTasks = new WaPassiveTasksCoordinator({

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -1,4 +1,7 @@
+import type { WaIncomingMessageEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
+import { buildRecoveredIncomingEvent } from '@message/incoming'
+import type { PeerDataOperationRequester } from '@message/peer-data-operation'
 import type { WaMessageClient } from '@message/WaMessageClient'
 import { proto, type Proto } from '@proto'
 import { WA_MESSAGE_TAGS, WA_MESSAGE_TYPES } from '@protocol/constants'
@@ -6,7 +9,7 @@ import {
     isGroupOrBroadcastJid,
     normalizeDeviceJid,
     parseJidFull,
-    type parseSignalAddressFromJid,
+    parseSignalAddressFromJid,
     toUserJid
 } from '@protocol/jid'
 import {
@@ -57,6 +60,8 @@ interface WaRetryCoordinatorOptions {
     readonly getCurrentMeJid: () => string | null | undefined
     readonly getCurrentMeLid: () => string | null | undefined
     readonly getCurrentSignedIdentity: () => Proto.IADVSignedDeviceIdentity | null | undefined
+    readonly peerDataOperation?: PeerDataOperationRequester
+    readonly emitIncomingMessage?: (event: WaIncomingMessageEvent) => void
 }
 
 type RetryAuthorization =
@@ -69,6 +74,7 @@ interface RetryDecryptFailurePreparation {
     readonly retryKeys?: WaRetryKeyBundle
     readonly retryReason: number | undefined
     readonly timestamp: string
+    readonly delegatedToPlaceholderResend: boolean
 }
 
 interface RetryResendPreparation {
@@ -80,6 +86,24 @@ interface RetryResendPreparation {
 
 const RETRY_CLEANUP_INTERVAL_MS = 30_000
 const RETRY_SESSION_BASE_KEY_CACHE_MAX_ENTRIES = 8_192
+
+const PLACEHOLDER_RESEND_RETRY_THRESHOLD = 3
+const PLACEHOLDER_RESEND_BATCH_SIZE = 32
+const PLACEHOLDER_RESEND_DEBOUNCE_MS = 200
+const PLACEHOLDER_RESEND_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
+const PLACEHOLDER_RESEND_IN_FLIGHT_MAX = 256
+const PLACEHOLDER_RESEND_SKIP_SUBTYPES = new Set<string>([
+    'bot_unavailable_fanout',
+    'hosted_unavailable_fanout',
+    'view_once_unavailable_fanout'
+])
+
+interface PlaceholderResendQueueItem {
+    readonly remoteJid: string
+    readonly id: string
+    readonly fromMe: boolean
+    readonly participant?: string
+}
 
 interface RetrySessionBaseKeySnapshot {
     readonly baseKey: Uint8Array
@@ -130,6 +154,11 @@ export class WaRetryCoordinator {
     private readonly retryProcessingByMessageId: Map<string, Promise<void>>
     private readonly retrySessionBaseKeys: Map<string, RetrySessionBaseKeySnapshot>
     private nextRetryCleanupAtMs = 0
+    private readonly peerDataOperation: PeerDataOperationRequester | null
+    private readonly emitIncomingMessage: ((event: WaIncomingMessageEvent) => void) | null
+    private readonly placeholderInFlight: Set<string> = new Set()
+    private placeholderQueue: PlaceholderResendQueueItem[] = []
+    private placeholderTimer: ReturnType<typeof setTimeout> | null = null
 
     public constructor(options: WaRetryCoordinatorOptions) {
         this.logger = options.logger
@@ -156,6 +185,8 @@ export class WaRetryCoordinator {
         })
         this.retryProcessingByMessageId = new Map()
         this.retrySessionBaseKeys = new Map()
+        this.peerDataOperation = options.peerDataOperation ?? null
+        this.emitIncomingMessage = options.emitIncomingMessage ?? null
     }
 
     public async onDecryptFailure(
@@ -166,6 +197,9 @@ export class WaRetryCoordinator {
             const prepared = await this.prepareDecryptFailureRetry(context, error)
             if (!prepared) {
                 return false
+            }
+            if (prepared.delegatedToPlaceholderResend) {
+                return true
             }
             await this.sendDecryptFailureRetryReceipt(context, prepared)
             return true
@@ -250,6 +284,18 @@ export class WaRetryCoordinator {
             nowMs,
             expiresAtMs
         )
+        const delegatedToPlaceholderResend =
+            retryCount >= PLACEHOLDER_RESEND_RETRY_THRESHOLD &&
+            this.enqueuePlaceholderResend(context)
+        if (delegatedToPlaceholderResend) {
+            return {
+                registrationId: registrationInfo.registrationId,
+                retryCount,
+                retryReason: mapRetryReasonFromError(error),
+                timestamp: context.t ?? String(Math.trunc(nowMs / 1000)),
+                delegatedToPlaceholderResend: true
+            }
+        }
         return {
             registrationId: registrationInfo.registrationId,
             retryCount,
@@ -260,7 +306,8 @@ export class WaRetryCoordinator {
                       )) ?? undefined)
                     : undefined,
             retryReason: mapRetryReasonFromError(error),
-            timestamp: context.t ?? String(Math.trunc(nowMs / 1000))
+            timestamp: context.t ?? String(Math.trunc(nowMs / 1000)),
+            delegatedToPlaceholderResend: false
         }
     }
 
@@ -980,6 +1027,106 @@ export class WaRetryCoordinator {
                 continue
             }
             this.retrySessionBaseKeys.delete(key)
+        }
+    }
+
+    private isSenderFromOwnAccount(context: WaRetryDecryptFailureContext): boolean {
+        const senderUser = parseSignalAddressFromJid(context.participant ?? context.from).user
+        const meLid = this.getCurrentMeLid()
+        if (meLid && parseSignalAddressFromJid(meLid).user === senderUser) return true
+        const meJid = this.getCurrentMeJid()
+        return !!meJid && parseSignalAddressFromJid(meJid).user === senderUser
+    }
+
+    private enqueuePlaceholderResend(context: WaRetryDecryptFailureContext): boolean {
+        if (!this.peerDataOperation || !this.emitIncomingMessage) {
+            return false
+        }
+        const subtype = context.messageNode.attrs.subtype
+        if (typeof subtype === 'string' && PLACEHOLDER_RESEND_SKIP_SUBTYPES.has(subtype)) {
+            return false
+        }
+        const timestampSeconds = context.t ? Number(context.t) : Date.now() / 1000
+        if (Number.isFinite(timestampSeconds)) {
+            const ageSeconds = Date.now() / 1000 - timestampSeconds
+            if (ageSeconds > PLACEHOLDER_RESEND_MAX_AGE_SECONDS) {
+                return false
+            }
+        }
+        if (this.placeholderInFlight.has(context.stanzaId)) {
+            return true
+        }
+        if (this.placeholderInFlight.size >= PLACEHOLDER_RESEND_IN_FLIGHT_MAX) {
+            this.logger.warn('placeholder resend: in-flight set saturated, dropping enqueue', {
+                id: context.stanzaId,
+                maxInFlight: PLACEHOLDER_RESEND_IN_FLIGHT_MAX
+            })
+            return false
+        }
+        this.placeholderInFlight.add(context.stanzaId)
+        this.placeholderQueue.push({
+            remoteJid: context.from,
+            id: context.stanzaId,
+            fromMe: this.isSenderFromOwnAccount(context),
+            participant: context.participant
+        })
+        if (this.placeholderTimer === null) {
+            this.placeholderTimer = setTimeout(() => {
+                this.placeholderTimer = null
+                void this.flushPlaceholderBatch()
+            }, PLACEHOLDER_RESEND_DEBOUNCE_MS)
+        }
+        return true
+    }
+
+    private async flushPlaceholderBatch(): Promise<void> {
+        const peerDataOperation = this.peerDataOperation
+        const emitIncomingMessage = this.emitIncomingMessage
+        if (!peerDataOperation || !emitIncomingMessage) {
+            this.placeholderQueue = []
+            this.placeholderInFlight.clear()
+            return
+        }
+        while (this.placeholderQueue.length > 0) {
+            const batch = this.placeholderQueue.splice(0, PLACEHOLDER_RESEND_BATCH_SIZE)
+            try {
+                const results = await peerDataOperation.request(
+                    proto.Message.PeerDataOperationRequestType.PLACEHOLDER_MESSAGE_RESEND,
+                    {
+                        placeholderMessageResendRequest: batch.map((item) => ({
+                            messageKey: {
+                                remoteJid: item.remoteJid,
+                                id: item.id,
+                                fromMe: item.fromMe,
+                                participant: item.participant
+                            }
+                        }))
+                    }
+                )
+                for (const result of results) {
+                    const bytes = result.placeholderMessageResendResponse?.webMessageInfoBytes
+                    if (!bytes) {
+                        continue
+                    }
+                    try {
+                        const recovered = proto.WebMessageInfo.decode(bytes)
+                        emitIncomingMessage(buildRecoveredIncomingEvent(recovered))
+                    } catch (error) {
+                        this.logger.warn('placeholder resend: failed to decode WebMessageInfo', {
+                            message: toError(error).message
+                        })
+                    }
+                }
+            } catch (error) {
+                this.logger.warn('placeholder resend: request failed', {
+                    batchSize: batch.length,
+                    message: toError(error).message
+                })
+            } finally {
+                for (const item of batch) {
+                    this.placeholderInFlight.delete(item.id)
+                }
+            }
         }
     }
 }

--- a/src/client/coordinators/__tests__/retry-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/retry-coordinator.test.ts
@@ -2,8 +2,15 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import { WaRetryCoordinator } from '@client/coordinators/WaRetryCoordinator'
+import type { WaIncomingMessageEvent } from '@client/types'
 import { createNoopLogger } from '@infra/log/types'
-import type { WaRetryOutboundMessageRecord, WaRetryOutboundState } from '@retry/types'
+import type { PeerDataOperationRequester } from '@message/peer-data-operation'
+import { proto, type Proto } from '@proto'
+import type {
+    WaRetryDecryptFailureContext,
+    WaRetryOutboundMessageRecord,
+    WaRetryOutboundState
+} from '@retry/types'
 import type { WaRetryStore } from '@store/contracts/retry.store'
 import type { BinaryNode } from '@transport/types'
 
@@ -143,6 +150,219 @@ function buildReceiptNode(messageId: string, type: string): BinaryNode {
         content: []
     }
 }
+
+interface PlaceholderHarness {
+    readonly coordinator: WaRetryCoordinator
+    readonly captured: Array<readonly Proto.Message.IPeerDataOperationRequestMessage[]>
+    readonly emitted: WaIncomingMessageEvent[]
+    readonly resolveNext: (
+        results: readonly Proto.Message.PeerDataOperationRequestResponseMessage.IPeerDataOperationResult[]
+    ) => void
+    readonly enqueue: (context: WaRetryDecryptFailureContext) => void
+    readonly flush: () => Promise<void>
+}
+
+function buildPlaceholderContext(
+    overrides: Partial<WaRetryDecryptFailureContext> = {}
+): WaRetryDecryptFailureContext {
+    return {
+        messageNode: { tag: 'message', attrs: {} },
+        stanzaId: overrides.stanzaId ?? 'msg-x',
+        from: overrides.from ?? '551100000000@s.whatsapp.net',
+        participant: overrides.participant,
+        recipient: overrides.recipient,
+        t: overrides.t,
+        ...overrides
+    } as WaRetryDecryptFailureContext
+}
+
+function createPlaceholderHarness(): PlaceholderHarness {
+    const captured: PlaceholderHarness['captured'] = []
+    const emitted: WaIncomingMessageEvent[] = []
+    const pendingResolvers: Array<
+        (
+            results: readonly Proto.Message.PeerDataOperationRequestResponseMessage.IPeerDataOperationResult[]
+        ) => void
+    > = []
+    const peerDataOperation: PeerDataOperationRequester = {
+        request: async (_type, body) => {
+            captured.push((body.placeholderMessageResendRequest ?? []) as never)
+            return new Promise((resolve) => {
+                pendingResolvers.push(resolve)
+            })
+        },
+        send: async () => ({ messageId: 'unused' })
+    }
+    const coordinator = new WaRetryCoordinator({
+        logger: createNoopLogger(),
+        retryStore: {} as never,
+        signalStore: {} as never,
+        preKeyStore: {} as never,
+        sessionStore: {} as never,
+        senderKeyStore: {} as never,
+        signalProtocol: {} as never,
+        signalDeviceSync: {} as never,
+        signalMissingPreKeysSync: {} as never,
+        messageClient: {} as never,
+        sendNode: async () => undefined,
+        getCurrentMeJid: () => null,
+        getCurrentMeLid: () => null,
+        getCurrentSignedIdentity: () => null,
+        peerDataOperation,
+        emitIncomingMessage: (event) => emitted.push(event)
+    })
+    const internals = coordinator as unknown as {
+        enqueuePlaceholderResend: (context: WaRetryDecryptFailureContext) => boolean
+        flushPlaceholderBatch: () => Promise<void>
+    }
+    return {
+        coordinator,
+        captured,
+        emitted,
+        resolveNext: (results) => {
+            const resolver = pendingResolvers.shift()
+            if (!resolver) {
+                throw new Error('no pending placeholder resend request to resolve')
+            }
+            resolver(results)
+        },
+        enqueue: (context) => internals.enqueuePlaceholderResend(context),
+        flush: () => internals.flushPlaceholderBatch()
+    }
+}
+
+function makeWebMessageInfoBytes(id: string, remoteJid: string): Uint8Array {
+    return proto.WebMessageInfo.encode({
+        key: { id, remoteJid, fromMe: false },
+        messageTimestamp: 1_700_000_000,
+        message: { conversation: 'recovered' }
+    }).finish()
+}
+
+async function flushMicrotasks(): Promise<void> {
+    await new Promise<void>((resolve) => setImmediate(resolve))
+}
+
+test('placeholder resend: dedups by stanzaId in flight', async () => {
+    const harness = createPlaceholderHarness()
+    harness.enqueue(buildPlaceholderContext({ stanzaId: 'dup' }))
+    harness.enqueue(buildPlaceholderContext({ stanzaId: 'dup' }))
+    harness.enqueue(buildPlaceholderContext({ stanzaId: 'other' }))
+    const flushPromise = harness.flush()
+    harness.resolveNext([])
+    await flushPromise
+    assert.equal(harness.captured.length, 1)
+    assert.equal(harness.captured[0].length, 2)
+})
+
+test('placeholder resend: skips unavailable fanout subtypes', async () => {
+    const harness = createPlaceholderHarness()
+    harness.enqueue(
+        buildPlaceholderContext({
+            stanzaId: 'bot-msg',
+            messageNode: {
+                tag: 'message',
+                attrs: { subtype: 'bot_unavailable_fanout' }
+            }
+        })
+    )
+    harness.enqueue(
+        buildPlaceholderContext({
+            stanzaId: 'view-once-msg',
+            messageNode: {
+                tag: 'message',
+                attrs: { subtype: 'view_once_unavailable_fanout' }
+            }
+        })
+    )
+    harness.enqueue(buildPlaceholderContext({ stanzaId: 'normal' }))
+    const flushPromise = harness.flush()
+    harness.resolveNext([])
+    await flushPromise
+    assert.equal(harness.captured.length, 1)
+    assert.equal(harness.captured[0].length, 1)
+    assert.equal(
+        (harness.captured[0][0] as { messageKey?: { id?: string } }).messageKey?.id,
+        'normal'
+    )
+})
+
+test('placeholder resend: drops items older than the max age window', async () => {
+    const harness = createPlaceholderHarness()
+    const oldEnoughSeconds = Math.trunc(Date.now() / 1000) - 31 * 24 * 60 * 60
+    harness.enqueue(
+        buildPlaceholderContext({
+            stanzaId: 'too-old',
+            t: String(oldEnoughSeconds)
+        })
+    )
+    harness.enqueue(buildPlaceholderContext({ stanzaId: 'fresh' }))
+    const flushPromise = harness.flush()
+    harness.resolveNext([])
+    await flushPromise
+    assert.equal(harness.captured.length, 1)
+    assert.equal(harness.captured[0].length, 1)
+})
+
+test('placeholder resend: splits queue into batches of 32', async () => {
+    const harness = createPlaceholderHarness()
+    for (let i = 0; i < 33; i += 1) {
+        harness.enqueue(buildPlaceholderContext({ stanzaId: `msg-${i}` }))
+    }
+    const flushPromise = harness.flush()
+    harness.resolveNext([])
+    await flushMicrotasks()
+    harness.resolveNext([])
+    await flushPromise
+    assert.equal(harness.captured.length, 2)
+    assert.equal(harness.captured[0].length, 32)
+    assert.equal(harness.captured[1].length, 1)
+})
+
+test('placeholder resend: decodes WebMessageInfo and re-emits as incoming message', async () => {
+    const harness = createPlaceholderHarness()
+    harness.enqueue(buildPlaceholderContext({ stanzaId: 'recover-1' }))
+    const flushPromise = harness.flush()
+    harness.resolveNext([
+        {
+            placeholderMessageResendResponse: {
+                webMessageInfoBytes: makeWebMessageInfoBytes(
+                    'recover-1',
+                    '551122223333@s.whatsapp.net'
+                )
+            }
+        }
+    ])
+    await flushPromise
+    assert.equal(harness.emitted.length, 1)
+    const event = harness.emitted[0]
+    assert.equal(event.stanzaId, 'recover-1')
+    assert.equal(event.chatJid, '551122223333@s.whatsapp.net')
+    assert.equal(event.encryptionType, 'placeholder_recovery')
+    assert.equal(event.message?.conversation, 'recovered')
+})
+
+test('placeholder resend: tolerates results without webMessageInfoBytes', async () => {
+    const harness = createPlaceholderHarness()
+    harness.enqueue(buildPlaceholderContext({ stanzaId: 'no-payload' }))
+    const flushPromise = harness.flush()
+    harness.resolveNext([{ placeholderMessageResendResponse: {} }, {}])
+    await flushPromise
+    assert.equal(harness.emitted.length, 0)
+})
+
+test('placeholder resend: releases in-flight slots after each batch completes', async () => {
+    const harness = createPlaceholderHarness()
+    harness.enqueue(buildPlaceholderContext({ stanzaId: 'msg-a' }))
+    const firstFlush = harness.flush()
+    harness.resolveNext([])
+    await firstFlush
+    harness.enqueue(buildPlaceholderContext({ stanzaId: 'msg-a' }))
+    const secondFlush = harness.flush()
+    harness.resolveNext([])
+    await secondFlush
+    assert.equal(harness.captured.length, 2)
+})
 
 test('retry coordinator serializes outbound receipt tracking per message id', async () => {
     const nowMs = Date.now()

--- a/src/message/incoming.ts
+++ b/src/message/incoming.ts
@@ -22,7 +22,7 @@ import type { SignalAddress } from '@signal/types'
 import { buildAckNode, buildReceiptNode } from '@transport/node/builders/global'
 import { decodeNodeContentBase64OrBytes, findNodeChild } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
-import { parseOptionalInt, toError } from '@util/primitives'
+import { longToNumber, parseOptionalInt, toError } from '@util/primitives'
 
 interface WaIncomingMessageAckHandlerOptions {
     readonly logger: Logger
@@ -82,6 +82,43 @@ function buildIncomingEventRawNode(node: BinaryNode): BinaryNode {
         tag: node.tag,
         attrs: node.attrs,
         content: children
+    }
+}
+
+export function buildRecoveredIncomingEvent(
+    webMessageInfo: proto.IWebMessageInfo
+): WaIncomingMessageEvent {
+    const key = webMessageInfo.key ?? {}
+    const chatJid = key.remoteJid ?? undefined
+    const fromMe = key.fromMe === true
+    const participant = key.participant ?? undefined
+    const isGroup = chatJid ? isGroupJid(chatJid) : false
+    const isBroadcast = chatJid ? isBroadcastJid(chatJid) : false
+    const senderJid = fromMe ? undefined : isGroup || isBroadcast ? participant : chatJid
+    const timestampSeconds =
+        webMessageInfo.messageTimestamp !== null && webMessageInfo.messageTimestamp !== undefined
+            ? longToNumber(webMessageInfo.messageTimestamp)
+            : undefined
+    const stanzaId = key.id ?? undefined
+    const rawNode: BinaryNode = {
+        tag: WA_MESSAGE_TAGS.MESSAGE,
+        attrs: {
+            ...(stanzaId !== undefined ? { id: stanzaId } : {}),
+            ...(chatJid !== undefined ? { from: chatJid } : {}),
+            ...(participant !== undefined ? { participant } : {})
+        }
+    }
+    return {
+        rawNode,
+        stanzaId,
+        chatJid,
+        timestampSeconds,
+        senderJid,
+        encryptionType: 'placeholder_recovery',
+        isGroupChat: isGroup,
+        isBroadcastChat: isBroadcast,
+        isSender: fromMe,
+        message: webMessageInfo.message ?? undefined
     }
 }
 


### PR DESCRIPTION
After RETRY_THRESHOLD failed decrypt attempts on the same stanzaId, the retry coordinator delegates recovery to the placeholder_message_resend PDO instead of sending another retry receipt. The primary device answers with the original WebMessageInfo bytes, which are decoded and re-emitted through the normal incoming-message pipeline tagged as encryptionType: 'placeholder_recovery'.

- batch up to 32 stanzaIds per PDO with a 200ms debounce
- skip {bot,hosted,view_once}_unavailable_fanout subtypes and msgs older than 30 days (parity with wa-web)
- dedup via bounded in-flight set (cap 256)
- compute msgKey.fromMe by matching sender user against meJid/meLid so primary can locate the msg in its own store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced message recovery when decryption failures occur, with improved fallback mechanisms for better message delivery reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->