### PR TITLE
feat(events): expose offline flag on incoming events

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -1020,6 +1020,7 @@ export function buildWaClientDependencies(input: {
                 stanzaId: node.attrs.id,
                 chatJid: newsletterJid,
                 stanzaType: node.attrs.type,
+                offline: node.attrs.offline !== undefined,
                 newsletterJid,
                 action,
                 subType: childTag
@@ -1145,6 +1146,7 @@ export function buildWaClientDependencies(input: {
                     stanzaId: parsed.stanzaId,
                     chatJid: parsed.fromJid,
                     stanzaType: WA_NOTIFICATION_TYPES.ENCRYPT,
+                    offline: node.attrs.offline !== undefined,
                     notificationType: WA_NOTIFICATION_TYPES.ENCRYPT,
                     classification: 'core',
                     details: {
@@ -1218,6 +1220,7 @@ export function buildWaClientDependencies(input: {
                 stanzaId: parsed.stanzaId,
                 chatJid: parsed.fromJid,
                 stanzaType: WA_NOTIFICATION_TYPES.DEVICES,
+                offline: node.attrs.offline !== undefined,
                 notificationType: WA_NOTIFICATION_TYPES.DEVICES,
                 classification: 'core',
                 details: {

--- a/src/client/coordinators/WaBotCoordinator.ts
+++ b/src/client/coordinators/WaBotCoordinator.ts
@@ -336,6 +336,7 @@ export function createBotCoordinator(options: WaBotCoordinatorOptions): WaBotCoo
                 stanzaId: event.stanzaId,
                 chatJid: event.chatJid,
                 stanzaType: event.stanzaType,
+                offline: event.offline,
                 senderJid,
                 targetMessageId,
                 editType,

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -225,6 +225,7 @@ export class WaMessageCoordinator {
             stanzaId: event.stanzaId,
             chatJid: event.chatJid,
             stanzaType: event.stanzaType,
+            offline: event.offline,
             kind: addon.kind,
             targetMessageId,
             senderJid: modificationSender,

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -408,6 +408,7 @@ test('incoming node coordinator emits info bulletin notifications and forwards o
         stanzaId: 'ib-1',
         chatJid: 's.whatsapp.net',
         stanzaType: undefined,
+        offline: false,
         notificationType: 'ib.offline_preview',
         classification: 'info_bulletin',
         details: {
@@ -445,6 +446,7 @@ test('incoming node coordinator emits info bulletin notifications and forwards o
         stanzaId: 'ib-1',
         chatJid: 's.whatsapp.net',
         stanzaType: undefined,
+        offline: false,
         notificationType: 'ib.offline',
         classification: 'info_bulletin',
         details: {

--- a/src/client/events/business.ts
+++ b/src/client/events/business.ts
@@ -305,6 +305,7 @@ function createBaseBusinessEvent(notificationNode: BinaryNode): Omit<WaBusinessE
         stanzaId: notificationNode.attrs.id,
         chatJid: notificationNode.attrs.from,
         stanzaType: notificationNode.attrs.type,
+        offline: notificationNode.attrs.offline !== undefined,
         timestampSeconds: parseOptionalInt(notificationNode.attrs.t)
     }
 }

--- a/src/client/events/group.ts
+++ b/src/client/events/group.ts
@@ -112,6 +112,7 @@ function createBaseGroupEvent(
         stanzaId: notificationNode.attrs.id,
         chatJid: notificationNode.attrs.from,
         stanzaType: notificationNode.attrs.type,
+        offline: notificationNode.attrs.offline !== undefined,
         groupJid: notificationNode.attrs.from,
         authorJid: notificationNode.attrs.participant,
         timestampSeconds: parseOptionalInt(notificationNode.attrs.t)

--- a/src/client/events/incoming.ts
+++ b/src/client/events/incoming.ts
@@ -157,7 +157,8 @@ export function createIncomingBaseEvent(node: BinaryNode): WaIncomingBaseEvent {
         rawNode: node,
         stanzaId: node.attrs.id,
         chatJid: node.attrs.from,
-        stanzaType: node.attrs.type
+        stanzaType: node.attrs.type,
+        offline: node.attrs.offline !== undefined
     }
 }
 

--- a/src/client/events/picture.ts
+++ b/src/client/events/picture.ts
@@ -29,6 +29,7 @@ export function parsePictureNotificationEvents(node: BinaryNode): WaParsePicture
             stanzaId: node.attrs.id,
             chatJid: node.attrs.from,
             stanzaType: node.attrs.type,
+            offline: node.attrs.offline !== undefined,
             action,
             targetJid: actionNode.attrs.jid,
             authorJid: actionNode.attrs.author,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -245,6 +245,7 @@ export interface WaIncomingBaseEvent {
     readonly stanzaId?: string
     readonly chatJid?: string
     readonly stanzaType?: string
+    readonly offline?: boolean
 }
 
 export interface WaIncomingMessageEvent extends WaIncomingBaseEvent {

--- a/src/message/kinds/newsletter.ts
+++ b/src/message/kinds/newsletter.ts
@@ -40,6 +40,7 @@ export function processIncomingNewsletterMessage(
             stanzaId: node.attrs.id,
             chatJid,
             stanzaType: messageType,
+            offline: node.attrs.offline !== undefined,
             reason: 'newsletter.missing_plaintext'
         })
         return
@@ -62,6 +63,7 @@ export function processIncomingNewsletterMessage(
             stanzaId: node.attrs.id,
             chatJid,
             stanzaType: messageType,
+            offline: node.attrs.offline !== undefined,
             reason: 'newsletter.decode_failed'
         })
         return
@@ -72,6 +74,7 @@ export function processIncomingNewsletterMessage(
         stanzaId: node.attrs.id,
         chatJid,
         stanzaType: messageType,
+        offline: node.attrs.offline !== undefined,
         timestampSeconds: parseOptionalInt(node.attrs.t),
         senderJid: chatJid,
         encryptionType: 'plaintext',
@@ -98,6 +101,7 @@ function emitReactionEvent(
             stanzaId: node.attrs.id,
             chatJid,
             stanzaType: node.attrs.type,
+            offline: node.attrs.offline !== undefined,
             reason: 'newsletter.missing_reaction'
         })
         return
@@ -107,6 +111,7 @@ function emitReactionEvent(
         stanzaId: node.attrs.id,
         chatJid,
         stanzaType: node.attrs.type,
+        offline: node.attrs.offline !== undefined,
         timestampSeconds: parseOptionalInt(node.attrs.t),
         parentMessageServerId: parseOptionalInt(node.attrs.server_id),
         reactionCode: reactionNode.attrs.code,

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -294,6 +294,7 @@ function processMsmsgEncNode(
                 stanzaId: node.attrs.id,
                 chatJid: node.attrs.from,
                 stanzaType: node.attrs.type,
+                offline: node.attrs.offline !== undefined,
                 reason: 'message.msmsg.missing_payload'
             })
             return { success: false, encType: 'msmsg' }
@@ -312,6 +313,7 @@ function processMsmsgEncNode(
             stanzaId: node.attrs.id,
             chatJid,
             stanzaType: node.attrs.type,
+            offline: node.attrs.offline !== undefined,
             timestampSeconds: parseOptionalInt(node.attrs.t),
             senderJid: sender?.userJid,
             senderDevice: sender?.address.device,
@@ -334,6 +336,7 @@ function processMsmsgEncNode(
             stanzaId: node.attrs.id,
             chatJid: node.attrs.from,
             stanzaType: node.attrs.type,
+            offline: node.attrs.offline !== undefined,
             reason: 'message.msmsg.decode_failed'
         })
         return { success: false, encType: 'msmsg', error }
@@ -389,6 +392,7 @@ async function decryptAndProcessEncNode(
                 stanzaId: node.attrs.id,
                 chatJid,
                 stanzaType: node.attrs.type,
+                offline: node.attrs.offline !== undefined,
                 timestampSeconds: parseOptionalInt(node.attrs.t),
                 senderJid: `${senderAddress.user}@${senderAddress.server}`,
                 senderDevice: senderAddress.device,
@@ -414,6 +418,7 @@ async function decryptAndProcessEncNode(
             stanzaId: node.attrs.id,
             chatJid: node.attrs.from,
             stanzaType: node.attrs.type,
+            offline: node.attrs.offline !== undefined,
             reason: `message.decrypt_failed.${encType}`
         })
         return { success: false, encType, error }
@@ -459,6 +464,7 @@ export async function handleIncomingMessageAck(
                             stanzaId: node.attrs.id,
                             chatJid: node.attrs.from,
                             stanzaType: node.attrs.type,
+                            offline: node.attrs.offline !== undefined,
                             reason: 'message.skmsg.missing_group_context'
                         })
                         continue


### PR DESCRIPTION
Propagates the inbound stanza's offline attribute as a boolean field on WaIncomingBaseEvent, so consumers can tell whether a message/notification/ receipt came from the offline resume backlog or was delivered live.