### PR TITLE
ci: add conventional commit pr title validator

### DIFF
--- a/.github/workflows/pr-validate-title.yml
+++ b/.github/workflows/pr-validate-title.yml
@@ -1,0 +1,33 @@
+name: pr-validate-title
+
+on:
+    pull_request_target:
+        types: [opened, edited, reopened]
+
+permissions:
+    pull-requests: write
+    issues: write
+
+jobs:
+    title:
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+
+        steps:
+            - uses: amannn/action-semantic-pull-request@v5
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  types: |
+                      feat
+                      fix
+                      perf
+                      refactor
+                      docs
+                      test
+                      chore
+                      build
+                      ci
+                      style
+                      deps
+                      revert


### PR DESCRIPTION
uses amannn/action-semantic-pull-request to enforce conventional commit format on pr titles. allow-list matches pr-auto-label workflow. posts comment to author when title doesn't match and removes it when fixed.