### PR TITLE
feat(message): decrypt inbound secretEncryptedMessage addons

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -306,7 +306,15 @@ export interface WaAccountTakeoverNoticeEvent extends WaIncomingBaseEvent {
     readonly newDeviceAppVersion?: string
 }
 
-export type WaAddonKind = 'reaction' | 'poll_vote' | 'event_response' | 'comment'
+export type WaAddonKind =
+    | 'reaction'
+    | 'poll_vote'
+    | 'event_response'
+    | 'comment'
+    | 'message_edit'
+    | 'event_edit'
+    | 'poll_edit'
+    | 'poll_add_option'
 
 export interface WaIncomingAddonEvent extends WaIncomingBaseEvent {
     readonly kind: WaAddonKind

--- a/src/message/crypto/__tests__/addon-crypto.test.ts
+++ b/src/message/crypto/__tests__/addon-crypto.test.ts
@@ -3,13 +3,16 @@ import test from 'node:test'
 
 import {
     buildAddonAdditionalData,
+    decodeAddonPlaintext,
     decryptAddonPayload,
-    encryptAddonPayload
+    encryptAddonPayload,
+    identifyEncryptedAddon
 } from '@message/crypto/addon-crypto'
 import {
     createUseCaseSecret,
     WA_USE_CASE_SECRET_MODIFICATION_TYPES
 } from '@message/crypto/use-case-secret'
+import { proto, type Proto } from '@proto'
 
 test('addon crypto helpers encrypt/decrypt payloads and validate aad', async () => {
     const context = {
@@ -86,4 +89,151 @@ test('addon AAD includes salt id and author jid', () => {
     assert.deepEqual(aad, aad2)
     const aad3 = buildAddonAdditionalData('CHUNK-2', '551100000000@s.whatsapp.net')
     assert.notDeepEqual(aad, aad3)
+})
+
+const SECRET_ENC_CASES = [
+    {
+        label: 'message_edit',
+        kind: 'message_edit' as const,
+        secretEncType: proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT,
+        modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.MESSAGE_EDIT,
+        plaintextMessage: {
+            protocolMessage: {
+                type: proto.Message.ProtocolMessage.Type.MESSAGE_EDIT,
+                editedMessage: { conversation: 'edited body' }
+            }
+        }
+    },
+    {
+        label: 'event_edit',
+        kind: 'event_edit' as const,
+        secretEncType: proto.Message.SecretEncryptedMessage.SecretEncType.EVENT_EDIT,
+        modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.EVENT_EDIT_ENCRYPTED,
+        plaintextMessage: {
+            protocolMessage: {
+                type: proto.Message.ProtocolMessage.Type.MESSAGE_EDIT,
+                editedMessage: { eventMessage: { name: 'renamed event' } }
+            }
+        }
+    },
+    {
+        label: 'poll_edit',
+        kind: 'poll_edit' as const,
+        secretEncType: proto.Message.SecretEncryptedMessage.SecretEncType.POLL_EDIT,
+        modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.POLL_EDIT_ENCRYPTED,
+        plaintextMessage: {
+            protocolMessage: {
+                type: proto.Message.ProtocolMessage.Type.MESSAGE_EDIT,
+                editedMessage: { pollCreationMessage: { name: 'renamed poll' } }
+            }
+        }
+    },
+    {
+        label: 'poll_add_option',
+        kind: 'poll_add_option' as const,
+        secretEncType: proto.Message.SecretEncryptedMessage.SecretEncType.POLL_ADD_OPTION,
+        modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.POLL_ADD_OPTION,
+        plaintextMessage: {
+            pollAddOptionMessage: {
+                pollCreationMessageKey: {
+                    remoteJid: '120363000000000000@g.us',
+                    fromMe: false,
+                    id: 'PARENT-1'
+                },
+                addOption: { optionName: 'new option' }
+            }
+        }
+    }
+] as const
+
+for (const tc of SECRET_ENC_CASES) {
+    test(`secretEncryptedMessage round-trip: ${tc.label}`, async () => {
+        const messageSecret = new Uint8Array(32).fill(11)
+        const iv = new Uint8Array(12).fill(3)
+        const targetMessageKey = {
+            remoteJid: '551100000000@s.whatsapp.net',
+            fromMe: false,
+            id: 'PARENT-1'
+        }
+        const ctx = {
+            messageSecret,
+            stanzaId: targetMessageKey.id,
+            parentMsgOriginalSender: '551100000000@s.whatsapp.net',
+            modificationSender: '551188888888@s.whatsapp.net',
+            modificationType: tc.modificationType
+        }
+        const plaintext = proto.Message.encode(tc.plaintextMessage).finish()
+        const encPayload = await encryptAddonPayload({ ...ctx, payload: plaintext, iv })
+
+        const wrapper: Proto.IMessage = {
+            secretEncryptedMessage: {
+                targetMessageKey,
+                encPayload,
+                encIv: iv,
+                secretEncType: tc.secretEncType
+            }
+        }
+
+        const identified = identifyEncryptedAddon(wrapper)
+        assert.ok(identified, 'expected secretEncryptedMessage to be identified')
+        assert.equal(identified.kind, tc.kind)
+        assert.equal(identified.modificationType, tc.modificationType)
+        assert.equal(identified.targetMessageKey.id, targetMessageKey.id)
+
+        const decrypted = await decryptAddonPayload({
+            messageSecret,
+            stanzaId: targetMessageKey.id,
+            parentMsgOriginalSender: ctx.parentMsgOriginalSender,
+            modificationSender: ctx.modificationSender,
+            modificationType: identified.modificationType,
+            ciphertext: identified.encPayload,
+            iv: identified.encIv
+        })
+        const decoded = decodeAddonPlaintext(identified.kind, decrypted)
+        assert.equal(decoded.kind, tc.kind)
+        assert.ok('message' in decoded, 'expected decoded payload to expose message')
+        if (tc.kind === 'poll_add_option') {
+            assert.equal(decoded.message.pollAddOptionMessage?.addOption?.optionName, 'new option')
+        } else {
+            assert.ok(decoded.message.protocolMessage?.editedMessage)
+        }
+    })
+}
+
+test('secretEncryptedMessage with MESSAGE_SCHEDULE or UNKNOWN is not identified', () => {
+    const targetMessageKey = {
+        remoteJid: '551100000000@s.whatsapp.net',
+        fromMe: false,
+        id: 'PARENT-2'
+    }
+    for (const secretEncType of [
+        proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_SCHEDULE,
+        proto.Message.SecretEncryptedMessage.SecretEncType.UNKNOWN
+    ]) {
+        const wrapper: Proto.IMessage = {
+            secretEncryptedMessage: {
+                targetMessageKey,
+                encPayload: new Uint8Array(16),
+                encIv: new Uint8Array(12),
+                secretEncType
+            }
+        }
+        assert.equal(identifyEncryptedAddon(wrapper), null)
+    }
+})
+
+test('secretEncryptedMessage with non-12-byte iv is not identified', () => {
+    const wrapper: Proto.IMessage = {
+        secretEncryptedMessage: {
+            targetMessageKey: {
+                remoteJid: '551100000000@s.whatsapp.net',
+                fromMe: false,
+                id: 'PARENT-3'
+            },
+            encPayload: new Uint8Array(16),
+            encIv: new Uint8Array(8),
+            secretEncType: proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT
+        }
+    }
+    assert.equal(identifyEncryptedAddon(wrapper), null)
 })

--- a/src/message/crypto/addon-crypto.ts
+++ b/src/message/crypto/addon-crypto.ts
@@ -151,7 +151,58 @@ export function identifyEncryptedAddon(message: Proto.IMessage): WaIdentifiedEnc
         }
     }
 
+    if (msg.secretEncryptedMessage) {
+        const { targetMessageKey, encPayload, encIv, secretEncType } = msg.secretEncryptedMessage
+        if (
+            targetMessageKey?.id &&
+            encPayload &&
+            encIv &&
+            encIv.byteLength === WA_ADDON_ENCRYPTION_NONCE_BYTES
+        ) {
+            const mapped = mapSecretEncType(secretEncType)
+            if (mapped) {
+                return {
+                    kind: mapped.kind,
+                    targetMessageKey,
+                    encPayload,
+                    encIv,
+                    modificationType: mapped.modificationType,
+                    raw: message
+                }
+            }
+        }
+    }
+
     return null
+}
+
+function mapSecretEncType(
+    secretEncType: Proto.Message.SecretEncryptedMessage.SecretEncType | null | undefined
+): { kind: WaAddonKind; modificationType: ModificationType } | null {
+    switch (secretEncType) {
+        case proto.Message.SecretEncryptedMessage.SecretEncType.MESSAGE_EDIT:
+            return {
+                kind: 'message_edit',
+                modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.MESSAGE_EDIT
+            }
+        case proto.Message.SecretEncryptedMessage.SecretEncType.EVENT_EDIT:
+            return {
+                kind: 'event_edit',
+                modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.EVENT_EDIT_ENCRYPTED
+            }
+        case proto.Message.SecretEncryptedMessage.SecretEncType.POLL_EDIT:
+            return {
+                kind: 'poll_edit',
+                modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.POLL_EDIT_ENCRYPTED
+            }
+        case proto.Message.SecretEncryptedMessage.SecretEncType.POLL_ADD_OPTION:
+            return {
+                kind: 'poll_add_option',
+                modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.POLL_ADD_OPTION
+            }
+        default:
+            return null
+    }
 }
 
 export type WaDecodedAddon =
@@ -166,6 +217,10 @@ export type WaDecodedAddon =
           readonly eventResponse: Proto.Message.IEventResponseMessage
       }
     | { readonly kind: 'comment'; readonly comment: Proto.Message.ICommentMessage }
