### PR TITLE
ci: post sticky comment on pr title validation failure

### DIFF
--- a/.github/workflows/pr-validate-title.yml
+++ b/.github/workflows/pr-validate-title.yml
@@ -15,6 +15,7 @@ jobs:
 
         steps:
             - uses: amannn/action-semantic-pull-request@v5
+              id: lint
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
@@ -31,3 +32,25 @@ jobs:
                       style
                       deps
                       revert
+
+            - if: always() && steps.lint.outputs.error_message != null
+              uses: marocchino/sticky-pull-request-comment@v2
+              with:
+                  header: pr-title-lint-error
+                  message: |
+                      ❌ **PR title must follow [Conventional Commits](https://www.conventionalcommits.org/)**
+
+                      Allowed types: `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `chore`, `build`, `ci`, `style`, `deps`, `revert`
+
+                      Format: `type(scope): description` or `type!: description` for breaking changes
+
+                      **Error:**
+                      ```
+                      ${{ steps.lint.outputs.error_message }}
+                      ```
+
+            - if: steps.lint.outputs.error_message == null
+              uses: marocchino/sticky-pull-request-comment@v2
+              with:
+                  header: pr-title-lint-error
+                  delete: true


### PR DESCRIPTION
uses marocchino/sticky-pull-request-comment to post (and update) a comment when title fails validation, and delete it when corrected. comment includes allowed types and the specific error from amannn/action-semantic-pull-request.