### PR TITLE
feat(build): add dual ESM/CJS support to optional packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "build:cjs": "tsc -p tsconfig.build.cjs.json && tsc-alias -p tsconfig.build.cjs.json",
         "build:esm": "tsc -p tsconfig.build.esm.json && tsc-alias -p tsconfig.build.esm.json",
         "build:types": "tsc -p tsconfig.build.types.json && tsc-alias -p tsconfig.build.types.json",
-        "build:esm:finalize": "node ./scripts/finalize-esm-build.cjs",
+        "build:esm:finalize": "node ./scripts/finalize-esm-build.cjs --proto-bridge",
         "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:types && npm run build:esm:finalize",
         "build:packages": "turbo run build",
         "proto:generate": "node ./scripts/generate-proto.cjs",

--- a/packages/fake-server/package.json
+++ b/packages/fake-server/package.json
@@ -3,6 +3,7 @@
     "version": "0.3.0",
     "description": "Fake WhatsApp Web server used to test zapo-js",
     "main": "dist/index.js",
+    "module": "dist/esm/index.js",
     "types": "dist/index.d.ts",
     "bin": {
         "fake-wa-server": "./dist/cli.js"
@@ -11,6 +12,7 @@
         ".": {
             "types": "./dist/index.d.ts",
             "require": "./dist/index.js",
+            "import": "./dist/esm/index.js",
             "default": "./dist/index.js"
         }
     },
@@ -21,7 +23,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsc -p tsconfig.build.cjs.json",
+        "build": "tsc -p tsconfig.build.cjs.json && tsc -p tsconfig.build.esm.json && node ../../scripts/finalize-esm-build.cjs",
         "typecheck": "tsc --noEmit",
         "test": "node --import tsx --test --test-concurrency=1 \"src/**/__tests__/**/*.test.ts\"",
         "cli": "node --import tsx src/cli.ts",

--- a/packages/fake-server/tsconfig.build.esm.json
+++ b/packages/fake-server/tsconfig.build.esm.json
@@ -1,0 +1,16 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.build.paths.json"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist/esm",
+        "module": "ES2020",
+        "moduleResolution": "Node",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": true
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.0",
     "description": "MCP server exposing zapo-js WaClient as dynamic tools for end-to-end testing",
     "main": "dist/index.js",
+    "module": "dist/esm/index.js",
     "types": "dist/index.d.ts",
     "bin": {
         "zapo-mcp-server": "./dist/bin.js"
@@ -11,6 +12,7 @@
         ".": {
             "types": "./dist/index.d.ts",
             "require": "./dist/index.js",
+            "import": "./dist/esm/index.js",
             "default": "./dist/index.js"
         }
     },
@@ -21,7 +23,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsc -p tsconfig.build.cjs.json",
+        "build": "tsc -p tsconfig.build.cjs.json && tsc -p tsconfig.build.esm.json && node ../../scripts/finalize-esm-build.cjs",
         "typecheck": "tsc --noEmit",
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\"",
         "start": "node --import tsx src/bin.ts",

--- a/packages/mcp-server/tsconfig.build.esm.json
+++ b/packages/mcp-server/tsconfig.build.esm.json
@@ -1,0 +1,16 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.build.paths.json"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist/esm",
+        "module": "ES2020",
+        "moduleResolution": "Node",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": true
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -3,11 +3,13 @@
     "version": "0.1.0",
     "description": "Media processing utilities for zapo-js (thumbnails, waveforms, probing)",
     "main": "dist/index.js",
+    "module": "dist/esm/index.js",
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
             "require": "./dist/index.js",
+            "import": "./dist/esm/index.js",
             "default": "./dist/index.js"
         }
     },
@@ -18,7 +20,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsc -p tsconfig.build.cjs.json",
+        "build": "tsc -p tsconfig.build.cjs.json && tsc -p tsconfig.build.esm.json && node ../../scripts/finalize-esm-build.cjs",
         "typecheck": "tsc --noEmit",
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
     },

