### PR TITLE
refactor: dispatch envelope + customNodes array; expose option in sendMessage

### DIFF
--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -115,6 +115,16 @@ interface GroupSendRetryContext {
     readonly forceAddressingMode?: GroupAddressingMode
 }
 
+interface WaOutboundEnvelope {
+    readonly message: Proto.IMessage
+    readonly plaintext: Uint8Array
+    readonly type: string
+    readonly edit?: string
+    readonly mediatype?: string
+    readonly customNodes?: readonly BinaryNode[]
+    readonly sendOptions: WaSendMessageOptions
+}
+
 export class WaMessageDispatchCoordinator {
     private readonly deps: WaMessageDispatchCoordinatorOptions
     private readonly mobileMessageIdFormat: boolean
@@ -344,44 +354,30 @@ export class WaMessageDispatchCoordinator {
             : (resolveEncMediaType(messageWithIcdc) ?? undefined)
         const metaAttrs = resolveMetaAttrs(messageWithIcdc)
         const metaNode = metaAttrs ? buildMetaNode(metaAttrs as Record<string, string>) : undefined
+        const customNodes: BinaryNode[] = []
+        if (metaNode) customNodes.push(metaNode)
+        if (buttonAddonNode) customNodes.push(buttonAddonNode)
+        if (options.customNodes) {
+            for (const node of options.customNodes) {
+                customNodes.push(node)
+            }
+        }
+
+        const envelope: WaOutboundEnvelope = {
+            message: messageWithIcdc,
+            plaintext,
+            type,
+            edit,
+            mediatype,
+            customNodes: customNodes.length > 0 ? customNodes : undefined,
+            sendOptions
+        }
 
         const publishResult = isGroup
             ? this.shouldUseGroupDirectPath(messageWithIcdc)
-                ? await this.publishGroupDirectMessage(
-                      recipientJid,
-                      messageWithIcdc,
-                      plaintext,
-                      type,
-                      sendOptions,
-                      {},
-                      edit,
-                      mediatype,
-                      metaNode,
-                      buttonAddonNode
-                  )
-                : await this.publishGroupSenderKeyMessage(
-                      recipientJid,
-                      messageWithIcdc,
-                      plaintext,
-                      type,
-                      sendOptions,
-                      {},
-                      edit,
-                      mediatype,
-                      metaNode,
-                      buttonAddonNode
-                  )
-            : await this.publishDirectSignalMessageWithFanout(
-                  toUserJid(recipientJid),
-                  messageWithIcdc,
-                  plaintext,
-                  type,
-                  sendOptions,
-                  edit,
-                  mediatype,
-                  metaNode,
-                  buttonAddonNode
-              )
+                ? await this.publishGroupDirectMessage(recipientJid, envelope)
+                : await this.publishGroupSenderKeyMessage(recipientJid, envelope)
+            : await this.publishDirectSignalMessageWithFanout(toUserJid(recipientJid), envelope)
         return upload ? { ...publishResult, upload } : publishResult
     }
 
@@ -480,10 +476,11 @@ export class WaMessageDispatchCoordinator {
                     remoteJid: WA_DEFAULTS.STATUS_BROADCAST_JID,
                     context: 'status'
                 })
+                const customNodes: BinaryNode[] = [buildMetaNode({ status_setting: statusSetting })]
+                if (reportingArtifacts?.node) customNodes.push(reportingArtifacts.node)
                 return {
                     extraParticipants: ackHints,
-                    metaNode: buildMetaNode({ status_setting: statusSetting }),
-                    reportingNode: reportingArtifacts?.node
+                    customNodes
                 }
             }
         })
