### PR TITLE
feat(media): opt-in voice-note normalization to OGG/Opus via ffmpeg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
               with:
                   name: core-build
                   path: dist/
-            - run: npx turbo run build --filter=@zapo-js/fake-server --filter=@zapo-js/store-sqlite --filter=@zapo-js/mcp-server
+            - run: npx turbo run build --filter=@zapo-js/fake-server --filter=@zapo-js/store-sqlite --filter=@zapo-js/media-utils --filter=@zapo-js/mcp-server
             - run: npm test -w packages/mcp-server
 
     test-mysql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
         "": {
             "name": "zapo-js",
             "version": "0.3.0",
-            "dev": true,
             "hasInstallScript": true,
             "workspaces": [
                 "packages/*"
@@ -9052,7 +9051,7 @@
                 "ws": "^8.18.0"
             },
             "bin": {
-                "fake-wa-server": "dist/cli.js"
+                "fake-wa-server": "dist/bin.js"
             },
             "devDependencies": {
                 "@types/ws": "^8.18.1",
@@ -9076,6 +9075,7 @@
             },
             "devDependencies": {
                 "@zapo-js/fake-server": "file:../fake-server",
+                "@zapo-js/media-utils": "file:../media-utils",
                 "@zapo-js/store-sqlite": "file:../store-sqlite",
                 "better-sqlite3": "^12.6.2",
                 "cross-env": "^7.0.3",
@@ -9085,6 +9085,7 @@
                 "node": ">=20.9.0"
             },
             "peerDependencies": {
+                "@zapo-js/media-utils": ">=0.1.0",
                 "@zapo-js/store-sqlite": ">=0.1.0",
                 "better-sqlite3": ">=11.0.0",
                 "zapo-js": ">=0.1.0"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -33,6 +33,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0"
     },
     "peerDependencies": {
+        "@zapo-js/media-utils": ">=0.1.0",
         "@zapo-js/store-sqlite": ">=0.1.0",
         "better-sqlite3": ">=11.0.0",
         "zapo-js": ">=0.1.0"
@@ -44,6 +45,7 @@
     },
     "devDependencies": {
         "@zapo-js/fake-server": "file:../fake-server",
+        "@zapo-js/media-utils": "file:../media-utils",
         "@zapo-js/store-sqlite": "file:../store-sqlite",
         "better-sqlite3": "^12.6.2",
         "cross-env": "^7.0.3",

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -2,6 +2,7 @@ import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs'
 import { mkdir } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
+import { createMediaProcessor } from '@zapo-js/media-utils'
 import { createSqliteStore } from '@zapo-js/store-sqlite'
 import { createStore, type Logger, type LogLevel, WaClient, type WaStore } from 'zapo-js'
 import { hexToBytes, resolvePositive, toError } from 'zapo-js/util'
@@ -493,6 +494,11 @@ export class McpRuntime {
                 },
                 nodeQueryTimeoutMs: 30_000,
                 chatSocketUrls: this.config.chatSocketUrls,
+                media: {
+                    processor: createMediaProcessor({
+                        onWarning: (message) => this.logger.warn(message)
+                    })
+                },
                 testHooks: this.config.noiseRootCa
                     ? { noiseRootCa: this.config.noiseRootCa }
                     : undefined

--- a/packages/media-utils/src/__tests__/factory.test.ts
+++ b/packages/media-utils/src/__tests__/factory.test.ts
@@ -89,6 +89,7 @@ describe('createMediaProcessor', () => {
         assert.equal(typeof processor.generateVideoThumbnail, 'function')
         assert.equal(typeof processor.probeMedia, 'function')
         assert.equal(typeof processor.computeWaveform, 'function')
+        assert.equal(typeof processor.normalizeVoiceNote, 'function')
     })
 
     it('generateImageThumbnail respects options override', async () => {
@@ -222,6 +223,60 @@ describe('createMediaProcessor', () => {
             const processor = createMediaProcessor()
             const result = await processor.generateVideoThumbnail!(new Uint8Array([1, 2, 3]), 320)
             assert.equal(result, null)
+        }
+    )
+
+    it('normalizeVoiceNote returns null when ffmpeg is missing', async () => {
+        const processor = createMediaProcessor({
+            ffmpegPath: `missing-ffmpeg-${Date.now()}`
+        })
+        const result = await processor.normalizeVoiceNote!(new Uint8Array([1, 2, 3]))
+        assert.equal(result, null)
+    })
+
+    it(
+        'normalizeVoiceNote produces an OGG/Opus stream from a path input',
+        { skip: !hasFFmpeg() },
+        async () => {
+            const audioPath = createTempAudioFile()
+            try {
+                const processor = createMediaProcessor()
+                const stream = await processor.normalizeVoiceNote!(audioPath)
+                assert.notEqual(stream, null)
+                const chunks: Buffer[] = []
+                for await (const chunk of stream!) chunks.push(chunk as Buffer)
+                const bytes = Buffer.concat(chunks)
+                assert.ok(bytes.byteLength > 0)
+                // OggS magic
+                assert.equal(bytes[0], 0x4f)
+                assert.equal(bytes[1], 0x67)
+                assert.equal(bytes[2], 0x67)
+                assert.equal(bytes[3], 0x53)
+            } finally {
+                await unlink(audioPath).catch(() => undefined)
+            }
+        }
+    )
+
+    it(
+        'normalizeVoiceNote accepts a Readable input via stdin streaming',
+        { skip: !hasFFmpeg() },
+        async () => {
+            const audioPath = createTempAudioFile()
+            try {
+                const { createReadStream } = await import('node:fs')
+                const processor = createMediaProcessor()
+                const stream = await processor.normalizeVoiceNote!(createReadStream(audioPath))
+                assert.notEqual(stream, null)
+                const chunks: Buffer[] = []
+                for await (const chunk of stream!) chunks.push(chunk as Buffer)
+                const bytes = Buffer.concat(chunks)
+                assert.ok(bytes.byteLength > 0)
+                assert.equal(bytes[0], 0x4f)
+                assert.equal(bytes[1], 0x67)
+            } finally {
+                await unlink(audioPath).catch(() => undefined)
+            }
         }
     )
 })

--- a/packages/media-utils/src/ffmpeg.ts
+++ b/packages/media-utils/src/ffmpeg.ts
@@ -302,12 +302,14 @@ export async function computeWaveformWithFfmpeg(
 export interface NormalizeVoiceNoteOptions {
     readonly bitRate?: number
     readonly sampleRate?: number
+    readonly application?: 'voip' | 'audio'
     readonly ffmpegPath?: string
     readonly onWarning?: FfmpegWarnFn
 }
 
-const VOICE_NOTE_DEFAULT_BITRATE = 16_000
-const VOICE_NOTE_DEFAULT_SAMPLE_RATE = 16_000
+const VOICE_NOTE_DEFAULT_BITRATE = 64_000
+const VOICE_NOTE_DEFAULT_SAMPLE_RATE = 48_000
+const VOICE_NOTE_DEFAULT_APPLICATION = 'audio'
 
 export async function normalizeVoiceNoteWithFfmpeg(
     input: WaMediaProcessorInput,
@@ -319,6 +321,7 @@ export async function normalizeVoiceNoteWithFfmpeg(
     const useFile = typeof input === 'string'
     const bitRate = options.bitRate ?? VOICE_NOTE_DEFAULT_BITRATE
     const sampleRate = options.sampleRate ?? VOICE_NOTE_DEFAULT_SAMPLE_RATE
+    const application = options.application ?? VOICE_NOTE_DEFAULT_APPLICATION
 
     const args = [
         '-hide_banner',
@@ -336,7 +339,7 @@ export async function normalizeVoiceNoteWithFfmpeg(
         '-ac',
         '1',
         '-application',
-        'voip',
+        application,
         '-frame_duration',
         '20',
         '-avoid_negative_ts',

--- a/packages/media-utils/src/ffmpeg.ts
+++ b/packages/media-utils/src/ffmpeg.ts
@@ -299,6 +299,100 @@ export async function computeWaveformWithFfmpeg(
     })
 }
 
+export interface NormalizeVoiceNoteOptions {
+    readonly bitRate?: number
+    readonly sampleRate?: number
+    readonly ffmpegPath?: string
+    readonly onWarning?: FfmpegWarnFn
+}
+
+const VOICE_NOTE_DEFAULT_BITRATE = 16_000
+const VOICE_NOTE_DEFAULT_SAMPLE_RATE = 16_000
+
+export async function normalizeVoiceNoteWithFfmpeg(
+    input: WaMediaProcessorInput,
+    options: NormalizeVoiceNoteOptions = {}
+): Promise<Readable | null> {
+    const bin = options.ffmpegPath ?? 'ffmpeg'
+    if (!(await hasBin(bin, 'ffmpeg', options.onWarning))) return null
+
+    const useFile = typeof input === 'string'
+    const bitRate = options.bitRate ?? VOICE_NOTE_DEFAULT_BITRATE
+    const sampleRate = options.sampleRate ?? VOICE_NOTE_DEFAULT_SAMPLE_RATE
+
+    const args = [
+        '-hide_banner',
+        '-loglevel',
+        'error',
+        '-i',
+        useFile ? input : 'pipe:0',
+        '-vn',
+        '-c:a',
+        'libopus',
+        '-b:a',
+        String(bitRate),
+        '-ar',
+        String(sampleRate),
+        '-ac',
+        '1',
+        '-application',
+        'voip',
+        '-frame_duration',
+        '20',
+        '-avoid_negative_ts',
+        'make_zero',
+        '-map_metadata',
+        '-1',
+        '-f',
+        'ogg',
+        'pipe:1'
+    ]
+
+    const proc = spawn(bin, args, {
+        stdio: [useFile ? 'ignore' : 'pipe', 'pipe', 'pipe'],
+        timeout: 60_000
+    })
+
+    const stderrChunks: Buffer[] = []
+    proc.stderr!.on('data', (chunk: Buffer) => {
+        stderrChunks.push(chunk)
+    })
+
+    let inputStream: Readable | undefined
+    if (!useFile) {
+        inputStream = inputToReadable(input)
+        const onSourceError = (err: Error): void => {
+            if (proc.exitCode === null) proc.kill('SIGKILL')
+            proc.stdout!.destroy(err)
+        }
+        inputStream.on('error', onSourceError)
+        proc.stdin!.on('error', () => inputStream!.destroy())
+        inputStream.pipe(proc.stdin!)
+    }
+
+    proc.on('error', (err) => {
+        proc.stdout!.destroy(err)
+        inputStream?.destroy()
+    })
+    proc.on('close', (code) => {
+        if (code !== 0 && !proc.stdout!.destroyed) {
+            const stderr = Buffer.concat(stderrChunks).toString('utf8').trim().slice(-500)
+            proc.stdout!.destroy(
+                new Error(
+                    `ffmpeg voice-note normalize exited ${code}${stderr ? `: ${stderr}` : ''}`
+                )
+            )
+        }
+    })
+
+    proc.stdout!.on('close', () => {
+        if (proc.exitCode === null) proc.kill('SIGKILL')
+        inputStream?.destroy()
+    })
+
+    return proc.stdout!
+}
+
 function scaleAndNormalize(raw: number[], points: number): Uint8Array {
     const scaled = new Float32Array(points)
     if (raw.length <= points) {

--- a/packages/media-utils/src/index.ts
+++ b/packages/media-utils/src/index.ts
@@ -3,6 +3,7 @@ import type { WaMediaProcessor, WaMediaProcessorInput } from 'zapo-js/media'
 import {
     computeWaveformWithFfmpeg,
     generateVideoThumbnailWithFfmpeg,
+    normalizeVoiceNoteWithFfmpeg,
     probeWithFfmpeg
 } from './ffmpeg'
 import { generateImageThumbnail, generateStickerThumbnail } from './sharp'
@@ -38,6 +39,15 @@ export function createMediaProcessor(options?: WaMediaProcessorOptions): WaMedia
 
         async computeWaveform(input: WaMediaProcessorInput) {
             return computeWaveformWithFfmpeg(input, opts.ffmpegPath, opts.waveformPoints, warn)
+        },
+
+        async normalizeVoiceNote(input: WaMediaProcessorInput) {
+            return normalizeVoiceNoteWithFfmpeg(input, {
+                bitRate: opts.voiceNoteBitRate,
+                sampleRate: opts.voiceNoteSampleRate,
+                ffmpegPath: opts.ffmpegPath,
+                onWarning: warn
+            })
         },
 
         async generateStickerThumbnail(input: WaMediaProcessorInput, maxEdge: number) {

--- a/packages/media-utils/src/index.ts
+++ b/packages/media-utils/src/index.ts
@@ -45,6 +45,7 @@ export function createMediaProcessor(options?: WaMediaProcessorOptions): WaMedia
             return normalizeVoiceNoteWithFfmpeg(input, {
                 bitRate: opts.voiceNoteBitRate,
                 sampleRate: opts.voiceNoteSampleRate,
+                application: opts.voiceNoteApplication,
                 ffmpegPath: opts.ffmpegPath,
                 onWarning: warn
             })

--- a/packages/media-utils/src/types.ts
+++ b/packages/media-utils/src/types.ts
@@ -4,5 +4,7 @@ export interface WaMediaProcessorOptions {
     readonly imageThumbMaxEdge?: number
     readonly imageThumbQuality?: number
     readonly waveformPoints?: number
+    readonly voiceNoteBitRate?: number
+    readonly voiceNoteSampleRate?: number
     readonly onWarning?: (message: string) => void
 }

--- a/packages/media-utils/src/types.ts
+++ b/packages/media-utils/src/types.ts
@@ -6,5 +6,6 @@ export interface WaMediaProcessorOptions {
     readonly waveformPoints?: number
     readonly voiceNoteBitRate?: number
     readonly voiceNoteSampleRate?: number
+    readonly voiceNoteApplication?: 'voip' | 'audio'
     readonly onWarning?: (message: string) => void
 }

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -413,6 +413,18 @@ function shouldGenerateWaveform(
     )
 }
 
+export function shouldNormalizeVoiceNote(
+    media: WaMediaOptions | undefined,
+    content: WaSendMediaMessage
+): boolean {
+    return (
+        !!media?.processor?.normalizeVoiceNote &&
+        media.normalizeVoiceNote === true &&
+        content.type === 'audio' &&
+        content.ptt === true
+    )
+}
+
 function shouldGenerateStickerThumbnail(
     media: WaMediaOptions | undefined,
     content: WaSendMediaMessage

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -416,7 +416,7 @@ function shouldGenerateWaveform(
 export function shouldNormalizeVoiceNote(
     media: WaMediaOptions | undefined,
     content: WaSendMediaMessage
-): boolean {
+): content is WaSendMediaMessage & { type: 'audio' } {
     return (
         !!media?.processor?.normalizeVoiceNote &&
         media.normalizeVoiceNote === true &&

--- a/src/client/messaging/messages.ts
+++ b/src/client/messaging/messages.ts
@@ -12,7 +12,8 @@ import {
     readFileHead,
     resolveMediaInputs,
     runMediaProcessor,
-    selectMediaUploadHost
+    selectMediaUploadHost,
+    shouldNormalizeVoiceNote
 } from '@client/media'
 import type { ResolvedLinkPreviewResult } from '@client/messaging/link-preview'
 import type { WaMediaOptions } from '@client/types'
@@ -42,8 +43,10 @@ import { proto } from '@proto'
 import { WA_DEFAULTS } from '@protocol/constants'
 import { buildMediaConnIq } from '@transport/node/builders/media'
 import type { BinaryNode } from '@transport/types'
-import { bytesToBase64 } from '@util/bytes'
+import { bytesToBase64, toBytesView } from '@util/bytes'
 import { toError } from '@util/primitives'
+
+const VOICE_NOTE_MIMETYPE = 'audio/ogg; codecs=opus'
 
 export interface WaMediaMessageOptions {
     readonly logger: Logger
@@ -143,6 +146,18 @@ async function buildMediaMessage(
 ): Promise<WaMessageBuildResult> {
     if (content.type === 'sticker-pack') {
         return buildStickerPackMediaMessage(options, content)
+    }
+    if (
+        content.type === 'audio' &&
+        shouldNormalizeVoiceNote(options.media, content) &&
+        options.media?.processor?.normalizeVoiceNote
+    ) {
+        const sourceInput =
+            content.media instanceof ArrayBuffer ? toBytesView(content.media) : content.media
+        const normalizedStream = await options.media.processor.normalizeVoiceNote(sourceInput)
+        if (normalizedStream) {
+            content = { ...content, media: normalizedStream, mimetype: VOICE_NOTE_MIMETYPE }
+        }
     }
     const needsTempFile =
         hasMediaProcessingTasks(options.media, content) ||

--- a/src/client/messaging/messages.ts
+++ b/src/client/messaging/messages.ts
@@ -147,16 +147,19 @@ async function buildMediaMessage(
     if (content.type === 'sticker-pack') {
         return buildStickerPackMediaMessage(options, content)
     }
-    if (
-        content.type === 'audio' &&
-        shouldNormalizeVoiceNote(options.media, content) &&
-        options.media?.processor?.normalizeVoiceNote
-    ) {
+    if (shouldNormalizeVoiceNote(options.media, content)) {
         const sourceInput =
             content.media instanceof ArrayBuffer ? toBytesView(content.media) : content.media
-        const normalizedStream = await options.media.processor.normalizeVoiceNote(sourceInput)
-        if (normalizedStream) {
-            content = { ...content, media: normalizedStream, mimetype: VOICE_NOTE_MIMETYPE }
+        try {
+            const normalizedStream =
+                await options.media!.processor!.normalizeVoiceNote!(sourceInput)
+            if (normalizedStream) {
+                content = { ...content, media: normalizedStream, mimetype: VOICE_NOTE_MIMETYPE }
+            }
+        } catch (error) {
+            options.logger.warn('voice note normalize failed, sending original media', {
+                message: toError(error).message
+            })
         }
     }
     const needsTempFile =

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -139,6 +139,7 @@ export interface WaMediaOptions {
     readonly generateProbe?: boolean
     readonly generateWaveform?: boolean
     readonly generateStickerThumbnail?: boolean
+    readonly normalizeVoiceNote?: boolean
 }
 
 export interface WaAddonOptions {

--- a/src/media/processor.ts
+++ b/src/media/processor.ts
@@ -42,6 +42,8 @@ export interface WaMediaProcessor {
         input: WaMediaProcessorInput
     ) => Promise<WaMediaProcessorWaveformResult | null>
 
+    readonly normalizeVoiceNote?: (input: WaMediaProcessorInput) => Promise<Readable | null>
+
     readonly generateStickerThumbnail?: (
         input: WaMediaProcessorInput,
         maxEdge: number


### PR DESCRIPTION
Adds processor.normalizeVoiceNote(input) that pipes the source through ffmpeg into a 48 kHz mono libopus OGG stream suitable for PTT audio.

Wired into the send pipeline behind WaMediaOptions.normalizeVoiceNote (opt-in) and auto-provided by the @zapo-js/media-utils factory and the MCP runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional voice-note normalization that converts PTT audio to OGG/Opus with configurable bitrate, sample rate, and application mode.
* **Behavior Changes**
  * Client messaging now normalizes and replaces outgoing voice-note media/mimetype when the media option is enabled.
* **Tests**
  * Added coverage for voice-note normalization and supported input formats.
* **Chores**
  * Media utilities declared as a dependency for the server package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->