### PR TITLE
refactor!: consolidate client deps, stores, and session drilling

### DIFF
--- a/src/appstate/sync/WaAppStateSyncClient.ts
+++ b/src/appstate/sync/WaAppStateSyncClient.ts
@@ -14,7 +14,6 @@ import type {
     WaAppStateMissingKeysEvent,
     WaAppStateMutation,
     WaAppStateMutationInput,
-    WaAppStateStoreData,
     WaAppStateSyncKey,
     WaAppStateSyncOptions,
     WaAppStateSyncResult
@@ -117,11 +116,6 @@ export class WaAppStateSyncClient {
         this.mobilePrimary = options.mobilePrimary ?? false
         this.syncContext = null
         this.syncPromise = null
-    }
-
-    public async exportState(): Promise<WaAppStateStoreData> {
-        this.logger.trace('app-state export requested')
-        return this.store.exportData()
     }
 
     public async ensureInitialSyncKey(): Promise<WaAppStateSyncKey> {

--- a/src/auth/WaAuthClient.ts
+++ b/src/auth/WaAuthClient.ts
@@ -31,6 +31,7 @@ type WaAuthClientDeps = Readonly<{
         readonly sendNode: (node: BinaryNode) => Promise<void>
         readonly query: (node: BinaryNode, timeoutMs?: number) => Promise<BinaryNode>
     }
+    readonly isConnected?: () => boolean
     readonly callbacks?: {
         readonly onQr?: (qr: string, ttlMs: number) => void
         readonly onPairingCode?: (code: string) => void
@@ -47,6 +48,7 @@ export class WaAuthClient {
     private readonly authStore: WaAuthStore
     private readonly signalStore: WaSignalStore
     private readonly preKeyStore: WaPreKeyStore
+    private readonly isConnected?: () => boolean
     private readonly qrFlow: WaQrFlow
     private readonly pairingFlow: WaPairingFlow
     private credentials: WaAuthCredentials | null
@@ -70,6 +72,7 @@ export class WaAuthClient {
         this.authStore = deps.authStore
         this.signalStore = deps.signalStore
         this.preKeyStore = deps.preKeyStore
+        this.isConnected = deps.isConnected
         this.credentials = null
 
         this.qrFlow = new WaQrFlow({
@@ -271,6 +274,7 @@ export class WaAuthClient {
         shouldShowPushNotification = true,
         customCode?: string
     ): Promise<string> {
+        this.requireConnected()
         this.requireCredentials()
         this.logger.info('auth client requesting pairing code')
         return this.runHandled(() =>
@@ -279,6 +283,7 @@ export class WaAuthClient {
     }
 
     public async fetchPairingCountryCodeIso(): Promise<string> {
+        this.requireConnected()
         this.requireCredentials()
         this.logger.trace('auth client fetching pairing country code ISO')
         return this.runHandled(() => this.pairingFlow.fetchPairingCountryCodeIso())
@@ -344,6 +349,12 @@ export class WaAuthClient {
             },
             credentials
         )
+    }
+
+    private requireConnected(): void {
+        if (this.isConnected && !this.isConnected()) {
+            throw new Error('client is not connected')
+        }
     }
 
     private requireCredentials(): WaAuthCredentials {

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -8,22 +8,16 @@ import type {
 } from '@appstate/types'
 import { downloadExternalBlobReference } from '@appstate/utils'
 import type { WaAuthClient } from '@auth/WaAuthClient'
-import type { WaConnectionManager } from '@client/connection/WaConnectionManager'
-import type { WaReceiptQueue } from '@client/connection/WaReceiptQueue'
 import type { WaAppStateMutationCoordinator } from '@client/coordinators/WaAppStateMutationCoordinator'
 import type { WaBotCoordinator } from '@client/coordinators/WaBotCoordinator'
 import type { WaBroadcastListCoordinator } from '@client/coordinators/WaBroadcastListCoordinator'
 import type { WaBusinessCoordinator } from '@client/coordinators/WaBusinessCoordinator'
 import type { WaEmailCoordinator } from '@client/coordinators/WaEmailCoordinator'
 import type { WaGroupCoordinator } from '@client/coordinators/WaGroupCoordinator'
-import type { WaIncomingNodeCoordinator } from '@client/coordinators/WaIncomingNodeCoordinator'
-import type { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
 import type { WaNewsletterCoordinator } from '@client/coordinators/WaNewsletterCoordinator'
-import type { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTasksCoordinator'
 import type { WaPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordinator'
 import type { WaProfileCoordinator } from '@client/coordinators/WaProfileCoordinator'
 import type { WaStatusCoordinator } from '@client/coordinators/WaStatusCoordinator'
-import type { WaTrustedContactTokenCoordinator } from '@client/coordinators/WaTrustedContactTokenCoordinator'
 import { parseAccountEventFromAppStateMutation } from '@client/events/account'
 import { parseChatEventFromAppStateMutation } from '@client/events/chat'
 import { aggregateReceiptTargets } from '@client/events/receipt'
@@ -41,7 +35,11 @@ import type {
     WaIncomingStanzaFilter,
     WaSendMessageOptions
 } from '@client/types'
-import { buildWaClientDependencies, resolveWaClientBase } from '@client/WaClientFactory'
+import {
+    buildWaClientDependencies,
+    resolveWaClientBase,
+    type WaClientDependencies
+} from '@client/WaClientFactory'
 import { ConsoleLogger } from '@infra/log/ConsoleLogger'
 import type { Logger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
@@ -56,7 +54,6 @@ import {
 } from '@message/crypto/addon-crypto'
 import { unwrapMessage } from '@message/encode/content'
 import { decryptBotChunk } from '@message/kinds/bot'
-import type { PeerDataOperationRequester } from '@message/primitives/peer-data-operation'
 import type {
     WaMessagePublishResult,
     WaSendMessageContent,
@@ -77,23 +74,8 @@ import {
 } from '@protocol/constants'
 import { isBotJid, normalizeDeviceJid, parsePhoneJid, toUserJid } from '@protocol/jid'
 import { WA_LOGOUT_REASONS, type WaLogoutReason } from '@protocol/stream'
-import type { SignalDeviceSyncApi, SignalLidSyncResult } from '@signal/api/SignalDeviceSyncApi'
-import type { WaAppStateStore } from '@store/contracts/appstate.store'
-import type { WaContactStore } from '@store/contracts/contact.store'
-import type { WaDeviceListStore } from '@store/contracts/device-list.store'
-import type { WaGroupMetadataStore } from '@store/contracts/group-metadata.store'
-import type { WaIdentityStore } from '@store/contracts/identity.store'
-import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
-import type { WaMessageStore } from '@store/contracts/message.store'
-import type { WaPreKeyStore } from '@store/contracts/pre-key.store'
-import type { WaPrivacyTokenStore } from '@store/contracts/privacy-token.store'
-import type { WaRetryStore } from '@store/contracts/retry.store'
-import type { WaSenderKeyStore } from '@store/contracts/sender-key.store'
-import type { WaSessionStore } from '@store/contracts/session.store'
-import type { WaSignalStore } from '@store/contracts/signal.store'
-import type { WaThreadStore } from '@store/contracts/thread.store'
+import type { SignalLidSyncResult } from '@signal/api/SignalDeviceSyncApi'
 import { NOOP_MESSAGE_SECRET_STORE } from '@store/noop.store'
-import type { WaKeepAlive } from '@transport/keepalive/WaKeepAlive'
 import {
     buildChatstateNode,
     type BuildChatstateNodeInput
@@ -106,8 +88,6 @@ import {
 } from '@transport/node/builders/presence'
 import { findNodeChild } from '@transport/node/helpers'
 import { assertIqResult, queryWithContext as queryNodeWithContext } from '@transport/node/query'
-import type { WaNodeOrchestrator } from '@transport/node/WaNodeOrchestrator'
-import type { WaNodeTransport } from '@transport/node/WaNodeTransport'
 import type { BinaryNode } from '@transport/types'
 import { bytesToHex, decodeProtoBytes } from '@util/bytes'
 import { toError } from '@util/primitives'
@@ -123,45 +103,11 @@ const SYNC_RELATED_PROTOCOL_TYPES = new Set<WaIncomingProtocolType>([
 export class WaClient extends EventEmitter {
     private readonly options!: Readonly<WaClientOptions>
     private readonly logger!: Logger
-    private readonly appStateStore!: WaAppStateStore
-    private readonly contactStore!: WaContactStore
-    private readonly messageStore!: WaMessageStore
-    private readonly messageSecretStore!: WaMessageSecretStore
-    private readonly groupMetadataStore!: WaGroupMetadataStore
-    private readonly privacyTokenStore!: WaPrivacyTokenStore
-    private readonly deviceListStore!: WaDeviceListStore
-    private readonly retryStore!: WaRetryStore
-    private readonly signalStore!: WaSignalStore
-    private readonly preKeyStore!: WaPreKeyStore
-    private readonly sessionStore!: WaSessionStore
-    private readonly identityStore!: WaIdentityStore
-    private readonly senderKeyStore!: WaSenderKeyStore
-    private readonly threadStore!: WaThreadStore
-    private readonly authClient!: WaAuthClient
-    private readonly nodeOrchestrator!: WaNodeOrchestrator
-    private readonly nodeTransport!: WaNodeTransport
-    private readonly signalDeviceSync!: SignalDeviceSyncApi
+    private readonly stores!: ReturnType<WaClientOptions['store']['session']>
+    private readonly deps!: WaClientDependencies
     public readonly appStateSync!: WaAppStateSyncClient
-    private readonly chatCoordinator!: WaAppStateMutationCoordinator
-    private readonly incomingNode!: WaIncomingNodeCoordinator
     public readonly mediaTransfer!: WaMediaTransferClient
-    private readonly messageDispatch!: WaMessageDispatchCoordinator
     public readonly messageClient!: WaMessageClient
-    private readonly groupCoordinator!: WaGroupCoordinator
-    private readonly statusCoordinator!: WaStatusCoordinator
-    private readonly broadcastListCoordinator!: WaBroadcastListCoordinator
-    private readonly newsletterCoordinator!: WaNewsletterCoordinator
-    private readonly privacyCoordinator!: WaPrivacyCoordinator
-    private readonly profileCoordinator!: WaProfileCoordinator
-    private readonly businessCoordinator!: WaBusinessCoordinator
-    private readonly botCoordinator!: WaBotCoordinator
-    private readonly emailCoordinator!: WaEmailCoordinator
-    private readonly passiveTasks!: WaPassiveTasksCoordinator
-    private readonly keepAlive!: WaKeepAlive
-    private readonly receiptQueue!: WaReceiptQueue
-    private readonly connectionManager!: WaConnectionManager
-    private readonly trustedContactToken!: WaTrustedContactTokenCoordinator
-    private readonly peerDataOperation!: PeerDataOperationRequester
     private readonly writeBehind!: WriteBehindPersistence
     private connectPromise: Promise<void> | null = null
     private acceptingIncomingEvents = true
@@ -174,25 +120,12 @@ export class WaClient extends EventEmitter {
         const base = resolveWaClientBase(options, logger)
         this.options = base.options
         this.logger = base.logger
-        this.appStateStore = base.sessionStore.appState
-        this.contactStore = base.sessionStore.contacts
-        this.messageStore = base.sessionStore.messages
-        this.messageSecretStore = base.sessionStore.messageSecret
-        this.groupMetadataStore = base.sessionStore.groupMetadata
-        this.privacyTokenStore = base.sessionStore.privacyToken
-        this.deviceListStore = base.sessionStore.deviceList
-        this.retryStore = base.sessionStore.retry
-        this.signalStore = base.sessionStore.signal
-        this.preKeyStore = base.sessionStore.preKey
-        this.sessionStore = base.sessionStore.session
-        this.identityStore = base.sessionStore.identity
-        this.senderKeyStore = base.sessionStore.senderKey
-        this.threadStore = base.sessionStore.threads
+        this.stores = base.sessionStore
         this.writeBehind = new WriteBehindPersistence(
             {
-                messageStore: this.messageStore,
-                threadStore: this.threadStore,
-                contactStore: this.contactStore
+                messageStore: this.stores.messages,
+                threadStore: this.stores.threads,
+                contactStore: this.stores.contacts
             },
             this.logger,
             this.options.writeBehind
@@ -200,7 +133,7 @@ export class WaClient extends EventEmitter {
 
         if (
             this.options.addons?.autoDecrypt &&
-            this.messageSecretStore === NOOP_MESSAGE_SECRET_STORE
+            this.stores.messageSecret === NOOP_MESSAGE_SECRET_STORE
         ) {
             this.logger.warn(
                 'addons.autoDecrypt is enabled but messageSecret cache is noop — ' +
@@ -235,7 +168,10 @@ export class WaClient extends EventEmitter {
                 }
             }
         })
-        Object.assign(this, dependencies)
+        this.deps = dependencies
+        this.appStateSync = dependencies.appStateSync
+        this.mediaTransfer = dependencies.mediaTransfer
+        this.messageClient = dependencies.messageClient
 
         this.bindNodeTransportEvents()
     }
@@ -268,31 +204,31 @@ export class WaClient extends EventEmitter {
     }
 
     public getState() {
-        const connected = this.connectionManager.isConnected()
+        const connected = this.deps.connectionManager.isConnected()
         this.logger.trace('wa client state requested', { connected })
-        return this.authClient.getState(connected)
+        return this.deps.authClient.getState(connected)
     }
 
     public getCredentials() {
-        return this.authClient.getCurrentCredentials()
+        return this.deps.authClient.getCurrentCredentials()
     }
 
     public getClockSkewMs(): number | null {
-        return this.connectionManager.getClockSkewMs()
+        return this.deps.connectionManager.getClockSkewMs()
     }
 
     public async sendNode(node: BinaryNode): Promise<void> {
         try {
-            await this.nodeOrchestrator.sendNode(node)
+            await this.deps.nodeOrchestrator.sendNode(node)
         } catch (error) {
             const normalized = toError(error)
-            if (this.receiptQueue.shouldQueue(node, normalized)) {
-                this.receiptQueue.enqueue(node)
+            if (this.deps.receiptQueue.shouldQueue(node, normalized)) {
+                this.deps.receiptQueue.enqueue(node)
                 this.logger.warn('queued dangling receipt after send failure', {
                     id: node.attrs.id,
                     to: node.attrs.to,
                     message: normalized.message,
-                    queueSize: this.receiptQueue.size()
+                    queueSize: this.deps.receiptQueue.size()
                 })
                 return
             }
@@ -301,8 +237,8 @@ export class WaClient extends EventEmitter {
     }
 
     public async sendPresence(type?: 'available' | 'unavailable'): Promise<void> {
-        const credentials = this.authClient.getCurrentCredentials()
-        await this.nodeOrchestrator.sendNode(
+        const credentials = this.deps.authClient.getCurrentCredentials()
+        await this.deps.nodeOrchestrator.sendNode(
             buildPresenceNode({ type, name: credentials?.meDisplayName ?? undefined }),
             false
         )
@@ -312,7 +248,7 @@ export class WaClient extends EventEmitter {
         jid: string,
         options: Omit<BuildChatstateNodeInput, 'jid'>
     ): Promise<void> {
-        await this.nodeOrchestrator.sendNode(buildChatstateNode({ jid, ...options }), false)
+        await this.deps.nodeOrchestrator.sendNode(buildChatstateNode({ jid, ...options }), false)
     }
 
     /**
@@ -324,7 +260,10 @@ export class WaClient extends EventEmitter {
         jid: string,
         options?: Omit<BuildPresenceSubscribeNodeInput, 'jid'>
     ): Promise<void> {
-        await this.nodeOrchestrator.sendNode(buildPresenceSubscribeNode({ jid, ...options }), false)
+        await this.deps.nodeOrchestrator.sendNode(
+            buildPresenceSubscribeNode({ jid, ...options }),
+            false
+        )
     }
 
     public async query(
@@ -332,19 +271,19 @@ export class WaClient extends EventEmitter {
         timeoutMs: number = this.options.iqTimeoutMs ?? WA_DEFAULTS.IQ_TIMEOUT_MS,
         options: { readonly useSystemId?: boolean } = {}
     ): Promise<BinaryNode> {
-        if (!this.connectionManager.isConnected()) {
+        if (!this.deps.connectionManager.isConnected()) {
             throw new Error('client is not connected')
         }
         this.logger.debug('wa client query', { tag: node.tag, id: node.attrs.id, timeoutMs })
-        return this.nodeOrchestrator.query(node, timeoutMs, options)
+        return this.deps.nodeOrchestrator.query(node, timeoutMs, options)
     }
 
     public registerIncomingHandler(registration: WaIncomingNodeHandlerRegistration): () => void {
-        return this.incomingNode.registerIncomingHandler(registration)
+        return this.deps.incomingNode.registerIncomingHandler(registration)
     }
 
     public unregisterIncomingHandler(registration: WaIncomingNodeHandlerRegistration): boolean {
-        return this.incomingNode.unregisterIncomingHandler(registration)
+        return this.deps.incomingNode.unregisterIncomingHandler(registration)
     }
 
     /**
@@ -354,19 +293,23 @@ export class WaClient extends EventEmitter {
      * filters to keep the auth flow intact.
      */
     public registerIncomingStanzaFilter(filter: WaIncomingStanzaFilter): () => void {
-        return this.incomingNode.registerIncomingStanzaFilter(filter)
+        return this.deps.incomingNode.registerIncomingStanzaFilter(filter)
     }
 
     private bindNodeTransportEvents(): void {
-        this.nodeTransport.on('frame_in', (frame) => this.emit('transport_frame_in', { frame }))
-        this.nodeTransport.on('frame_out', (frame) => this.emit('transport_frame_out', { frame }))
-        this.nodeTransport.on('node_in', (node, frame) =>
+        this.deps.nodeTransport.on('frame_in', (frame) =>
+            this.emit('transport_frame_in', { frame })
+        )
+        this.deps.nodeTransport.on('frame_out', (frame) =>
+            this.emit('transport_frame_out', { frame })
+        )
+        this.deps.nodeTransport.on('node_in', (node, frame) =>
             this.emit('transport_node_in', { node, frame })
         )
-        this.nodeTransport.on('node_out', (node, frame) =>
+        this.deps.nodeTransport.on('node_out', (node, frame) =>
             this.emit('transport_node_out', { node, frame })
         )
-        this.nodeTransport.on('decode_error', (error, frame) => {
+        this.deps.nodeTransport.on('decode_error', (error, frame) => {
             this.emit('transport_decode_error', { error, frame })
             this.handleError(error)
         })
@@ -381,7 +324,7 @@ export class WaClient extends EventEmitter {
             void persistIncomingMailboxEntities({
                 logger: this.logger,
                 writeBehind: this.writeBehind,
-                messageSecretStore: this.messageSecretStore,
+                messageSecretStore: this.stores.messageSecret,
                 event
             })
             if (this.options.addons?.autoDecrypt && event.message) {
@@ -547,7 +490,7 @@ export class WaClient extends EventEmitter {
             return
         }
 
-        const requestedKeys = await this.appStateStore.getSyncKeysBatch(requestedKeyIds)
+        const requestedKeys = await this.stores.appState.getSyncKeysBatch(requestedKeyIds)
         const availableKeys: WaAppStateStoreData['keys'][number][] = []
         const missingKeyIds: Uint8Array[] = []
         for (let i = 0; i < requestedKeys.length; i += 1) {
@@ -560,7 +503,7 @@ export class WaClient extends EventEmitter {
         }
 
         try {
-            await this.messageDispatch.sendAppStateSyncKeyShare(
+            await this.deps.messageDispatch.sendAppStateSyncKeyShare(
                 requesterDeviceJid,
                 availableKeys,
                 missingKeyIds
@@ -606,7 +549,7 @@ export class WaClient extends EventEmitter {
     }
 
     private isOwnAccountDeviceJid(candidateJid: string): boolean {
-        const credentials = this.authClient.getCurrentCredentials()
+        const credentials = this.deps.authClient.getCurrentCredentials()
         if (!credentials) {
             return false
         }
@@ -631,9 +574,9 @@ export class WaClient extends EventEmitter {
                         typeof processHistorySyncNotification
                     >[0]['emitEvent'],
                     onPrivacyTokens: (conversations) =>
-                        this.trustedContactToken.hydrateFromHistorySync(conversations),
+                        this.deps.trustedContactToken.hydrateFromHistorySync(conversations),
                     onNctSalt: (salt) =>
-                        this.trustedContactToken.hydrateNctSaltFromHistorySync(salt)
+                        this.deps.trustedContactToken.hydrateNctSaltFromHistorySync(salt)
                 },
                 notification
             )
@@ -665,8 +608,8 @@ export class WaClient extends EventEmitter {
 
     private async handleIncomingFrame(frame: Uint8Array): Promise<void> {
         try {
-            await this.nodeTransport.dispatchIncomingFrame(frame, async (node) =>
-                this.incomingNode.handleIncomingNode(node)
+            await this.deps.nodeTransport.dispatchIncomingFrame(frame, async (node) =>
+                this.deps.incomingNode.handleIncomingNode(node)
             )
         } catch (error) {
             this.handleError(toError(error))
@@ -680,10 +623,10 @@ export class WaClient extends EventEmitter {
         }
 
         this.acceptingIncomingEvents = true
-        this.connectPromise = this.connectionManager
+        this.connectPromise = this.deps.connectionManager
             .connect((frame) => this.handleIncomingFrame(frame))
             .then(() => {
-                if (!this.authClient.getCurrentCredentials()?.meJid) {
+                if (!this.deps.authClient.getCurrentCredentials()?.meJid) {
                     return
                 }
                 this.emit('connection', {
@@ -710,7 +653,7 @@ export class WaClient extends EventEmitter {
                 remaining: writeBehindFlush.remaining
             })
         }
-        await this.connectionManager.disconnect()
+        await this.deps.connectionManager.disconnect()
         this.emit('connection', {
             status: 'close',
             reason: 'client_disconnected',
@@ -720,34 +663,13 @@ export class WaClient extends EventEmitter {
         })
     }
 
-    public async requestPairingCode(
-        phoneNumber: string,
-        shouldShowPushNotification = true,
-        customCode?: string
-    ): Promise<string> {
-        if (!this.connectionManager.isConnected() || !this.authClient.getCurrentCredentials()) {
-            throw new Error('client is not connected')
-        }
-        this.logger.debug('wa client request pairing code')
-        return this.authClient.requestPairingCode(
-            phoneNumber,
-            shouldShowPushNotification,
-            customCode
-        )
-    }
-
-    public async fetchPairingCountryCodeIso(): Promise<string> {
-        if (!this.connectionManager.isConnected() || !this.authClient.getCurrentCredentials()) {
-            throw new Error('client is not connected')
-        }
-        this.logger.trace('wa client fetch pairing country code iso')
-        return this.authClient.fetchPairingCountryCodeIso()
-    }
-
     public async getLidsByPhoneNumbers(
         phoneNumbers: readonly string[]
     ): Promise<readonly SignalLidSyncResult[]> {
-        if (!this.connectionManager.isConnected() || !this.authClient.getCurrentCredentials()) {
+        if (
+            !this.deps.connectionManager.isConnected() ||
+            !this.deps.authClient.getCurrentCredentials()
+        ) {
             throw new Error('client is not connected')
         }
         const normalizedPhoneJids = new Array<string>(phoneNumbers.length)
@@ -757,7 +679,7 @@ export class WaClient extends EventEmitter {
         this.logger.trace('wa client query lids by phone numbers', {
             phones: normalizedPhoneJids.length
         })
-        return this.signalDeviceSync.queryLidsByPhoneJids(normalizedPhoneJids)
+        return this.deps.signalDeviceSync.queryLidsByPhoneJids(normalizedPhoneJids)
     }
 
     public sendMessage(
@@ -765,13 +687,13 @@ export class WaClient extends EventEmitter {
         content: WaSendMessageContent,
         options: WaSendMessageOptions = {}
     ): Promise<WaMessagePublishResult> {
-        return this.messageDispatch.sendMessage(to, content, options)
+        return this.deps.messageDispatch.sendMessage(to, content, options)
     }
 
     public async syncSignalSession(jid: string, reasonIdentity = false): Promise<void> {
-        await this.messageDispatch.syncSignalSession(jid, reasonIdentity)
+        await this.deps.messageDispatch.syncSignalSession(jid, reasonIdentity)
         if (reasonIdentity) {
-            this.trustedContactToken.reissueOnIdentityChange(jid).catch((err) =>
+            this.deps.trustedContactToken.reissueOnIdentityChange(jid).catch((err) =>
                 this.logger.warn('tc token reissue on identity change failed', {
                     jid,
                     message: toError(err).message
@@ -780,39 +702,42 @@ export class WaClient extends EventEmitter {
         }
     }
 
+    public get auth(): WaAuthClient {
+        return this.deps.authClient
+    }
     public get chat(): WaAppStateMutationCoordinator {
-        return this.chatCoordinator
+        return this.deps.chatCoordinator
     }
     public get group(): WaGroupCoordinator {
-        return this.groupCoordinator
+        return this.deps.groupCoordinator
     }
     public get status(): WaStatusCoordinator {
-        return this.statusCoordinator
+        return this.deps.statusCoordinator
     }
     public get broadcastList(): WaBroadcastListCoordinator {
-        return this.broadcastListCoordinator
+        return this.deps.broadcastListCoordinator
     }
     public get newsletter(): WaNewsletterCoordinator {
-        return this.newsletterCoordinator
+        return this.deps.newsletterCoordinator
     }
     public get privacy(): WaPrivacyCoordinator {
-        return this.privacyCoordinator
+        return this.deps.privacyCoordinator
     }
     public get profile(): WaProfileCoordinator {
-        return this.profileCoordinator
+        return this.deps.profileCoordinator
     }
     public get business(): WaBusinessCoordinator {
-        return this.businessCoordinator
+        return this.deps.businessCoordinator
     }
     public get bot(): WaBotCoordinator {
-        return this.botCoordinator
+        return this.deps.botCoordinator
     }
     public get email(): WaEmailCoordinator {
-        return this.emailCoordinator
+        return this.deps.emailCoordinator
     }
 
     public async logout(reason: WaLogoutReason = WA_LOGOUT_REASONS.USER_INITIATED): Promise<void> {
-        const meJid = this.authClient.getCurrentCredentials()?.meJid
+        const meJid = this.deps.authClient.getCurrentCredentials()?.meJid
         if (!meJid) {
             throw new Error('cannot logout: client is not authenticated')
         }
@@ -882,19 +807,11 @@ export class WaClient extends EventEmitter {
             id,
             listIds: rest.length > 0 ? rest : undefined
         }
-        return this.messageDispatch.sendReceipt(input)
-    }
-
-    public flushAppStateMutations(): Promise<void> {
-        return this.chatCoordinator.flushMutations()
-    }
-
-    public async exportAppState(): Promise<WaAppStateStoreData> {
-        return this.appStateSync.exportState()
+        return this.deps.messageDispatch.sendReceipt(input)
     }
 
     public async syncAppState(options: WaAppStateSyncOptions = {}): Promise<WaAppStateSyncResult> {
-        if (!this.connectionManager.isConnected()) {
+        if (!this.deps.connectionManager.isConnected()) {
             throw new Error('client is not connected')
         }
         const syncResult = await this.executeAppStateSync(options)
@@ -990,13 +907,13 @@ export class WaClient extends EventEmitter {
             return
         }
         if (mutation.operation === 'set' && nctAction.salt) {
-            this.trustedContactToken.handleNctSaltSync(nctAction.salt).catch((err) =>
+            this.deps.trustedContactToken.handleNctSaltSync(nctAction.salt).catch((err) =>
                 this.logger.warn('nct salt sync set failed', {
                     message: toError(err).message
                 })
             )
         } else if (mutation.operation === 'remove') {
-            this.trustedContactToken.handleNctSaltSync(null).catch((err) =>
+            this.deps.trustedContactToken.handleNctSaltSync(null).catch((err) =>
                 this.logger.warn('nct salt sync remove failed', {
                     message: toError(err).message
                 })
@@ -1014,7 +931,7 @@ export class WaClient extends EventEmitter {
                 `clear stored state aborted: write-behind did not fully drain (remaining=${writeBehindDestroy.remaining})`
             )
         }
-        const danglingReceipts = this.receiptQueue.take()
+        const danglingReceipts = this.deps.receiptQueue.take()
         if (danglingReceipts.length > 0) {
             this.logger.debug('cleared dangling receipts while clearing stored state', {
                 count: danglingReceipts.length
@@ -1025,21 +942,21 @@ export class WaClient extends EventEmitter {
         const shouldClear = (key: keyof NonNullable<typeof s>): boolean =>
             s === undefined || s[key] !== false
 
-        if (shouldClear('auth')) await this.authClient.clearStoredCredentials()
-        if (shouldClear('appState')) await this.appStateStore.clear()
-        if (shouldClear('contacts')) await this.contactStore.clear()
-        if (shouldClear('messages')) await this.messageStore.clear()
-        if (shouldClear('messageSecret')) await this.messageSecretStore.clear()
-        if (shouldClear('groupMetadata')) await this.groupMetadataStore.clear()
-        if (shouldClear('deviceList')) await this.deviceListStore.clear()
-        if (shouldClear('retry')) await this.retryStore.clear()
-        if (shouldClear('signal')) await this.signalStore.clear()
-        if (shouldClear('preKey')) await this.preKeyStore.clear()
-        if (shouldClear('session')) await this.sessionStore.clear()
-        if (shouldClear('identity')) await this.identityStore.clear()
-        if (shouldClear('senderKey')) await this.senderKeyStore.clear()
-        if (shouldClear('threads')) await this.threadStore.clear()
-        if (shouldClear('privacyToken')) await this.privacyTokenStore.clear()
+        if (shouldClear('auth')) await this.deps.authClient.clearStoredCredentials()
+        if (shouldClear('appState')) await this.stores.appState.clear()
+        if (shouldClear('contacts')) await this.stores.contacts.clear()
+        if (shouldClear('messages')) await this.stores.messages.clear()
+        if (shouldClear('messageSecret')) await this.stores.messageSecret.clear()
+        if (shouldClear('groupMetadata')) await this.stores.groupMetadata.clear()
+        if (shouldClear('deviceList')) await this.stores.deviceList.clear()
+        if (shouldClear('retry')) await this.stores.retry.clear()
+        if (shouldClear('signal')) await this.stores.signal.clear()
+        if (shouldClear('preKey')) await this.stores.preKey.clear()
+        if (shouldClear('session')) await this.stores.session.clear()
+        if (shouldClear('identity')) await this.stores.identity.clear()
+        if (shouldClear('senderKey')) await this.stores.senderKey.clear()
+        if (shouldClear('threads')) await this.stores.threads.clear()
+        if (shouldClear('privacyToken')) await this.stores.privacyToken.clear()
     }
 
     private async tryDecryptAddon(event: WaIncomingMessageEvent): Promise<void> {
@@ -1054,8 +971,8 @@ export class WaClient extends EventEmitter {
 
         const parentEntry = await resolveParentMessageSecret(
             targetMessageId,
-            this.messageSecretStore,
-            this.messageStore
+            this.stores.messageSecret,
+            this.stores.messages
         )
         if (!parentEntry) {
             this.logger.debug('addon parent message secret not found', {
@@ -1086,7 +1003,7 @@ export class WaClient extends EventEmitter {
             const names = await resolvePollOptionNames(
                 decrypted.pollVote.selectedOptions,
                 targetMessageId,
-                this.messageStore
+                this.stores.messages
             )
             if (names) {
                 decrypted = { ...decrypted, selectedOptionNames: names }
@@ -1153,7 +1070,7 @@ export class WaClient extends EventEmitter {
         }
 
         const metaTargetSenderJid = metaNode?.attrs[WA_META_NODE_ATTRS_BOT.TARGET_SENDER_JID]
-        const credentials = this.authClient.getCurrentCredentials()
+        const credentials = this.deps.authClient.getCurrentCredentials()
         const isFbidBotChat = event.chatJid ? isBotJid(event.chatJid) : false
         // FBID bot (`*@bot`) keys on user LID; legacy PN bot keys on user PN
         const meFallbackJid = isFbidBotChat
@@ -1174,8 +1091,8 @@ export class WaClient extends EventEmitter {
 
         const parentEntry = await resolveParentMessageSecret(
             targetMessageId,
-            this.messageSecretStore,
-            this.messageStore
+            this.stores.messageSecret,
+            this.stores.messages
         )
         if (!parentEntry) {
             this.logger.debug('bot chunk parent message secret not found', {

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -1,5 +1,6 @@
 import { WaAppStateSyncClient } from '@appstate/sync/WaAppStateSyncClient'
 import type { WaAppStateSyncOptions, WaAppStateSyncResult } from '@appstate/types'
+import type { WaAuthCredentials } from '@auth/types'
 import { WaAuthClient } from '@auth/WaAuthClient'
 import { WaConnectionManager } from '@client/connection/WaConnectionManager'
 import { WaReceiptQueue } from '@client/connection/WaReceiptQueue'
@@ -153,7 +154,7 @@ interface WaClientBuildRuntime {
     ) => () => void
 }
 
-interface WaClientDependencies {
+export interface WaClientDependencies {
     readonly nodeTransport: WaNodeTransport
     readonly nodeOrchestrator: WaNodeOrchestrator
     readonly keepAlive: WaKeepAlive
@@ -281,7 +282,7 @@ function createIncomingNodeRuntime(input: {
         code: WaConnectionCode | null
     ) => Promise<void>
     readonly clearStoredCredentials: () => Promise<void>
-    readonly getCurrentMeJid: () => string | null | undefined
+    readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly handleClientDirtyBits: (
         dirtyBits: Parameters<typeof handleDirtyBits>[1]
     ) => Promise<void>
@@ -301,7 +302,7 @@ function createIncomingNodeRuntime(input: {
         syncAppState,
         disconnect,
         clearStoredCredentials,
-        getCurrentMeJid,
+        getCurrentCredentials,
         handleClientDirtyBits,
         incomingMessageAckOptions
     } = input
@@ -312,7 +313,8 @@ function createIncomingNodeRuntime(input: {
         emitSuccessNode: (node) => emitEvent('connection_success', { node }),
         updateClockSkewFromSuccess: (serverUnixSeconds) =>
             connectionManager.updateClockSkewFromSuccess(serverUnixSeconds),
-        shouldWarmupMediaConn: () => !!(getCurrentMeJid() && connectionManager.isConnected()),
+        shouldWarmupMediaConn: () =>
+            !!(getCurrentCredentials()?.meJid && connectionManager.isConnected()),
         warmupMediaConn: async () => {
             await getClientMediaConn(mediaMessageBuildOptions, true)
         },
@@ -571,6 +573,7 @@ export function buildWaClientDependencies(input: {
                 sendNode: runtime.sendNode,
                 query: runtime.query
             },
+            isConnected: () => connectionManager?.isConnected() ?? false,
             callbacks: {
                 onQr: (qr, ttlMs) => runtime.emitEvent('auth_qr', { qr, ttlMs }),
                 onPairingCode: (code) => runtime.emitEvent('auth_pairing_code', { code }),
@@ -586,9 +589,6 @@ export function buildWaClientDependencies(input: {
     )
 
     const getCurrentCredentials = authClient.getCurrentCredentials.bind(authClient)
-    const getCurrentMeJid = () => getCurrentCredentials()?.meJid
-    const getCurrentMeLid = () => getCurrentCredentials()?.meLid
-    const getCurrentSignedIdentity = () => getCurrentCredentials()?.signedIdentity
 
     const groupCoordinator = createGroupCoordinator({
         queryWithContext: runtime.queryWithContext,
@@ -641,8 +641,7 @@ export function buildWaClientDependencies(input: {
     })
     const fanoutResolver = createDeviceFanoutResolver({
         signalDeviceSync,
-        getCurrentMeJid,
-        getCurrentMeLid,
+        getCurrentCredentials,
         logger
     })
     const groupMetadataCache = createGroupMetadataCache({
@@ -667,7 +666,7 @@ export function buildWaClientDependencies(input: {
         runtime: {
             queryWithContext: runtime.queryWithContext,
             emitEvent: runtime.emitEvent,
-            getCurrentMeLid: () => getCurrentMeLid() ?? null
+            getCurrentCredentials
         },
         serverClock,
         durationS: options.privacyToken?.tcTokenDurationS,
@@ -698,8 +697,7 @@ export function buildWaClientDependencies(input: {
         publishProtocolMessageToDevice: (deviceJid, protocolMessage, opts) =>
             messageDispatch.publishProtocolMessageToDevice(deviceJid, protocolMessage, opts),
         fanoutResolver,
-        getCurrentMeJid,
-        getCurrentMeLid,
+        getCurrentCredentials,
         logger
     })
 
@@ -720,9 +718,7 @@ export function buildWaClientDependencies(input: {
         identityStore: sessionStore.identity,
         deviceListStore: sessionStore.deviceList,
         messageSecretStore: sessionStore.messageSecret,
-        getCurrentMeJid,
-        getCurrentMeLid,
-        getCurrentSignedIdentity,
+        getCurrentCredentials,
         resolvePrivacyTokenNode: (recipientJid) =>
             trustedContactToken.resolveTokenForMessage(recipientJid),
         onDirectMessageSent: (recipientJid) => {
@@ -746,7 +742,7 @@ export function buildWaClientDependencies(input: {
         logger,
         publishProtocolMessageToDevice: (deviceJid, protocolMessage, opts) =>
             messageDispatch.publishProtocolMessageToDevice(deviceJid, protocolMessage, opts),
-        getCurrentMeJid,
+        getCurrentCredentials,
         generateOutgoingMessageId: () => messageDispatch.generateOutgoingMessageId(),
         subscribeToProtocolMessage: runtime.subscribeProtocolMessage
     })
@@ -763,9 +759,7 @@ export function buildWaClientDependencies(input: {
         signalMissingPreKeysSync,
         messageClient,
         sendNode: runtime.sendNode,
-        getCurrentMeJid,
-        getCurrentMeLid,
-        getCurrentSignedIdentity,
+        getCurrentCredentials,
         peerDataOperation,
         emitIncomingMessage: (event) => {
             void runtime
@@ -785,7 +779,7 @@ export function buildWaClientDependencies(input: {
     const appStateSync = new WaAppStateSyncClient({
         logger,
         query: runtime.query,
-        getCurrentMeJid,
+        getCurrentMeJid: () => getCurrentCredentials()?.meJid,
         defaultTimeoutMs: options.appStateSyncTimeoutMs,
         store: sessionStore.appState,
         serverClock,
@@ -894,7 +888,7 @@ export function buildWaClientDependencies(input: {
     const incomingMessageAckOptions: Parameters<typeof handleIncomingMessageAck>[1] = {
         logger,
         sendNode: runtime.sendNode,
-        getMeJid: getCurrentMeJid,
+        getMeJid: () => getCurrentCredentials()?.meJid,
         signalProtocol,
         senderKeyManager,
         onDecryptFailure: (context: WaRetryDecryptFailureContext, error: unknown) =>
@@ -947,7 +941,7 @@ export function buildWaClientDependencies(input: {
             syncAppState: runtime.syncAppState,
             disconnect: disconnectWithClientSideEffects,
             clearStoredCredentials: clearStoredCredentialsWithClientSideEffects,
-            getCurrentMeJid,
+            getCurrentCredentials,
             handleClientDirtyBits,
             incomingMessageAckOptions
         })
@@ -1061,7 +1055,7 @@ export function buildWaClientDependencies(input: {
                     return true
                 }
 
-                const meJid = getCurrentMeJid()
+                const meJid = getCurrentCredentials()?.meJid
                 if (meJid) {
                     const meUser = toUserJid(meJid)
                     const fromUser = toUserJid(parsed.fromJid)

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -477,83 +477,87 @@ function createClearStoredStateHarness(logoutStoreClear?: {
         writeBehind: {
             destroy: async () => ({ remaining: 0 })
         },
-        receiptQueue: {
-            take: () => []
-        },
         logger: createNoopLogger(),
-        authClient: {
-            clearStoredCredentials: async () => {
-                cleared.push('auth')
+        deps: {
+            receiptQueue: {
+                take: () => []
+            },
+            authClient: {
+                clearStoredCredentials: async () => {
+                    cleared.push('auth')
+                }
             }
         },
-        appStateStore: {
-            clear: async () => {
-                cleared.push('appState')
-            }
-        },
-        contactStore: {
-            clear: async () => {
-                cleared.push('contacts')
-            }
-        },
-        messageStore: {
-            clear: async () => {
-                cleared.push('messages')
-            }
-        },
-        groupMetadataStore: {
-            clear: async () => {
-                cleared.push('groupMetadata')
-            }
-        },
-        deviceListStore: {
-            clear: async () => {
-                cleared.push('deviceList')
-            }
-        },
-        retryStore: {
-            clear: async () => {
-                cleared.push('retry')
-            }
-        },
-        signalStore: {
-            clear: async () => {
-                cleared.push('signal')
-            }
-        },
-        preKeyStore: {
-            clear: async () => {
-                cleared.push('preKey')
-            }
-        },
-        sessionStore: {
-            clear: async () => {
-                cleared.push('session')
-            }
-        },
-        identityStore: {
-            clear: async () => {
-                cleared.push('identity')
-            }
-        },
-        senderKeyStore: {
-            clear: async () => {
-                cleared.push('senderKey')
-            }
-        },
-        threadStore: {
-            clear: async () => {
-                cleared.push('threads')
-            }
-        },
-        privacyTokenStore: {
-            clear: async () => {
-                cleared.push('privacyToken')
-            }
-        },
-        messageSecretStore: {
-            clear: async () => {
-                cleared.push('messageSecret')
+        stores: {
+            appState: {
+                clear: async () => {
+                    cleared.push('appState')
+                }
+            },
+            contacts: {
+                clear: async () => {
+                    cleared.push('contacts')
+                }
+            },
+            messages: {
+                clear: async () => {
+                    cleared.push('messages')
+                }
+            },
+            groupMetadata: {
+                clear: async () => {
+                    cleared.push('groupMetadata')
+                }
+            },
+            deviceList: {
+                clear: async () => {
+                    cleared.push('deviceList')
+                }
+            },
+            retry: {
+                clear: async () => {
+                    cleared.push('retry')
+                }
+            },
+            signal: {
+                clear: async () => {
+                    cleared.push('signal')
+                }
+            },
+            preKey: {
+                clear: async () => {
+                    cleared.push('preKey')
+                }
+            },
+            session: {
+                clear: async () => {
+                    cleared.push('session')
+                }
+            },
+            identity: {
+                clear: async () => {
+                    cleared.push('identity')
+                }
+            },
+            senderKey: {
+                clear: async () => {
+                    cleared.push('senderKey')
+                }
+            },
+            threads: {
+                clear: async () => {
+                    cleared.push('threads')
+                }
+            },
+            privacyToken: {
+                clear: async () => {
+                    cleared.push('privacyToken')
+                }
+            },
+            messageSecret: {
+                clear: async () => {
+                    cleared.push('messageSecret')
+                }
             }
         }
     }
@@ -588,14 +592,16 @@ test('WaClient.sendPresence sends a presence node without auto-generated id', as
 
     await getSendPresenceMethod().call(
         {
-            authClient: {
-                getCurrentCredentials: () => ({
-                    meDisplayName: 'Vinicius'
-                })
-            },
-            nodeOrchestrator: {
-                sendNode: async (node: BinaryNode, autoId?: boolean) => {
-                    calls.push({ node, autoId })
+            deps: {
+                authClient: {
+                    getCurrentCredentials: () => ({
+                        meDisplayName: 'Vinicius'
+                    })
+                },
+                nodeOrchestrator: {
+                    sendNode: async (node: BinaryNode, autoId?: boolean) => {
+                        calls.push({ node, autoId })
+                    }
                 }
             }
         },
@@ -621,9 +627,11 @@ test('WaClient exposes chat/group/privacy coordinator getters', () => {
     const groupCoordinator = { queryGroupMetadata: async () => ({}) }
     const privacyCoordinator = { getPrivacySettings: async () => ({}) }
     const fakeClient = {
-        chatCoordinator,
-        groupCoordinator,
-        privacyCoordinator
+        deps: {
+            chatCoordinator,
+            groupCoordinator,
+            privacyCoordinator
+        }
     }
 
     assert.equal(getCoordinatorGetterMethod('chat').call(fakeClient), chatCoordinator)

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -1,4 +1,5 @@
 import type { WaAppStateSyncKey } from '@appstate/types'
+import type { WaAuthCredentials } from '@auth/types'
 import type { DeviceFanoutResolver } from '@client/messaging/fanout'
 import type { GroupMetadataCache } from '@client/messaging/group-metadata'
 import type { AppStateSyncKeyProtocol } from '@client/messaging/key-protocol'
@@ -93,9 +94,7 @@ interface WaMessageDispatchCoordinatorOptions {
     readonly identityStore: WaIdentityStore
     readonly deviceListStore: WaDeviceListStore
     readonly messageSecretStore: WaMessageSecretStore
-    readonly getCurrentMeJid: () => string | null | undefined
-    readonly getCurrentMeLid: () => string | null | undefined
-    readonly getCurrentSignedIdentity: () => Proto.IADVSignedDeviceIdentity | null | undefined
+    readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly resolvePrivacyTokenNode: (recipientJid: string) => Promise<BinaryNode | null>
     readonly onDirectMessageSent: (recipientJid: string) => void
     readonly sendNewsletterMessage?: (
@@ -117,68 +116,14 @@ interface GroupSendRetryContext {
 }
 
 export class WaMessageDispatchCoordinator {
-    private readonly logger: Logger
-    private readonly messageClient: WaMessageClient
-    private readonly retryTracker: OutboundRetryTracker
-    private readonly sessionResolver: SignalSessionResolver
-    private readonly fanoutResolver: DeviceFanoutResolver
-    private readonly groupMetadataCache: GroupMetadataCache
-    private readonly appStateSyncKeyProtocol: AppStateSyncKeyProtocol
-    private readonly buildMessageContent: (
-        content: WaSendMessageContent
-    ) => Promise<WaMessageBuildResult>
-    private readonly senderKeyManager: SenderKeyManager
-    private readonly signalProtocol: SignalProtocol
-    private readonly signalStore: WaSignalStore
-    private readonly sessionStore: WaSessionStore
-    private readonly identityStore: WaIdentityStore
-    private readonly deviceListStore: WaDeviceListStore
-    private readonly messageSecretStore: WaMessageSecretStore
-    private readonly getCurrentMeJid: () => string | null | undefined
-    private readonly getCurrentMeLid: () => string | null | undefined
-    private readonly getCurrentSignedIdentity: () =>
-        | Proto.IADVSignedDeviceIdentity
-        | null
-        | undefined
-    private readonly resolvePrivacyTokenNode: (recipientJid: string) => Promise<BinaryNode | null>
-    private readonly onDirectMessageSent: (recipientJid: string) => void
-    private readonly sendNewsletterMessage:
-        | ((
-              newsletterJid: string,
-              content: WaSendMessageContent,
-              options: WaSendMessageOptions,
-              contextInfo: WaSendContextInfo | null
-          ) => Promise<WaMessagePublishResult>)
-        | undefined
-    private readonly getIcdcHashLength: (() => number) | undefined
+    private readonly deps: WaMessageDispatchCoordinatorOptions
     private readonly mobileMessageIdFormat: boolean
     private readonly icdcDedup = new PromiseDedup()
     private readonly privacyTokenDedup = new PromiseDedup()
     private readonly distributionDedup = new PromiseDedup()
 
     public constructor(options: WaMessageDispatchCoordinatorOptions) {
-        this.logger = options.logger
-        this.messageClient = options.messageClient
-        this.retryTracker = options.retryTracker
-        this.sessionResolver = options.sessionResolver
-        this.fanoutResolver = options.fanoutResolver
-        this.groupMetadataCache = options.groupMetadataCache
-        this.appStateSyncKeyProtocol = options.appStateSyncKeyProtocol
-        this.buildMessageContent = options.buildMessageContent
-        this.senderKeyManager = options.senderKeyManager
-        this.signalProtocol = options.signalProtocol
-        this.signalStore = options.signalStore
-        this.sessionStore = options.sessionStore
-        this.identityStore = options.identityStore
-        this.deviceListStore = options.deviceListStore
-        this.messageSecretStore = options.messageSecretStore
-        this.getCurrentMeJid = options.getCurrentMeJid
-        this.getCurrentMeLid = options.getCurrentMeLid
-        this.getCurrentSignedIdentity = options.getCurrentSignedIdentity
-        this.resolvePrivacyTokenNode = options.resolvePrivacyTokenNode
-        this.onDirectMessageSent = options.onDirectMessageSent
-        this.sendNewsletterMessage = options.sendNewsletterMessage
-        this.getIcdcHashLength = options.getIcdcHashLength
+        this.deps = options
         this.mobileMessageIdFormat = options.mobileMessageIdFormat ?? false
     }
 
@@ -186,7 +131,7 @@ export class WaMessageDispatchCoordinator {
         node: BinaryNode,
         options: WaMessagePublishOptions = {}
     ): Promise<WaMessagePublishResult> {
-        this.logger.debug('wa client publish message node', {
+        this.deps.logger.debug('wa client publish message node', {
             tag: node.tag,
             type: node.attrs.type,
             to: node.attrs.to
@@ -196,7 +141,7 @@ export class WaMessageDispatchCoordinator {
             mode: 'opaque_node',
             node: encodeBinaryNode(node)
         }
-        return this.retryTracker.track(
+        return this.deps.retryTracker.track(
             {
                 messageIdHint: node.attrs.id,
                 toJid: node.attrs.to,
@@ -205,7 +150,7 @@ export class WaMessageDispatchCoordinator {
                 participantJid: node.attrs.participant,
                 recipientJid: node.attrs.recipient
             },
-            async () => this.messageClient.publishNode(node, options)
+            async () => this.deps.messageClient.publishNode(node, options)
         )
     }
 
@@ -213,7 +158,7 @@ export class WaMessageDispatchCoordinator {
         input: WaEncryptedMessageInput,
         options: WaMessagePublishOptions = {}
     ): Promise<WaMessagePublishResult> {
-        this.logger.debug('wa client publish encrypted message', {
+        this.deps.logger.debug('wa client publish encrypted message', {
             to: input.to,
             type: input.type,
             encType: input.encType
@@ -226,7 +171,7 @@ export class WaMessageDispatchCoordinator {
             ciphertext: input.ciphertext,
             participant: input.participant
         }
-        return this.retryTracker.track(
+        return this.deps.retryTracker.track(
             {
                 messageIdHint: input.id,
                 toJid: input.to,
@@ -235,7 +180,7 @@ export class WaMessageDispatchCoordinator {
                 participantJid: input.participant,
                 eligibleRequesterDeviceJids: [input.to]
             },
-            async () => this.messageClient.publishEncrypted(input, options)
+            async () => this.deps.messageClient.publishEncrypted(input, options)
         )
     }
 
@@ -250,15 +195,15 @@ export class WaMessageDispatchCoordinator {
                 'publishSignalMessage currently supports only direct chats; use sender-key flow for groups'
             )
         }
-        this.logger.debug('wa client publish signal message', {
+        this.deps.logger.debug('wa client publish signal message', {
             to: input.to,
             type: input.type
         })
         const [paddedPlaintext] = await Promise.all([
             writeRandomPadMax16(input.plaintext),
-            this.sessionResolver.ensureSession(address, input.to, input.expectedIdentity)
+            this.deps.sessionResolver.ensureSession(address, input.to, input.expectedIdentity)
         ])
-        const encrypted = await this.signalProtocol.encryptMessage(
+        const encrypted = await this.deps.signalProtocol.encryptMessage(
             address,
             paddedPlaintext,
             input.expectedIdentity
@@ -270,7 +215,7 @@ export class WaMessageDispatchCoordinator {
             type: messageType,
             plaintext: paddedPlaintext
         }
-        return this.retryTracker.track(
+        return this.deps.retryTracker.track(
             {
                 messageIdHint: input.id,
                 toJid: input.to,
@@ -280,7 +225,7 @@ export class WaMessageDispatchCoordinator {
                 eligibleRequesterDeviceJids: [input.to]
             },
             async () =>
-                this.messageClient.publishEncrypted(
+                this.deps.messageClient.publishEncrypted(
                     {
                         to: input.to,
                         encType: encrypted.type,
@@ -304,7 +249,7 @@ export class WaMessageDispatchCoordinator {
     ): Promise<WaMessagePublishResult> {
         const recipientJid = normalizeRecipientJid(to)
         if (isNewsletterJid(recipientJid)) {
-            if (!this.sendNewsletterMessage) {
+            if (!this.deps.sendNewsletterMessage) {
                 throw new Error('newsletter sendMessage requires sendNewsletterMessage dependency')
             }
             const newsletterCtx = resolveSendContextInfo({
@@ -316,10 +261,15 @@ export class WaMessageDispatchCoordinator {
             })
             assertNewsletterContextInfoCompatible(newsletterCtx)
             const sendOptions = await this.withResolvedMessageId(options)
-            return this.sendNewsletterMessage(recipientJid, content, sendOptions, newsletterCtx)
+            return this.deps.sendNewsletterMessage(
+                recipientJid,
+                content,
+                sendOptions,
+                newsletterCtx
+            )
         }
         const [built, sendOptions] = await Promise.all([
-            this.buildMessageContent(content),
+            this.deps.buildMessageContent(content),
             this.withResolvedMessageId(options)
         ])
         let optionsCtx = options.contextInfo
@@ -328,7 +278,8 @@ export class WaMessageDispatchCoordinator {
             optionsCtx?.expirationSeconds === undefined &&
             !options.disableGroupEphemeralAutoInject
         ) {
-            const cachedEphemeral = await this.groupMetadataCache.resolveEphemeral(recipientJid)
+            const cachedEphemeral =
+                await this.deps.groupMetadataCache.resolveEphemeral(recipientJid)
             if (cachedEphemeral !== null && cachedEphemeral > 0) {
                 optionsCtx = { ...optionsCtx, expirationSeconds: cachedEphemeral }
             }
@@ -350,19 +301,19 @@ export class WaMessageDispatchCoordinator {
             sendOptions.id &&
             needsSecretPersistence(messageWithSecret)
         ) {
-            const meJid = this.getCurrentMeJid() ?? ''
-            void this.messageSecretStore
+            const meJid = this.deps.getCurrentCredentials()?.meJid ?? ''
+            void this.deps.messageSecretStore
                 .set(sendOptions.id, { secret: rawSecret, senderJid: meJid })
                 .catch((error) => {
-                    this.logger.warn('failed to persist outgoing message secret', {
+                    this.deps.logger.warn('failed to persist outgoing message secret', {
                         id: sendOptions.id,
                         message: toError(error).message
                     })
                 })
         }
 
-        const meJid = this.getCurrentMeJid()
-        const regInfo = meJid ? await this.signalStore.getRegistrationInfo() : null
+        const meJid = this.deps.getCurrentCredentials()?.meJid
+        const regInfo = meJid ? await this.deps.signalStore.getRegistrationInfo() : null
         const localPubKey = regInfo?.identityKeyPair.pubKey
         const meParsed = meJid ? parseJidFull(meJid) : undefined
         const meUserJid = meParsed?.userJid
@@ -439,11 +390,11 @@ export class WaMessageDispatchCoordinator {
         if (address.server === WA_DEFAULTS.GROUP_SERVER) {
             throw new Error('syncSignalSession supports only direct chats')
         }
-        await this.sessionResolver.ensureSession(address, jid, undefined, reasonIdentity)
+        await this.deps.sessionResolver.ensureSession(address, jid, undefined, reasonIdentity)
     }
 
     public async sendReceipt(input: WaSendReceiptInput): Promise<void> {
-        await this.messageClient.sendReceipt(input)
+        await this.deps.messageClient.sendReceipt(input)
     }
 
     public async publishProtocolMessageToDevice(
@@ -471,7 +422,7 @@ export class WaMessageDispatchCoordinator {
             throw new Error('publishStatusMessage requires at least one recipient')
         }
         this.requireCurrentMeJid('publishStatusMessage')
-        const meLid = this.getCurrentMeLid()
+        const meLid = this.deps.getCurrentCredentials()?.meLid
         if (!meLid) {
             throw new Error('publishStatusMessage requires current me lid')
         }
@@ -602,7 +553,11 @@ export class WaMessageDispatchCoordinator {
             distributionMessage,
             ciphertext: groupCiphertext,
             keyId: senderKeyId
-        } = await this.senderKeyManager.prepareGroupEncryption(input.groupJid, sender, plaintext)
+        } = await this.deps.senderKeyManager.prepareGroupEncryption(
+            input.groupJid,
+            sender,
+            plaintext
+        )
         const { fanoutDeviceJids, distributionParticipants } =
             await this.encryptGroupDistributionParticipants(
                 input.groupJid,
@@ -661,7 +616,7 @@ export class WaMessageDispatchCoordinator {
             plaintext,
             ...(input.replayStatusSetting ? { statusSetting: input.replayStatusSetting } : {})
         }
-        const result = await this.retryTracker.track(
+        const result = await this.deps.retryTracker.track(
             {
                 messageIdHint: sendOptions.id ?? messageNode.attrs.id,
                 toJid: input.groupJid,
@@ -669,24 +624,27 @@ export class WaMessageDispatchCoordinator {
                 replayPayload,
                 eligibleRequesterDeviceJids: undefined
             },
-            async () => this.messageClient.publishNode(messageNode, sendOptions)
+            async () => this.deps.messageClient.publishNode(messageNode, sendOptions)
         )
         const distributedAddresses = new Array<SignalAddress>(distributionParticipants.length)
         for (let i = 0; i < distributionParticipants.length; i += 1) {
             distributedAddresses[i] = distributionParticipants[i].address
         }
         try {
-            await this.senderKeyManager.markSenderKeyDistributed(
+            await this.deps.senderKeyManager.markSenderKeyDistributed(
                 input.groupJid,
                 senderKeyId,
                 distributedAddresses
             )
         } catch (error) {
-            this.logger.warn(`failed to mark ${input.logTag} sender key distribution targets`, {
-                groupJid: input.groupJid,
-                participants: distributedAddresses.length,
-                message: toError(error).message
-            })
+            this.deps.logger.warn(
+                `failed to mark ${input.logTag} sender key distribution targets`,
+                {
+                    groupJid: input.groupJid,
+                    participants: distributedAddresses.length,
+                    message: toError(error).message
+                }
+            )
         }
         return result
     }
@@ -694,7 +652,7 @@ export class WaMessageDispatchCoordinator {
     public async requestAppStateSyncKeys(
         keyIds: readonly Uint8Array[]
     ): Promise<readonly string[]> {
-        return this.appStateSyncKeyProtocol.requestKeys(keyIds)
+        return this.deps.appStateSyncKeyProtocol.requestKeys(keyIds)
     }
 
     public async sendAppStateSyncKeyShare(
@@ -702,11 +660,11 @@ export class WaMessageDispatchCoordinator {
         keys: readonly WaAppStateSyncKey[],
         missingKeyIds: readonly Uint8Array[] = []
     ): Promise<void> {
-        await this.appStateSyncKeyProtocol.sendKeyShare(toDeviceJid, keys, missingKeyIds)
+        await this.deps.appStateSyncKeyProtocol.sendKeyShare(toDeviceJid, keys, missingKeyIds)
     }
 
     public async mutateGroupMetadataCacheFromGroupEvent(event: WaGroupEvent): Promise<void> {
-        await this.groupMetadataCache.mutateFromGroupEvent(event)
+        await this.deps.groupMetadataCache.mutateFromGroupEvent(event)
     }
 
     private shouldUseGroupDirectPath(message: Proto.IMessage): boolean {
@@ -735,19 +693,19 @@ export class WaMessageDispatchCoordinator {
         const sendOptions = await this.withResolvedMessageId(options)
         const meJid = this.requireCurrentMeJid('sendMessage')
         const participantUserJids = retryContext.forceRefreshParticipants
-            ? await this.groupMetadataCache.refreshParticipantUsers(groupJid)
-            : await this.groupMetadataCache.resolveParticipantUsers(groupJid)
+            ? await this.deps.groupMetadataCache.refreshParticipantUsers(groupJid)
+            : await this.deps.groupMetadataCache.resolveParticipantUsers(groupJid)
         const addressingMode =
             retryContext.forceAddressingMode ??
             this.resolveGroupAddressingMode(participantUserJids, groupJid)
         const senderForPhash = this.resolveSenderForAddressingMode(addressingMode, meJid)
         const fanoutDeviceJids =
-            await this.fanoutResolver.resolveGroupParticipantDeviceJids(participantUserJids)
+            await this.deps.fanoutResolver.resolveGroupParticipantDeviceJids(participantUserJids)
         if (fanoutDeviceJids.length === 0) {
             throw new Error('group direct send resolved no target devices')
         }
         const resolvedFanoutTargets =
-            await this.sessionResolver.ensureSessionsBatch(fanoutDeviceJids)
+            await this.deps.sessionResolver.ensureSessionsBatch(fanoutDeviceJids)
         const uniqueNormalizedFanoutJids = new Set<string>()
         for (let index = 0; index < fanoutDeviceJids.length; index += 1) {
             uniqueNormalizedFanoutJids.add(normalizeDeviceJid(fanoutDeviceJids[index]))
@@ -766,7 +724,7 @@ export class WaMessageDispatchCoordinator {
                 plaintext
             }
         }
-        const encryptedParticipants = await this.signalProtocol.encryptMessagesBatch(
+        const encryptedParticipants = await this.deps.signalProtocol.encryptMessagesBatch(
             participantEncryptRequests,
             resolvedFanoutTargets
         )
@@ -825,7 +783,7 @@ export class WaMessageDispatchCoordinator {
             type,
             plaintext
         }
-        const result = await this.retryTracker.track(
+        const result = await this.deps.retryTracker.track(
             {
                 messageIdHint: sendOptions.id ?? messageNode.attrs.id,
                 toJid: groupJid,
@@ -833,7 +791,7 @@ export class WaMessageDispatchCoordinator {
                 replayPayload,
                 eligibleRequesterDeviceJids: undefined
             },
-            async () => this.messageClient.publishNode(messageNode, sendOptions)
+            async () => this.deps.messageClient.publishNode(messageNode, sendOptions)
         )
         const ackError = result.ack.error
         const serverPhash = result.ack.phash
@@ -846,7 +804,7 @@ export class WaMessageDispatchCoordinator {
             !retryContext.retried &&
             (hasPhashMismatch || hasAddressingMismatch || hasAddressingError)
         ) {
-            this.logger.warn('group direct publish acknowledged with mismatch metadata', {
+            this.deps.logger.warn('group direct publish acknowledged with mismatch metadata', {
                 id: result.id,
                 groupJid,
                 localPhash,
@@ -891,7 +849,7 @@ export class WaMessageDispatchCoordinator {
         try {
             address = parseSignalAddressFromJid(botJid)
         } catch (error) {
-            this.logger.warn('bot sidecar: failed to parse bot jid', {
+            this.deps.logger.warn('bot sidecar: failed to parse bot jid', {
                 botJid,
                 message: toError(error).message
             })
@@ -900,16 +858,16 @@ export class WaMessageDispatchCoordinator {
 
         let resolvedTargets: readonly SignalResolvedSessionTarget[]
         try {
-            resolvedTargets = await this.sessionResolver.ensureSessionsBatch([botJid])
+            resolvedTargets = await this.deps.sessionResolver.ensureSessionsBatch([botJid])
         } catch (error) {
-            this.logger.warn('bot sidecar: signal session sync failed', {
+            this.deps.logger.warn('bot sidecar: signal session sync failed', {
                 botJid,
                 message: toError(error).message
             })
             return null
         }
         if (resolvedTargets.length === 0) {
-            this.logger.warn('bot sidecar: signal session not established', { botJid })
+            this.deps.logger.warn('bot sidecar: signal session not established', { botJid })
             return null
         }
 
@@ -922,7 +880,7 @@ export class WaMessageDispatchCoordinator {
         const botCopy = buildBotInvokeProtoCopy(message, botMessageSecret)
         const botPlaintext = await writeRandomPadMax16(proto.Message.encode(botCopy).finish())
         try {
-            const [encrypted] = await this.signalProtocol.encryptMessagesBatch(
+            const [encrypted] = await this.deps.signalProtocol.encryptMessagesBatch(
                 [{ address, plaintext: botPlaintext }],
                 resolvedTargets.map((target) => ({
                     address: target.address,
@@ -930,14 +888,14 @@ export class WaMessageDispatchCoordinator {
                 }))
             )
             if (!encrypted) return null
-            this.logger.debug('bot sidecar encrypted', { botJid, encType: encrypted.type })
+            this.deps.logger.debug('bot sidecar encrypted', { botJid, encType: encrypted.type })
             return {
                 jid: botJid,
                 encType: encrypted.type,
                 ciphertext: encrypted.ciphertext
             }
         } catch (error) {
-            this.logger.warn('bot sidecar: encryption failed', {
+            this.deps.logger.warn('bot sidecar: encryption failed', {
                 botJid,
                 message: toError(error).message
             })
@@ -960,8 +918,8 @@ export class WaMessageDispatchCoordinator {
         const sendOptions = await this.withResolvedMessageId(options)
         const meJid = this.requireCurrentMeJid('sendMessage')
         const participantUserJids = retryContext.forceRefreshParticipants
-            ? await this.groupMetadataCache.refreshParticipantUsers(groupJid)
-            : await this.groupMetadataCache.resolveParticipantUsers(groupJid)
+            ? await this.deps.groupMetadataCache.refreshParticipantUsers(groupJid)
+            : await this.deps.groupMetadataCache.resolveParticipantUsers(groupJid)
         const addressingMode =
             retryContext.forceAddressingMode ??
             this.resolveGroupAddressingMode(participantUserJids, groupJid)
@@ -971,7 +929,7 @@ export class WaMessageDispatchCoordinator {
             distributionMessage: senderKeyDistributionMessage,
             ciphertext: groupCiphertext,
             keyId: senderKeyId
-        } = await this.senderKeyManager.prepareGroupEncryption(groupJid, sender, plaintext)
+        } = await this.deps.senderKeyManager.prepareGroupEncryption(groupJid, sender, plaintext)
         const distributionData = await this.distributionDedup.run(
             `dist:${groupJid}:${senderKeyId}`,
             () =>
@@ -1030,7 +988,7 @@ export class WaMessageDispatchCoordinator {
             type,
             plaintext
         }
-        const result = await this.retryTracker.track(
+        const result = await this.deps.retryTracker.track(
             {
                 messageIdHint: sendOptions.id ?? messageNode.attrs.id,
                 toJid: groupJid,
@@ -1038,20 +996,20 @@ export class WaMessageDispatchCoordinator {
                 replayPayload,
                 eligibleRequesterDeviceJids: undefined
             },
-            async () => this.messageClient.publishNode(messageNode, sendOptions)
+            async () => this.deps.messageClient.publishNode(messageNode, sendOptions)
         )
         const distributedAddresses = new Array<SignalAddress>(distributionParticipants.length)
         for (let index = 0; index < distributionParticipants.length; index += 1) {
             distributedAddresses[index] = distributionParticipants[index].address
         }
         try {
-            await this.senderKeyManager.markSenderKeyDistributed(
+            await this.deps.senderKeyManager.markSenderKeyDistributed(
                 groupJid,
                 senderKeyId,
                 distributedAddresses
             )
         } catch (error) {
-            this.logger.warn('failed to mark sender key distribution targets', {
+            this.deps.logger.warn('failed to mark sender key distribution targets', {
                 groupJid,
                 participants: distributedAddresses.length,
                 message: toError(error).message
@@ -1068,7 +1026,7 @@ export class WaMessageDispatchCoordinator {
             !retryContext.retried &&
             (hasPhashMismatch || hasAddressingMismatch || hasAddressingError)
         ) {
-            this.logger.warn('group message publish acknowledged with mismatch metadata', {
+            this.deps.logger.warn('group message publish acknowledged with mismatch metadata', {
                 id: result.id,
                 groupJid,
                 localPhash,
@@ -1110,7 +1068,7 @@ export class WaMessageDispatchCoordinator {
             }
         }
 
-        this.logger.trace('group addressing mode resolved to pn (default)', {
+        this.deps.logger.trace('group addressing mode resolved to pn (default)', {
             groupJid,
             participants: participantUserJids.length
         })
@@ -1122,12 +1080,12 @@ export class WaMessageDispatchCoordinator {
         meJid: string
     ): string {
         if (addressingMode === 'lid') {
-            const meLid = this.getCurrentMeLid()
+            const meLid = this.deps.getCurrentCredentials()?.meLid
             if (meLid && meLid.includes('@')) {
                 try {
                     return normalizeDeviceJid(meLid)
                 } catch (error) {
-                    this.logger.trace('ignoring malformed me lid jid', {
+                    this.deps.logger.trace('ignoring malformed me lid jid', {
                         meLid,
                         message: toError(error).message
                     })
@@ -1157,7 +1115,7 @@ export class WaMessageDispatchCoordinator {
             }).finish()
         )
         const fanoutDeviceJids =
-            await this.fanoutResolver.resolveGroupParticipantDeviceJids(participantUserJids)
+            await this.deps.fanoutResolver.resolveGroupParticipantDeviceJids(participantUserJids)
         if (fanoutDeviceJids.length === 0) {
             return {
                 fanoutDeviceJids,
@@ -1178,11 +1136,12 @@ export class WaMessageDispatchCoordinator {
             fanoutAddresses[index] = address
             fanoutTargetsByAddressKey.set(signalAddressKey(address), { jid, address })
         }
-        const pendingAddresses = await this.senderKeyManager.filterParticipantsNeedingDistribution(
-            groupJid,
-            senderKeyId,
-            fanoutAddresses
-        )
+        const pendingAddresses =
+            await this.deps.senderKeyManager.filterParticipantsNeedingDistribution(
+                groupJid,
+                senderKeyId,
+                fanoutAddresses
+            )
         if (pendingAddresses.length === 0) {
             return {
                 fanoutDeviceJids,
@@ -1222,7 +1181,7 @@ export class WaMessageDispatchCoordinator {
         let prefetchedAvailableTargets: readonly SignalResolvedSessionTarget[] | undefined
         try {
             const resolvedTargets =
-                await this.sessionResolver.ensureSessionsBatch(pendingTargetJids)
+                await this.deps.sessionResolver.ensureSessionsBatch(pendingTargetJids)
             availableTargets = resolvedTargets
             prefetchedAvailableTargets = resolvedTargets
         } catch (error) {
@@ -1230,7 +1189,7 @@ export class WaMessageDispatchCoordinator {
             if (normalized.message === 'identity mismatch') {
                 throw normalized
             }
-            this.logger.warn(
+            this.deps.logger.warn(
                 'group sender-key distribution session sync failed, continuing with available sessions',
                 {
                     groupJid,
@@ -1242,7 +1201,8 @@ export class WaMessageDispatchCoordinator {
             for (let index = 0; index < pendingTargets.length; index += 1) {
                 pendingTargetAddresses[index] = pendingTargets[index].address
             }
-            const hasPendingSessions = await this.sessionStore.hasSessions(pendingTargetAddresses)
+            const hasPendingSessions =
+                await this.deps.sessionStore.hasSessions(pendingTargetAddresses)
             const nextAvailableTargets: {
                 readonly jid: string
                 readonly address: SignalAddress
@@ -1272,10 +1232,11 @@ export class WaMessageDispatchCoordinator {
                 plaintext: distributionPayload
             }
         }
-        const encryptedDistributionParticipants = await this.signalProtocol.encryptMessagesBatch(
-            distributionEncryptRequests,
-            prefetchedAvailableTargets
-        )
+        const encryptedDistributionParticipants =
+            await this.deps.signalProtocol.encryptMessagesBatch(
+                distributionEncryptRequests,
+                prefetchedAvailableTargets
+            )
         const distributionParticipants: {
             readonly jid: string
             readonly address: SignalAddress
@@ -1310,13 +1271,13 @@ export class WaMessageDispatchCoordinator {
     ): Promise<WaMessagePublishResult> {
         const sendOptions = await this.withResolvedMessageId(options)
         const meJid = this.requireCurrentMeJid('sendMessage')
-        const meLid = this.getCurrentMeLid()
-        const selfDeviceJidForRecipient = this.fanoutResolver.resolveSelfDeviceJidForRecipient(
+        const meLid = this.deps.getCurrentCredentials()?.meLid
+        const selfDeviceJidForRecipient = this.deps.fanoutResolver.resolveSelfDeviceJidForRecipient(
             recipientJid,
             meJid,
             meLid
         )
-        const deviceJids = await this.fanoutResolver.resolveDirectFanoutDeviceJids(
+        const deviceJids = await this.deps.fanoutResolver.resolveDirectFanoutDeviceJids(
             recipientJid,
             selfDeviceJidForRecipient
         )
@@ -1337,7 +1298,7 @@ export class WaMessageDispatchCoordinator {
         const recipientUserJid = toUserJid(recipientJid)
         const meUserJid = toUserJid(selfDeviceJidForRecipient)
 
-        this.logger.debug('wa client publish signal fanout', {
+        this.deps.logger.debug('wa client publish signal fanout', {
             to: recipientJid,
             devices: deviceJids.length,
             type
@@ -1351,7 +1312,7 @@ export class WaMessageDispatchCoordinator {
                 }
             }
         }
-        const resolvedFanoutTargets = await this.sessionResolver.ensureSessionsBatch(
+        const resolvedFanoutTargets = await this.deps.sessionResolver.ensureSessionsBatch(
             deviceJids,
             expectedIdentityByJid
         )
@@ -1425,7 +1386,7 @@ export class WaMessageDispatchCoordinator {
                 session: request.session
             }
         }
-        const encryptedParticipants = await this.signalProtocol.encryptMessagesBatch(
+        const encryptedParticipants = await this.deps.signalProtocol.encryptMessagesBatch(
             encryptRequests,
             prefetchedSessions
         )
@@ -1470,10 +1431,10 @@ export class WaMessageDispatchCoordinator {
             try {
                 privacyTokenNode =
                     (await this.privacyTokenDedup.run(`pt:${recipientUserJid}`, () =>
-                        this.resolvePrivacyTokenNode(recipientUserJid)
+                        this.deps.resolvePrivacyTokenNode(recipientUserJid)
                     )) ?? undefined
             } catch (error) {
-                this.logger.warn('privacy token resolution failed', {
+                this.deps.logger.warn('privacy token resolution failed', {
                     to: recipientUserJid,
                     message: toError(error).message
                 })
@@ -1499,7 +1460,7 @@ export class WaMessageDispatchCoordinator {
             type,
             plaintext
         }
-        const result = await this.retryTracker.track(
+        const result = await this.deps.retryTracker.track(
             {
                 messageIdHint: sendOptions.id ?? messageNode.attrs.id,
                 toJid: recipientJid,
@@ -1507,9 +1468,9 @@ export class WaMessageDispatchCoordinator {
                 replayPayload,
                 eligibleRequesterDeviceJids: deviceJids
             },
-            async () => this.messageClient.publishNode(messageNode, sendOptions)
+            async () => this.deps.messageClient.publishNode(messageNode, sendOptions)
         )
-        this.onDirectMessageSent(recipientUserJid)
+        this.deps.onDirectMessageSent(recipientUserJid)
         return result
     }
 
@@ -1560,7 +1521,7 @@ export class WaMessageDispatchCoordinator {
             ])
             return `3EB0${bytesToHex(digest.subarray(0, 9)).toUpperCase()}`
         } catch (error) {
-            this.logger.warn('failed to generate message id, falling back to random', {
+            this.deps.logger.warn('failed to generate message id, falling back to random', {
                 message: toError(error).message
             })
             if (this.mobileMessageIdFormat) {
@@ -1591,7 +1552,7 @@ export class WaMessageDispatchCoordinator {
                 remoteJid: input.remoteJid
             })
         } catch (error) {
-            this.logger.warn('failed to generate reporting token', {
+            this.deps.logger.warn('failed to generate reporting token', {
                 context: input.context,
                 id: input.stanzaId,
                 remoteJid: input.remoteJid,
@@ -1602,7 +1563,7 @@ export class WaMessageDispatchCoordinator {
     }
 
     private getEncodedSignedDeviceIdentity(): Uint8Array | undefined {
-        const signedIdentity = this.getCurrentSignedIdentity()
+        const signedIdentity = this.deps.getCurrentCredentials()?.signedIdentity
         if (!signedIdentity) {
             return undefined
         }
@@ -1615,20 +1576,20 @@ export class WaMessageDispatchCoordinator {
     ): Promise<IcdcMeta | null> {
         return this.icdcDedup.run(`icdc:${userJid}:${localIdentity ? '1' : '0'}`, async () => {
             try {
-                const snapshots = await this.deviceListStore.getUserDevicesBatch([userJid])
+                const snapshots = await this.deps.deviceListStore.getUserDevicesBatch([userJid])
                 const snapshot = snapshots[0]
                 if (!snapshot || snapshot.deviceJids.length === 0) {
                     return null
                 }
                 return resolveIcdcMeta(
                     snapshot.deviceJids,
-                    this.identityStore,
+                    this.deps.identityStore,
                     snapshot.updatedAtMs,
                     localIdentity,
-                    this.getIcdcHashLength?.()
+                    this.deps.getIcdcHashLength?.()
                 )
             } catch (error) {
-                this.logger.trace('icdc resolution failed', {
+                this.deps.logger.trace('icdc resolution failed', {
                     userJid,
                     message: toError(error).message
                 })
@@ -1638,7 +1599,7 @@ export class WaMessageDispatchCoordinator {
     }
 
     private requireCurrentMeJid(context: string): string {
-        const meJid = this.getCurrentMeJid()
+        const meJid = this.deps.getCurrentCredentials()?.meJid
         if (meJid) {
             return meJid
         }

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -1,9 +1,10 @@
+import type { WaAuthCredentials } from '@auth/types'
 import type { WaIncomingMessageEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import { buildRecoveredIncomingEvent } from '@message/primitives/incoming'
 import type { PeerDataOperationRequester } from '@message/primitives/peer-data-operation'
 import type { WaMessageClient } from '@message/WaMessageClient'
-import { proto, type Proto } from '@proto'
+import { proto } from '@proto'
 import { WA_MESSAGE_TAGS, WA_MESSAGE_TYPES } from '@protocol/constants'
 import {
     isGroupOrBroadcastJid,
@@ -57,9 +58,7 @@ interface WaRetryCoordinatorOptions {
     readonly signalMissingPreKeysSync: SignalMissingPreKeysSyncApi
     readonly messageClient: WaMessageClient
     readonly sendNode: (node: BinaryNode) => Promise<void>
-    readonly getCurrentMeJid: () => string | null | undefined
-    readonly getCurrentMeLid: () => string | null | undefined
-    readonly getCurrentSignedIdentity: () => Proto.IADVSignedDeviceIdentity | null | undefined
+    readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly peerDataOperation?: PeerDataOperationRequester
     readonly emitIncomingMessage?: (event: WaIncomingMessageEvent) => void
 }
@@ -133,60 +132,27 @@ function getRemoteRetryReasonLogFields(reason: number | undefined): {
 }
 
 export class WaRetryCoordinator {
-    private readonly logger: Logger
-    private readonly retryStore: WaRetryStore
+    private readonly deps: WaRetryCoordinatorOptions
     private readonly retryTtlMs: number
-    private readonly signalStore: WaSignalStore
-    private readonly preKeyStore: WaPreKeyStore
-    private readonly sessionStore: WaSessionStore
-    private readonly senderKeyStore: WaSenderKeyStore
-    private readonly signalProtocol: SignalProtocol
-    private readonly signalDeviceSync: SignalDeviceSyncApi
-    private readonly signalMissingPreKeysSync: SignalMissingPreKeysSyncApi
     private readonly retryReplayService: WaRetryReplayService
-    private readonly sendNode: (node: BinaryNode) => Promise<void>
-    private readonly getCurrentMeJid: () => string | null | undefined
-    private readonly getCurrentMeLid: () => string | null | undefined
-    private readonly getCurrentSignedIdentity: () =>
-        | Proto.IADVSignedDeviceIdentity
-        | null
-        | undefined
     private readonly retryProcessingByMessageId: Map<string, Promise<void>>
     private readonly retrySessionBaseKeys: Map<string, RetrySessionBaseKeySnapshot>
     private nextRetryCleanupAtMs = 0
-    private readonly peerDataOperation: PeerDataOperationRequester | null
-    private readonly emitIncomingMessage: ((event: WaIncomingMessageEvent) => void) | null
     private readonly placeholderInFlight: Set<string> = new Set()
     private placeholderQueue: PlaceholderResendQueueItem[] = []
     private placeholderTimer: ReturnType<typeof setTimeout> | null = null
 
     public constructor(options: WaRetryCoordinatorOptions) {
-        this.logger = options.logger
-        this.retryStore = options.retryStore
-        this.retryTtlMs = this.retryStore.getTtlMs?.() ?? RETRY_OUTBOUND_TTL_MS
-        this.signalStore = options.signalStore
-        this.preKeyStore = options.preKeyStore
-        this.sessionStore = options.sessionStore
-        this.senderKeyStore = options.senderKeyStore
-        this.signalProtocol = options.signalProtocol
-        this.signalDeviceSync = options.signalDeviceSync
-        this.signalMissingPreKeysSync = options.signalMissingPreKeysSync
-        this.sendNode = options.sendNode
-        this.getCurrentMeJid = options.getCurrentMeJid
-        this.getCurrentMeLid = options.getCurrentMeLid
-        this.getCurrentSignedIdentity = options.getCurrentSignedIdentity
+        this.deps = options
+        this.retryTtlMs = options.retryStore.getTtlMs?.() ?? RETRY_OUTBOUND_TTL_MS
         this.retryReplayService = new WaRetryReplayService({
-            logger: this.logger,
+            logger: options.logger,
             messageClient: options.messageClient,
-            signalProtocol: this.signalProtocol,
-            getCurrentMeJid: this.getCurrentMeJid,
-            getCurrentMeLid: this.getCurrentMeLid,
-            getCurrentSignedIdentity: this.getCurrentSignedIdentity
+            signalProtocol: options.signalProtocol,
+            getCurrentCredentials: options.getCurrentCredentials
         })
         this.retryProcessingByMessageId = new Map()
         this.retrySessionBaseKeys = new Map()
-        this.peerDataOperation = options.peerDataOperation ?? null
-        this.emitIncomingMessage = options.emitIncomingMessage ?? null
     }
 
     public async onDecryptFailure(
@@ -204,7 +170,7 @@ export class WaRetryCoordinator {
             await this.sendDecryptFailureRetryReceipt(context, prepared)
             return true
         } catch (sendError) {
-            this.logger.warn('failed to send retry receipt for decrypt failure', {
+            this.deps.logger.warn('failed to send retry receipt for decrypt failure', {
                 id: context.stanzaId,
                 from: context.from,
                 participant: context.participant,
@@ -223,8 +189,9 @@ export class WaRetryCoordinator {
         try {
             await this.maybeCleanupRetryStore(Date.now())
             const expectedToJids: string[] = []
-            const meJid = this.getCurrentMeJid()?.trim()
-            const meLid = this.getCurrentMeLid()?.trim()
+            const credentials = this.deps.getCurrentCredentials()
+            const meJid = credentials?.meJid?.trim()
+            const meLid = credentials?.meLid?.trim()
             if (meJid) {
                 expectedToJids.push(meJid)
             }
@@ -241,7 +208,7 @@ export class WaRetryCoordinator {
             shouldAck = true
             await this.handleParsedRetryRequest(receiptNode, request)
         } catch (error) {
-            this.logger.warn('failed handling incoming retry request', {
+            this.deps.logger.warn('failed handling incoming retry request', {
                 id: receiptNode.attrs.id,
                 from: receiptNode.attrs.from,
                 participant: receiptNode.attrs.participant,
@@ -267,9 +234,9 @@ export class WaRetryCoordinator {
         error: unknown
     ): Promise<RetryDecryptFailurePreparation | null> {
         const nowMs = Date.now()
-        const registrationInfo = await this.signalStore.getRegistrationInfo()
+        const registrationInfo = await this.deps.signalStore.getRegistrationInfo()
         if (!registrationInfo) {
-            this.logger.warn('retry receipt skipped: missing local registration info', {
+            this.deps.logger.warn('retry receipt skipped: missing local registration info', {
                 id: context.stanzaId,
                 from: context.from
             })
@@ -278,7 +245,7 @@ export class WaRetryCoordinator {
 
         const requester = context.participant ?? context.from
         const expiresAtMs = nowMs + this.retryTtlMs
-        const retryCount = await this.retryStore.incrementInboundCounter(
+        const retryCount = await this.deps.retryStore.incrementInboundCounter(
             context.stanzaId,
             requester,
             nowMs,
@@ -329,8 +296,8 @@ export class WaRetryCoordinator {
             categoryPeer: context.messageNode.attrs.category === 'peer',
             keys: prepared.retryKeys
         })
-        await this.sendNode(retryReceiptNode)
-        this.logger.debug('sent retry receipt for decrypt failure', {
+        await this.deps.sendNode(retryReceiptNode)
+        this.deps.logger.debug('sent retry receipt for decrypt failure', {
             id: context.stanzaId,
             to: context.from,
             participant: context.participant,
@@ -345,7 +312,7 @@ export class WaRetryCoordinator {
         if (!context.participant) {
             return undefined
         }
-        const meLid = this.getCurrentMeLid()
+        const meLid = this.deps.getCurrentCredentials()?.meLid
         if (!meLid) {
             return undefined
         }
@@ -366,7 +333,7 @@ export class WaRetryCoordinator {
         request: WaParsedRetryRequest
     ): Promise<void> {
         if (request.type === 'enc_rekey_retry') {
-            this.logger.info('received enc_rekey_retry request (voip path deferred)', {
+            this.deps.logger.info('received enc_rekey_retry request (voip path deferred)', {
                 id: request.stanzaId,
                 originalMsgId: request.originalMsgId,
                 from: request.from,
@@ -393,7 +360,7 @@ export class WaRetryCoordinator {
             request.retryCount
         )
         if (resendResult === 'ineligible') {
-            this.logger.info('retry request marked ineligible for resend', {
+            this.deps.logger.info('retry request marked ineligible for resend', {
                 id: request.stanzaId,
                 originalMsgId: request.originalMsgId,
                 requester: prepared.requesterJid,
@@ -402,7 +369,7 @@ export class WaRetryCoordinator {
             return
         }
 
-        this.logger.info('retry request processed and resent', {
+        this.deps.logger.info('retry request processed and resent', {
             id: request.stanzaId,
             originalMsgId: request.originalMsgId,
             requester: prepared.requesterJid,
@@ -417,7 +384,7 @@ export class WaRetryCoordinator {
     ): Promise<RetryResendPreparation | null> {
         const requesterJid = request.participant ?? request.from ?? null
         if (!requesterJid) {
-            this.logger.warn('retry request ignored: missing requester jid', {
+            this.deps.logger.warn('retry request ignored: missing requester jid', {
                 id: request.stanzaId,
                 originalMsgId: request.originalMsgId
             })
@@ -430,7 +397,7 @@ export class WaRetryCoordinator {
             requesterAddress = requesterParsed.address
             requesterNormalizedDeviceJid = requesterParsed.normalizedJid
         } catch (error) {
-            this.logger.info('retry request rejected: invalid requester jid', {
+            this.deps.logger.info('retry request rejected: invalid requester jid', {
                 id: request.stanzaId,
                 originalMsgId: request.originalMsgId,
                 requester: requesterJid,
@@ -440,7 +407,7 @@ export class WaRetryCoordinator {
         }
 
         if (request.retryCount >= MAX_RETRY_ATTEMPTS) {
-            this.logger.info('retry request rejected: retry count exceeded', {
+            this.deps.logger.info('retry request rejected: retry count exceeded', {
                 id: request.stanzaId,
                 originalMsgId: request.originalMsgId,
                 requester: requesterJid,
@@ -450,9 +417,9 @@ export class WaRetryCoordinator {
             return null
         }
 
-        const outbound = await this.retryStore.getOutboundMessage(request.originalMsgId)
+        const outbound = await this.deps.retryStore.getOutboundMessage(request.originalMsgId)
         if (!outbound) {
-            this.logger.info('retry request ignored: outbound message not found', {
+            this.deps.logger.info('retry request ignored: outbound message not found', {
                 id: request.stanzaId,
                 originalMsgId: request.originalMsgId,
                 requester: requesterJid
@@ -467,7 +434,7 @@ export class WaRetryCoordinator {
             requesterNormalizedDeviceJid
         )
         if (!sessionReady) {
-            this.logger.info('retry request rejected: missing compatible session', {
+            this.deps.logger.info('retry request rejected: missing compatible session', {
                 id: request.stanzaId,
                 originalMsgId: request.originalMsgId,
                 requester: requesterJid,
@@ -485,7 +452,7 @@ export class WaRetryCoordinator {
             requesterNormalizedDeviceJid
         )
         if (!authorization.authorized) {
-            this.logger.info('retry request rejected', {
+            this.deps.logger.info('retry request rejected', {
                 id: request.stanzaId,
                 originalMsgId: request.originalMsgId,
                 requester: requesterJid,
@@ -522,7 +489,7 @@ export class WaRetryCoordinator {
         }
 
         await this.runRetryTaskSerialized(messageId, async () => {
-            const current = await this.retryStore.getOutboundMessage(messageId)
+            const current = await this.deps.retryStore.getOutboundMessage(messageId)
             if (!current) {
                 return
             }
@@ -530,7 +497,7 @@ export class WaRetryCoordinator {
             const expiresAtMs = nowMs + this.retryTtlMs
             const merged = pickRetryStateMax(current.state, nextState)
             if (merged !== current.state) {
-                await this.retryStore.updateOutboundMessageState(
+                await this.deps.retryStore.updateOutboundMessageState(
                     messageId,
                     merged,
                     nowMs,
@@ -542,14 +509,14 @@ export class WaRetryCoordinator {
                 return
             }
             try {
-                await this.retryStore.markOutboundRequesterDelivered(
+                await this.deps.retryStore.markOutboundRequesterDelivered(
                     messageId,
                     normalizeDeviceJid(requesterJid),
                     nowMs,
                     expiresAtMs
                 )
             } catch (error) {
-                this.logger.warn('failed to update outbound requester delivery state', {
+                this.deps.logger.warn('failed to update outbound requester delivery state', {
                     id: messageId,
                     requester: requesterJid,
                     message: toError(error).message
@@ -582,15 +549,15 @@ export class WaRetryCoordinator {
 
     private async buildRetryKeysSection(identity: Uint8Array): Promise<WaRetryKeyBundle | null> {
         const [signedPreKey, preKey] = await Promise.all([
-            this.signalStore.getSignedPreKey(),
-            this.preKeyStore.getOrGenSinglePreKey(generatePreKeyPair)
+            this.deps.signalStore.getSignedPreKey(),
+            this.deps.preKeyStore.getOrGenSinglePreKey(generatePreKeyPair)
         ])
         if (!signedPreKey) {
-            this.logger.warn('retry keys section skipped: signed prekey unavailable')
+            this.deps.logger.warn('retry keys section skipped: signed prekey unavailable')
             return null
         }
-        await this.preKeyStore.markKeyAsUploaded(preKey.keyId)
-        const signedIdentity = this.getCurrentSignedIdentity()
+        await this.deps.preKeyStore.markKeyAsUploaded(preKey.keyId)
+        const signedIdentity = this.deps.getCurrentCredentials()?.signedIdentity
         return {
             identity,
             key: {
@@ -616,12 +583,12 @@ export class WaRetryCoordinator {
     ): Promise<boolean> {
         const [, currentSession] = await Promise.all([
             this.markRetryRequesterSenderKeyAsStale(request, requesterJid, requesterAddress),
-            this.sessionStore.getSession(requesterAddress)
+            this.deps.sessionStore.getSession(requesterAddress)
         ])
         const regIdMismatch =
             !!currentSession && request.regId > 0 && currentSession.remote.regId !== request.regId
         if (regIdMismatch && !request.keyBundle) {
-            await this.sessionStore.deleteSession(requesterAddress)
+            await this.deps.sessionStore.deleteSession(requesterAddress)
         }
         if (request.keyBundle) {
             if (!request.keyBundle.key || !request.keyBundle.skey.signature) {
@@ -629,7 +596,7 @@ export class WaRetryCoordinator {
             }
             if (request.offline) {
                 if (!currentSession) {
-                    this.logger.info(
+                    this.deps.logger.info(
                         'retry request rejected: offline retry missing existing session',
                         {
                             id: request.stanzaId,
@@ -639,11 +606,11 @@ export class WaRetryCoordinator {
                             ...getRemoteRetryReasonLogFields(request.retryReason)
                         }
                     )
-                    await this.sessionStore.deleteSession(requesterAddress)
+                    await this.deps.sessionStore.deleteSession(requesterAddress)
                     return false
                 }
                 if (regIdMismatch) {
-                    this.logger.info(
+                    this.deps.logger.info(
                         'retry request rejected: offline retry registration id mismatch',
                         {
                             id: request.stanzaId,
@@ -653,13 +620,13 @@ export class WaRetryCoordinator {
                             ...getRemoteRetryReasonLogFields(request.retryReason)
                         }
                     )
-                    await this.sessionStore.deleteSession(requesterAddress)
+                    await this.deps.sessionStore.deleteSession(requesterAddress)
                     return false
                 }
             } else if (regIdMismatch) {
-                await this.sessionStore.deleteSession(requesterAddress)
+                await this.deps.sessionStore.deleteSession(requesterAddress)
             }
-            await this.signalProtocol.establishOutgoingSession(requesterAddress, {
+            await this.deps.signalProtocol.establishOutgoingSession(requesterAddress, {
                 regId: request.regId,
                 identity: request.keyBundle.identity,
                 signedKey: {
@@ -699,7 +666,7 @@ export class WaRetryCoordinator {
         if (!fetched) {
             return false
         }
-        await this.signalProtocol.establishOutgoingSession(requesterAddress, fetched)
+        await this.deps.signalProtocol.establishOutgoingSession(requesterAddress, fetched)
         return this.applySessionBaseKeyPolicy(
             request,
             requesterJid,
@@ -717,7 +684,7 @@ export class WaRetryCoordinator {
         if (request.retryCount < 2) {
             return true
         }
-        const currentSession = await this.sessionStore.getSession(requesterAddress)
+        const currentSession = await this.deps.sessionStore.getSession(requesterAddress)
         const sessionBaseKey = currentSession?.aliceBaseKey ?? null
         if (!sessionBaseKey) {
             return true
@@ -741,8 +708,8 @@ export class WaRetryCoordinator {
             return true
         }
 
-        await this.sessionStore.deleteSession(requesterAddress)
-        this.logger.info('retry request forcing session refresh due to repeated base key', {
+        await this.deps.sessionStore.deleteSession(requesterAddress)
+        this.deps.logger.info('retry request forcing session refresh due to repeated base key', {
             id: request.stanzaId,
             originalMsgId: request.originalMsgId,
             requester: requesterJid,
@@ -758,7 +725,7 @@ export class WaRetryCoordinator {
         if (!fetched) {
             return false
         }
-        await this.signalProtocol.establishOutgoingSession(requesterAddress, fetched)
+        await this.deps.signalProtocol.establishOutgoingSession(requesterAddress, fetched)
         return true
     }
 
@@ -771,16 +738,16 @@ export class WaRetryCoordinator {
             return
         }
         try {
-            const deleted = await this.senderKeyStore.markForgetSenderKey(request.from, [
+            const deleted = await this.deps.senderKeyStore.markForgetSenderKey(request.from, [
                 requesterAddress
             ])
-            this.logger.debug('marked sender key as stale for group retry requester', {
+            this.deps.logger.debug('marked sender key as stale for group retry requester', {
                 groupJid: request.from,
                 requester: requesterJid,
                 deleted
             })
         } catch (error) {
-            this.logger.warn('failed to mark sender key as stale for group retry requester', {
+            this.deps.logger.warn('failed to mark sender key as stale for group retry requester', {
                 groupJid: request.from,
                 requester: requesterJid,
                 message: toError(error).message
@@ -795,7 +762,7 @@ export class WaRetryCoordinator {
         requesterRegistrationId: number
     ): Promise<SignalPreKeyBundle | null> {
         try {
-            const results = await this.signalMissingPreKeysSync.fetchMissingPreKeys([
+            const results = await this.deps.signalMissingPreKeysSync.fetchMissingPreKeys([
                 {
                     userJid: `${requesterAddress.user}@${requesterAddress.server}`,
                     devices: [
@@ -808,7 +775,7 @@ export class WaRetryCoordinator {
             ])
             const first = results[0]
             if (!first || !('devices' in first)) {
-                this.logger.warn('missing prekeys fetch returned user error', {
+                this.deps.logger.warn('missing prekeys fetch returned user error', {
                     requester: requesterJid,
                     errorText: first && 'errorText' in first ? first.errorText : 'unknown'
                 })
@@ -819,7 +786,7 @@ export class WaRetryCoordinator {
                 (device) => normalizeDeviceJid(device.deviceJid) === requesterNormalizedDeviceJid
             )
             if (!matched) {
-                this.logger.warn('missing prekeys fetch did not return requested device', {
+                this.deps.logger.warn('missing prekeys fetch did not return requested device', {
                     requester: requesterJid,
                     devices: first.devices.length
                 })
@@ -827,7 +794,7 @@ export class WaRetryCoordinator {
             }
             return matched.bundle
         } catch (error) {
-            this.logger.warn('failed to fetch missing prekeys for retry requester', {
+            this.deps.logger.warn('failed to fetch missing prekeys for retry requester', {
                 requester: requesterJid,
                 message: toError(error).message
             })
@@ -850,12 +817,12 @@ export class WaRetryCoordinator {
             readonly delivered: boolean
         } | null = null
         try {
-            requesterStatus = await this.retryStore.getOutboundRequesterStatus(
+            requesterStatus = await this.deps.retryStore.getOutboundRequesterStatus(
                 outbound.messageId,
                 requesterNormalizedDeviceJid
             )
         } catch (error) {
-            this.logger.warn('failed to resolve outbound requester status from retry store', {
+            this.deps.logger.warn('failed to resolve outbound requester status from retry store', {
                 id: request.stanzaId,
                 originalMsgId: request.originalMsgId,
                 requester: requesterJid,
@@ -897,7 +864,7 @@ export class WaRetryCoordinator {
             if (requesterNormalizedDeviceJid === normalizeDeviceJid(requesterUser)) {
                 return true
             }
-            const synced = await this.signalDeviceSync.syncDeviceList([requesterUser])
+            const synced = await this.deps.signalDeviceSync.syncDeviceList([requesterUser])
             const target = synced.find((entry) => entry.jid === requesterUser)
             if (!target) {
                 return false
@@ -909,10 +876,13 @@ export class WaRetryCoordinator {
             }
             return false
         } catch (error) {
-            this.logger.warn('retry authorization failed while syncing requester device list', {
-                requester: requesterJid,
-                message: toError(error).message
-            })
+            this.deps.logger.warn(
+                'retry authorization failed while syncing requester device list',
+                {
+                    requester: requesterJid,
+                    message: toError(error).message
+                }
+            )
             return false
         }
     }
@@ -939,7 +909,7 @@ export class WaRetryCoordinator {
 
     private async sendRetryAckSafe(receiptNode: BinaryNode): Promise<void> {
         if (!receiptNode.attrs.id || !receiptNode.attrs.from) {
-            this.logger.warn('retry ack skipped: missing receipt id/from', {
+            this.deps.logger.warn('retry ack skipped: missing receipt id/from', {
                 hasId: receiptNode.attrs.id !== undefined,
                 hasFrom: receiptNode.attrs.from !== undefined,
                 participant: receiptNode.attrs.participant,
@@ -948,7 +918,7 @@ export class WaRetryCoordinator {
             return
         }
         try {
-            await this.sendNode(
+            await this.deps.sendNode(
                 buildAckNode({
                     kind: 'receipt',
                     node: receiptNode,
@@ -956,7 +926,7 @@ export class WaRetryCoordinator {
                 })
             )
         } catch (error) {
-            this.logger.warn('failed to send retry ack', {
+            this.deps.logger.warn('failed to send retry ack', {
                 id: receiptNode.attrs.id,
                 from: receiptNode.attrs.from,
                 participant: receiptNode.attrs.participant,
@@ -972,9 +942,9 @@ export class WaRetryCoordinator {
         this.nextRetryCleanupAtMs = nowMs + RETRY_CLEANUP_INTERVAL_MS
         this.cleanupRetrySessionBaseKeys(nowMs)
         try {
-            await this.retryStore.cleanupExpired(nowMs)
+            await this.deps.retryStore.cleanupExpired(nowMs)
         } catch (error) {
-            this.logger.warn('retry store cleanup failed', {
+            this.deps.logger.warn('retry store cleanup failed', {
                 message: toError(error).message
             })
         }
@@ -1032,14 +1002,15 @@ export class WaRetryCoordinator {
 
     private isSenderFromOwnAccount(context: WaRetryDecryptFailureContext): boolean {
         const senderUser = parseSignalAddressFromJid(context.participant ?? context.from).user
-        const meLid = this.getCurrentMeLid()
+        const credentials = this.deps.getCurrentCredentials()
+        const meLid = credentials?.meLid
         if (meLid && parseSignalAddressFromJid(meLid).user === senderUser) return true
-        const meJid = this.getCurrentMeJid()
+        const meJid = credentials?.meJid
         return !!meJid && parseSignalAddressFromJid(meJid).user === senderUser
     }
 
     private enqueuePlaceholderResend(context: WaRetryDecryptFailureContext): boolean {
-        if (!this.peerDataOperation || !this.emitIncomingMessage) {
+        if (!this.deps.peerDataOperation || !this.deps.emitIncomingMessage) {
             return false
         }
         const subtype = context.messageNode.attrs.subtype
@@ -1057,7 +1028,7 @@ export class WaRetryCoordinator {
             return true
         }
         if (this.placeholderInFlight.size >= PLACEHOLDER_RESEND_IN_FLIGHT_MAX) {
-            this.logger.warn('placeholder resend: in-flight set saturated, dropping enqueue', {
+            this.deps.logger.warn('placeholder resend: in-flight set saturated, dropping enqueue', {
                 id: context.stanzaId,
                 maxInFlight: PLACEHOLDER_RESEND_IN_FLIGHT_MAX
             })
@@ -1080,8 +1051,8 @@ export class WaRetryCoordinator {
     }
 
     private async flushPlaceholderBatch(): Promise<void> {
-        const peerDataOperation = this.peerDataOperation
-        const emitIncomingMessage = this.emitIncomingMessage
+        const peerDataOperation = this.deps.peerDataOperation
+        const emitIncomingMessage = this.deps.emitIncomingMessage
         if (!peerDataOperation || !emitIncomingMessage) {
             this.placeholderQueue = []
             this.placeholderInFlight.clear()
@@ -1112,13 +1083,16 @@ export class WaRetryCoordinator {
                         const recovered = proto.WebMessageInfo.decode(bytes)
                         emitIncomingMessage(buildRecoveredIncomingEvent(recovered))
                     } catch (error) {
-                        this.logger.warn('placeholder resend: failed to decode WebMessageInfo', {
-                            message: toError(error).message
-                        })
+                        this.deps.logger.warn(
+                            'placeholder resend: failed to decode WebMessageInfo',
+                            {
+                                message: toError(error).message
+                            }
+                        )
                     }
                 }
             } catch (error) {
-                this.logger.warn('placeholder resend: request failed', {
+                this.deps.logger.warn('placeholder resend: request failed', {
                     batchSize: batch.length,
                     message: toError(error).message
                 })

--- a/src/client/coordinators/WaTrustedContactTokenCoordinator.ts
+++ b/src/client/coordinators/WaTrustedContactTokenCoordinator.ts
@@ -1,3 +1,4 @@
+import type { WaAuthCredentials } from '@auth/types'
 import type { ParsedPrivacyToken } from '@client/events/privacy-token'
 import { CsTokenGenerator } from '@client/tokens/cs-token'
 import { clampDuration, isTokenExpired, shouldSendNewToken } from '@client/tokens/tc-token'
@@ -28,7 +29,7 @@ type WaTrustedContactTokenRuntime = {
         event: K,
         ...args: Parameters<WaClientEventMap[K]>
     ) => void
-    readonly getCurrentMeLid: () => string | null
+    readonly getCurrentCredentials: () => WaAuthCredentials | null
 }
 
 interface WaTrustedContactTokenConfig {
@@ -127,7 +128,7 @@ export class WaTrustedContactTokenCoordinator {
             return null
         }
 
-        const meLid = this.runtime.getCurrentMeLid()
+        const meLid = this.runtime.getCurrentCredentials()?.meLid
         if (!meLid) {
             return null
         }

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -93,7 +93,7 @@ function createGroupEvent(input: {
 function createMessageDispatchCoordinator(
     groupMetadataStore: WaGroupMetadataMemoryStore,
     overrides?: {
-        readonly getCurrentMeJid?: () => string | null
+        readonly meJid?: string
         readonly mobileMessageIdFormat?: boolean
     }
 ): WaMessageDispatchCoordinator {
@@ -121,9 +121,8 @@ function createMessageDispatchCoordinator(
         messageSecretStore: {
             set: async (_id: string, _entry: { secret: Uint8Array; senderJid: string }) => {}
         } as never,
-        getCurrentMeJid: overrides?.getCurrentMeJid ?? (() => null),
-        getCurrentMeLid: () => null,
-        getCurrentSignedIdentity: () => null,
+        getCurrentCredentials: () =>
+            overrides?.meJid ? ({ meJid: overrides.meJid } as never) : null,
         resolvePrivacyTokenNode: async () => null,
         onDirectMessageSent: () => undefined,
         mobileMessageIdFormat: overrides?.mobileMessageIdFormat
@@ -717,7 +716,7 @@ test('message dispatch coordinator handles linked and modify participant cache e
 test('mobile message id format: AC + 30 hex chars uppercase', async () => {
     const groupMetadataStore = new WaGroupMetadataMemoryStore(60_000)
     const coordinator = createMessageDispatchCoordinator(groupMetadataStore, {
-        getCurrentMeJid: () => '5596965746475@s.whatsapp.net',
+        meJid: '5596965746475@s.whatsapp.net',
         mobileMessageIdFormat: true
     })
     const gen = coordinator as unknown as {
@@ -736,7 +735,7 @@ test('mobile message id format: AC + 30 hex chars uppercase', async () => {
 test('web message id format stays 3EB0 + 18 hex chars when mobile flag unset', async () => {
     const groupMetadataStore = new WaGroupMetadataMemoryStore(60_000)
     const coordinator = createMessageDispatchCoordinator(groupMetadataStore, {
-        getCurrentMeJid: () => '5596965746475@s.whatsapp.net'
+        meJid: '5596965746475@s.whatsapp.net'
     })
     const gen = coordinator as unknown as {
         generateOutgoingMessageId(): Promise<string>

--- a/src/client/coordinators/__tests__/retry-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/retry-coordinator.test.ts
@@ -205,9 +205,7 @@ function createPlaceholderHarness(): PlaceholderHarness {
         signalMissingPreKeysSync: {} as never,
         messageClient: {} as never,
         sendNode: async () => undefined,
-        getCurrentMeJid: () => null,
-        getCurrentMeLid: () => null,
-        getCurrentSignedIdentity: () => null,
+        getCurrentCredentials: () => null,
         peerDataOperation,
         emitIncomingMessage: (event) => emitted.push(event)
     })
@@ -395,9 +393,7 @@ test('retry coordinator serializes outbound receipt tracking per message id', as
         signalMissingPreKeysSync: {} as never,
         messageClient: {} as never,
         sendNode: async () => undefined,
-        getCurrentMeJid: () => null,
-        getCurrentMeLid: () => null,
-        getCurrentSignedIdentity: () => null
+        getCurrentCredentials: () => null
     })
 
     const deliveryTracking = coordinator.trackOutboundReceipt(buildReceiptNode('msg-1', 'delivery'))

--- a/src/client/coordinators/__tests__/trusted-contact-token-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/trusted-contact-token-coordinator.test.ts
@@ -10,11 +10,13 @@ import { WaPrivacyTokenMemoryStore } from '@store/memory/privacy-token.store'
 import type { BinaryNode } from '@transport/types'
 
 function createRuntime(options?: {
-    readonly getCurrentMeLid?: () => string | null
+    readonly meLid?: string | null
     readonly queryDelayMs?: number
 }) {
     const queries: { readonly context: string; readonly node: BinaryNode }[] = []
     const emitted: { readonly event: keyof WaClientEventMap; readonly payload: unknown }[] = []
+
+    const meLid = options?.meLid === undefined ? '551199999999:0@lid' : options.meLid
 
     const runtime = {
         queryWithContext: async (context: string, node: BinaryNode) => {
@@ -30,7 +32,7 @@ function createRuntime(options?: {
             event: K,
             ...args: Parameters<WaClientEventMap[K]>
         ) => void,
-        getCurrentMeLid: options?.getCurrentMeLid ?? (() => '551199999999:0@lid')
+        getCurrentCredentials: () => (meLid ? ({ meLid } as never) : null)
     }
 
     return {

--- a/src/client/messaging/__tests__/messaging.test.ts
+++ b/src/client/messaging/__tests__/messaging.test.ts
@@ -36,8 +36,11 @@ function createGroupEvent(input: {
 test('device fanout resolver picks meLid only when recipient is lid', () => {
     const resolver = createDeviceFanoutResolver({
         signalDeviceSync: {} as never,
-        getCurrentMeJid: () => '551100000000:1@s.whatsapp.net',
-        getCurrentMeLid: () => '551100000000:1@lid',
+        getCurrentCredentials: () =>
+            ({
+                meJid: '551100000000:1@s.whatsapp.net',
+                meLid: '551100000000:1@lid'
+            }) as never,
         logger: createNoopLogger()
     })
 
@@ -73,8 +76,11 @@ test('device fanout resolver keeps hosted devices in direct fanout', async () =>
                 }
             ]
         } as never,
-        getCurrentMeJid: () => '551100000000:1@s.whatsapp.net',
-        getCurrentMeLid: () => '551100000000:1@lid',
+        getCurrentCredentials: () =>
+            ({
+                meJid: '551100000000:1@s.whatsapp.net',
+                meLid: '551100000000:1@lid'
+            }) as never,
         logger: createNoopLogger()
     })
 
@@ -103,8 +109,7 @@ test('device fanout resolver excludes hosted devices in group fanout', async () 
                 }
             ]
         } as never,
-        getCurrentMeJid: () => '551100000000:1@s.whatsapp.net',
-        getCurrentMeLid: () => null,
+        getCurrentCredentials: () => ({ meJid: '551100000000:1@s.whatsapp.net' }) as never,
         logger: createNoopLogger()
     })
 
@@ -307,8 +312,7 @@ test('app-state sync key protocol requests keys from peer devices and dedupes ke
                 '551100000000:3@s.whatsapp.net'
             ]
         } as never,
-        getCurrentMeJid: () => '551100000000:1@s.whatsapp.net',
-        getCurrentMeLid: () => null,
+        getCurrentCredentials: () => ({ meJid: '551100000000:1@s.whatsapp.net' }) as never,
         logger: createNoopLogger()
     })
 

--- a/src/client/messaging/fanout.ts
+++ b/src/client/messaging/fanout.ts
@@ -1,3 +1,4 @@
+import type { WaAuthCredentials } from '@auth/types'
 import type { Logger } from '@infra/log/types'
 import { PromiseDedup } from '@infra/perf/PromiseDedup'
 import { isHostedDeviceJid, normalizeDeviceJid, splitJid, toUserJid } from '@protocol/jid'
@@ -25,11 +26,10 @@ export type DeviceFanoutResolver = {
 
 export function createDeviceFanoutResolver(options: {
     readonly signalDeviceSync: SignalDeviceSyncApi
-    readonly getCurrentMeJid: () => string | null | undefined
-    readonly getCurrentMeLid: () => string | null | undefined
+    readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly logger: Logger
 }): DeviceFanoutResolver {
-    const { signalDeviceSync, getCurrentMeJid, getCurrentMeLid, logger } = options
+    const { signalDeviceSync, getCurrentCredentials, logger } = options
     const dedup = new PromiseDedup()
 
     const resolveDirectFanoutDeviceJids = async (
@@ -83,7 +83,8 @@ export function createDeviceFanoutResolver(options: {
         participantUserJids: readonly string[]
     ): Promise<readonly string[]> => {
         const meDeviceJids = new Set<string>()
-        const meJid = getCurrentMeJid()
+        const credentials = getCurrentCredentials()
+        const meJid = credentials?.meJid
         if (meJid) {
             try {
                 meDeviceJids.add(normalizeDeviceJid(meJid))
@@ -95,7 +96,7 @@ export function createDeviceFanoutResolver(options: {
             }
         }
 
-        const meLid = getCurrentMeLid()
+        const meLid = credentials?.meLid
         if (meLid && meLid.includes('@')) {
             try {
                 meDeviceJids.add(normalizeDeviceJid(meLid))
@@ -172,7 +173,8 @@ export function createDeviceFanoutResolver(options: {
     }
 
     const resolveOwnPeerDeviceJids = async (): Promise<readonly string[]> => {
-        const meJid = getCurrentMeJid()
+        const credentials = getCurrentCredentials()
+        const meJid = credentials?.meJid
         if (!meJid) {
             throw new Error('resolveOwnPeerDeviceJids requires registered meJid')
         }
@@ -180,7 +182,7 @@ export function createDeviceFanoutResolver(options: {
         const meDevices = new Set<string>()
         meDevices.add(normalizeDeviceJid(meJid))
 
-        const meLid = getCurrentMeLid()
+        const meLid = credentials?.meLid
         if (meLid && meLid.includes('@')) {
             try {
                 meDevices.add(normalizeDeviceJid(meLid))

--- a/src/client/messaging/key-protocol.ts
+++ b/src/client/messaging/key-protocol.ts
@@ -1,4 +1,5 @@
 import type { WaAppStateSyncKey } from '@appstate/types'
+import type { WaAuthCredentials } from '@auth/types'
 import type { DeviceFanoutResolver } from '@client/messaging/fanout'
 import type { Logger } from '@infra/log/types'
 import type { WaMessagePublishResult } from '@message/types'
@@ -24,22 +25,15 @@ export type AppStateSyncKeyProtocol = {
 export function createAppStateSyncKeyProtocol(options: {
     readonly publishProtocolMessageToDevice: PublishProtocolMessageToDeviceFn
     readonly fanoutResolver: DeviceFanoutResolver
-    readonly getCurrentMeJid: () => string | null | undefined
-    readonly getCurrentMeLid: () => string | null | undefined
+    readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly logger: Logger
 }): AppStateSyncKeyProtocol {
-    const {
-        publishProtocolMessageToDevice,
-        fanoutResolver,
-        getCurrentMeJid,
-        getCurrentMeLid,
-        logger
-    } = options
+    const { publishProtocolMessageToDevice, fanoutResolver, getCurrentCredentials, logger } =
+        options
 
     const requireCurrentIdentity = (context: string): void => {
-        const meJid = getCurrentMeJid()
-        const meLid = getCurrentMeLid()
-        if (meJid || meLid) {
+        const credentials = getCurrentCredentials()
+        if (credentials?.meJid || credentials?.meLid) {
             return
         }
         throw new Error(`${context} requires registered identity`)

--- a/src/message/primitives/__tests__/peer-data-operation.test.ts
+++ b/src/message/primitives/__tests__/peer-data-operation.test.ts
@@ -40,7 +40,7 @@ function createHarness(opts?: {
             published.push({ deviceJid, protocolMessage, id })
             return { id } as WaMessagePublishResult
         },
-        getCurrentMeJid: () => '5511920387975:0@s.whatsapp.net',
+        getCurrentCredentials: () => ({ meJid: '5511920387975:0@s.whatsapp.net' }) as never,
         generateOutgoingMessageId: async () => {
             const id = `msg-${counter}`
             counter += 1

--- a/src/message/primitives/peer-data-operation.ts
+++ b/src/message/primitives/peer-data-operation.ts
@@ -1,3 +1,4 @@
+import type { WaAuthCredentials } from '@auth/types'
 import type { PublishProtocolMessageToDeviceFn } from '@client/messaging/key-protocol'
 import type { WaIncomingProtocolMessageEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
@@ -8,7 +9,7 @@ import { setBoundedMapEntry } from '@util/collections'
 export interface PeerDataOperationRequesterOptions {
     readonly logger: Logger
     readonly publishProtocolMessageToDevice: PublishProtocolMessageToDeviceFn
-    readonly getCurrentMeJid: () => string | null | undefined
+    readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly generateOutgoingMessageId: () => Promise<string>
     readonly subscribeToProtocolMessage: (
         handler: (event: WaIncomingProtocolMessageEvent) => void
@@ -61,7 +62,7 @@ export function createPeerDataOperationRequester(
     const {
         logger,
         publishProtocolMessageToDevice,
-        getCurrentMeJid,
+        getCurrentCredentials,
         generateOutgoingMessageId,
         subscribeToProtocolMessage
     } = options
@@ -108,7 +109,7 @@ export function createPeerDataOperationRequester(
         body: Proto.Message.IPeerDataOperationRequestMessage,
         id: string
     ): Promise<string> => {
-        const meJid = getCurrentMeJid()
+        const meJid = getCurrentCredentials()?.meJid
         if (!meJid) {
             throw new Error('peer data operation requires current me jid')
         }

--- a/src/retry/__tests__/retry.test.ts
+++ b/src/retry/__tests__/retry.test.ts
@@ -199,9 +199,7 @@ test('retry replay service resends plaintext when requester matches destination 
                 ciphertext: new Uint8Array([9, 9])
             })
         } as unknown as SignalProtocol,
-        getCurrentMeJid: () => null,
-        getCurrentMeLid: () => null,
-        getCurrentSignedIdentity: () => null
+        getCurrentCredentials: () => null
     })
 
     const outbound = buildOutboundRecord('m-plain-1', {
@@ -238,9 +236,7 @@ test('retry replay service accepts raw replay payloads from memory store', async
                 ciphertext: new Uint8Array([4, 4])
             })
         } as unknown as SignalProtocol,
-        getCurrentMeJid: () => null,
-        getCurrentMeLid: () => null,
-        getCurrentSignedIdentity: () => null
+        getCurrentCredentials: () => null
     })
 
     const now = Date.now()
@@ -284,9 +280,7 @@ test('retry replay service returns ineligible on plaintext destination mismatch'
                 ciphertext: new Uint8Array([1])
             })
         } as unknown as SignalProtocol,
-        getCurrentMeJid: () => null,
-        getCurrentMeLid: () => null,
-        getCurrentSignedIdentity: () => null
+        getCurrentCredentials: () => null
     })
 
     const outbound = buildOutboundRecord('m-plain-2', {
@@ -321,9 +315,7 @@ test('retry replay service handles group plaintext retries and pkmsg identity gu
                 ciphertext: new Uint8Array([5, 6, 7])
             })
         } as unknown as SignalProtocol,
-        getCurrentMeJid: () => null,
-        getCurrentMeLid: () => null,
-        getCurrentSignedIdentity: () => null
+        getCurrentCredentials: () => null
     })
 
     const outbound = buildOutboundRecord('m-group-1', {
@@ -374,9 +366,7 @@ test('retry replay service emits status@broadcast retry with meta and no address
                 ciphertext: new Uint8Array([1, 2, 3])
             })
         } as unknown as SignalProtocol,
-        getCurrentMeJid: () => null,
-        getCurrentMeLid: () => null,
-        getCurrentSignedIdentity: () => null
+        getCurrentCredentials: () => null
     })
 
     const now = Date.now()
@@ -427,9 +417,7 @@ test('retry replay service handles encrypted mode eligibility', async () => {
                 ciphertext: new Uint8Array([1])
             })
         } as unknown as SignalProtocol,
-        getCurrentMeJid: () => null,
-        getCurrentMeLid: () => null,
-        getCurrentSignedIdentity: () => null
+        getCurrentCredentials: () => null
     })
 
     const skmsgOutbound = buildOutboundRecord('m-encrypted-skmsg', {
@@ -489,9 +477,7 @@ test('retry replay service handles opaque replay compatibility checks', async ()
                 ciphertext: new Uint8Array([1])
             })
         } as unknown as SignalProtocol,
-        getCurrentMeJid: () => null,
-        getCurrentMeLid: () => null,
-        getCurrentSignedIdentity: () => null
+        getCurrentCredentials: () => null
     })
 
     const compatibleNode: BinaryNode = {

--- a/src/retry/replay.ts
+++ b/src/retry/replay.ts
@@ -1,8 +1,9 @@
+import type { WaAuthCredentials } from '@auth/types'
 import type { Logger } from '@infra/log/types'
 import { wrapDeviceSentMessage } from '@message/encode/device-sent'
 import { unpadPkcs7, writeRandomPadMax16 } from '@message/encode/padding'
 import type { WaMessageClient } from '@message/WaMessageClient'
-import { proto, type Proto } from '@proto'
+import { proto } from '@proto'
 import { WA_DEFAULTS, WA_NODE_TAGS } from '@protocol/constants'
 import {
     isGroupOrBroadcastJid,
@@ -30,9 +31,7 @@ export interface WaRetryReplayServiceOptions {
     readonly logger: Logger
     readonly messageClient: WaMessageClient
     readonly signalProtocol: SignalProtocol
-    readonly getCurrentMeJid: () => string | null | undefined
-    readonly getCurrentMeLid: () => string | null | undefined
-    readonly getCurrentSignedIdentity: () => Proto.IADVSignedDeviceIdentity | null | undefined
+    readonly getCurrentCredentials: () => WaAuthCredentials | null
 }
 
 export type WaRetryResendResult = 'resent' | 'ineligible'
@@ -137,7 +136,7 @@ export class WaRetryReplayService {
         let deviceIdentity: Uint8Array | undefined
 
         if (encrypted.type === 'pkmsg') {
-            const signedIdentity = this.options.getCurrentSignedIdentity()
+            const signedIdentity = this.options.getCurrentCredentials()?.signedIdentity
             if (!signedIdentity) {
                 this.options.logger.warn(
                     'retry request rejected: missing signed identity for pkmsg group retry'
@@ -247,12 +246,11 @@ export class WaRetryReplayService {
 
     private isRequesterCurrentAccount(requesterJid: string): boolean {
         const requesterUser = toUserJid(requesterJid)
-        const meJid = this.options.getCurrentMeJid()
-        if (meJid && toUserJid(meJid) === requesterUser) {
+        const credentials = this.options.getCurrentCredentials()
+        if (credentials?.meJid && toUserJid(credentials.meJid) === requesterUser) {
             return true
         }
-        const meLid = this.options.getCurrentMeLid()
-        if (meLid && toUserJid(meLid) === requesterUser) {
+        if (credentials?.meLid && toUserJid(credentials.meLid) === requesterUser) {
             return true
         }
         return false


### PR DESCRIPTION
- Replace session-identity drilling (getCurrentMeJid/MeLid/SignedIdentity closures across 8 modules) with a single getCurrentCredentials closure
- Apply this.deps pattern in WaMessageDispatchCoordinator (24 fields) and WaRetryCoordinator (13 fields) to collapse boilerplate
- Apply this.stores + this.deps patterns in WaClient: 14 store fields and 25 dependency fields fold into two grouped properties, dropping Object.assign(this, dependencies)
- Expose WaAuthClient directly via client.auth; move the isConnected guard into WaAuthClient.requestPairingCode/fetchPairingCountryCodeIso so removed WaClient wrappers preserve behaviour
- Drop dead client.flushAppStateMutations, client.exportAppState, and WaAppStateSyncClient.exportState (zero callers; canonical paths are client.chat.flushMutations and client.appStateSync)

BREAKING CHANGE:
- client.requestPairingCode -> client.auth.requestPairingCode
- client.fetchPairingCountryCodeIso -> client.auth.fetchPairingCountryCodeIso
- client.flushAppStateMutations -> client.chat.flushMutations
- client.exportAppState removed (was a passthrough to WaAppStateSyncClient.exportState, which is also removed; no replacement)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added authentication client accessor to improve credential management workflow.

* **Bug Fixes**
  * Authentication operations now validate connection status before executing, preventing unnecessary failures.

* **Refactor**
  * Consolidated internal dependency injection patterns for improved maintainability and consistency across client components.
  * Removed `exportState()` method from app state sync client.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->