@@ -538,8 +535,7 @@ export class WaMessageDispatchCoordinator {
             readonly sendOptions: WaSendMessageOptions
         }) => Promise<{
             readonly extraParticipants?: readonly { readonly jid: string }[]
-            readonly metaNode?: BinaryNode
-            readonly reportingNode?: BinaryNode
+            readonly customNodes?: readonly BinaryNode[]
             readonly phash?: string
         }>
     }): Promise<WaMessagePublishResult> {
@@ -606,8 +602,7 @@ export class WaMessageDispatchCoordinator {
             deviceIdentity: shouldAttachDeviceIdentity
                 ? this.getEncodedSignedDeviceIdentity()
                 : undefined,
-            metaNode: extras.metaNode,
-            reportingNode: extras.reportingNode
+            customNodes: extras.customNodes
         })
         const replayPayload: WaRetryReplayPayload = {
             mode: 'plaintext',
@@ -680,17 +675,10 @@ export class WaMessageDispatchCoordinator {
 
     private async publishGroupDirectMessage(
         groupJid: string,
-        message: Proto.IMessage,
-        plaintext: Uint8Array,
-        type: string,
-        options: WaSendMessageOptions,
-        retryContext: GroupSendRetryContext = {},
-        edit?: string,
-        mediatype?: string,
-        metaNode?: BinaryNode,
-        buttonAddonNode?: BinaryNode
+        envelope: WaOutboundEnvelope,
+        retryContext: GroupSendRetryContext = {}
     ): Promise<WaMessagePublishResult> {
-        const sendOptions = await this.withResolvedMessageId(options)
+        const { message, plaintext, type, edit, mediatype, sendOptions } = envelope
         const meJid = this.requireCurrentMeJid('sendMessage')
         const participantUserJids = retryContext.forceRefreshParticipants
             ? await this.deps.groupMetadataCache.refreshParticipantUsers(groupJid)
@@ -761,6 +749,8 @@ export class WaMessageDispatchCoordinator {
             remoteJid: groupJid,
             context: 'group_direct'
         })
+        const customNodes: BinaryNode[] = envelope.customNodes ? [...envelope.customNodes] : []
+        if (reportingArtifacts?.node) customNodes.push(reportingArtifacts.node)
         const messageNode = buildDirectMessageFanoutNode({
             to: groupJid,
             type,
@@ -772,9 +762,7 @@ export class WaMessageDispatchCoordinator {
             deviceIdentity: shouldAttachDeviceIdentity
                 ? this.getEncodedSignedDeviceIdentity()
                 : undefined,
-            reportingNode: reportingArtifacts?.node ?? undefined,
-            metaNode,
-            buttonAddonNode,
+            customNodes: customNodes.length > 0 ? customNodes : undefined,
             mediatype
         })
         const replayPayload: WaRetryReplayPayload = {
@@ -815,22 +803,15 @@ export class WaMessageDispatchCoordinator {
             })
             return this.publishGroupDirectMessage(
                 groupJid,
-                message,
-                plaintext,
-                type,
                 {
-                    ...sendOptions,
-                    id: result.id
+                    ...envelope,
+                    sendOptions: { ...sendOptions, id: result.id }
                 },
                 {
                     retried: true,
                     forceRefreshParticipants: true,
                     forceAddressingMode: serverAddressingMode
-                },
-                edit,
-                mediatype,
-                metaNode,
-                buttonAddonNode
+                }
             )
         }
         return result
@@ -905,17 +886,10 @@ export class WaMessageDispatchCoordinator {
 
     private async publishGroupSenderKeyMessage(
         groupJid: string,
-        message: Proto.IMessage,
-        plaintext: Uint8Array,
-        type: string,
-        options: WaSendMessageOptions,
-        retryContext: GroupSendRetryContext = {},
-        edit?: string,
-        mediatype?: string,
-        metaNode?: BinaryNode,
-        buttonAddonNode?: BinaryNode
+        envelope: WaOutboundEnvelope,
+        retryContext: GroupSendRetryContext = {}
     ): Promise<WaMessagePublishResult> {
-        const sendOptions = await this.withResolvedMessageId(options)
+        const { message, plaintext, type, edit, mediatype, sendOptions } = envelope
         const meJid = this.requireCurrentMeJid('sendMessage')
         const participantUserJids = retryContext.forceRefreshParticipants
             ? await this.deps.groupMetadataCache.refreshParticipantUsers(groupJid)
@@ -962,6 +936,8 @@ export class WaMessageDispatchCoordinator {
             context: 'group_sender_key'
         })
         const botSidecar = await this.buildBotSidecarParticipant(message)
+        const customNodes: BinaryNode[] = envelope.customNodes ? [...envelope.customNodes] : []
+        if (reportingArtifacts?.node) customNodes.push(reportingArtifacts.node)
         const messageNode = buildGroupSenderKeyMessageNode({
             to: groupJid,
             type,
@@ -975,9 +951,7 @@ export class WaMessageDispatchCoordinator {
                 shouldAttachDeviceIdentity || botSidecar?.encType === 'pkmsg'
                     ? this.getEncodedSignedDeviceIdentity()
                     : undefined,
-            reportingNode: reportingArtifacts?.node ?? undefined,
-            metaNode,
-            buttonAddonNode,
+            customNodes: customNodes.length > 0 ? customNodes : undefined,
             mediatype,
             botParticipants: botSidecar ? [botSidecar] : undefined
         })
@@ -1037,22 +1011,15 @@ export class WaMessageDispatchCoordinator {
             })
             return this.publishGroupSenderKeyMessage(
                 groupJid,
-                message,
-                plaintext,
-                type,
                 {
-                    ...sendOptions,
-                    id: result.id
+                    ...envelope,
+                    sendOptions: { ...sendOptions, id: result.id }
                 },
                 {
                     retried: true,
                     forceRefreshParticipants: true,
                     forceAddressingMode: serverAddressingMode
-                },
-                edit,
-                mediatype,
-                metaNode,
-                buttonAddonNode
+                }
             )
         }
         return result