+    | { readonly kind: 'message_edit'; readonly message: Proto.IMessage }
+    | { readonly kind: 'event_edit'; readonly message: Proto.IMessage }
+    | { readonly kind: 'poll_edit'; readonly message: Proto.IMessage }
+    | { readonly kind: 'poll_add_option'; readonly message: Proto.IMessage }
 
 export function decodeAddonPlaintext(kind: WaAddonKind, plaintext: Uint8Array): WaDecodedAddon {
     switch (kind) {
@@ -181,6 +236,11 @@ export function decodeAddonPlaintext(kind: WaAddonKind, plaintext: Uint8Array): 
             return { kind, eventResponse: proto.Message.EventResponseMessage.decode(plaintext) }
         case 'comment':
             return { kind, comment: proto.Message.CommentMessage.decode(plaintext) }
+        case 'message_edit':
+        case 'event_edit':
+        case 'poll_edit':
+        case 'poll_add_option':
+            return { kind, message: proto.Message.decode(plaintext) }
     }
 }
 

--- a/src/message/crypto/use-case-secret.ts
+++ b/src/message/crypto/use-case-secret.ts
@@ -11,7 +11,9 @@ export const WA_USE_CASE_SECRET_MODIFICATION_TYPES = Object.freeze({
     REPORT_TOKEN: 'Report Token',
     EVENT_RESPONSE: 'Event Response',
     EVENT_EDIT_ENCRYPTED: 'Event Edit',
-    MESSAGE_EDIT: 'Message Edit'
+    MESSAGE_EDIT: 'Message Edit',
+    POLL_EDIT_ENCRYPTED: 'Poll Edit',
+    POLL_ADD_OPTION: 'Poll Add Option'
 } as const)
 
 export function assertMessageSecret(


### PR DESCRIPTION
Recognize SecretEncryptedMessage in identifyEncryptedAddon for the four enc types wa-web supports (MESSAGE_EDIT, EVENT_EDIT, POLL_EDIT, POLL_ADD_OPTION) and decode the AES-GCM plaintext as a full proto.Message. MESSAGE_SCHEDULE and UNKNOWN stay unhandled to match wa-web parity.

The HKDF derivation is identical to existing addons (createUseCaseSecret with the mapped modification-type string), so tryDecryptAddon picks the new kinds up without any client wiring change. Adds POLL_EDIT_ENCRYPTED and POLL_ADD_OPTION to WA_USE_CASE_SECRET_MODIFICATION_TYPES and extends WaAddonKind / WaDecodedAddon with four new variants carrying the decoded message tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended addon event support to include message edits, event edits, poll edits, and poll add option events.
  * Updated encryption and decryption logic to recognize and process these new addon modification types.
  * Added validation and plaintext decoding for encrypted addon messages related to these new event kinds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->