### PR TITLE
feat(incoming): surface user-level sender/recipient identity on message events

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -459,10 +459,8 @@ export class WaClient extends EventEmitter {
             return
         }
 
-        const requesterRaw = event.senderJid
-            ? applyDeviceToJid(event.senderJid, event.senderDevice)
-            : event.chatJid
-        if (!requesterRaw) {
+        const requesterSource = event.senderJid ?? event.chatJid
+        if (!requesterSource) {
             this.logger.warn('incoming app-state key request missing sender jid', {
                 id: event.stanzaId
             })
@@ -471,11 +469,14 @@ export class WaClient extends EventEmitter {
 
         let requesterDeviceJid: string
         try {
+            const requesterRaw = event.senderJid
+                ? applyDeviceToJid(event.senderJid, event.senderDevice)
+                : requesterSource
             requesterDeviceJid = normalizeDeviceJid(requesterRaw)
         } catch (error) {
             this.logger.warn('incoming app-state key request has malformed sender jid', {
                 id: event.stanzaId,
-                from: requesterRaw,
+                from: requesterSource,
                 message: toError(error).message
             })
             return

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -72,7 +72,13 @@ import {
     WA_NODE_TAGS,
     type WaBotMsgEditType
 } from '@protocol/constants'
-import { isBotJid, normalizeDeviceJid, parsePhoneJid, toUserJid } from '@protocol/jid'
+import {
+    applyDeviceToJid,
+    isBotJid,
+    normalizeDeviceJid,
+    parsePhoneJid,
+    toUserJid
+} from '@protocol/jid'
 import { WA_LOGOUT_REASONS, type WaLogoutReason } from '@protocol/stream'
 import type { SignalLidSyncResult } from '@signal/api/SignalDeviceSyncApi'
 import { NOOP_MESSAGE_SECRET_STORE } from '@store/noop.store'
@@ -453,7 +459,9 @@ export class WaClient extends EventEmitter {
             return
         }
 
-        const requesterRaw = event.senderJid ?? event.chatJid
+        const requesterRaw = event.senderJid
+            ? applyDeviceToJid(event.senderJid, event.senderDevice)
+            : event.chatJid
         if (!requesterRaw) {
             this.logger.warn('incoming app-state key request missing sender jid', {
                 id: event.stanzaId
@@ -778,7 +786,9 @@ export class WaClient extends EventEmitter {
             return {
                 chatJid: event.chatJid,
                 id: event.stanzaId,
-                senderJid: event.senderJid,
+                senderJid: event.senderJid
+                    ? applyDeviceToJid(event.senderJid, event.senderDevice)
+                    : undefined,
                 isGroupChat: event.isGroupChat,
                 isBroadcastChat: event.isBroadcastChat
             }

--- a/src/client/persistence/mailbox.ts
+++ b/src/client/persistence/mailbox.ts
@@ -3,6 +3,7 @@ import type { WaIncomingMessageEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import { needsSecretPersistence } from '@message/encode/content'
 import { proto } from '@proto'
+import { toUserJid } from '@protocol/jid'
 import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
 import { toError } from '@util/primitives'
 
@@ -63,7 +64,8 @@ export function persistIncomingMailboxEntities(options: WaPersistIncomingMailbox
             event.message &&
             needsSecretPersistence(event.message)
         ) {
-            const senderJid = event.senderJid ?? event.rawNode.attrs.participant ?? ''
+            const rawSender = event.senderJid ?? event.rawNode.attrs.participant
+            const senderJid = rawSender ? toUserJid(rawSender) : ''
             void messageSecretStore
                 .set(stanzaId, { secret: rawSecret, senderJid })
                 .catch((error) => {

--- a/src/client/persistence/mailbox.ts
+++ b/src/client/persistence/mailbox.ts
@@ -20,7 +20,8 @@ function persistContacts(
     nowMs: number
 ): void {
     const senderJid = event.senderJid
-    const participantJid = event.rawNode.attrs.participant
+    const rawParticipant = event.rawNode.attrs.participant
+    const participantJid = rawParticipant ? toUserJid(rawParticipant) : undefined
     if (!senderJid && !participantJid) {
         return
     }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -243,6 +243,12 @@ export interface WaIncomingBaseEvent {
 export interface WaIncomingMessageEvent extends WaIncomingBaseEvent {
     readonly timestampSeconds?: number
     readonly senderJid?: string
+    readonly senderAlt?: string
+    readonly senderDevice?: number
+    readonly senderUsername?: string
+    readonly recipientJid?: string
+    readonly recipientAlt?: string
+    readonly pushName?: string
     readonly encryptionType?: string
     readonly isGroupChat: boolean
     readonly isBroadcastChat: boolean

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -41,6 +41,28 @@ interface WaIncomingMessageAckHandlerOptions {
     readonly emitUnhandledStanza?: (event: WaIncomingUnhandledStanzaEvent) => void
 }
 
+interface MessageIdentityAttrs {
+    readonly senderAlt: string | undefined
+    readonly senderUsername: string | undefined
+    readonly recipientJid: string | undefined
+    readonly recipientAlt: string | undefined
+    readonly pushName: string | undefined
+}
+
+function extractMessageIdentityAttrs(attrs: BinaryNode['attrs']): MessageIdentityAttrs {
+    const rawAlt =
+        attrs.participant_pn ?? attrs.sender_pn ?? attrs.participant_lid ?? attrs.sender_lid
+    const rawRecipientAlt = attrs.peer_recipient_pn ?? attrs.peer_recipient_lid
+    const rawRecipient = attrs.recipient
+    return {
+        senderAlt: rawAlt ? toUserJid(rawAlt) : undefined,
+        senderUsername: attrs.participant_username ?? attrs.username,
+        recipientJid: rawRecipient ? toUserJid(rawRecipient) : undefined,
+        recipientAlt: rawRecipientAlt ? toUserJid(rawRecipientAlt) : undefined,
+        pushName: attrs.notify
+    }
+}
+
 function pickNextRetryCount(node: BinaryNode): number {
     const retryNode = findNodeChild(node, 'retry')
     const parsed = parseOptionalInt(retryNode?.attrs.count)
@@ -284,13 +306,7 @@ function processMsmsgEncNode(
         }
         const chatJid = node.attrs.from
         const sender = senderJid ? parseJidFull(senderJid) : null
-        const rawAlt =
-            node.attrs.participant_pn ??
-            node.attrs.sender_pn ??
-            node.attrs.participant_lid ??
-            node.attrs.sender_lid
-        const rawRecipientAlt = node.attrs.peer_recipient_pn ?? node.attrs.peer_recipient_lid
-        const rawRecipient = node.attrs.recipient
+        const identity = extractMessageIdentityAttrs(node.attrs)
         options.emitIncomingMessage?.({
             rawNode: buildIncomingEventRawNode(node),
             stanzaId: node.attrs.id,
@@ -298,12 +314,8 @@ function processMsmsgEncNode(
             stanzaType: node.attrs.type,
             timestampSeconds: parseOptionalInt(node.attrs.t),
             senderJid: sender?.userJid,
-            senderAlt: rawAlt ? toUserJid(rawAlt) : undefined,
             senderDevice: sender?.address.device,
-            senderUsername: node.attrs.participant_username ?? node.attrs.username,
-            recipientJid: rawRecipient ? toUserJid(rawRecipient) : undefined,
-            recipientAlt: rawRecipientAlt ? toUserJid(rawRecipientAlt) : undefined,
-            pushName: node.attrs.notify,
+            ...identity,
             encryptionType: 'msmsg',
             isGroupChat: chatJid ? isGroupJid(chatJid) : false,
             isBroadcastChat: chatJid ? isBroadcastJid(chatJid) : false,
@@ -371,13 +383,7 @@ async function decryptAndProcessEncNode(
         }
         if (shouldEmitIncomingMessage(message)) {
             const chatJid = node.attrs.from
-            const rawAlt =
-                node.attrs.participant_pn ??
-                node.attrs.sender_pn ??
-                node.attrs.participant_lid ??
-                node.attrs.sender_lid
-            const rawRecipientAlt = node.attrs.peer_recipient_pn ?? node.attrs.peer_recipient_lid
-            const rawRecipient = node.attrs.recipient
+            const identity = extractMessageIdentityAttrs(node.attrs)
             options.emitIncomingMessage?.({
                 rawNode: buildIncomingEventRawNode(node),
                 stanzaId: node.attrs.id,
@@ -385,12 +391,8 @@ async function decryptAndProcessEncNode(
                 stanzaType: node.attrs.type,
                 timestampSeconds: parseOptionalInt(node.attrs.t),
                 senderJid: `${senderAddress.user}@${senderAddress.server}`,
-                senderAlt: rawAlt ? toUserJid(rawAlt) : undefined,
                 senderDevice: senderAddress.device,
-                senderUsername: node.attrs.participant_username ?? node.attrs.username,
-                recipientJid: rawRecipient ? toUserJid(rawRecipient) : undefined,
-                recipientAlt: rawRecipientAlt ? toUserJid(rawRecipientAlt) : undefined,
-                pushName: node.attrs.notify,
+                ...identity,
                 encryptionType: encType,
                 isGroupChat: chatJid ? isGroupJid(chatJid) : false,
                 isBroadcastChat: chatJid ? isBroadcastJid(chatJid) : false,

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -13,7 +13,9 @@ import {
     isBroadcastJid,
     isGroupJid,
     isNewsletterJid,
-    parseSignalAddressFromJid
+    parseJidFull,
+    parseSignalAddressFromJid,
+    toUserJid
 } from '@protocol/jid'
 import type { WaRetryDecryptFailureContext } from '@retry/types'
 import type { SenderKeyManager } from '@signal/group/SenderKeyManager'
@@ -94,7 +96,10 @@ export function buildRecoveredIncomingEvent(
     const participant = key.participant ?? undefined
     const isGroup = chatJid ? isGroupJid(chatJid) : false
     const isBroadcast = chatJid ? isBroadcastJid(chatJid) : false
-    const senderJid = fromMe ? undefined : isGroup || isBroadcast ? participant : chatJid
+    const rawSender = fromMe ? undefined : isGroup || isBroadcast ? participant : chatJid
+    const sender = rawSender ? parseJidFull(rawSender) : null
+    const senderJid = sender?.userJid
+    const senderDevice = sender?.address.device
     const timestampSeconds =
         webMessageInfo.messageTimestamp !== null && webMessageInfo.messageTimestamp !== undefined
             ? longToNumber(webMessageInfo.messageTimestamp)
@@ -114,6 +119,7 @@ export function buildRecoveredIncomingEvent(
         chatJid,
         timestampSeconds,
         senderJid,
+        senderDevice,
         encryptionType: 'placeholder_recovery',
         isGroupChat: isGroup,
         isBroadcastChat: isBroadcast,
@@ -277,13 +283,27 @@ function processMsmsgEncNode(
             }
         }
         const chatJid = node.attrs.from
+        const sender = senderJid ? parseJidFull(senderJid) : null
+        const rawAlt =
+            node.attrs.participant_pn ??
+            node.attrs.sender_pn ??
+            node.attrs.participant_lid ??
+            node.attrs.sender_lid
+        const rawRecipientAlt = node.attrs.peer_recipient_pn ?? node.attrs.peer_recipient_lid
+        const rawRecipient = node.attrs.recipient
         options.emitIncomingMessage?.({
             rawNode: buildIncomingEventRawNode(node),
             stanzaId: node.attrs.id,
             chatJid,
             stanzaType: node.attrs.type,
             timestampSeconds: parseOptionalInt(node.attrs.t),
-            senderJid,
+            senderJid: sender?.userJid,
+            senderAlt: rawAlt ? toUserJid(rawAlt) : undefined,
+            senderDevice: sender?.address.device,
+            senderUsername: node.attrs.participant_username ?? node.attrs.username,
+            recipientJid: rawRecipient ? toUserJid(rawRecipient) : undefined,
+            recipientAlt: rawRecipientAlt ? toUserJid(rawRecipientAlt) : undefined,
+            pushName: node.attrs.notify,
             encryptionType: 'msmsg',
             isGroupChat: chatJid ? isGroupJid(chatJid) : false,
             isBroadcastChat: chatJid ? isBroadcastJid(chatJid) : false,
@@ -351,13 +371,26 @@ async function decryptAndProcessEncNode(
         }
         if (shouldEmitIncomingMessage(message)) {
             const chatJid = node.attrs.from
+            const rawAlt =
+                node.attrs.participant_pn ??
+                node.attrs.sender_pn ??
+                node.attrs.participant_lid ??
+                node.attrs.sender_lid
+            const rawRecipientAlt = node.attrs.peer_recipient_pn ?? node.attrs.peer_recipient_lid
+            const rawRecipient = node.attrs.recipient
             options.emitIncomingMessage?.({
                 rawNode: buildIncomingEventRawNode(node),
                 stanzaId: node.attrs.id,
                 chatJid,
                 stanzaType: node.attrs.type,
                 timestampSeconds: parseOptionalInt(node.attrs.t),
-                senderJid,
+                senderJid: `${senderAddress.user}@${senderAddress.server}`,
+                senderAlt: rawAlt ? toUserJid(rawAlt) : undefined,
+                senderDevice: senderAddress.device,
+                senderUsername: node.attrs.participant_username ?? node.attrs.username,
+                recipientJid: rawRecipient ? toUserJid(rawRecipient) : undefined,
+                recipientAlt: rawRecipientAlt ? toUserJid(rawRecipientAlt) : undefined,
+                pushName: node.attrs.notify,
                 encryptionType: encType,
                 isGroupChat: chatJid ? isGroupJid(chatJid) : false,
                 isBroadcastChat: chatJid ? isBroadcastJid(chatJid) : false,

--- a/src/protocol/__tests__/protocol.test.ts
+++ b/src/protocol/__tests__/protocol.test.ts
@@ -17,6 +17,7 @@ import {
     WA_PRIVACY_VALUES
 } from '@protocol/constants'
 import {
+    applyDeviceToJid,
     buildDeviceJid,
     canonicalizeSignalJid,
     canonicalizeSignalServer,
@@ -84,6 +85,12 @@ test('jid type detection and device handling', () => {
     assert.equal(toUserJid('5511:3@s.whatsapp.net'), '5511@s.whatsapp.net')
     assert.equal(normalizeDeviceJid('5511:0@s.whatsapp.net'), '5511@s.whatsapp.net')
     assert.equal(normalizeDeviceJid('5511:5@s.whatsapp.net'), '5511:5@s.whatsapp.net')
+
+    assert.equal(applyDeviceToJid('5511@s.whatsapp.net', undefined), '5511@s.whatsapp.net')
+    assert.equal(applyDeviceToJid('5511@s.whatsapp.net', 0), '5511@s.whatsapp.net')
+    assert.equal(applyDeviceToJid('5511@s.whatsapp.net', 5), '5511:5@s.whatsapp.net')
+    assert.equal(applyDeviceToJid('5511@lid', 65), '5511:65@lid')
+    assert.equal(applyDeviceToJid('5511@s.whatsapp.net', 99), '5511:99@s.whatsapp.net')
 
     assert.equal(canonicalizeSignalServer('hosted'), 's.whatsapp.net')
     assert.equal(canonicalizeSignalServer('hosted.lid'), 'lid')

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -1,5 +1,6 @@
 export * from '@protocol/constants'
 export {
+    applyDeviceToJid,
     buildDeviceJid,
     canonicalizeSignalJid,
     canonicalizeSignalServer,

--- a/src/protocol/jid.ts
+++ b/src/protocol/jid.ts
@@ -182,6 +182,12 @@ export function normalizeDeviceJid(jid: string): string {
     return `${address.user}:${address.device}@${address.server}`
 }
 
+export function applyDeviceToJid(userJid: string, device: number | undefined): string {
+    if (!device) return userJid
+    const address = parseSignalAddressFromJid(userJid)
+    return buildDeviceJid(address.user, address.server ?? WA_DEFAULTS.HOST_DOMAIN, device)
+}
+
 export function isHostedDeviceId(deviceId: number): boolean {
     return deviceId === WA_DEFAULTS.HOSTED_DEVICE_ID
 }


### PR DESCRIPTION
WaIncomingMessageEvent now exposes device-stripped `senderJid` plus `senderDevice`, `senderAlt`, `senderUsername`, `recipientJid`, `recipientAlt`, and `pushName`. `senderAlt` falls back across participant_pn/sender_pn/participant_lid/sender_lid and `recipientAlt` across peer_recipient_pn/peer_recipient_lid, matching the attribute set /wa-web pulls in WAWebHandleMsgParser.

Internal consumers that still need the device-inclusive JID (`isOwnAccountDeviceJid` for app-state key requests, the receipt `participant` attr which /wa-web emits via DEVICE_JID) rebuild it via a new `applyDeviceToJid` helper. Addon AAD and the messageSecret store keep the user-level form per /wa-web's `widToUserJid` convention, fixing a latent AAD mismatch for non-primary-device senders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incoming message events now include richer sender/recipient metadata (device id, alternate IDs, username, push name) for improved client context.

* **Refactor**
  * Normalized JID and device handling across message processing and storage, improving receipt routing and sync reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->