@@ -1260,16 +1227,9 @@ export class WaMessageDispatchCoordinator {
 
     private async publishDirectSignalMessageWithFanout(
         recipientJid: string,
-        message: Proto.IMessage,
-        plaintext: Uint8Array,
-        type: string,
-        options: WaSendMessageOptions,
-        edit?: string,
-        mediatype?: string,
-        metaNode?: BinaryNode,
-        buttonAddonNode?: BinaryNode
+        envelope: WaOutboundEnvelope
     ): Promise<WaMessagePublishResult> {
-        const sendOptions = await this.withResolvedMessageId(options)
+        const { message, plaintext, type, edit, mediatype, sendOptions } = envelope
         const meJid = this.requireCurrentMeJid('sendMessage')
         const meLid = this.deps.getCurrentCredentials()?.meLid
         const selfDeviceJidForRecipient = this.deps.fanoutResolver.resolveSelfDeviceJidForRecipient(
@@ -1440,6 +1400,9 @@ export class WaMessageDispatchCoordinator {
                 })
             }
         }
+        const customNodes: BinaryNode[] = envelope.customNodes ? [...envelope.customNodes] : []
+        if (reportingArtifacts?.node) customNodes.push(reportingArtifacts.node)
+        if (privacyTokenNode) customNodes.push(privacyTokenNode)
         const messageNode = buildDirectMessageFanoutNode({
             to: recipientJid,
             type,
@@ -1447,10 +1410,7 @@ export class WaMessageDispatchCoordinator {
             edit,
             participants,
             deviceIdentity,
-            reportingNode: reportingArtifacts?.node ?? undefined,
-            privacyTokenNode,
-            metaNode,
-            buttonAddonNode,
+            customNodes: customNodes.length > 0 ? customNodes : undefined,
             mediatype
         })
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -185,6 +185,7 @@ export interface WaSendMessageOptions extends WaMessagePublishOptions {
     readonly forward?: boolean | { readonly score?: number }
     readonly mentions?: readonly string[]
     readonly disableGroupEphemeralAutoInject?: boolean
+    readonly customNodes?: readonly BinaryNode[]
 }
 
 export interface WaClearChatOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,6 +171,7 @@ export type {
 } from '@message/addons/link-preview/types'
 export type { SignalLidSyncResult } from '@signal/api/SignalDeviceSyncApi'
 export type { WaAuthCredentials } from '@auth/types'
+export type { BinaryNode } from '@transport/types'
 export { ConsoleLogger } from '@infra/log/ConsoleLogger'
 export { PinoLogger, createPinoLogger } from '@infra/log/PinoLogger'
 export type { PinoLoggerOptions } from '@infra/log/PinoLogger'

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -492,22 +492,24 @@ test('message builders create fanout nodes and validate participant requirements
         type: 'text',
         id: 'm1',
         participants: [participant],
-        reportingNode: {
-            tag: 'reporting',
-            attrs: {},
-            content: [
-                {
-                    tag: 'reporting_token',
-                    attrs: { v: '2' },
-                    content: new Uint8Array([9])
-                }
-            ]
-        },
-        privacyTokenNode: {
-            tag: WA_PRIVACY_TOKEN_TAGS.TC_TOKEN,
-            attrs: {},
-            content: new Uint8Array([4])
-        }
+        customNodes: [
+            {
+                tag: 'reporting',
+                attrs: {},
+                content: [
+                    {
+                        tag: 'reporting_token',
+                        attrs: { v: '2' },
+                        content: new Uint8Array([9])
+                    }
+                ]
+            },
+            {
+                tag: WA_PRIVACY_TOKEN_TAGS.TC_TOKEN,
+                attrs: {},
+                content: new Uint8Array([4])
+            }
+        ]
     })
 
     assert.equal(node.tag, 'message')
@@ -612,7 +614,7 @@ test('message builders create fanout nodes and validate participant requirements
         type: 'text',
         id: 'btn-1',
         participants: [participant],
-        buttonAddonNode: interactiveAddon
+        customNodes: [interactiveAddon]
     })
     const addonChild = Array.isArray(fanoutWithAddon.content)
         ? fanoutWithAddon.content.find((child) => child.tag === 'biz')
@@ -743,17 +745,19 @@ test('message builders cover group and inbound receipt branches', () => {
             }
         ],
         deviceIdentity: new Uint8Array([2, 3]),
