### PR TITLE
refactor(client)!: extract WaClient surface into coordinator namespaces

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -149,7 +149,7 @@ async function startSession(client: WaClient): Promise<void> {
         const nowSeconds = Date.now() / 1_000
         const deltaSeconds =
             event.timestampSeconds === undefined ? 0 : nowSeconds - event.timestampSeconds
-        await client.sendMessage(to, {
+        await client.message.send(to, {
             extendedTextMessage: {
                 text: `pong ${deltaSeconds.toFixed(3)}`
             }

--- a/packages/fake-server/bench/messaging.bench.ts
+++ b/packages/fake-server/bench/messaging.bench.ts
@@ -633,7 +633,7 @@ async function scenarioSend1to1(
         const promises = new Array<Promise<unknown>>(messages)
         for (let i = 0; i < messages; i += 1) {
             const contact = contacts[i % contacts.length]
-            promises[i] = client.sendMessage(contact.userJid, {
+            promises[i] = client.message.send(contact.userJid, {
                 conversation: `bench send ${i}`
             })
         }
@@ -715,13 +715,13 @@ async function scenarioSendGroup(
     // Warm up: send 1 message to each group OUTSIDE the timed window
     // so the SKDM fanout cost (1 pkmsg per member) is amortised.
     for (const group of groups) {
-        await client.sendMessage(group.groupJid, { conversation: 'warmup' })
+        await client.message.send(group.groupJid, { conversation: 'warmup' })
     }
     return runScenario('SEND group', messages, async () => {
         const promises = new Array<Promise<unknown>>(messages)
         for (let i = 0; i < messages; i += 1) {
             const group = groups[i % groups.length]
-            promises[i] = client.sendMessage(group.groupJid, {
+            promises[i] = client.message.send(group.groupJid, {
                 conversation: `bench gsend ${i}`
             })
         }

--- a/packages/fake-server/src/__tests__/appstate-sync.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/appstate-sync.cross-check.test.ts
@@ -47,7 +47,7 @@ test('server_sync notification triggers a full app-state sync IQ round-trip', as
             `expected regular_high in sync IQ, got ${requestedNames.join(',')}`
         )
 
-        await client.syncAppState()
+        await client.chat.sync()
     } finally {
         await client.disconnect().catch(() => undefined)
         await server.stop()

--- a/packages/fake-server/src/__tests__/bidirectional-1on1.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/bidirectional-1on1.cross-check.test.ts
@@ -80,7 +80,7 @@ test('bidirectional 1:1 ping-pong (peer\u2192client\u2192peer\u2192client\u2192p
         assert.equal(round1Event.message?.conversation, 'peer-to-client #1')
 
         const round2ReceivedByPeer = peer.expectMessage({ timeoutMs: 8_000 })
-        await client.sendMessage(peerJid, { conversation: 'client-to-peer #1' })
+        await client.message.send(peerJid, { conversation: 'client-to-peer #1' })
         const round2 = await round2ReceivedByPeer
         assert.equal(round2.message.conversation, 'client-to-peer #1')
 
@@ -93,7 +93,7 @@ test('bidirectional 1:1 ping-pong (peer\u2192client\u2192peer\u2192client\u2192p
         assert.equal(round3Event.message?.conversation, 'peer-to-client #2')
 
         const round4ReceivedByPeer = peer.expectMessage({ timeoutMs: 8_000 })
-        await client.sendMessage(peerJid, { conversation: 'client-to-peer #2' })
+        await client.message.send(peerJid, { conversation: 'client-to-peer #2' })
         const round4 = await round4ReceivedByPeer
         assert.equal(round4.message.conversation, 'client-to-peer #2')
 
@@ -153,7 +153,7 @@ test('bidirectional 1:1 starting with the lib (client\u2192peer\u2192client\u219
         await server.triggerPreKeyUpload(pipelineAfterPair)
 
         const round1Promise = peer.expectMessage({ timeoutMs: 8_000 })
-        await client.sendMessage(peerJid, { conversation: 'lib first #1' })
+        await client.message.send(peerJid, { conversation: 'lib first #1' })
         const round1 = await round1Promise
         assert.equal(round1.message.conversation, 'lib first #1')
         assert.equal(round1.encType, 'pkmsg')
@@ -167,7 +167,7 @@ test('bidirectional 1:1 starting with the lib (client\u2192peer\u2192client\u219
         assert.equal(round2.message?.conversation, 'peer reply #1')
 
         const round3Promise = peer.expectMessage({ timeoutMs: 8_000 })
-        await client.sendMessage(peerJid, { conversation: 'lib reply #2' })
+        await client.message.send(peerJid, { conversation: 'lib reply #2' })
         const round3 = await round3Promise
         assert.equal(round3.message.conversation, 'lib reply #2')
 

--- a/packages/fake-server/src/__tests__/bidirectional-group.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/bidirectional-group.cross-check.test.ts
@@ -95,7 +95,7 @@ test('bidirectional group ping-pong (peer\u2192client\u2192peer\u2192client) dec
             timeoutMs: 8_000,
             senderJid: meJid
         })
-        await client.sendMessage(groupJid, { conversation: 'lib-group #1' })
+        await client.message.send(groupJid, { conversation: 'lib-group #1' })
         const round2 = await round2Promise
         assert.equal(round2.encType, 'skmsg')
         assert.equal(round2.message.conversation, 'lib-group #1')
@@ -112,7 +112,7 @@ test('bidirectional group ping-pong (peer\u2192client\u2192peer\u2192client) dec
             timeoutMs: 8_000,
             senderJid: meJid
         })
-        await client.sendMessage(groupJid, { conversation: 'lib-group #2' })
+        await client.message.send(groupJid, { conversation: 'lib-group #2' })
         const round4 = await round4Promise
         assert.equal(round4.encType, 'skmsg')
         assert.equal(round4.message.conversation, 'lib-group #2')

--- a/packages/fake-server/src/__tests__/client-group-message-decrypt.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/client-group-message-decrypt.cross-check.test.ts
@@ -61,7 +61,7 @@ test('paired client.sendMessage to a group is decrypted by the fake peer', async
             timeoutMs: 8_000,
             senderJid: meJid
         })
-        await client.sendMessage(groupJid, { conversation: 'hello group from real client' })
+        await client.message.send(groupJid, { conversation: 'hello group from real client' })
         const received = await groupReceivedPromise
         assert.equal(received.encType, 'skmsg')
         assert.equal(received.message.conversation, 'hello group from real client')

--- a/packages/fake-server/src/__tests__/client-image-upload.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/client-image-upload.cross-check.test.ts
@@ -63,7 +63,7 @@ test('paired client.sendMessage uploads an image to the fake media HTTPS listene
             { timeoutMs: 8_000 }
         )
 
-        await client.sendMessage(peerJid, {
+        await client.message.send(peerJid, {
             type: 'image',
             media: plaintext,
             mimetype: 'image/jpeg',

--- a/packages/fake-server/src/__tests__/client-send-message-decrypt.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/client-send-message-decrypt.cross-check.test.ts
@@ -54,13 +54,13 @@ test('paired client.sendMessage is decrypted by the fake peer', async () => {
         await server.triggerPreKeyUpload(pipelineAfterPair)
 
         const firstReceivedPromise = peer.expectMessage({ timeoutMs: 5_000 })
-        await client.sendMessage(peerJid, { conversation: 'hello peer from real client' })
+        await client.message.send(peerJid, { conversation: 'hello peer from real client' })
         const first = await firstReceivedPromise
         assert.equal(first.encType, 'pkmsg')
         assert.equal(first.message.conversation, 'hello peer from real client')
 
         const secondReceivedPromise = peer.expectMessage({ timeoutMs: 5_000 })
-        await client.sendMessage(peerJid, { conversation: 'second one' })
+        await client.message.send(peerJid, { conversation: 'second one' })
         const second = await secondReceivedPromise
         assert.equal(second.encType, 'pkmsg')
         assert.equal(second.message.conversation, 'second one')

--- a/packages/fake-server/src/__tests__/client-send-message.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/client-send-message.cross-check.test.ts
@@ -70,7 +70,7 @@ test('paired client.sendMessage reaches the wire as a real <message> stanza', as
             { timeoutMs: 5_000 }
         )
 
-        await client.sendMessage(peerJid, {
+        await client.message.send(peerJid, {
             extendedTextMessage: { text: 'hello peer from real client' }
         })
 

--- a/packages/fake-server/src/__tests__/image-message.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/image-message.cross-check.test.ts
@@ -76,13 +76,7 @@ test('fake peer pushes an imageMessage and the lib downloads + decrypts the atta
         assert.ok(imageMessage.directPath, 'directPath should be set')
         assert.ok(imageMessage.mediaKey, 'mediaKey should be set')
 
-        const downloaded = await client.mediaTransfer.downloadAndDecrypt({
-            directPath: imageMessage.directPath,
-            mediaType: 'image',
-            mediaKey: imageMessage.mediaKey,
-            fileSha256: imageMessage.fileSha256 as Uint8Array,
-            fileEncSha256: imageMessage.fileEncSha256 as Uint8Array
-        })
+        const downloaded = await client.message.downloadBytes(event)
 
         assert.equal(downloaded.byteLength, plaintext.byteLength)
         for (let index = 0; index < plaintext.byteLength; index += 1) {

--- a/packages/fake-server/src/__tests__/lid-addressing.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/lid-addressing.cross-check.test.ts
@@ -101,7 +101,7 @@ test('paired client.sendMessage to a @lid peer is decrypted by the fake peer', a
         await server.triggerPreKeyUpload(pipelineAfterPair)
 
         const decryptedPromise = peer.expectMessage({ timeoutMs: 8_000 })
-        await client.sendMessage(lidJid, { conversation: outboundText })
+        await client.message.send(lidJid, { conversation: outboundText })
         const decrypted = await decryptedPromise
         assert.equal(decrypted.message.conversation, outboundText)
         assert.equal(decrypted.encType, 'pkmsg')

--- a/packages/fake-server/src/__tests__/media-types.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/media-types.cross-check.test.ts
@@ -145,13 +145,7 @@ for (const testCase of cases) {
             assert.ok(descriptor.directPath, 'directPath should be set')
             assert.ok(descriptor.mediaKey, 'mediaKey should be set')
 
-            const downloaded = await client.mediaTransfer.downloadAndDecrypt({
-                directPath: descriptor.directPath,
-                mediaType: testCase.mediaType,
-                mediaKey: descriptor.mediaKey,
-                fileSha256: descriptor.fileSha256 as Uint8Array,
-                fileEncSha256: descriptor.fileEncSha256 as Uint8Array
-            })
+            const downloaded = await client.message.downloadBytes(event)
             assert.equal(downloaded.byteLength, plaintext.byteLength)
             for (let index = 0; index < plaintext.byteLength; index += 1) {
                 if (downloaded[index] !== plaintext[index]) {

--- a/packages/fake-server/src/__tests__/multi-device-fanout.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/multi-device-fanout.cross-check.test.ts
@@ -60,7 +60,7 @@ test('paired client.sendMessage fans out to all devices of a multi-device peer',
         const device0Promise = peers[0].expectMessage({ timeoutMs: 8_000 })
         const device1Promise = peers[1].expectMessage({ timeoutMs: 8_000 })
 
-        await client.sendMessage(userJid, { conversation: expectedText })
+        await client.message.send(userJid, { conversation: expectedText })
 
         const stanza = await stanzaPromise
         assert.equal(stanza.tag, 'message')

--- a/packages/fake-server/src/__tests__/multi-participant-group.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/multi-participant-group.cross-check.test.ts
@@ -89,7 +89,7 @@ test('paired client.sendMessage to a 3-participant group fans out via the regist
             senderJid: meJid
         })
 
-        await client.sendMessage(groupJid, { conversation: text })
+        await client.message.send(groupJid, { conversation: text })
 
         const stanza = await stanzaPromise
         const children: readonly BinaryNode[] = Array.isArray(stanza.content) ? stanza.content : []

--- a/packages/fake-server/src/__tests__/out-of-order-recv.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/out-of-order-recv.cross-check.test.ts
@@ -58,7 +58,7 @@ test('fake peer decrypts out-of-order msgs (counter 0,2,1,3) via the unused-keys
             server.expectStanza({ tag: 'message', to: peerJid }, { timeoutMs: 8_000 })
         ]
         for (const text of messages) {
-            await client.sendMessage(peerJid, { conversation: text })
+            await client.message.send(peerJid, { conversation: text })
         }
         const stanzas = await Promise.all(stanzaPromises)
         assert.equal(stanzas.length, 4)

--- a/packages/fake-server/src/__tests__/presence-chatstate.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/presence-chatstate.cross-check.test.ts
@@ -143,16 +143,16 @@ test('the lib sends presence subscribe and chatstate stanzas the server captures
             { tag: 'presence', type: 'subscribe', to: peerJid },
             { timeoutMs: 2_000 }
         )
-        await client.subscribePresence(peerJid)
+        await client.presence.subscribe(peerJid)
         await subscribePromise
 
-        await client.sendChatstate(peerJid, { state: 'composing' })
-        await client.sendChatstate(peerJid, { state: 'composing', media: 'audio' })
+        await client.presence.sendChatstate(peerJid, { state: 'composing' })
+        await client.presence.sendChatstate(peerJid, { state: 'composing', media: 'audio' })
         const pausedPromise = server.expectStanza(
             { tag: 'chatstate', to: peerJid, childTag: 'paused' },
             { timeoutMs: 2_000 }
         )
-        await client.sendChatstate(peerJid, { state: 'paused' })
+        await client.presence.sendChatstate(peerJid, { state: 'paused' })
         await pausedPromise
 
         const chatstates = server

--- a/packages/fake-server/src/__tests__/receipts.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/receipts.cross-check.test.ts
@@ -67,7 +67,7 @@ test('client.sendReceipt emits a real <receipt/> stanza captured by the fake ser
 
         const stanzaPromise = server.expectStanza({ tag: 'receipt' }, { timeoutMs: 5_000 })
 
-        await client.sendReceipt(peerJid, messageId, { type: 'read' })
+        await client.message.sendReceipt(peerJid, messageId, { type: 'read' })
 
         const stanza = await stanzaPromise
         assert.equal(stanza.tag, 'receipt')

--- a/packages/mcp-server/src/__tests__/fake-server.cross-check.test.ts
+++ b/packages/mcp-server/src/__tests__/fake-server.cross-check.test.ts
@@ -184,7 +184,7 @@ test('mcp runtime drives pairing + send/receive against fake-server', async () =
         const peerExpect = peer.expectMessage({ timeoutMs: 8_000 })
         const sendResult = (await callTool.handler(
             {
-                path: 'sendMessage',
+                path: 'message.send',
                 args: [PEER_JID, { conversation: 'hello via mcp call tool' }]
             },
             runtime

--- a/src/appstate/sync/WaAppStateSyncClient.ts
+++ b/src/appstate/sync/WaAppStateSyncClient.ts
@@ -28,7 +28,7 @@ import {
     WA_NODE_TAGS,
     WA_XMLNS
 } from '@protocol/constants'
-import { parseSignalAddressFromJid } from '@protocol/jid'
+import { applyDeviceToJid, normalizeDeviceJid, parseSignalAddressFromJid } from '@protocol/jid'
 import type {
     WaAppStateCollectionStateUpdate,
     WaAppStateCollectionStoreState,
@@ -55,6 +55,13 @@ interface MacMutation {
 
 type DecryptedPatchMutation = WaAppStateMutation & { operationCode: number }
 
+export interface IncomingKeyEventContext {
+    readonly stanzaId?: string
+    readonly chatJid?: string
+    readonly senderJid?: string
+    readonly senderDevice?: number
+}
+
 interface WaAppStateSyncClientOptions {
     readonly logger: Logger
     readonly query: (node: BinaryNode, timeoutMs: number) => Promise<BinaryNode>
@@ -66,6 +73,13 @@ interface WaAppStateSyncClientOptions {
     readonly onMissingKeys?: (event: WaAppStateMissingKeysEvent) => Promise<void>
     readonly skipMacVerification?: boolean
     readonly mobilePrimary?: boolean
+    readonly isOwnAccountDevice?: (deviceJid: string) => boolean
+    readonly sendKeyShare?: (
+        toDeviceJid: string,
+        keys: readonly WaAppStateSyncKey[],
+        missingKeyIds: readonly Uint8Array[]
+    ) => Promise<void>
+    readonly triggerSync?: () => Promise<void>
 }
 
 class WaAppStateMissingKeyError extends Error {
@@ -93,6 +107,13 @@ export class WaAppStateSyncClient {
     private readonly hostDomain: string
     private readonly defaultTimeoutMs: number
     private readonly onMissingKeys?: (event: WaAppStateMissingKeysEvent) => Promise<void>
+    private readonly isOwnAccountDevice?: (deviceJid: string) => boolean
+    private readonly sendKeyShare?: (
+        toDeviceJid: string,
+        keys: readonly WaAppStateSyncKey[],
+        missingKeyIds: readonly Uint8Array[]
+    ) => Promise<void>
+    private readonly triggerSync?: () => Promise<void>
     private readonly crypto: WaAppStateCrypto
     private readonly mobilePrimary: boolean
     private syncContext: {
@@ -111,6 +132,9 @@ export class WaAppStateSyncClient {
         this.hostDomain = options.hostDomain ?? WA_DEFAULTS.HOST_DOMAIN
         this.defaultTimeoutMs = options.defaultTimeoutMs ?? WA_DEFAULTS.APP_STATE_SYNC_TIMEOUT_MS
         this.onMissingKeys = options.onMissingKeys
+        this.isOwnAccountDevice = options.isOwnAccountDevice
+        this.sendKeyShare = options.sendKeyShare
+        this.triggerSync = options.triggerSync
 
         this.crypto = new WaAppStateCrypto(undefined, options.skipMacVerification === true)
         this.mobilePrimary = options.mobilePrimary ?? false
@@ -149,6 +173,159 @@ export class WaAppStateSyncClient {
             this.logger.info('app-state sync keys persisted', { inserted })
         }
         return inserted
+    }
+
+    public async handleIncomingKeyShare(
+        context: IncomingKeyEventContext,
+        protocolMessage: Proto.Message.IProtocolMessage
+    ): Promise<void> {
+        const share = protocolMessage.appStateSyncKeyShare
+        if (!share) {
+            this.logger.warn('incoming app-state key share protocol message without payload', {
+                id: context.stanzaId,
+                from: context.chatJid
+            })
+            return
+        }
+
+        try {
+            const imported = await this.importSyncKeyShare(share)
+            this.logger.info('imported app-state sync key share from protocol message', {
+                id: context.stanzaId,
+                from: context.chatJid,
+                imported
+            })
+            if (imported > 0 && this.triggerSync) {
+                void this.triggerSync().catch((error) => {
+                    this.logger.warn('failed to sync app-state after key share import', {
+                        id: context.stanzaId,
+                        from: context.chatJid,
+                        message: toError(error).message
+                    })
+                })
+            }
+        } catch (error) {
+            this.logger.warn('failed to import app-state sync key share from protocol message', {
+                id: context.stanzaId,
+                from: context.chatJid,
+                message: toError(error).message
+            })
+        }
+    }
+
+    public async handleIncomingKeyRequest(
+        context: IncomingKeyEventContext,
+        protocolMessage: Proto.Message.IProtocolMessage
+    ): Promise<void> {
+        const request = protocolMessage.appStateSyncKeyRequest
+        if (!request) {
+            this.logger.warn('incoming app-state key request protocol message without payload', {
+                id: context.stanzaId,
+                from: context.chatJid
+            })
+            return
+        }
+
+        const requesterSource = context.senderJid ?? context.chatJid
+        if (!requesterSource) {
+            this.logger.warn('incoming app-state key request missing sender jid', {
+                id: context.stanzaId
+            })
+            return
+        }
+
+        let requesterDeviceJid: string
+        try {
+            const requesterRaw = context.senderJid
+                ? applyDeviceToJid(context.senderJid, context.senderDevice)
+                : requesterSource
+            requesterDeviceJid = normalizeDeviceJid(requesterRaw)
+        } catch (error) {
+            this.logger.warn('incoming app-state key request has malformed sender jid', {
+                id: context.stanzaId,
+                from: requesterSource,
+                message: toError(error).message
+            })
+            return
+        }
+
+        if (this.isOwnAccountDevice && !this.isOwnAccountDevice(requesterDeviceJid)) {
+            this.logger.warn('incoming app-state key request ignored: sender is not own account', {
+                id: context.stanzaId,
+                from: requesterDeviceJid
+            })
+            return
+        }
+
+        const requestedKeyIds = this.extractKeyRequestIds(request)
+        if (requestedKeyIds.length === 0) {
+            this.logger.warn('incoming app-state key request has no valid key ids', {
+                id: context.stanzaId,
+                from: requesterDeviceJid
+            })
+            return
+        }
+
+        if (!this.sendKeyShare) {
+            this.logger.warn('incoming app-state key request received but no sendKeyShare wired', {
+                id: context.stanzaId,
+                from: requesterDeviceJid
+            })
+            return
+        }
+
+        const requestedKeys = await this.store.getSyncKeysBatch(requestedKeyIds)
+        const availableKeys: WaAppStateSyncKey[] = []
+        const missingKeyIds: Uint8Array[] = []
+        for (let i = 0; i < requestedKeys.length; i += 1) {
+            const key = requestedKeys[i]
+            if (key !== null) {
+                availableKeys.push(key)
+            } else {
+                missingKeyIds.push(requestedKeyIds[i])
+            }
+        }
+
+        try {
+            await this.sendKeyShare(requesterDeviceJid, availableKeys, missingKeyIds)
+            this.logger.info('responded to app-state key request', {
+                id: context.stanzaId,
+                to: requesterDeviceJid,
+                requested: requestedKeyIds.length,
+                shared: availableKeys.length,
+                missing: missingKeyIds.length
+            })
+        } catch (error) {
+            this.logger.warn('failed to respond to app-state key request', {
+                id: context.stanzaId,
+                to: requesterDeviceJid,
+                requested: requestedKeyIds.length,
+                shared: availableKeys.length,
+                missing: missingKeyIds.length,
+                message: toError(error).message
+            })
+        }
+    }
+
+    private extractKeyRequestIds(
+        request: Proto.Message.IAppStateSyncKeyRequest
+    ): readonly Uint8Array[] {
+        const deduped = new Map<string, Uint8Array>()
+        for (const key of request.keyIds ?? []) {
+            try {
+                const keyId = decodeProtoBytes(key.keyId, 'appStateSyncKeyRequest.keyIds[].keyId')
+                const keyHex = bytesToHex(keyId)
+                if (deduped.has(keyHex)) {
+                    continue
+                }
+                deduped.set(keyHex, keyId)
+            } catch (error) {
+                this.logger.trace('ignoring malformed app-state key id request entry', {
+                    message: toError(error).message
+                })
+            }
+        }
+        return [...deduped.values()]
     }
 
     public async importSyncKeyShare(share: Proto.Message.IAppStateSyncKeyShare): Promise<number> {

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -1,12 +1,6 @@
 import { EventEmitter } from 'node:events'
 
 import type { WaAppStateSyncClient } from '@appstate/sync/WaAppStateSyncClient'
-import type {
-    WaAppStateStoreData,
-    WaAppStateSyncOptions,
-    WaAppStateSyncResult
-} from '@appstate/types'
-import { downloadExternalBlobReference } from '@appstate/utils'
 import type { WaAuthClient } from '@auth/WaAuthClient'
 import type { WaAppStateMutationCoordinator } from '@client/coordinators/WaAppStateMutationCoordinator'
 import type { WaBotCoordinator } from '@client/coordinators/WaBotCoordinator'
@@ -14,26 +8,21 @@ import type { WaBroadcastListCoordinator } from '@client/coordinators/WaBroadcas
 import type { WaBusinessCoordinator } from '@client/coordinators/WaBusinessCoordinator'
 import type { WaEmailCoordinator } from '@client/coordinators/WaEmailCoordinator'
 import type { WaGroupCoordinator } from '@client/coordinators/WaGroupCoordinator'
+import type { WaLowLevelCoordinator } from '@client/coordinators/WaLowLevelCoordinator'
+import type { WaMessageCoordinator } from '@client/coordinators/WaMessageCoordinator'
 import type { WaNewsletterCoordinator } from '@client/coordinators/WaNewsletterCoordinator'
+import type { WaPresenceCoordinator } from '@client/coordinators/WaPresenceCoordinator'
 import type { WaPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordinator'
 import type { WaProfileCoordinator } from '@client/coordinators/WaProfileCoordinator'
 import type { WaStatusCoordinator } from '@client/coordinators/WaStatusCoordinator'
-import { parseAccountEventFromAppStateMutation } from '@client/events/account'
-import { parseChatEventFromAppStateMutation } from '@client/events/chat'
-import { aggregateReceiptTargets } from '@client/events/receipt'
-import { processHistorySyncNotification } from '@client/persistence/history-sync'
+import { runHistorySyncNotification } from '@client/persistence/history-sync'
 import { persistIncomingMailboxEntities } from '@client/persistence/mailbox'
 import { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
 import type {
     WaClientEventMap,
     WaClientOptions,
-    WaIncomingAddonEvent,
-    WaIncomingBotChunkEvent,
     WaIncomingMessageEvent,
-    WaIncomingNodeHandlerRegistration,
-    WaIncomingProtocolMessageEvent,
-    WaIncomingStanzaFilter,
-    WaSendMessageOptions
+    WaIncomingProtocolMessageEvent
 } from '@client/types'
 import {
     buildWaClientDependencies,
@@ -43,59 +32,15 @@ import {
 import { ConsoleLogger } from '@infra/log/ConsoleLogger'
 import type { Logger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
-import {
-    buildAddonAdditionalData,
-    decodeAddonPlaintext,
-    decryptAddonPayload,
-    identifyEncryptedAddon,
-    resolveParentMessageSecret,
-    resolvePollOptionNames,
-    shouldUseAddonAdditionalData
-} from '@message/crypto/addon-crypto'
-import { unwrapMessage } from '@message/encode/content'
-import { decryptBotChunk } from '@message/kinds/bot'
-import type {
-    WaMessagePublishResult,
-    WaSendMessageContent,
-    WaSendReceiptEventOptions,
-    WaSendReceiptInput,
-    WaSendReceiptOptions
-} from '@message/types'
-import type { WaMessageClient } from '@message/WaMessageClient'
 import { proto, type Proto } from '@proto'
-import {
-    WA_APP_STATE_COLLECTION_STATES,
-    WA_BOT_MSG_EDIT_TYPES,
-    WA_BOT_NODE_ATTRS,
-    WA_DEFAULTS,
-    WA_META_NODE_ATTRS_BOT,
-    WA_NODE_TAGS,
-    type WaBotMsgEditType
-} from '@protocol/constants'
-import {
-    applyDeviceToJid,
-    isBotJid,
-    normalizeDeviceJid,
-    parsePhoneJid,
-    toUserJid
-} from '@protocol/jid'
+import { WA_DEFAULTS } from '@protocol/constants'
+import { normalizeDeviceJid, parsePhoneJid } from '@protocol/jid'
 import { WA_LOGOUT_REASONS, type WaLogoutReason } from '@protocol/stream'
 import type { SignalLidSyncResult } from '@signal/api/SignalDeviceSyncApi'
 import { NOOP_MESSAGE_SECRET_STORE } from '@store/noop.store'
-import {
-    buildChatstateNode,
-    type BuildChatstateNodeInput
-} from '@transport/node/builders/chatstate'
 import { buildRemoveCompanionDeviceIq } from '@transport/node/builders/device'
-import {
-    buildPresenceNode,
-    buildPresenceSubscribeNode,
-    type BuildPresenceSubscribeNodeInput
-} from '@transport/node/builders/presence'
-import { findNodeChild } from '@transport/node/helpers'
 import { assertIqResult, queryWithContext as queryNodeWithContext } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
-import { bytesToHex, decodeProtoBytes } from '@util/bytes'
 import { toError } from '@util/primitives'
 
 type WaIncomingProtocolType = NonNullable<Proto.Message.IProtocolMessage['type']>
@@ -111,9 +56,8 @@ export class WaClient extends EventEmitter {
     private readonly logger!: Logger
     private readonly stores!: ReturnType<WaClientOptions['store']['session']>
     private readonly deps!: WaClientDependencies
-    public readonly appStateSync!: WaAppStateSyncClient
-    public readonly mediaTransfer!: WaMediaTransferClient
-    public readonly messageClient!: WaMessageClient
+    private readonly appStateSync!: WaAppStateSyncClient
+    private readonly mediaTransfer!: WaMediaTransferClient
     private readonly writeBehind!: WriteBehindPersistence
     private connectPromise: Promise<void> | null = null
     private acceptingIncomingEvents = true
@@ -150,11 +94,13 @@ export class WaClient extends EventEmitter {
         const dependencies = buildWaClientDependencies({
             base,
             runtime: {
-                sendNode: (node) => this.sendNode(node),
-                query: (node, timeoutMs, options) => this.query(node, timeoutMs, options),
+                sendNode: (node) => this.deps.lowLevelCoordinator.sendNode(node),
+                query: (node, timeoutMs, options) =>
+                    this.deps.lowLevelCoordinator.query(node, timeoutMs, options),
                 queryWithContext: this.queryWithContext.bind(this),
-                syncAppState: () => this.syncAppState().then(() => {}),
-                syncAppStateWithOptions: (syncOptions) => this.syncAppState(syncOptions),
+                syncAppState: () => this.deps.chatCoordinator.sync().then(() => {}),
+                syncAppStateWithOptions: (syncOptions) =>
+                    this.deps.chatCoordinator.sync(syncOptions),
                 emitEvent: this.emit.bind(this) as <K extends keyof WaClientEventMap>(
                     event: K,
                     ...args: Parameters<WaClientEventMap[K]>
@@ -177,7 +123,6 @@ export class WaClient extends EventEmitter {
         this.deps = dependencies
         this.appStateSync = dependencies.appStateSync
         this.mediaTransfer = dependencies.mediaTransfer
-        this.messageClient = dependencies.messageClient
 
         this.bindNodeTransportEvents()
     }
@@ -223,85 +168,6 @@ export class WaClient extends EventEmitter {
         return this.deps.connectionManager.getClockSkewMs()
     }
 
-    public async sendNode(node: BinaryNode): Promise<void> {
-        try {
-            await this.deps.nodeOrchestrator.sendNode(node)
-        } catch (error) {
-            const normalized = toError(error)
-            if (this.deps.receiptQueue.shouldQueue(node, normalized)) {
-                this.deps.receiptQueue.enqueue(node)
-                this.logger.warn('queued dangling receipt after send failure', {
-                    id: node.attrs.id,
-                    to: node.attrs.to,
-                    message: normalized.message,
-                    queueSize: this.deps.receiptQueue.size()
-                })
-                return
-            }
-            throw normalized
-        }
-    }
-
-    public async sendPresence(type?: 'available' | 'unavailable'): Promise<void> {
-        const credentials = this.deps.authClient.getCurrentCredentials()
-        await this.deps.nodeOrchestrator.sendNode(
-            buildPresenceNode({ type, name: credentials?.meDisplayName ?? undefined }),
-            false
-        )
-    }
-
-    public async sendChatstate(
-        jid: string,
-        options: Omit<BuildChatstateNodeInput, 'jid'>
-    ): Promise<void> {
-        await this.deps.nodeOrchestrator.sendNode(buildChatstateNode({ jid, ...options }), false)
-    }
-
-    /**
-     * Subscribes to presence updates (online/offline + chatstate) for a chat.
-     * The subscription is per-jid and lives only for the current connection;
-     * after a reconnect the caller must re-subscribe to keep receiving events.
-     */
-    public async subscribePresence(
-        jid: string,
-        options?: Omit<BuildPresenceSubscribeNodeInput, 'jid'>
-    ): Promise<void> {
-        await this.deps.nodeOrchestrator.sendNode(
-            buildPresenceSubscribeNode({ jid, ...options }),
-            false
-        )
-    }
-
-    public async query(
-        node: BinaryNode,
-        timeoutMs: number = this.options.iqTimeoutMs ?? WA_DEFAULTS.IQ_TIMEOUT_MS,
-        options: { readonly useSystemId?: boolean } = {}
-    ): Promise<BinaryNode> {
-        if (!this.deps.connectionManager.isConnected()) {
-            throw new Error('client is not connected')
-        }
-        this.logger.debug('wa client query', { tag: node.tag, id: node.attrs.id, timeoutMs })
-        return this.deps.nodeOrchestrator.query(node, timeoutMs, options)
-    }
-
-    public registerIncomingHandler(registration: WaIncomingNodeHandlerRegistration): () => void {
-        return this.deps.incomingNode.registerIncomingHandler(registration)
-    }
-
-    public unregisterIncomingHandler(registration: WaIncomingNodeHandlerRegistration): boolean {
-        return this.deps.incomingNode.unregisterIncomingHandler(registration)
-    }
-
-    /**
-     * Registers a predicate that drops inbound stanzas before any handler runs.
-     * Returning `true` blocks the stanza and sends the protocol ack for
-     * `message`/`receipt`/`notification`. `success`/`failure` always bypass
-     * filters to keep the auth flow intact.
-     */
-    public registerIncomingStanzaFilter(filter: WaIncomingStanzaFilter): () => void {
-        return this.deps.incomingNode.registerIncomingStanzaFilter(filter)
-    }
-
     private bindNodeTransportEvents(): void {
         this.deps.nodeTransport.on('frame_in', (frame) =>
             this.emit('transport_frame_in', { frame })
@@ -334,7 +200,7 @@ export class WaClient extends EventEmitter {
                 event
             })
             if (this.options.addons?.autoDecrypt && event.message) {
-                void this.tryDecryptAddon(event).catch((err) => {
+                void this.deps.messageCoordinator.tryDecryptAddon(event).catch((err) => {
                     this.logger.warn('addon auto-decrypt failed', {
                         id: event.stanzaId,
                         message: toError(err).message
@@ -344,7 +210,7 @@ export class WaClient extends EventEmitter {
             // Decode unconditionally — chunks whose parent prompt we never sent
             // are skipped by the secret-store lookup downstream.
             if (event.message) {
-                void this.tryDecryptBotChunk(event).catch((err) => {
+                void this.deps.botCoordinator.tryDecryptChunk(event).catch((err) => {
                     this.logger.warn('bot chunk auto-decrypt failed', {
                         id: event.stanzaId,
                         message: toError(err).message
@@ -371,18 +237,30 @@ export class WaClient extends EventEmitter {
             }
 
             if (protocolType === proto.Message.ProtocolMessage.Type.APP_STATE_SYNC_KEY_REQUEST) {
-                await this.handleIncomingAppStateSyncKeyRequest(event, protocolMessage)
+                await this.appStateSync.handleIncomingKeyRequest(event, protocolMessage)
                 return
             }
 
             if (protocolType === proto.Message.ProtocolMessage.Type.APP_STATE_SYNC_KEY_SHARE) {
-                await this.handleIncomingAppStateSyncKeyShare(event, protocolMessage)
+                await this.appStateSync.handleIncomingKeyShare(event, protocolMessage)
                 return
             }
 
             if (protocolType === proto.Message.ProtocolMessage.Type.HISTORY_SYNC_NOTIFICATION) {
                 if (this.options.history?.enabled && protocolMessage.historySyncNotification) {
-                    await this.handleHistorySyncNotification(
+                    await runHistorySyncNotification(
+                        {
+                            logger: this.logger,
+                            mediaTransfer: this.mediaTransfer,
+                            writeBehind: this.writeBehind,
+                            emitEvent: this.emit.bind(this) as Parameters<
+                                typeof runHistorySyncNotification
+                            >[0]['emitEvent'],
+                            onPrivacyTokens: (conversations) =>
+                                this.deps.trustedContactToken.hydrateFromHistorySync(conversations),
+                            onNctSalt: (salt) =>
+                                this.deps.trustedContactToken.hydrateNctSaltFromHistorySync(salt)
+                        },
                         protocolMessage.historySyncNotification
                     )
                 }
@@ -408,196 +286,6 @@ export class WaClient extends EventEmitter {
         }
     }
 
-    private async handleIncomingAppStateSyncKeyShare(
-        event: WaIncomingMessageEvent,
-        protocolMessage: Proto.Message.IProtocolMessage
-    ): Promise<void> {
-        const share = protocolMessage.appStateSyncKeyShare
-        if (!share) {
-            this.logger.warn('incoming app-state key share protocol message without payload', {
-                id: event.stanzaId,
-                from: event.chatJid
-            })
-            return
-        }
-
-        try {
-            const imported = await this.appStateSync.importSyncKeyShare(share)
-            this.logger.info('imported app-state sync key share from protocol message', {
-                id: event.stanzaId,
-                from: event.chatJid,
-                imported
-            })
-            if (imported > 0) {
-                void this.syncAppState().catch((error) => {
-                    this.logger.warn('failed to sync app-state after key share import', {
-                        id: event.stanzaId,
-                        from: event.chatJid,
-                        message: toError(error).message
-                    })
-                })
-            }
-        } catch (error) {
-            this.logger.warn('failed to import app-state sync key share from protocol message', {
-                id: event.stanzaId,
-                from: event.chatJid,
-                message: toError(error).message
-            })
-        }
-    }
-
-    private async handleIncomingAppStateSyncKeyRequest(
-        event: WaIncomingMessageEvent,
-        protocolMessage: Proto.Message.IProtocolMessage
-    ): Promise<void> {
-        const request = protocolMessage.appStateSyncKeyRequest
-        if (!request) {
-            this.logger.warn('incoming app-state key request protocol message without payload', {
-                id: event.stanzaId,
-                from: event.chatJid
-            })
-            return
-        }
-
-        const requesterSource = event.senderJid ?? event.chatJid
-        if (!requesterSource) {
-            this.logger.warn('incoming app-state key request missing sender jid', {
-                id: event.stanzaId
-            })
-            return
-        }
-
-        let requesterDeviceJid: string
-        try {
-            const requesterRaw = event.senderJid
-                ? applyDeviceToJid(event.senderJid, event.senderDevice)
-                : requesterSource
-            requesterDeviceJid = normalizeDeviceJid(requesterRaw)
-        } catch (error) {
-            this.logger.warn('incoming app-state key request has malformed sender jid', {
-                id: event.stanzaId,
-                from: requesterSource,
-                message: toError(error).message
-            })
-            return
-        }
-
-        if (!this.isOwnAccountDeviceJid(requesterDeviceJid)) {
-            this.logger.warn('incoming app-state key request ignored: sender is not own account', {
-                id: event.stanzaId,
-                from: requesterDeviceJid
-            })
-            return
-        }
-
-        const requestedKeyIds = this.extractAppStateSyncKeyRequestIds(request)
-        if (requestedKeyIds.length === 0) {
-            this.logger.warn('incoming app-state key request has no valid key ids', {
-                id: event.stanzaId,
-                from: requesterDeviceJid
-            })
-            return
-        }
-
-        const requestedKeys = await this.stores.appState.getSyncKeysBatch(requestedKeyIds)
-        const availableKeys: WaAppStateStoreData['keys'][number][] = []
-        const missingKeyIds: Uint8Array[] = []
-        for (let i = 0; i < requestedKeys.length; i += 1) {
-            const key = requestedKeys[i]
-            if (key !== null) {
-                availableKeys.push(key)
-            } else {
-                missingKeyIds.push(requestedKeyIds[i])
-            }
-        }
-
-        try {
-            await this.deps.messageDispatch.sendAppStateSyncKeyShare(
-                requesterDeviceJid,
-                availableKeys,
-                missingKeyIds
-            )
-            this.logger.info('responded to app-state key request', {
-                id: event.stanzaId,
-                to: requesterDeviceJid,
-                requested: requestedKeyIds.length,
-                shared: availableKeys.length,
-                missing: missingKeyIds.length
-            })
-        } catch (error) {
-            this.logger.warn('failed to respond to app-state key request', {
-                id: event.stanzaId,
-                to: requesterDeviceJid,
-                requested: requestedKeyIds.length,
-                shared: availableKeys.length,
-                missing: missingKeyIds.length,
-                message: toError(error).message
-            })
-        }
-    }
-
-    private extractAppStateSyncKeyRequestIds(
-        request: Proto.Message.IAppStateSyncKeyRequest
-    ): readonly Uint8Array[] {
-        const deduped = new Map<string, Uint8Array>()
-        for (const key of request.keyIds ?? []) {
-            try {
-                const keyId = decodeProtoBytes(key.keyId, 'appStateSyncKeyRequest.keyIds[].keyId')
-                const keyHex = bytesToHex(keyId)
-                if (deduped.has(keyHex)) {
-                    continue
-                }
-                deduped.set(keyHex, keyId)
-            } catch (error) {
-                this.logger.trace('ignoring malformed app-state key id request entry', {
-                    message: toError(error).message
-                })
-            }
-        }
-        return [...deduped.values()]
-    }
-
-    private isOwnAccountDeviceJid(candidateJid: string): boolean {
-        const credentials = this.deps.authClient.getCurrentCredentials()
-        if (!credentials) {
-            return false
-        }
-
-        const candidateUser = toUserJid(candidateJid)
-        return (
-            (!!credentials.meJid && toUserJid(credentials.meJid) === candidateUser) ||
-            (!!credentials.meLid && toUserJid(credentials.meLid) === candidateUser)
-        )
-    }
-
-    private async handleHistorySyncNotification(
-        notification: Proto.Message.IHistorySyncNotification
-    ): Promise<void> {
-        try {
-            await processHistorySyncNotification(
-                {
-                    logger: this.logger,
-                    mediaTransfer: this.mediaTransfer,
-                    writeBehind: this.writeBehind,
-                    emitEvent: this.emit.bind(this) as Parameters<
-                        typeof processHistorySyncNotification
-                    >[0]['emitEvent'],
-                    onPrivacyTokens: (conversations) =>
-                        this.deps.trustedContactToken.hydrateFromHistorySync(conversations),
-                    onNctSalt: (salt) =>
-                        this.deps.trustedContactToken.hydrateNctSaltFromHistorySync(salt)
-                },
-                notification
-            )
-        } catch (error) {
-            this.logger.warn('failed to process history sync notification', {
-                syncType: notification.syncType,
-                chunkOrder: notification.chunkOrder,
-                message: toError(error).message
-            })
-        }
-    }
-
     private async queryWithContext(
         context: string,
         node: BinaryNode,
@@ -606,7 +294,8 @@ export class WaClient extends EventEmitter {
         options: { readonly useSystemId?: boolean } = {}
     ): Promise<BinaryNode> {
         return queryNodeWithContext(
-            async (queryNode, queryTimeoutMs) => this.query(queryNode, queryTimeoutMs, options),
+            async (queryNode, queryTimeoutMs) =>
+                this.deps.lowLevelCoordinator.query(queryNode, queryTimeoutMs, options),
             this.logger,
             context,
             node,
@@ -691,28 +380,17 @@ export class WaClient extends EventEmitter {
         return this.deps.signalDeviceSync.queryLidsByPhoneJids(normalizedPhoneJids)
     }
 
-    public sendMessage(
-        to: string,
-        content: WaSendMessageContent,
-        options: WaSendMessageOptions = {}
-    ): Promise<WaMessagePublishResult> {
-        return this.deps.messageDispatch.sendMessage(to, content, options)
-    }
-
-    public async syncSignalSession(jid: string, reasonIdentity = false): Promise<void> {
-        await this.deps.messageDispatch.syncSignalSession(jid, reasonIdentity)
-        if (reasonIdentity) {
-            this.deps.trustedContactToken.reissueOnIdentityChange(jid).catch((err) =>
-                this.logger.warn('tc token reissue on identity change failed', {
-                    jid,
-                    message: toError(err).message
-                })
-            )
-        }
-    }
-
     public get auth(): WaAuthClient {
         return this.deps.authClient
+    }
+    public get message(): WaMessageCoordinator {
+        return this.deps.messageCoordinator
+    }
+    public get presence(): WaPresenceCoordinator {
+        return this.deps.presenceCoordinator
+    }
+    public get lowlevel(): WaLowLevelCoordinator {
+        return this.deps.lowLevelCoordinator
     }
     public get chat(): WaAppStateMutationCoordinator {
         return this.deps.chatCoordinator
@@ -759,179 +437,6 @@ export class WaClient extends EventEmitter {
         assertIqResult(result, 'client.logout')
     }
 
-    public sendReceipt(
-        target: WaIncomingMessageEvent | readonly WaIncomingMessageEvent[],
-        options?: WaSendReceiptEventOptions
-    ): Promise<void>
-    public sendReceipt(
-        jid: string,
-        ids: string | readonly string[],
-        options?: WaSendReceiptOptions
-    ): Promise<void>
-    public async sendReceipt(
-        first: string | WaIncomingMessageEvent | readonly WaIncomingMessageEvent[],
-        second?: string | readonly string[] | WaSendReceiptEventOptions,
-        third?: WaSendReceiptOptions
-    ): Promise<void> {
-        if (typeof first === 'string') {
-            const ids = second as string | readonly string[]
-            await this.dispatchReceipt(first, ids, third ?? {})
-            return
-        }
-        const events = Array.isArray(first) ? first : [first as WaIncomingMessageEvent]
-        const options = (second as WaSendReceiptEventOptions | undefined) ?? {}
-        const targets = events.map((event) => {
-            if (!event.chatJid || !event.stanzaId) {
-                throw new Error('sendReceipt event is missing chatJid or stanzaId')
-            }
-            return {
-                chatJid: event.chatJid,
-                id: event.stanzaId,
-                senderJid: event.senderJid
-                    ? applyDeviceToJid(event.senderJid, event.senderDevice)
-                    : undefined,
-                isGroupChat: event.isGroupChat,
-                isBroadcastChat: event.isBroadcastChat
-            }
-        })
-        for (const group of aggregateReceiptTargets(targets)) {
-            await this.dispatchReceipt(group.jid, group.ids, {
-                ...options,
-                participant: group.participant
-            })
-        }
-    }
-
-    private dispatchReceipt(
-        jid: string,
-        ids: string | readonly string[],
-        options: WaSendReceiptOptions
-    ): Promise<void> {
-        const idArray = typeof ids === 'string' ? [ids] : ids
-        if (idArray.length === 0) {
-            throw new Error('sendReceipt requires at least one message id')
-        }
-        const [id, ...rest] = idArray
-        const input: WaSendReceiptInput = {
-            ...options,
-            to: jid,
-            id,
-            listIds: rest.length > 0 ? rest : undefined
-        }
-        return this.deps.messageDispatch.sendReceipt(input)
-    }
-
-    public async syncAppState(options: WaAppStateSyncOptions = {}): Promise<WaAppStateSyncResult> {
-        if (!this.deps.connectionManager.isConnected()) {
-            throw new Error('client is not connected')
-        }
-        const syncResult = await this.executeAppStateSync(options)
-        const blockedCollections = this.getBlockedAppStateCollections(syncResult)
-        if (blockedCollections.length > 0) {
-            this.logger.warn('app-state sync has blocked collections', {
-                blockedCollections: blockedCollections.join(',')
-            })
-        }
-        this.emitChatEventsFromAppStateSyncResult(syncResult)
-        return syncResult
-    }
-
-    private async executeAppStateSync(
-        options: WaAppStateSyncOptions
-    ): Promise<WaAppStateSyncResult> {
-        return options.downloadExternalBlob
-            ? this.appStateSync.sync(options)
-            : this.appStateSync.sync({
-                  ...options,
-                  downloadExternalBlob: async (_collection, _kind, reference) =>
-                      downloadExternalBlobReference(this.mediaTransfer, reference)
-              })
-    }
-
-    private getBlockedAppStateCollections(syncResult: WaAppStateSyncResult): readonly string[] {
-        const blocked: string[] = []
-        for (const entry of syncResult.collections) {
-            if (entry.state === WA_APP_STATE_COLLECTION_STATES.BLOCKED) {
-                blocked.push(entry.collection)
-            }
-        }
-        return blocked
-    }
-
-    private emitChatEventsFromAppStateSyncResult(syncResult: WaAppStateSyncResult): void {
-        const shouldEmitSnapshotMutations = this.options.chatEvents?.emitSnapshotMutations === true
-        for (const collectionResult of syncResult.collections) {
-            const mutations = collectionResult.mutations ?? []
-            const lastMutationIndexByKey = new Map<string, number>()
-            for (let mutationIndex = 0; mutationIndex < mutations.length; mutationIndex += 1) {
-                const mutation = mutations[mutationIndex]
-                if (!shouldEmitSnapshotMutations && mutation.source === 'snapshot') {
-                    continue
-                }
-                lastMutationIndexByKey.set(
-                    `${mutation.collection}\u0001${mutation.index}`,
-                    mutationIndex
-                )
-            }
-
-            for (let mutationIndex = 0; mutationIndex < mutations.length; mutationIndex += 1) {
-                const mutation = mutations[mutationIndex]
-                if (!shouldEmitSnapshotMutations && mutation.source === 'snapshot') {
-                    continue
-                }
-                const coalesceKey = `${mutation.collection}\u0001${mutation.index}`
-                if (lastMutationIndexByKey.get(coalesceKey) !== mutationIndex) {
-                    continue
-                }
-                try {
-                    this.handleNctSaltMutation(mutation)
-                    const accountEvent = parseAccountEventFromAppStateMutation(mutation)
-                    if (accountEvent) {
-                        this.emit('account_event', accountEvent)
-                        continue
-                    }
-                    const event = parseChatEventFromAppStateMutation(mutation)
-                    if (!event) {
-                        continue
-                    }
-                    this.emit('chat_event', event)
-                } catch (error) {
-                    this.logger.debug('failed to parse chat event from app-state mutation', {
-                        collection: mutation.collection,
-                        source: mutation.source,
-                        index: mutation.index,
-                        message: toError(error).message
-                    })
-                }
-            }
-        }
-    }
-
-    private handleNctSaltMutation(mutation: {
-        readonly operation: 'set' | 'remove'
-        readonly value: {
-            readonly nctSaltSyncAction?: { readonly salt?: Uint8Array | null } | null
-        } | null
-    }): void {
-        const nctAction = mutation.value?.nctSaltSyncAction
-        if (!nctAction) {
-            return
-        }
-        if (mutation.operation === 'set' && nctAction.salt) {
-            this.deps.trustedContactToken.handleNctSaltSync(nctAction.salt).catch((err) =>
-                this.logger.warn('nct salt sync set failed', {
-                    message: toError(err).message
-                })
-            )
-        } else if (mutation.operation === 'remove') {
-            this.deps.trustedContactToken.handleNctSaltSync(null).catch((err) =>
-                this.logger.warn('nct salt sync remove failed', {
-                    message: toError(err).message
-                })
-            )
-        }
-    }
-
     private async clearStoredState(): Promise<void> {
         await this.pauseIncomingEventsAndWaitDrain()
         const writeBehindDestroy = await this.writeBehind.destroy(
@@ -968,200 +473,6 @@ export class WaClient extends EventEmitter {
         if (shouldClear('senderKey')) await this.stores.senderKey.clear()
         if (shouldClear('threads')) await this.stores.threads.clear()
         if (shouldClear('privacyToken')) await this.stores.privacyToken.clear()
-    }
-
-    private async tryDecryptAddon(event: WaIncomingMessageEvent): Promise<void> {
-        const message = event.message
-        if (!message) return
-
-        const addon = identifyEncryptedAddon(message)
-        if (!addon) return
-
-        const targetMessageId = addon.targetMessageKey.id
-        if (!targetMessageId) return
-
-        const parentEntry = await resolveParentMessageSecret(
-            targetMessageId,
-            this.stores.messageSecret,
-            this.stores.messages
-        )
-        if (!parentEntry) {
-            this.logger.debug('addon parent message secret not found', {
-                id: event.stanzaId,
-                targetId: targetMessageId
-            })
-            return
-        }
-
-        const parentMsgOriginalSender = parentEntry.senderJid
-        const modificationSender = event.senderJid ?? ''
-
-        const plaintext = await decryptAddonPayload({
-            messageSecret: parentEntry.secret,
-            stanzaId: targetMessageId,
-            parentMsgOriginalSender,
-            modificationSender,
-            modificationType: addon.modificationType,
-            ciphertext: addon.encPayload,
-            iv: addon.encIv,
-            additionalData: shouldUseAddonAdditionalData(addon.modificationType)
-                ? buildAddonAdditionalData(targetMessageId, modificationSender)
-                : undefined
-        })
-
-        let decrypted = decodeAddonPlaintext(addon.kind, plaintext)
-        if (decrypted.kind === 'poll_vote' && decrypted.pollVote.selectedOptions) {
-            const names = await resolvePollOptionNames(
-                decrypted.pollVote.selectedOptions,
-                targetMessageId,
-                this.stores.messages
-            )
-            if (names) {
-                decrypted = { ...decrypted, selectedOptionNames: names }
-            }
-        }
-        const addonEvent: WaIncomingAddonEvent = {
-            rawNode: event.rawNode,
-            stanzaId: event.stanzaId,
-            chatJid: event.chatJid,
-            stanzaType: event.stanzaType,
-            kind: addon.kind,
-            targetMessageId,
-            senderJid: modificationSender,
-            decrypted,
-            raw: message
-        }
-        this.emit('message_addon', addonEvent)
-    }
-
-    private async tryDecryptBotChunk(event: WaIncomingMessageEvent): Promise<void> {
-        const message = event.message
-        if (!message) return
-
-        const inner = unwrapMessage(message)
-        const sec = inner.secretEncryptedMessage
-        if (!sec || !sec.encIv || !sec.encPayload) return
-
-        const botNode = findNodeChild(event.rawNode, WA_NODE_TAGS.BOT)
-        if (!botNode) return
-
-        const metaNode = findNodeChild(event.rawNode, WA_NODE_TAGS.META)
-        // msmsg chunks omit targetMessageKey; the prompt id lives in <meta target_id>
-        const targetMessageId =
-            sec.targetMessageKey?.id ?? metaNode?.attrs[WA_META_NODE_ATTRS_BOT.TARGET_ID]
-        if (!targetMessageId) return
-
-        const editAttr = botNode.attrs[WA_BOT_NODE_ATTRS.EDIT]
-        const editType = (
-            editAttr === WA_BOT_MSG_EDIT_TYPES.FIRST ||
-            editAttr === WA_BOT_MSG_EDIT_TYPES.INNER ||
-            editAttr === WA_BOT_MSG_EDIT_TYPES.LAST ||
-            editAttr === WA_BOT_MSG_EDIT_TYPES.FULL
-                ? editAttr
-                : WA_BOT_MSG_EDIT_TYPES.FULL
-        ) as WaBotMsgEditType
-        const editTargetId = botNode.attrs[WA_BOT_NODE_ATTRS.EDIT_TARGET_ID] || undefined
-
-        const useEditTargetSalt =
-            editType === WA_BOT_MSG_EDIT_TYPES.INNER || editType === WA_BOT_MSG_EDIT_TYPES.LAST
-        const saltId = useEditTargetSalt ? editTargetId : event.stanzaId
-        if (!saltId) {
-            this.logger.debug('bot chunk missing salt id', {
-                id: event.stanzaId,
-                editType,
-                hasEditTargetId: !!editTargetId
-            })
-            return
-        }
-
-        const senderJid = event.senderJid
-        if (!senderJid) {
-            this.logger.debug('bot chunk missing sender jid', { id: event.stanzaId })
-            return
-        }
-
-        const metaTargetSenderJid = metaNode?.attrs[WA_META_NODE_ATTRS_BOT.TARGET_SENDER_JID]
-        const credentials = this.deps.authClient.getCurrentCredentials()
-        const isFbidBotChat = event.chatJid ? isBotJid(event.chatJid) : false
-        // FBID bot (`*@bot`) keys on user LID; legacy PN bot keys on user PN
-        const meFallbackJid = isFbidBotChat
-            ? (credentials?.meLid ?? credentials?.meJid)
-            : credentials?.meJid
-        const targetSenderJid = metaTargetSenderJid
-            ? toUserJid(metaTargetSenderJid)
-            : meFallbackJid
-              ? toUserJid(meFallbackJid)
-              : undefined
-        if (!targetSenderJid) {
-            this.logger.debug('bot chunk missing target sender jid (no me jid)', {
-                id: event.stanzaId,
-                isFbidBotChat
-            })
-            return
-        }
-
-        const parentEntry = await resolveParentMessageSecret(
-            targetMessageId,
-            this.stores.messageSecret,
-            this.stores.messages
-        )
-        if (!parentEntry) {
-            this.logger.debug('bot chunk parent message secret not found', {
-                id: event.stanzaId,
-                targetId: targetMessageId
-            })
-            return
-        }
-
-        let plaintext: Uint8Array
-        try {
-            plaintext = decryptBotChunk({
-                parentMessageSecret: parentEntry.secret,
-                saltId,
-                targetSenderJid,
-                authorJid: toUserJid(senderJid),
-                encIv: sec.encIv,
-                encPayload: sec.encPayload
-            })
-        } catch (error) {
-            this.logger.warn('failed to decrypt bot chunk', {
-                id: event.stanzaId,
-                targetId: targetMessageId,
-                editType,
-                message: toError(error).message
-            })
-            return
-        }
-
-        let decoded: Proto.IMessage
-        try {
-            // msmsg payloads are not PKCS7-padded (unlike Signal messages);
-            // wa-web decodes the gcm plaintext directly as a proto Message.
-            decoded = proto.Message.decode(plaintext)
-        } catch (error) {
-            this.logger.warn('failed to decode decrypted bot chunk', {
-                id: event.stanzaId,
-                targetId: targetMessageId,
-                message: toError(error).message
-            })
-            return
-        }
-
-        const chunkEvent: WaIncomingBotChunkEvent = {
-            rawNode: event.rawNode,
-            stanzaId: event.stanzaId,
-            chatJid: event.chatJid,
-            stanzaType: event.stanzaType,
-            senderJid,
-            targetMessageId,
-            editType,
-            editTargetId,
-            saltId,
-            plaintext,
-            message: decoded,
-            raw: message
-        }
-        this.emit('message_bot_chunk', chunkEvent)
     }
 
     private tryEnterIncomingHandler(): boolean {

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -24,6 +24,11 @@ import {
     type WaGroupCoordinator
 } from '@client/coordinators/WaGroupCoordinator'
 import { WaIncomingNodeCoordinator } from '@client/coordinators/WaIncomingNodeCoordinator'
+import {
+    createLowLevelCoordinator,
+    type WaLowLevelCoordinator
+} from '@client/coordinators/WaLowLevelCoordinator'
+import { WaMessageCoordinator } from '@client/coordinators/WaMessageCoordinator'
 import { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
 import {
     createNewsletterCoordinator,
@@ -31,6 +36,10 @@ import {
 } from '@client/coordinators/WaNewsletterCoordinator'
 import { WaOfflineResumeCoordinator } from '@client/coordinators/WaOfflineResumeCoordinator'
 import { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTasksCoordinator'
+import {
+    createPresenceCoordinator,
+    type WaPresenceCoordinator
+} from '@client/coordinators/WaPresenceCoordinator'
 import {
     createPrivacyCoordinator,
     type WaPrivacyCoordinator
@@ -171,11 +180,14 @@ export interface WaClientDependencies {
     readonly signalSessionSync: SignalSessionSyncApi
     readonly authClient: WaAuthClient
     readonly messageDispatch: WaMessageDispatchCoordinator
+    readonly messageCoordinator: WaMessageCoordinator
+    readonly presenceCoordinator: WaPresenceCoordinator
     readonly retryCoordinator: WaRetryCoordinator
     readonly appStateSync: WaAppStateSyncClient
     readonly chatCoordinator: WaAppStateMutationCoordinator
     readonly streamControl: WaStreamControlHandler
     readonly incomingNode: WaIncomingNodeCoordinator
+    readonly lowLevelCoordinator: WaLowLevelCoordinator
     readonly passiveTasks: WaPassiveTasksCoordinator
     readonly groupCoordinator: WaGroupCoordinator
     readonly statusCoordinator: WaStatusCoordinator
@@ -738,6 +750,21 @@ export function buildWaClientDependencies(input: {
         mobileMessageIdFormat: options.mobileTransport !== undefined
     })
 
+    const messageCoordinator = new WaMessageCoordinator({
+        messageDispatch,
+        mediaTransfer,
+        logger,
+        messageStore: sessionStore.messages,
+        messageSecretStore: sessionStore.messageSecret,
+        trustedContactToken,
+        emitAddon: (event) => runtime.emitEvent('message_addon', event)
+    })
+
+    const presenceCoordinator = createPresenceCoordinator({
+        sendNode: (node) => nodeOrchestrator.sendNode(node, false),
+        getCurrentCredentials
+    })
+
     const peerDataOperation = createPeerDataOperationRequester({
         logger,
         publishProtocolMessageToDevice: (deviceJid, protocolMessage, opts) =>
@@ -769,11 +796,16 @@ export function buildWaClientDependencies(input: {
     })
 
     const botCoordinator = createBotCoordinator({
+        logger,
         queryWithContext: runtime.queryWithContext,
         buildMessageContent: async (content) =>
             buildMediaMessageContent(mediaMessageBuildOptions, content),
         sendMessage: (to, content, sendOptions) =>
-            messageDispatch.sendMessage(to, content, sendOptions ?? {})
+            messageDispatch.sendMessage(to, content, sendOptions ?? {}),
+        messageStore: sessionStore.messages,
+        messageSecretStore: sessionStore.messageSecret,
+        getCurrentCredentials,
+        emitBotChunk: (event) => runtime.emitEvent('message_bot_chunk', event)
     })
 
     const appStateSync = new WaAppStateSyncClient({
@@ -787,14 +819,34 @@ export function buildWaClientDependencies(input: {
             await messageDispatch.requestAppStateSyncKeys(keyIds)
         },
         skipMacVerification: options.dangerous?.disableAppStateMacVerification,
-        mobilePrimary: options.mobileTransport !== undefined
+        mobilePrimary: options.mobileTransport !== undefined,
+        isOwnAccountDevice: (deviceJid) => {
+            const credentials = getCurrentCredentials()
+            if (!credentials) return false
+            const candidateUser = toUserJid(deviceJid)
+            return (
+                (!!credentials.meJid && toUserJid(credentials.meJid) === candidateUser) ||
+                (!!credentials.meLid && toUserJid(credentials.meLid) === candidateUser)
+            )
+        },
+        sendKeyShare: (toDeviceJid, keys, missingKeyIds) =>
+            messageDispatch.sendAppStateSyncKeyShare(toDeviceJid, keys, missingKeyIds),
+        triggerSync: async () => {
+            await runtime.syncAppState()
+        }
     })
 
     const appStateMutations = new WaAppStateMutationCoordinator({
         logger,
         messageStore: sessionStore.messages,
-        syncAppState: runtime.syncAppStateWithOptions,
-        serverClock
+        appStateSync,
+        mediaTransfer,
+        isConnected: () => connectionManager?.isConnected() ?? false,
+        serverClock,
+        emitSnapshotMutations: options.chatEvents?.emitSnapshotMutations === true,
+        emitChatEvent: (event) => runtime.emitEvent('chat_event', event),
+        emitAccountEvent: (event) => runtime.emitEvent('account_event', event),
+        nctSaltSink: (salt) => trustedContactToken.handleNctSaltSync(salt)
     })
 
     const statusCoordinator = createStatusCoordinator({
@@ -1242,6 +1294,15 @@ export function buildWaClientDependencies(input: {
         appStateSync
     })
 
+    const lowLevelCoordinator = createLowLevelCoordinator({
+        logger,
+        nodeOrchestrator,
+        incomingNode,
+        receiptQueue,
+        isConnected: () => connectionManager?.isConnected() ?? false,
+        defaultIqTimeoutMs: options.iqTimeoutMs
+    })
+
     return {
         nodeTransport,
         nodeOrchestrator,
@@ -1259,11 +1320,14 @@ export function buildWaClientDependencies(input: {
         signalSessionSync,
         authClient,
         messageDispatch,
+        messageCoordinator,
+        presenceCoordinator,
         retryCoordinator,
         appStateSync,
         chatCoordinator: appStateMutations,
         streamControl,
         incomingNode,
+        lowLevelCoordinator,
         passiveTasks,
         groupCoordinator,
         statusCoordinator,

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -436,17 +436,6 @@ function getClearStoredStateMethod() {
     ).clearStoredState
 }
 
-function getSendPresenceMethod() {
-    return (
-        WaClient.prototype as unknown as {
-            readonly sendPresence: (
-                this: unknown,
-                type?: 'available' | 'unavailable'
-            ) => Promise<void>
-        }
-    ).sendPresence
-}
-
 function getCoordinatorGetterMethod(name: 'chat' | 'group' | 'privacy') {
     const descriptor = Object.getOwnPropertyDescriptor(WaClient.prototype, name)
     if (!descriptor?.get) {
@@ -584,41 +573,6 @@ test('clearStoredState clears every store domain by default', async () => {
         'senderKey',
         'threads',
         'privacyToken'
-    ])
-})
-
-test('WaClient.sendPresence sends a presence node without auto-generated id', async () => {
-    const calls: Array<{ readonly node: BinaryNode; readonly autoId: boolean | undefined }> = []
-
-    await getSendPresenceMethod().call(
-        {
-            deps: {
-                authClient: {
-                    getCurrentCredentials: () => ({
-                        meDisplayName: 'Vinicius'
-                    })
-                },
-                nodeOrchestrator: {
-                    sendNode: async (node: BinaryNode, autoId?: boolean) => {
-                        calls.push({ node, autoId })
-                    }
-                }
-            }
-        },
-        'available'
-    )
-
-    assert.deepEqual(calls, [
-        {
-            node: {
-                tag: 'presence',
-                attrs: {
-                    type: 'available',
-                    name: 'Vinicius'
-                }
-            },
-            autoId: false
-        }
     ])
 })
 

--- a/src/client/coordinators/WaAppStateMutationCoordinator.ts
+++ b/src/client/coordinators/WaAppStateMutationCoordinator.ts
@@ -1,16 +1,23 @@
+import type { WaAppStateSyncClient } from '@appstate/sync/WaAppStateSyncClient'
 import type {
     AppStateCollectionName,
     WaAppStateMutationInput,
     WaAppStateSyncOptions,
     WaAppStateSyncResult
 } from '@appstate/types'
+import { downloadExternalBlobReference } from '@appstate/utils'
+import { parseAccountEventFromAppStateMutation } from '@client/events/account'
+import { parseChatEventFromAppStateMutation } from '@client/events/chat'
 import type {
+    WaAccountEvent,
     WaAppStateMessageKey,
+    WaChatEvent,
     WaClearChatOptions,
     WaDeleteChatOptions,
     WaDeleteMessageForMeOptions
 } from '@client/types'
 import type { Logger } from '@infra/log/types'
+import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import { proto, type Proto } from '@proto'
 import {
     WA_APP_STATE_ACCOUNT_MUTATION_SPECS,
@@ -50,9 +57,15 @@ function serializeMutationIndex(action: string, parts: readonly string[]): strin
 interface WaAppStateMutationCoordinatorOptions {
     readonly logger: Logger
     readonly messageStore: WaMessageStore
-    readonly syncAppState: (options?: WaAppStateSyncOptions) => Promise<WaAppStateSyncResult>
+    readonly appStateSync: WaAppStateSyncClient
+    readonly mediaTransfer: WaMediaTransferClient
+    readonly isConnected: () => boolean
     readonly serverClock: ServerClock
     readonly archiveRangeLimit?: number
+    readonly emitChatEvent?: (event: WaChatEvent) => void
+    readonly emitAccountEvent?: (event: WaAccountEvent) => void
+    readonly emitSnapshotMutations?: boolean
+    readonly nctSaltSink?: (salt: Uint8Array | null) => Promise<void>
 }
 
 type WaAppStateChatMutationSpec =
@@ -83,26 +96,142 @@ export interface WaSetBroadcastListInput {
 export class WaAppStateMutationCoordinator {
     private readonly logger: Logger
     private readonly messageStore: WaMessageStore
-    private readonly syncAppState: (
-        options?: WaAppStateSyncOptions
-    ) => Promise<WaAppStateSyncResult>
+    private readonly appStateSync: WaAppStateSyncClient
+    private readonly mediaTransfer: WaMediaTransferClient
+    private readonly isConnected: () => boolean
     private readonly serverClock: ServerClock
     private readonly archiveRangeLimit: number
+    private readonly emitChatEvent?: (event: WaChatEvent) => void
+    private readonly emitAccountEvent?: (event: WaAccountEvent) => void
+    private readonly emitSnapshotMutations: boolean
+    private readonly nctSaltSink?: (salt: Uint8Array | null) => Promise<void>
     private readonly pendingMutations: Map<string, WaAppStateMutationInput>
     private flushPromise: Promise<void> | null
 
     public constructor(options: WaAppStateMutationCoordinatorOptions) {
         this.logger = options.logger
         this.messageStore = options.messageStore
-        this.syncAppState = options.syncAppState
+        this.appStateSync = options.appStateSync
+        this.mediaTransfer = options.mediaTransfer
+        this.isConnected = options.isConnected
         this.serverClock = options.serverClock
         this.archiveRangeLimit = resolvePositive(
             options.archiveRangeLimit,
             WA_APP_STATE_ARCHIVE_RANGE_DEFAULT_LIMIT,
             'WaAppStateMutationCoordinatorOptions.archiveRangeLimit'
         )
+        this.emitChatEvent = options.emitChatEvent
+        this.emitAccountEvent = options.emitAccountEvent
+        this.emitSnapshotMutations = options.emitSnapshotMutations === true
+        this.nctSaltSink = options.nctSaltSink
         this.pendingMutations = new Map()
         this.flushPromise = null
+    }
+
+    public async sync(options: WaAppStateSyncOptions = {}): Promise<WaAppStateSyncResult> {
+        if (!this.isConnected()) {
+            throw new Error('client is not connected')
+        }
+        const syncOptions: WaAppStateSyncOptions = options.downloadExternalBlob
+            ? options
+            : {
+                  ...options,
+                  downloadExternalBlob: async (_collection, _kind, reference) =>
+                      downloadExternalBlobReference(this.mediaTransfer, reference)
+              }
+        const syncResult = await this.appStateSync.sync(syncOptions)
+        const blockedCollections = this.getBlockedCollections(syncResult)
+        if (blockedCollections.length > 0) {
+            this.logger.warn('app-state sync has blocked collections', {
+                blockedCollections: blockedCollections.join(',')
+            })
+        }
+        this.emitEventsFromSyncResult(syncResult)
+        return syncResult
+    }
+
+    public getBlockedCollections(syncResult: WaAppStateSyncResult): readonly string[] {
+        const blocked: string[] = []
+        for (const entry of syncResult.collections) {
+            if (entry.state === WA_APP_STATE_COLLECTION_STATES.BLOCKED) {
+                blocked.push(entry.collection)
+            }
+        }
+        return blocked
+    }
+
+    public emitEventsFromSyncResult(syncResult: WaAppStateSyncResult): void {
+        for (const collectionResult of syncResult.collections) {
+            const mutations = collectionResult.mutations ?? []
+            const lastMutationIndexByKey = new Map<string, number>()
+            for (let mutationIndex = 0; mutationIndex < mutations.length; mutationIndex += 1) {
+                const mutation = mutations[mutationIndex]
+                if (!this.emitSnapshotMutations && mutation.source === 'snapshot') {
+                    continue
+                }
+                lastMutationIndexByKey.set(
+                    `${mutation.collection}\u0001${mutation.index}`,
+                    mutationIndex
+                )
+            }
+
+            for (let mutationIndex = 0; mutationIndex < mutations.length; mutationIndex += 1) {
+                const mutation = mutations[mutationIndex]
+                if (!this.emitSnapshotMutations && mutation.source === 'snapshot') {
+                    continue
+                }
+                const coalesceKey = `${mutation.collection}\u0001${mutation.index}`
+                if (lastMutationIndexByKey.get(coalesceKey) !== mutationIndex) {
+                    continue
+                }
+                try {
+                    this.handleNctSaltMutation(mutation)
+                    const accountEvent = parseAccountEventFromAppStateMutation(mutation)
+                    if (accountEvent) {
+                        this.emitAccountEvent?.(accountEvent)
+                        continue
+                    }
+                    const chatEvent = parseChatEventFromAppStateMutation(mutation)
+                    if (!chatEvent) {
+                        continue
+                    }
+                    this.emitChatEvent?.(chatEvent)
+                } catch (error) {
+                    this.logger.debug('failed to parse chat event from app-state mutation', {
+                        collection: mutation.collection,
+                        source: mutation.source,
+                        index: mutation.index,
+                        message: toError(error).message
+                    })
+                }
+            }
+        }
+    }
+
+    private handleNctSaltMutation(mutation: {
+        readonly operation: 'set' | 'remove'
+        readonly value: {
+            readonly nctSaltSyncAction?: { readonly salt?: Uint8Array | null } | null
+        } | null
+    }): void {
+        if (!this.nctSaltSink) return
+        const nctAction = mutation.value?.nctSaltSyncAction
+        if (!nctAction) {
+            return
+        }
+        if (mutation.operation === 'set' && nctAction.salt) {
+            this.nctSaltSink(nctAction.salt).catch((err) =>
+                this.logger.warn('nct salt sync set failed', {
+                    message: toError(err).message
+                })
+            )
+        } else if (mutation.operation === 'remove') {
+            this.nctSaltSink(null).catch((err) =>
+                this.logger.warn('nct salt sync remove failed', {
+                    message: toError(err).message
+                })
+            )
+        }
     }
 
     public async setChatMute(
@@ -396,7 +525,7 @@ export class WaAppStateMutationCoordinator {
                     seenCollections.add(mutation.collection)
                     collections.push(mutation.collection)
                 }
-                syncResult = await this.syncAppState({
+                syncResult = await this.sync({
                     collections,
                     pendingMutations: batch
                 })

--- a/src/client/coordinators/WaBotCoordinator.ts
+++ b/src/client/coordinators/WaBotCoordinator.ts
@@ -1,8 +1,16 @@
 import { randomUUID } from 'node:crypto'
 
-import type { WaSendMessageOptions } from '@client/types'
+import type { WaAuthCredentials } from '@auth/types'
+import type {
+    WaIncomingBotChunkEvent,
+    WaIncomingMessageEvent,
+    WaSendMessageOptions
+} from '@client/types'
+import type { Logger } from '@infra/log/types'
 import { applyContextInfo } from '@message/context-info'
-import { attachBotMetadata, attachBotThread } from '@message/kinds/bot'
+import { resolveParentMessageSecret } from '@message/crypto/addon-crypto'
+import { unwrapMessage } from '@message/encode/content'
+import { attachBotMetadata, attachBotThread, decryptBotChunk } from '@message/kinds/bot'
 import type {
     WaMessageBuildResult,
     WaMessagePublishResult,
@@ -15,12 +23,22 @@ import {
     WA_BOT_DEFAULT_CAPABILITIES,
     WA_BOT_RENDERING_PIXEL_DENSITY
 } from '@protocol/bot'
-import { WA_DEFAULTS, WA_NODE_TAGS } from '@protocol/constants'
-import { isBotJid } from '@protocol/jid'
+import {
+    WA_BOT_MSG_EDIT_TYPES,
+    WA_BOT_NODE_ATTRS,
+    WA_DEFAULTS,
+    WA_META_NODE_ATTRS_BOT,
+    WA_NODE_TAGS,
+    type WaBotMsgEditType
+} from '@protocol/constants'
+import { isBotJid, toUserJid } from '@protocol/jid'
+import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
+import type { WaMessageStore } from '@store/contracts/message.store'
 import { buildBotListIq } from '@transport/node/builders/bot'
 import { findNodeChild, getNodeChildrenByTag } from '@transport/node/helpers'
 import { assertIqResult } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
+import { toError } from '@util/primitives'
 
 export interface WaBotInfo {
     readonly jid: string
@@ -51,9 +69,11 @@ export interface WaBotCoordinator {
         content: WaSendMessageContent,
         options?: WaBotPromptOptions
     ) => Promise<WaMessagePublishResult>
+    readonly tryDecryptChunk: (event: WaIncomingMessageEvent) => Promise<void>
 }
 
 interface WaBotCoordinatorOptions {
+    readonly logger: Logger
     readonly queryWithContext: (
         context: string,
         node: BinaryNode,
@@ -66,6 +86,10 @@ interface WaBotCoordinatorOptions {
         content: WaSendMessageContent,
         options?: WaSendMessageOptions
     ) => Promise<WaMessagePublishResult>
+    readonly messageStore: WaMessageStore
+    readonly messageSecretStore: WaMessageSecretStore
+    readonly getCurrentCredentials: () => WaAuthCredentials | null
+    readonly emitBotChunk: (event: WaIncomingBotChunkEvent) => void
 }
 
 function deriveFbidJid(jid: string, personaId: string): string {
@@ -116,7 +140,16 @@ function normalizeBotJidToFbid(botJid: string): string {
 }
 
 export function createBotCoordinator(options: WaBotCoordinatorOptions): WaBotCoordinator {
-    const { queryWithContext, buildMessageContent, sendMessage } = options
+    const {
+        logger,
+        queryWithContext,
+        buildMessageContent,
+        sendMessage,
+        messageStore,
+        messageSecretStore,
+        getCurrentCredentials,
+        emitBotChunk
+    } = options
 
     return {
         listBots: async () => {
@@ -183,6 +216,135 @@ export function createBotCoordinator(options: WaBotCoordinatorOptions): WaBotCoo
                 botInvokeMessage: { message: inner }
             }
             return sendMessage(to, wrapped, opts)
+        },
+
+        tryDecryptChunk: async (event) => {
+            const message = event.message
+            if (!message) return
+
+            const inner = unwrapMessage(message)
+            const sec = inner.secretEncryptedMessage
+            if (!sec || !sec.encIv || !sec.encPayload) return
+
+            const botNode = findNodeChild(event.rawNode, WA_NODE_TAGS.BOT)
+            if (!botNode) return
+
+            const metaNode = findNodeChild(event.rawNode, WA_NODE_TAGS.META)
+            // msmsg chunks omit targetMessageKey; the prompt id lives in <meta target_id>
+            const targetMessageId =
+                sec.targetMessageKey?.id ?? metaNode?.attrs[WA_META_NODE_ATTRS_BOT.TARGET_ID]
+            if (!targetMessageId) return
+
+            const editAttr = botNode.attrs[WA_BOT_NODE_ATTRS.EDIT]
+            const editType = (
+                editAttr === WA_BOT_MSG_EDIT_TYPES.FIRST ||
+                editAttr === WA_BOT_MSG_EDIT_TYPES.INNER ||
+                editAttr === WA_BOT_MSG_EDIT_TYPES.LAST ||
+                editAttr === WA_BOT_MSG_EDIT_TYPES.FULL
+                    ? editAttr
+                    : WA_BOT_MSG_EDIT_TYPES.FULL
+            ) as WaBotMsgEditType
+            const editTargetId = botNode.attrs[WA_BOT_NODE_ATTRS.EDIT_TARGET_ID] || undefined
+
+            const useEditTargetSalt =
+                editType === WA_BOT_MSG_EDIT_TYPES.INNER || editType === WA_BOT_MSG_EDIT_TYPES.LAST
+            const saltId = useEditTargetSalt ? editTargetId : event.stanzaId
+            if (!saltId) {
+                logger.debug('bot chunk missing salt id', {
+                    id: event.stanzaId,
+                    editType,
+                    hasEditTargetId: !!editTargetId
+                })
+                return
+            }
+
+            const senderJid = event.senderJid
+            if (!senderJid) {
+                logger.debug('bot chunk missing sender jid', { id: event.stanzaId })
+                return
+            }
+
+            const metaTargetSenderJid = metaNode?.attrs[WA_META_NODE_ATTRS_BOT.TARGET_SENDER_JID]
+            const credentials = getCurrentCredentials()
+            const isFbidBotChat = event.chatJid ? isBotJid(event.chatJid) : false
+            // FBID bot (`*@bot`) keys on user LID; legacy PN bot keys on user PN
+            const meFallbackJid = isFbidBotChat
+                ? (credentials?.meLid ?? credentials?.meJid)
+                : credentials?.meJid
+            const targetSenderJid = metaTargetSenderJid
+                ? toUserJid(metaTargetSenderJid)
+                : meFallbackJid
+                  ? toUserJid(meFallbackJid)
+                  : undefined
+            if (!targetSenderJid) {
+                logger.debug('bot chunk missing target sender jid (no me jid)', {
+                    id: event.stanzaId,
+                    isFbidBotChat
+                })
+                return
+            }
+
+            const parentEntry = await resolveParentMessageSecret(
+                targetMessageId,
+                messageSecretStore,
+                messageStore
+            )
+            if (!parentEntry) {
+                logger.debug('bot chunk parent message secret not found', {
+                    id: event.stanzaId,
+                    targetId: targetMessageId
+                })
+                return
+            }
+
+            let plaintext: Uint8Array
+            try {
+                plaintext = decryptBotChunk({
+                    parentMessageSecret: parentEntry.secret,
+                    saltId,
+                    targetSenderJid,
+                    authorJid: toUserJid(senderJid),
+                    encIv: sec.encIv,
+                    encPayload: sec.encPayload
+                })
+            } catch (error) {
+                logger.warn('failed to decrypt bot chunk', {
+                    id: event.stanzaId,
+                    targetId: targetMessageId,
+                    editType,
+                    message: toError(error).message
+                })
+                return
+            }
+
+            let decoded: Proto.IMessage
+            try {
+                // msmsg payloads are not PKCS7-padded (unlike Signal messages);
+                // wa-web decodes the gcm plaintext directly as a proto Message.
+                decoded = proto.Message.decode(plaintext)
+            } catch (error) {
+                logger.warn('failed to decode decrypted bot chunk', {
+                    id: event.stanzaId,
+                    targetId: targetMessageId,
+                    message: toError(error).message
+                })
+                return
+            }
+
+            emitBotChunk({
+                rawNode: event.rawNode,
+                stanzaId: event.stanzaId,
+                chatJid: event.chatJid,
+                stanzaType: event.stanzaType,
+                senderJid,
+                targetMessageId,
+                editType,
+                editTargetId,
+                saltId,
+                plaintext,
+                message: decoded,
+                raw: message
+            })
         }
     }
 }

--- a/src/client/coordinators/WaLowLevelCoordinator.ts
+++ b/src/client/coordinators/WaLowLevelCoordinator.ts
@@ -1,0 +1,70 @@
+import type { WaReceiptQueue } from '@client/connection/WaReceiptQueue'
+import type { WaIncomingNodeCoordinator } from '@client/coordinators/WaIncomingNodeCoordinator'
+import type { WaIncomingNodeHandlerRegistration, WaIncomingStanzaFilter } from '@client/types'
+import type { Logger } from '@infra/log/types'
+import { WA_DEFAULTS } from '@protocol/constants'
+import type { WaNodeOrchestrator } from '@transport/node/WaNodeOrchestrator'
+import type { BinaryNode } from '@transport/types'
+import { toError } from '@util/primitives'
+
+export interface WaLowLevelCoordinator {
+    readonly sendNode: (node: BinaryNode) => Promise<void>
+    readonly query: (
+        node: BinaryNode,
+        timeoutMs?: number,
+        options?: { readonly useSystemId?: boolean }
+    ) => Promise<BinaryNode>
+    readonly registerIncomingHandler: (
+        registration: WaIncomingNodeHandlerRegistration
+    ) => () => void
+    readonly unregisterIncomingHandler: (registration: WaIncomingNodeHandlerRegistration) => boolean
+    readonly registerIncomingStanzaFilter: (filter: WaIncomingStanzaFilter) => () => void
+}
+
+interface WaLowLevelCoordinatorOptions {
+    readonly logger: Logger
+    readonly nodeOrchestrator: WaNodeOrchestrator
+    readonly incomingNode: WaIncomingNodeCoordinator
+    readonly receiptQueue: WaReceiptQueue
+    readonly isConnected: () => boolean
+    readonly defaultIqTimeoutMs?: number
+}
+
+export function createLowLevelCoordinator(
+    options: WaLowLevelCoordinatorOptions
+): WaLowLevelCoordinator {
+    const { logger, nodeOrchestrator, incomingNode, receiptQueue, isConnected } = options
+    const defaultIqTimeoutMs = options.defaultIqTimeoutMs ?? WA_DEFAULTS.IQ_TIMEOUT_MS
+    return {
+        sendNode: async (node) => {
+            try {
+                await nodeOrchestrator.sendNode(node)
+            } catch (error) {
+                const normalized = toError(error)
+                if (receiptQueue.shouldQueue(node, normalized)) {
+                    receiptQueue.enqueue(node)
+                    logger.warn('queued dangling receipt after send failure', {
+                        id: node.attrs.id,
+                        to: node.attrs.to,
+                        message: normalized.message,
+                        queueSize: receiptQueue.size()
+                    })
+                    return
+                }
+                throw normalized
+            }
+        },
+        query: async (node, timeoutMs = defaultIqTimeoutMs, queryOptions = {}) => {
+            if (!isConnected()) {
+                throw new Error('client is not connected')
+            }
+            logger.debug('wa client query', { tag: node.tag, id: node.attrs.id, timeoutMs })
+            return nodeOrchestrator.query(node, timeoutMs, queryOptions)
+        },
+        registerIncomingHandler: (registration) =>
+            incomingNode.registerIncomingHandler(registration),
+        unregisterIncomingHandler: (registration) =>
+            incomingNode.unregisterIncomingHandler(registration),
+        registerIncomingStanzaFilter: (filter) => incomingNode.registerIncomingStanzaFilter(filter)
+    }
+}

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -1,0 +1,254 @@
+import { createWriteStream } from 'node:fs'
+import type { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+
+import type { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
+import type { WaTrustedContactTokenCoordinator } from '@client/coordinators/WaTrustedContactTokenCoordinator'
+import { aggregateReceiptTargets } from '@client/events/receipt'
+import type {
+    WaDownloadMediaOptions,
+    WaIncomingAddonEvent,
+    WaIncomingMessageEvent,
+    WaSendMessageOptions
+} from '@client/types'
+import type { Logger } from '@infra/log/types'
+import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
+import {
+    buildAddonAdditionalData,
+    decodeAddonPlaintext,
+    decryptAddonPayload,
+    identifyEncryptedAddon,
+    resolveParentMessageSecret,
+    resolvePollOptionNames,
+    shouldUseAddonAdditionalData
+} from '@message/crypto/addon-crypto'
+import { resolveMediaPayload } from '@message/encode/media-payload'
+import type {
+    WaMessagePublishResult,
+    WaSendMessageContent,
+    WaSendReceiptEventOptions,
+    WaSendReceiptInput,
+    WaSendReceiptOptions
+} from '@message/types'
+import type { Proto } from '@proto'
+import { applyDeviceToJid } from '@protocol/jid'
+import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
+import type { WaMessageStore } from '@store/contracts/message.store'
+import { readAllBytes } from '@util/bytes'
+import { toError } from '@util/primitives'
+
+export interface WaMessageCoordinatorDeps {
+    readonly messageDispatch: WaMessageDispatchCoordinator
+    readonly mediaTransfer: WaMediaTransferClient
+    readonly logger: Logger
+    readonly messageStore: WaMessageStore
+    readonly messageSecretStore: WaMessageSecretStore
+    readonly trustedContactToken: WaTrustedContactTokenCoordinator
+    readonly emitAddon: (event: WaIncomingAddonEvent) => void
+}
+
+export class WaMessageCoordinator {
+    private readonly messageDispatch: WaMessageDispatchCoordinator
+    private readonly mediaTransfer: WaMediaTransferClient
+    private readonly logger: Logger
+    private readonly messageStore: WaMessageStore
+    private readonly messageSecretStore: WaMessageSecretStore
+    private readonly trustedContactToken: WaTrustedContactTokenCoordinator
+    private readonly emitAddon: (event: WaIncomingAddonEvent) => void
+
+    public constructor(deps: WaMessageCoordinatorDeps) {
+        this.messageDispatch = deps.messageDispatch
+        this.mediaTransfer = deps.mediaTransfer
+        this.logger = deps.logger
+        this.messageStore = deps.messageStore
+        this.messageSecretStore = deps.messageSecretStore
+        this.trustedContactToken = deps.trustedContactToken
+        this.emitAddon = deps.emitAddon
+    }
+
+    public async syncSignalSession(jid: string, reasonIdentity = false): Promise<void> {
+        await this.messageDispatch.syncSignalSession(jid, reasonIdentity)
+        if (reasonIdentity) {
+            this.trustedContactToken.reissueOnIdentityChange(jid).catch((err) =>
+                this.logger.warn('tc token reissue on identity change failed', {
+                    jid,
+                    message: toError(err).message
+                })
+            )
+        }
+    }
+
+    public send(
+        to: string,
+        content: WaSendMessageContent,
+        options: WaSendMessageOptions = {}
+    ): Promise<WaMessagePublishResult> {
+        return this.messageDispatch.sendMessage(to, content, options)
+    }
+
+    public sendReceipt(
+        target: WaIncomingMessageEvent | readonly WaIncomingMessageEvent[],
+        options?: WaSendReceiptEventOptions
+    ): Promise<void>
+    public sendReceipt(
+        jid: string,
+        ids: string | readonly string[],
+        options?: WaSendReceiptOptions
+    ): Promise<void>
+    public async sendReceipt(
+        first: string | WaIncomingMessageEvent | readonly WaIncomingMessageEvent[],
+        second?: string | readonly string[] | WaSendReceiptEventOptions,
+        third?: WaSendReceiptOptions
+    ): Promise<void> {
+        if (typeof first === 'string') {
+            const ids = second as string | readonly string[]
+            await this.dispatchReceipt(first, ids, third ?? {})
+            return
+        }
+        const events = Array.isArray(first) ? first : [first as WaIncomingMessageEvent]
+        const options = (second as WaSendReceiptEventOptions | undefined) ?? {}
+        const targets = events.map((event) => {
+            if (!event.chatJid || !event.stanzaId) {
+                throw new Error('sendReceipt event is missing chatJid or stanzaId')
+            }
+            return {
+                chatJid: event.chatJid,
+                id: event.stanzaId,
+                senderJid: event.senderJid
+                    ? applyDeviceToJid(event.senderJid, event.senderDevice)
+                    : undefined,
+                isGroupChat: event.isGroupChat,
+                isBroadcastChat: event.isBroadcastChat
+            }
+        })
+        for (const group of aggregateReceiptTargets(targets)) {
+            await this.dispatchReceipt(group.jid, group.ids, {
+                ...options,
+                participant: group.participant
+            })
+        }
+    }
+
+    public async download(
+        source: WaIncomingMessageEvent | Proto.IMessage,
+        options: WaDownloadMediaOptions = {}
+    ): Promise<Readable> {
+        const message: Proto.IMessage | null | undefined =
+            'rawNode' in source ? source.message : source
+        const payload = resolveMediaPayload(message)
+        if (!payload) {
+            throw new Error('message has no downloadable media')
+        }
+        const { plaintext, metadata } = await this.mediaTransfer.downloadAndDecryptStream({
+            directPath: payload.directPath,
+            mediaType: payload.mediaType,
+            mediaKey: payload.mediaKey,
+            fileSha256: payload.fileSha256,
+            fileEncSha256: payload.fileEncSha256,
+            timeoutMs: options.timeoutMs,
+            signal: options.signal,
+            maxBytes: options.maxBytes
+        })
+        metadata.catch(() => undefined)
+        return plaintext
+    }
+
+    public async downloadToFile(
+        source: WaIncomingMessageEvent | Proto.IMessage,
+        filePath: string,
+        options: WaDownloadMediaOptions = {}
+    ): Promise<void> {
+        const stream = await this.download(source, options)
+        await pipeline(stream, createWriteStream(filePath))
+    }
+
+    public async downloadBytes(
+        source: WaIncomingMessageEvent | Proto.IMessage,
+        options: WaDownloadMediaOptions = {}
+    ): Promise<Uint8Array> {
+        const stream = await this.download(source, options)
+        return readAllBytes(stream, { maxBytes: options.maxBytes })
+    }
+
+    public async tryDecryptAddon(event: WaIncomingMessageEvent): Promise<void> {
+        const message = event.message
+        if (!message) return
+
+        const addon = identifyEncryptedAddon(message)
+        if (!addon) return
+
+        const targetMessageId = addon.targetMessageKey.id
+        if (!targetMessageId) return
+
+        const parentEntry = await resolveParentMessageSecret(
+            targetMessageId,
+            this.messageSecretStore,
+            this.messageStore
+        )
+        if (!parentEntry) {
+            this.logger.debug('addon parent message secret not found', {
+                id: event.stanzaId,
+                targetId: targetMessageId
+            })
+            return
+        }
+
+        const parentMsgOriginalSender = parentEntry.senderJid
+        const modificationSender = event.senderJid ?? ''
+
+        const plaintext = await decryptAddonPayload({
+            messageSecret: parentEntry.secret,
+            stanzaId: targetMessageId,
+            parentMsgOriginalSender,
+            modificationSender,
+            modificationType: addon.modificationType,
+            ciphertext: addon.encPayload,
+            iv: addon.encIv,
+            additionalData: shouldUseAddonAdditionalData(addon.modificationType)
+                ? buildAddonAdditionalData(targetMessageId, modificationSender)
+                : undefined
+        })
+
+        let decrypted = decodeAddonPlaintext(addon.kind, plaintext)
+        if (decrypted.kind === 'poll_vote' && decrypted.pollVote.selectedOptions) {
+            const names = await resolvePollOptionNames(
+                decrypted.pollVote.selectedOptions,
+                targetMessageId,
+                this.messageStore
+            )
+            if (names) {
+                decrypted = { ...decrypted, selectedOptionNames: names }
+            }
+        }
+        this.emitAddon({
+            rawNode: event.rawNode,
+            stanzaId: event.stanzaId,
+            chatJid: event.chatJid,
+            stanzaType: event.stanzaType,
+            kind: addon.kind,
+            targetMessageId,
+            senderJid: modificationSender,
+            decrypted,
+            raw: message
+        })
+    }
+
+    private dispatchReceipt(
+        jid: string,
+        ids: string | readonly string[],
+        options: WaSendReceiptOptions
+    ): Promise<void> {
+        const idArray = typeof ids === 'string' ? [ids] : ids
+        if (idArray.length === 0) {
+            throw new Error('sendReceipt requires at least one message id')
+        }
+        const [id, ...rest] = idArray
+        const input: WaSendReceiptInput = {
+            ...options,
+            to: jid,
+            id,
+            listIds: rest.length > 0 ? rest : undefined
+        }
+        return this.messageDispatch.sendReceipt(input)
+    }
+}

--- a/src/client/coordinators/WaPresenceCoordinator.ts
+++ b/src/client/coordinators/WaPresenceCoordinator.ts
@@ -1,0 +1,53 @@
+import type { WaAuthCredentials } from '@auth/types'
+import {
+    buildChatstateNode,
+    type BuildChatstateNodeInput
+} from '@transport/node/builders/chatstate'
+import {
+    buildPresenceNode,
+    buildPresenceSubscribeNode,
+    type BuildPresenceSubscribeNodeInput
+} from '@transport/node/builders/presence'
+import type { BinaryNode } from '@transport/types'
+
+export interface WaPresenceCoordinator {
+    readonly send: (type?: 'available' | 'unavailable') => Promise<void>
+    readonly sendChatstate: (
+        jid: string,
+        options: Omit<BuildChatstateNodeInput, 'jid'>
+    ) => Promise<void>
+    /**
+     * Subscribes to presence updates (online/offline + chatstate) for a chat.
+     * The subscription is per-jid and lives only for the current connection;
+     * after a reconnect the caller must re-subscribe to keep receiving events.
+     */
+    readonly subscribe: (
+        jid: string,
+        options?: Omit<BuildPresenceSubscribeNodeInput, 'jid'>
+    ) => Promise<void>
+}
+
+interface WaPresenceCoordinatorOptions {
+    readonly sendNode: (node: BinaryNode) => Promise<void>
+    readonly getCurrentCredentials: () => WaAuthCredentials | null
+}
+
+export function createPresenceCoordinator(
+    options: WaPresenceCoordinatorOptions
+): WaPresenceCoordinator {
+    const { sendNode, getCurrentCredentials } = options
+    return {
+        send: async (type) => {
+            const credentials = getCurrentCredentials()
+            await sendNode(
+                buildPresenceNode({ type, name: credentials?.meDisplayName ?? undefined })
+            )
+        },
+        sendChatstate: async (jid, opts) => {
+            await sendNode(buildChatstateNode({ jid, ...opts }))
+        },
+        subscribe: async (jid, opts) => {
+            await sendNode(buildPresenceSubscribeNode({ jid, ...opts }))
+        }
+    }
+}

--- a/src/client/coordinators/__tests__/bot-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/bot-coordinator.test.ts
@@ -3,10 +3,21 @@ import test from 'node:test'
 
 import { createBotCoordinator } from '@client/coordinators/WaBotCoordinator'
 import type { WaSendMessageOptions } from '@client/types'
+import { createNoopLogger } from '@infra/log/types'
 import type { WaMessagePublishResult, WaSendMessageContent } from '@message/types'
 import type { Proto } from '@proto'
 import { WA_BOT_DEFAULT_CAPABILITIES } from '@protocol/bot'
+import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
+import type { WaMessageStore } from '@store/contracts/message.store'
 import type { BinaryNode } from '@transport/types'
+
+const decryptDepsStub = {
+    logger: createNoopLogger(),
+    messageStore: null as unknown as WaMessageStore,
+    messageSecretStore: null as unknown as WaMessageSecretStore,
+    getCurrentCredentials: () => null,
+    emitBotChunk: () => undefined
+}
 
 function createIqResult(content?: readonly BinaryNode[]): BinaryNode {
     return {
@@ -33,6 +44,7 @@ const MANUS_FBID = '1807055946647696@bot'
 test('bot coordinator listBots emits the expected IQ and parses sections', async () => {
     const calls: BinaryNode[] = []
     const coordinator = createBotCoordinator({
+        ...decryptDepsStub,
         queryWithContext: async (_context, node) => {
             calls.push(node)
             return createIqResult([
@@ -105,6 +117,7 @@ test('bot coordinator listBots emits the expected IQ and parses sections', async
 
 test('bot coordinator listBots derives fbidJid from personaId for PN bots', async () => {
     const coordinator = createBotCoordinator({
+        ...decryptDepsStub,
         queryWithContext: async () =>
             createIqResult([
                 {
@@ -144,6 +157,7 @@ test('bot coordinator sendPrompt direct path attaches default capabilities + per
         readonly options?: WaSendMessageOptions
     }> = []
     const coordinator = createBotCoordinator({
+        ...decryptDepsStub,
         queryWithContext: async () => createIqResult(),
         buildMessageContent: async (content) => {
             if (typeof content !== 'string') throw new Error('expected string content in test')
@@ -178,6 +192,7 @@ test('bot coordinator sendPrompt direct path attaches default capabilities + per
 test('bot coordinator sendPrompt direct path accepts custom capabilities override', async () => {
     let captured: Proto.IMessage | undefined
     const coordinator = createBotCoordinator({
+        ...decryptDepsStub,
         queryWithContext: async () => createIqResult(),
         buildMessageContent: async (content) => ({
             message:
@@ -203,6 +218,7 @@ test('bot coordinator sendPrompt direct path accepts custom capabilities overrid
 test('bot coordinator sendPrompt mention path wraps text in botInvokeMessage with mention metadata', async () => {
     const sends: Array<{ readonly to: string; readonly content: Proto.IMessage }> = []
     const coordinator = createBotCoordinator({
+        ...decryptDepsStub,
         queryWithContext: async () => createIqResult(),
         buildMessageContent: async (content) => ({
             message:
@@ -251,6 +267,7 @@ test('bot coordinator sendPrompt mention path wraps text in botInvokeMessage wit
 test('bot coordinator sendPrompt mention path resolves Meta AI PN jid to FBID', async () => {
     const sends: Array<{ readonly content: Proto.IMessage }> = []
     const coordinator = createBotCoordinator({
+        ...decryptDepsStub,
         queryWithContext: async () => createIqResult(),
         buildMessageContent: async (content) => ({
             message:
@@ -273,6 +290,7 @@ test('bot coordinator sendPrompt mention path resolves Meta AI PN jid to FBID', 
 
 test('bot coordinator sendPrompt mention path throws when bot jid cannot be resolved to FBID', async () => {
     const coordinator = createBotCoordinator({
+        ...decryptDepsStub,
         queryWithContext: async () => createIqResult(),
         buildMessageContent: async (content) => ({
             message:
@@ -292,6 +310,7 @@ test('bot coordinator sendPrompt mention path throws when bot jid cannot be reso
 test('bot coordinator sendPrompt direct path ignores opts.botJid to avoid misroute', async () => {
     let captured: string | undefined
     const coordinator = createBotCoordinator({
+        ...decryptDepsStub,
         queryWithContext: async () => createIqResult(),
         buildMessageContent: async () => ({ message: { conversation: 'hi' } }),
         sendMessage: async (to) => {
@@ -308,6 +327,7 @@ test('bot coordinator sendPrompt direct path ignores opts.botJid to avoid misrou
 
 test('bot coordinator sendPrompt throws when target is not a bot and botJid is missing', async () => {
     const coordinator = createBotCoordinator({
+        ...decryptDepsStub,
         queryWithContext: async () => createIqResult(),
         buildMessageContent: async () => ({ message: {} }),
         sendMessage: noopSendMessage
@@ -319,6 +339,7 @@ test('bot coordinator sendPrompt throws when target is not a bot and botJid is m
 test('bot coordinator sendPrompt mention path injects mention metadata into image contextInfo', async () => {
     const sends: Array<{ readonly content: Proto.IMessage }> = []
     const coordinator = createBotCoordinator({
+        ...decryptDepsStub,
         queryWithContext: async () => createIqResult(),
         buildMessageContent: async () => ({
             message: {

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import type { WaAppStateMutationInput, WaAppStateSyncResult } from '@appstate/types'
+import type { WaAppStateSyncClient } from '@appstate/sync/WaAppStateSyncClient'
+import type {
+    WaAppStateMutationInput,
+    WaAppStateSyncOptions,
+    WaAppStateSyncResult
+} from '@appstate/types'
 import { WaAppStateMutationCoordinator } from '@client/coordinators/WaAppStateMutationCoordinator'
 import { WaIncomingNodeCoordinator } from '@client/coordinators/WaIncomingNodeCoordinator'
 import { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
@@ -10,6 +15,7 @@ import { createStreamControlHandler } from '@client/coordinators/WaStreamControl
 import { createGroupMetadataCache } from '@client/messaging/group-metadata'
 import type { WaGroupEvent, WaGroupEventAction } from '@client/types'
 import { createNoopLogger } from '@infra/log/types'
+import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import {
     WA_APP_STATE_COLLECTION_STATES,
     WA_CONNECTION_REASONS,
@@ -19,6 +25,14 @@ import {
 import { WaGroupMetadataMemoryStore } from '@store/memory/group-metadata.store'
 import { WaMessageMemoryStore } from '@store/memory/message.store'
 import type { BinaryNode } from '@transport/types'
+
+function fakeSyncImpl(impl: (options?: WaAppStateSyncOptions) => Promise<WaAppStateSyncResult>) {
+    return {
+        appStateSync: { sync: impl } as unknown as WaAppStateSyncClient,
+        mediaTransfer: {} as unknown as WaMediaTransferClient,
+        isConnected: () => true
+    } as const
+}
 
 function createIncomingRuntime() {
     const unhandled: unknown[] = []
@@ -768,7 +782,7 @@ test('app-state mutation coordinator flushes queued mutations while sync is in-f
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             const pendingMutations = options.pendingMutations ?? []
             syncCalls.push(pendingMutations)
             if (syncCalls.length === 1) {
@@ -780,7 +794,7 @@ test('app-state mutation coordinator flushes queued mutations while sync is in-f
                 })
             }
             return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
-        }
+        })
     })
 
     const firstMutation = coordinator.setChatMute('551100000000@s.whatsapp.net', false)
@@ -810,11 +824,11 @@ test('app-state mutation coordinator emits pin + archive mutations when pinning 
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             const pendingMutations = options.pendingMutations ?? []
             syncCalls.push(pendingMutations)
             return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
-        }
+        })
     })
 
     await coordinator.setChatPin('551100000000@s.whatsapp.net', true)
@@ -850,7 +864,7 @@ test('app-state mutation coordinator flushes only targeted collections for queue
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             syncCalls.push({
                 collections: options.collections ?? [],
                 pending: options.pendingMutations?.length ?? 0
@@ -859,7 +873,7 @@ test('app-state mutation coordinator flushes only targeted collections for queue
                 options.pendingMutations ?? [],
                 WA_APP_STATE_COLLECTION_STATES.SUCCESS
             )
-        }
+        })
     })
 
     await coordinator.setChatPin('551100000000@s.whatsapp.net', true)
@@ -890,11 +904,11 @@ test('app-state mutation coordinator includes message range and auto-unpin on ar
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             const pendingMutations = options.pendingMutations ?? []
             syncCalls.push(pendingMutations)
             return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
-        }
+        })
     })
 
     await coordinator.setChatArchive('120@g.us', true)
@@ -936,11 +950,11 @@ test('app-state mutation coordinator preserves device participant jid in archive
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             const pendingMutations = options.pendingMutations ?? []
             syncCalls.push(pendingMutations)
             return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
-        }
+        })
     })
 
     await coordinator.setChatArchive('120@g.us', false)
@@ -977,11 +991,11 @@ test('app-state mutation coordinator skips incoming group messages without parti
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             const pendingMutations = options.pendingMutations ?? []
             syncCalls.push(pendingMutations)
             return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
-        }
+        })
     })
 
     await coordinator.setChatArchive('120@g.us', false)
@@ -1008,7 +1022,7 @@ test('app-state mutation coordinator keeps pending mutations after blocked flush
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             flushAttempt += 1
             const pendingMutations = options.pendingMutations ?? []
             syncCalls.push(pendingMutations)
@@ -1018,7 +1032,7 @@ test('app-state mutation coordinator keeps pending mutations after blocked flush
                     ? WA_APP_STATE_COLLECTION_STATES.BLOCKED
                     : WA_APP_STATE_COLLECTION_STATES.SUCCESS
             )
-        }
+        })
     })
 
     await assert.rejects(coordinator.setChatMute('551100000000@s.whatsapp.net', false))
@@ -1044,11 +1058,11 @@ test('app-state mutation coordinator emits read/clear/delete mutations with expe
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             const pendingMutations = options.pendingMutations ?? []
             syncCalls.push(pendingMutations)
             return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
-        }
+        })
     })
 
     await coordinator.setChatRead('551100000000@s.whatsapp.net', true)
@@ -1089,11 +1103,11 @@ test('app-state mutation coordinator emits archive and unpin before lock mutatio
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             const pendingMutations = options.pendingMutations ?? []
             syncCalls.push(pendingMutations)
             return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
-        }
+        })
     })
 
     await coordinator.setChatLock('551100000000@s.whatsapp.net', true)
@@ -1116,11 +1130,11 @@ test('app-state mutation coordinator emits star mutation with message-key index'
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             const pendingMutations = options.pendingMutations ?? []
             syncCalls.push(pendingMutations)
             return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
-        }
+        })
     })
 
     await coordinator.setMessageStar(
@@ -1156,11 +1170,11 @@ test('app-state mutation coordinator emits delete-message-for-me mutation and va
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             const pendingMutations = options.pendingMutations ?? []
             syncCalls.push(pendingMutations)
             return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
-        }
+        })
     })
 
     await coordinator.deleteMessageForMe(
@@ -1211,11 +1225,11 @@ test('app-state mutation coordinator emits status_privacy account mutation', asy
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             const pendingMutations = options.pendingMutations ?? []
             syncCalls.push(pendingMutations)
             return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
-        }
+        })
     })
 
     await coordinator.setStatusPrivacy({
@@ -1242,11 +1256,11 @@ test('app-state mutation coordinator emits userStatusMute mutation with target j
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             const pendingMutations = options.pendingMutations ?? []
             syncCalls.push(pendingMutations)
             return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
-        }
+        })
     })
 
     await coordinator.setUserStatusMute('5511000000000:3@s.whatsapp.net', true)
@@ -1266,11 +1280,11 @@ test('app-state mutation coordinator emits business_broadcast_list set/remove pa
         serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
         logger: createNoopLogger(),
         messageStore,
-        syncAppState: async (options = {}) => {
+        ...fakeSyncImpl(async (options = {}) => {
             const pendingMutations = options.pendingMutations ?? []
             syncCalls.push(pendingMutations)
             return buildAppStateSyncResult(pendingMutations, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
-        }
+        })
     })
 
     await coordinator.setBroadcastList({

--- a/src/client/coordinators/__tests__/presence-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/presence-coordinator.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { WaAuthCredentials } from '@auth/types'
+import { createPresenceCoordinator } from '@client/coordinators/WaPresenceCoordinator'
+import type { BinaryNode } from '@transport/types'
+
+function makeHarness(credentials: Partial<WaAuthCredentials> | null = null) {
+    const sent: BinaryNode[] = []
+    const coordinator = createPresenceCoordinator({
+        sendNode: async (node) => {
+            sent.push(node)
+        },
+        getCurrentCredentials: () => (credentials as WaAuthCredentials | null) ?? null
+    })
+    return { coordinator, sent }
+}
+
+test('presence.send emits a presence node with the current display name', async () => {
+    const { coordinator, sent } = makeHarness({ meDisplayName: 'Vinicius' })
+    await coordinator.send('available')
+    assert.deepEqual(sent, [
+        {
+            tag: 'presence',
+            attrs: { type: 'available', name: 'Vinicius' }
+        }
+    ])
+})
+
+test('presence.send omits name when credentials are absent', async () => {
+    const { coordinator, sent } = makeHarness(null)
+    await coordinator.send('unavailable')
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].tag, 'presence')
+    assert.equal(sent[0].attrs.type, 'unavailable')
+    assert.equal(sent[0].attrs.name, undefined)
+})
+
+test('presence.sendChatstate forwards jid and chatstate options to the builder', async () => {
+    const { coordinator, sent } = makeHarness()
+    await coordinator.sendChatstate('5511999999999@s.whatsapp.net', { state: 'composing' })
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].tag, 'chatstate')
+    assert.equal(sent[0].attrs.to, '5511999999999@s.whatsapp.net')
+})
+
+test('presence.subscribe sends a presence subscribe node for the jid', async () => {
+    const { coordinator, sent } = makeHarness()
+    await coordinator.subscribe('5511999999999@s.whatsapp.net')
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].tag, 'presence')
+    assert.equal(sent[0].attrs.type, 'subscribe')
+    assert.equal(sent[0].attrs.to, '5511999999999@s.whatsapp.net')
+})

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -7,7 +7,7 @@ import type { Logger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import { proto, type Proto } from '@proto'
 import { decodeProtoBytes, toBytesView } from '@util/bytes'
-import { longToNumber } from '@util/primitives'
+import { longToNumber, toError } from '@util/primitives'
 
 const unzipAsync = promisify(unzip)
 
@@ -36,6 +36,21 @@ interface WaHistorySyncDeps {
         }[]
     ) => Promise<void>
     readonly onNctSalt?: (salt: Uint8Array) => Promise<void>
+}
+
+export async function runHistorySyncNotification(
+    deps: WaHistorySyncDeps,
+    notification: Proto.Message.IHistorySyncNotification
+): Promise<void> {
+    try {
+        await processHistorySyncNotification(deps, notification)
+    } catch (error) {
+        deps.logger.warn('failed to process history sync notification', {
+            syncType: notification.syncType,
+            chunkOrder: notification.chunkOrder,
+            message: toError(error).message
+        })
+    }
 }
 
 export async function processHistorySyncNotification(

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -215,6 +215,12 @@ export interface WaDeleteMessageForMeOptions {
     readonly messageTimestampMs?: number
 }
 
+export interface WaDownloadMediaOptions {
+    readonly maxBytes?: number
+    readonly timeoutMs?: number
+    readonly signal?: AbortSignal
+}
+
 export type WaIncomingNodeHandler = (node: BinaryNode) => Promise<boolean>
 
 export interface WaIncomingNodeHandlerRegistration {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,12 @@ export type {
     WaClientEventMap,
     WaClientOptions,
     WaClientProxyOptions,
+    WaDownloadMediaOptions,
     WaHistorySyncChunkEvent,
     WaHistorySyncOptions,
     WaWriteBehindOptions
 } from '@client/types'
+export type { WaMessageCoordinator } from '@client/coordinators/WaMessageCoordinator'
 export type {
     WaAccountEvent,
     WaAccountTakeoverNoticeEvent,

--- a/src/message/encode/__tests__/media-payload.test.ts
+++ b/src/message/encode/__tests__/media-payload.test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resolveMediaPayload } from '@message/encode/media-payload'
+
+const key = new Uint8Array([1, 2, 3])
+const sha = new Uint8Array([4, 5, 6])
+const encSha = new Uint8Array([7, 8, 9])
+
+test('resolveMediaPayload returns null when message is empty or has no media', () => {
+    assert.equal(resolveMediaPayload(null), null)
+    assert.equal(resolveMediaPayload(undefined), null)
+    assert.equal(resolveMediaPayload({}), null)
+    assert.equal(resolveMediaPayload({ conversation: 'hi' }), null)
+})
+
+test('resolveMediaPayload returns null when directPath or mediaKey is missing', () => {
+    assert.equal(resolveMediaPayload({ imageMessage: { mediaKey: key } }), null)
+    assert.equal(resolveMediaPayload({ imageMessage: { directPath: '/x' } }), null)
+})
+
+test('resolveMediaPayload maps image and document', () => {
+    const img = resolveMediaPayload({
+        imageMessage: {
+            directPath: '/img',
+            mediaKey: key,
+            fileSha256: sha,
+            fileEncSha256: encSha,
+            mimetype: 'image/jpeg',
+            fileLength: 1234
+        }
+    })
+    assert.deepEqual(img, {
+        mediaType: 'image',
+        directPath: '/img',
+        mediaKey: key,
+        fileSha256: sha,
+        fileEncSha256: encSha,
+        mimetype: 'image/jpeg',
+        fileLength: 1234
+    })
+
+    const doc = resolveMediaPayload({
+        documentMessage: { directPath: '/doc', mediaKey: key }
+    })
+    assert.equal(doc?.mediaType, 'document')
+    assert.equal(doc?.directPath, '/doc')
+    assert.equal(doc?.fileLength, undefined)
+})
+
+test('resolveMediaPayload distinguishes video/gif and audio/ptt and ptv', () => {
+    const video = resolveMediaPayload({
+        videoMessage: { directPath: '/v', mediaKey: key }
+    })
+    assert.equal(video?.mediaType, 'video')
+
+    const gif = resolveMediaPayload({
+        videoMessage: { directPath: '/v', mediaKey: key, gifPlayback: true }
+    })
+    assert.equal(gif?.mediaType, 'gif')
+
+    const audio = resolveMediaPayload({
+        audioMessage: { directPath: '/a', mediaKey: key }
+    })
+    assert.equal(audio?.mediaType, 'audio')
+
+    const ptt = resolveMediaPayload({
+        audioMessage: { directPath: '/a', mediaKey: key, ptt: true }
+    })
+    assert.equal(ptt?.mediaType, 'ptt')
+
+    const ptv = resolveMediaPayload({
+        ptvMessage: { directPath: '/ptv', mediaKey: key }
+    })
+    assert.equal(ptv?.mediaType, 'ptv')
+
+    const sticker = resolveMediaPayload({
+        stickerMessage: { directPath: '/s', mediaKey: key }
+    })
+    assert.equal(sticker?.mediaType, 'sticker')
+})
+
+test('resolveMediaPayload unwraps ephemeral/viewOnce/documentWithCaption wrappers', () => {
+    const wrapped = resolveMediaPayload({
+        ephemeralMessage: {
+            message: {
+                imageMessage: { directPath: '/img', mediaKey: key }
+            }
+        }
+    })
+    assert.equal(wrapped?.mediaType, 'image')
+
+    const wrappedDoc = resolveMediaPayload({
+        documentWithCaptionMessage: {
+            message: {
+                documentMessage: { directPath: '/d', mediaKey: key }
+            }
+        }
+    })
+    assert.equal(wrappedDoc?.mediaType, 'document')
+
+    const wrappedViewOnce = resolveMediaPayload({
+        viewOnceMessageV2: {
+            message: {
+                videoMessage: { directPath: '/v', mediaKey: key, gifPlayback: true }
+            }
+        }
+    })
+    assert.equal(wrappedViewOnce?.mediaType, 'gif')
+})
+
+test('resolveMediaPayload converts protobuf Long fileLength via toNumber', () => {
+    const payload = resolveMediaPayload({
+        imageMessage: {
+            directPath: '/img',
+            mediaKey: key,
+            fileLength: { toNumber: () => 9876 } as unknown as number
+        }
+    })
+    assert.equal(payload?.fileLength, 9876)
+})

--- a/src/message/encode/media-payload.ts
+++ b/src/message/encode/media-payload.ts
@@ -1,0 +1,67 @@
+import type { MediaCryptoType } from '@media/types'
+import { unwrapMessage } from '@message/encode/content'
+import type { Proto } from '@proto'
+import { longToNumber } from '@util/primitives'
+
+export interface WaResolvedMediaPayload {
+    readonly mediaType: MediaCryptoType
+    readonly directPath: string
+    readonly mediaKey: Uint8Array
+    readonly fileSha256?: Uint8Array
+    readonly fileEncSha256?: Uint8Array
+    readonly mimetype?: string
+    readonly fileLength?: number
+}
+
+interface DownloadableMediaProtoFields {
+    readonly directPath?: string | null
+    readonly mediaKey?: Uint8Array | string | null
+    readonly fileSha256?: Uint8Array | string | null
+    readonly fileEncSha256?: Uint8Array | string | null
+    readonly mimetype?: string | null
+    readonly fileLength?: number | { toNumber(): number } | null
+}
+
+function buildPayload(
+    mediaType: MediaCryptoType,
+    fields: DownloadableMediaProtoFields
+): WaResolvedMediaPayload | null {
+    if (!fields.directPath || !fields.mediaKey) {
+        return null
+    }
+    const mediaKey = fields.mediaKey instanceof Uint8Array ? fields.mediaKey : null
+    if (!mediaKey) {
+        return null
+    }
+    const fileSha256 = fields.fileSha256 instanceof Uint8Array ? fields.fileSha256 : undefined
+    const fileEncSha256 =
+        fields.fileEncSha256 instanceof Uint8Array ? fields.fileEncSha256 : undefined
+    return {
+        mediaType,
+        directPath: fields.directPath,
+        mediaKey,
+        fileSha256,
+        fileEncSha256,
+        mimetype: fields.mimetype ?? undefined,
+        fileLength: fields.fileLength ? longToNumber(fields.fileLength) : undefined
+    }
+}
+
+export function resolveMediaPayload(
+    message: Proto.IMessage | null | undefined
+): WaResolvedMediaPayload | null {
+    if (!message) return null
+    const msg = unwrapMessage(message)
+
+    if (msg.imageMessage) return buildPayload('image', msg.imageMessage)
+    if (msg.videoMessage) {
+        return buildPayload(msg.videoMessage.gifPlayback ? 'gif' : 'video', msg.videoMessage)
+    }
+    if (msg.audioMessage) {
+        return buildPayload(msg.audioMessage.ptt ? 'ptt' : 'audio', msg.audioMessage)
+    }
+    if (msg.documentMessage) return buildPayload('document', msg.documentMessage)
+    if (msg.stickerMessage) return buildPayload('sticker', msg.stickerMessage)
+    if (msg.ptvMessage) return buildPayload('ptv', msg.ptvMessage)
+    return null
+}


### PR DESCRIPTION
WaClient grew into a 1140-line facade. Move cohesive slices into coordinators matching the client.<area>.* convention; the WaClient surface drops to 526 lines.

- client.message: send, sendReceipt, download(Bytes|ToFile), syncSignalSession, tryDecryptAddon
- client.presence: send, sendChatstate, subscribe
- client.lowlevel: sendNode, query, incoming handler/filter registration
- client.chat gains sync, emitEventsFromSyncResult, getBlockedCollections
- WaAppStateSyncClient absorbs incoming key share/request handlers
- client.bot absorbs tryDecryptChunk

mediaTransfer, messageClient and appStateSync are no longer public.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Client API reorganized: send/receipt/app-state/presence operations moved into dedicated namespaces; older top-level send/sync methods removed—update integrations.

* **New Features**
  * Built-in media download utilities (stream, file, bytes) with size/timeouts.
  * App-state sync: incoming key-share and key-request handling.
  * Presence and message coordinators for richer send/receipt behavior.

* **Refactor**
  * Core client simplified to delegate responsibilities to coordinators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->