--- a/packages/media-utils/tsconfig.build.esm.json
+++ b/packages/media-utils/tsconfig.build.esm.json
@@ -1,0 +1,16 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.build.paths.json"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist/esm",
+        "module": "ES2020",
+        "moduleResolution": "Node",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": true
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/store-mongo/package.json
+++ b/packages/store-mongo/package.json
@@ -3,11 +3,13 @@
     "version": "0.3.0",
     "description": "MongoDB store provider for zapo-js",
     "main": "dist/index.js",
+    "module": "dist/esm/index.js",
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
             "require": "./dist/index.js",
+            "import": "./dist/esm/index.js",
             "default": "./dist/index.js"
         }
     },
@@ -18,7 +20,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsc -p tsconfig.build.cjs.json",
+        "build": "tsc -p tsconfig.build.cjs.json && tsc -p tsconfig.build.esm.json && node ../../scripts/finalize-esm-build.cjs",
         "typecheck": "tsc --noEmit",
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
     },

--- a/packages/store-mongo/tsconfig.build.esm.json
+++ b/packages/store-mongo/tsconfig.build.esm.json
@@ -1,0 +1,16 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.build.paths.json"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist/esm",
+        "module": "ES2020",
+        "moduleResolution": "Node",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": true
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/store-mysql/package.json
+++ b/packages/store-mysql/package.json
@@ -3,11 +3,13 @@
     "version": "0.3.0",
     "description": "MySQL/MariaDB store provider for zapo-js",
     "main": "dist/index.js",
+    "module": "dist/esm/index.js",
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
             "require": "./dist/index.js",
+            "import": "./dist/esm/index.js",
             "default": "./dist/index.js"
         }
     },
@@ -18,7 +20,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsc -p tsconfig.build.cjs.json",
+        "build": "tsc -p tsconfig.build.cjs.json && tsc -p tsconfig.build.esm.json && node ../../scripts/finalize-esm-build.cjs",
         "typecheck": "tsc --noEmit",
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
     },

--- a/packages/store-mysql/tsconfig.build.esm.json
+++ b/packages/store-mysql/tsconfig.build.esm.json
@@ -1,0 +1,16 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.build.paths.json"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist/esm",
+        "module": "ES2020",
+        "moduleResolution": "Node",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": true
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/store-postgres/package.json
+++ b/packages/store-postgres/package.json
@@ -3,11 +3,13 @@
     "version": "0.3.0",
     "description": "PostgreSQL store provider for zapo-js",
     "main": "dist/index.js",
+    "module": "dist/esm/index.js",
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
             "require": "./dist/index.js",
+            "import": "./dist/esm/index.js",
             "default": "./dist/index.js"
         }
     },
@@ -18,7 +20,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsc -p tsconfig.build.cjs.json",
+        "build": "tsc -p tsconfig.build.cjs.json && tsc -p tsconfig.build.esm.json && node ../../scripts/finalize-esm-build.cjs",
         "typecheck": "tsc --noEmit",
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
     },

--- a/packages/store-postgres/tsconfig.build.esm.json
+++ b/packages/store-postgres/tsconfig.build.esm.json
@@ -1,0 +1,16 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.build.paths.json"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist/esm",
+        "module": "ES2020",
+        "moduleResolution": "Node",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": true
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/store-redis/package.json
+++ b/packages/store-redis/package.json
@@ -3,11 +3,13 @@
     "version": "0.3.0",
     "description": "Redis store provider for zapo-js",
     "main": "dist/index.js",
+    "module": "dist/esm/index.js",
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
             "require": "./dist/index.js",
+            "import": "./dist/esm/index.js",
             "default": "./dist/index.js"
         }
     },
@@ -18,7 +20,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsc -p tsconfig.build.cjs.json",
+        "build": "tsc -p tsconfig.build.cjs.json && tsc -p tsconfig.build.esm.json && node ../../scripts/finalize-esm-build.cjs",
         "typecheck": "tsc --noEmit",
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
     },