-        reportingNode: {
-            tag: 'reporting',
-            attrs: {},
-            content: [
-                {
-                    tag: 'reporting_token',
-                    attrs: { v: '2' },
-                    content: new Uint8Array([1, 2])
-                }
-            ]
-        }
+        customNodes: [
+            {
+                tag: 'reporting',
+                attrs: {},
+                content: [
+                    {
+                        tag: 'reporting_token',
+                        attrs: { v: '2' },
+                        content: new Uint8Array([1, 2])
+                    }
+                ]
+            }
+        ]
     })
     assert.equal(groupWithParticipants.attrs.addressing_mode, 'pn')
     assert.ok(Array.isArray(groupWithParticipants.content))
@@ -1260,7 +1264,7 @@ test('message builders include edit mediatype and meta node when provided', () =
         id: 'p1',
         edit: '7',
         participants: [participant],
-        metaNode: meta,
+        customNodes: [meta],
         mediatype: 'image'
     })
     assert.equal(direct.attrs.edit, '7')
@@ -1280,7 +1284,7 @@ test('message builders include edit mediatype and meta node when provided', () =
         edit: '1',
         groupCiphertext: new Uint8Array([2]),
         participants: [participant],
-        metaNode: buildMetaNode({ event_type: 'creation' }),
+        customNodes: [buildMetaNode({ event_type: 'creation' })],
         mediatype: 'video'
     })
     assert.equal(group.attrs.edit, '1')
@@ -1580,7 +1584,7 @@ test('group sender key message attaches a <bot> sidecar after <meta> for bot men
         groupCiphertext: new Uint8Array([9, 9, 9]),
         participants: [participant],
         botParticipants: [botSidecar],
-        metaNode
+        customNodes: [metaNode]
     })
 
     const content = node.content as readonly BinaryNode[]

--- a/src/transport/node/builders/message.ts
+++ b/src/transport/node/builders/message.ts
@@ -15,10 +15,7 @@ type DirectMessageFanoutInput = {
     readonly edit?: string
     readonly participants: readonly EncryptedParticipant[]
     readonly deviceIdentity?: Uint8Array
-    readonly reportingNode?: BinaryNode
-    readonly privacyTokenNode?: BinaryNode
-    readonly metaNode?: BinaryNode
-    readonly buttonAddonNode?: BinaryNode
+    readonly customNodes?: readonly BinaryNode[]
     readonly mediatype?: string
 }
 
@@ -119,10 +116,7 @@ function pushOptionalNodes(
     content: BinaryNode[],
     input: {
         readonly deviceIdentity?: Uint8Array
-        readonly reportingNode?: BinaryNode
-        readonly privacyTokenNode?: BinaryNode
-        readonly metaNode?: BinaryNode
-        readonly buttonAddonNode?: BinaryNode
+        readonly customNodes?: readonly BinaryNode[]
         readonly botParticipants?: readonly EncryptedParticipant[]
         readonly mediatype?: string
     }
@@ -134,8 +128,10 @@ function pushOptionalNodes(
             content: input.deviceIdentity
         })
     }
-    if (input.metaNode) {
-        content.push(input.metaNode)
+    if (input.customNodes) {
+        for (const node of input.customNodes) {
+            content.push(node)
+        }
     }
     if (input.botParticipants && input.botParticipants.length > 0) {
         content.push({
@@ -143,15 +139,6 @@ function pushOptionalNodes(
             attrs: {},
             content: input.botParticipants.map((p) => buildEncryptedToNode(p, input.mediatype))
         })
-    }
-    if (input.reportingNode) {
-        content.push(input.reportingNode)
-    }
-    if (input.privacyTokenNode) {
-        content.push(input.privacyTokenNode)
-    }
-    if (input.buttonAddonNode) {
-        content.push(input.buttonAddonNode)
     }
 }
 


### PR DESCRIPTION
- Builder input types collapse the four optional named BinaryNode fields (metaNode/reportingNode/privacyTokenNode/buttonAddonNode) into a single customNodes: readonly BinaryNode[]. The protocol does not constrain ordering between these nodes; the builder now spreads them in caller-supplied order.
- WaMessageDispatchCoordinator: introduce a local WaOutboundEnvelope struct so the three private publishXxx methods (groupDirect, groupSenderKey, directSignalFanout) accept (jid, envelope) instead of 10 positional arguments. sendMessage builds the envelope once and the redundant withResolvedMessageId calls inside publishXxx are dropped.
- publishSenderKeyFanout customize callback returns customNodes instead of separate metaNode/reportingNode fields.
- WaSendMessageOptions gains an optional customNodes array so consumers can attach arbitrary BinaryNodes to the outgoing stanza alongside the internally generated meta/biz/reporting nodes.
- BinaryNode is re-exported from the public barrel so consumers can construct nodes to pass via the new option.