--- a/packages/store-redis/tsconfig.build.esm.json
+++ b/packages/store-redis/tsconfig.build.esm.json
@@ -1,0 +1,16 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.build.paths.json"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist/esm",
+        "module": "ES2020",
+        "moduleResolution": "Node",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": true
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/store-sqlite/package.json
+++ b/packages/store-sqlite/package.json
@@ -3,11 +3,13 @@
     "version": "0.3.0",
     "description": "SQLite store provider for zapo-js",
     "main": "dist/index.js",
+    "module": "dist/esm/index.js",
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
             "require": "./dist/index.js",
+            "import": "./dist/esm/index.js",
             "default": "./dist/index.js"
         }
     },
@@ -18,7 +20,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsc -p tsconfig.build.cjs.json",
+        "build": "tsc -p tsconfig.build.cjs.json && tsc -p tsconfig.build.esm.json && node ../../scripts/finalize-esm-build.cjs",
         "typecheck": "tsc --noEmit",
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
     },

--- a/packages/store-sqlite/tsconfig.build.esm.json
+++ b/packages/store-sqlite/tsconfig.build.esm.json
@@ -1,0 +1,16 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.build.paths.json"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist/esm",
+        "module": "ES2020",
+        "moduleResolution": "Node",
+        "noEmit": false,
+        "types": ["node"],
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": true
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/scripts/finalize-esm-build.cjs
+++ b/scripts/finalize-esm-build.cjs
@@ -8,17 +8,25 @@ const {
 } = require('node:fs')
 const path = require('node:path')
 
-const projectRoot = process.cwd()
+const args = process.argv.slice(2)
+const rootArgIndex = args.indexOf('--root')
+const protoBridge = args.includes('--proto-bridge')
+const projectRoot =
+    rootArgIndex >= 0 && args[rootArgIndex + 1]
+        ? path.resolve(args[rootArgIndex + 1])
+        : process.cwd()
 const esmDir = path.join(projectRoot, 'dist', 'esm')
 const esmScopePath = path.join(esmDir, 'package.json')
-const esmProtoPath = path.join(esmDir, 'proto.js')
 
 mkdirSync(esmDir, { recursive: true })
 
 writeFileSync(esmScopePath, `${JSON.stringify({ type: 'module' }, null, 4)}\n`, 'utf8')
 
-if (!existsSync(esmProtoPath)) {
-    throw new Error(`missing ESM proto bridge at ${esmProtoPath}`)
+if (protoBridge) {
+    const esmProtoPath = path.join(esmDir, 'proto.js')
+    if (!existsSync(esmProtoPath)) {
+        throw new Error(`missing ESM proto bridge at ${esmProtoPath}`)
+    }
 }
 
 for (const filePath of listJsFiles(esmDir)) {
@@ -30,16 +38,19 @@ for (const filePath of listJsFiles(esmDir)) {
     }
 }
 
-writeFileSync(
-    esmProtoPath,
-    [
-        "import protoModule from '../proto.js'",
-        '',
-        'export const proto = protoModule.proto',
-        ''
-    ].join('\n'),
-    'utf8'
-)
+if (protoBridge) {
+    const esmProtoPath = path.join(esmDir, 'proto.js')
+    writeFileSync(
+        esmProtoPath,
+        [
+            "import protoModule from '../proto.js'",
+            '',
+            'export const proto = protoModule.proto',
+            ''
+        ].join('\n'),
+        'utf8'
+    )
+}
 
 function listJsFiles(dirPath) {
     const files = []


### PR DESCRIPTION
All @zapo-js/* packages now ship both CommonJS (dist/) and ESM (dist/esm/) outputs, matching the core build pipeline. Each package gains a tsconfig.build.esm.json and a chained build script that runs both compilers followed by scripts/finalize-esm-build.cjs.

The finalize script is now reusable across packages: it accepts --root <path> (defaults to cwd) and gates the proto bridge step behind --proto-bridge (core only).