### PR TITLE
feat(usync): add text_status, username, bot and business batch protocols

### DIFF
--- a/src/appstate/parsers/response-parser.ts
+++ b/src/appstate/parsers/response-parser.ts
@@ -14,6 +14,7 @@ import {
     getNodeChildrenByTag
 } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
+import { parseOptionalInt } from '@util/primitives'
 
 export interface CollectionResponsePayload {
     readonly collection: AppStateCollectionName
@@ -48,11 +49,10 @@ export function parseSyncResponse(iqNode: BinaryNode): readonly CollectionRespon
         const versionAttr = collectionNode.attrs.version
         let version: number | undefined
         if (versionAttr) {
-            const parsedVersion = Number.parseInt(versionAttr, 10)
-            if (!Number.isSafeInteger(parsedVersion) || parsedVersion < 0) {
+            version = parseOptionalInt(versionAttr)
+            if (version === undefined) {
                 throw new Error(`invalid app-state collection version "${versionAttr}"`)
             }
-            version = parsedVersion
         }
 
         const [patchesNode, snapshotNode] = findNodeChildrenByTags(collectionNode, [

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -625,14 +625,17 @@ export function buildWaClientDependencies(input: {
 
     const profileCoordinator = createProfileCoordinator({
         queryWithContext: runtime.queryWithContext,
-        generateSid: generateUsyncSid
+        generateSid: generateUsyncSid,
+        mexSocket: { query: runtime.query },
+        logger
     })
 
     const businessCoordinator = createBusinessCoordinator({
         queryWithContext: runtime.queryWithContext,
         mediaTransfer,
         getMediaConn: () => getClientMediaConn(mediaMessageBuildOptions),
-        logger
+        logger,
+        generateSid: generateUsyncSid
     })
 
     const emailCoordinator = createEmailCoordinator({
@@ -805,7 +808,8 @@ export function buildWaClientDependencies(input: {
         messageStore: sessionStore.messages,
         messageSecretStore: sessionStore.messageSecret,
         getCurrentCredentials,
-        emitBotChunk: (event) => runtime.emitEvent('message_bot_chunk', event)
+        emitBotChunk: (event) => runtime.emitEvent('message_bot_chunk', event),
+        generateSid: generateUsyncSid
     })
 
     const appStateSync = new WaAppStateSyncClient({

--- a/src/client/coordinators/WaAbPropsCoordinator.ts
+++ b/src/client/coordinators/WaAbPropsCoordinator.ts
@@ -11,7 +11,7 @@ import {
 import { WA_DEFAULTS } from '@protocol/constants'
 import { buildGetAbPropsIq } from '@transport/node/builders/abprops'
 import type { BinaryNode } from '@transport/types'
-import { toError } from '@util/primitives'
+import { parseOptionalInt, toError } from '@util/primitives'
 
 type WaAbPropsRuntime = {
     readonly queryWithContext: (
@@ -180,8 +180,7 @@ function parseConfigValue(
         return value === '1' || value === 'true' || value === 'True'
     }
     if (type === 'int') {
-        const parsed = Number.parseInt(value, 10)
-        return Number.isSafeInteger(parsed) ? parsed : (defaultValue as number)
+        return parseOptionalInt(value) ?? (defaultValue as number)
     }
     return value
 }

--- a/src/client/coordinators/WaBotCoordinator.ts
+++ b/src/client/coordinators/WaBotCoordinator.ts
@@ -44,11 +44,7 @@ import {
     iterateUsyncUsers,
     parseUsyncResultEnvelope
 } from '@transport/node/builders/usync'
-import {
-    findNodeChild,
-    getNodeChildrenByTag,
-    getNodeTextContent
-} from '@transport/node/helpers'
+import { findNodeChild, getNodeChildrenByTag, getNodeTextContent } from '@transport/node/helpers'
 import { assertIqResult } from '@transport/node/query'
 import { logUsyncProtocolErrors } from '@transport/node/usync'
 import type { BinaryNode } from '@transport/types'
@@ -180,7 +176,9 @@ function parseBotListResult(result: BinaryNode): readonly WaBotInfo[] {
     return out
 }
 
-function parseBotProfilePrompts(promptsNode: BinaryNode | undefined): readonly WaBotProfilePrompt[] {
+function parseBotProfilePrompts(
+    promptsNode: BinaryNode | undefined
+): readonly WaBotProfilePrompt[] {
     if (!promptsNode) return []
     const children = getNodeChildrenByTag(promptsNode, 'prompt')
     const out = new Array<WaBotProfilePrompt>(children.length)
@@ -201,7 +199,8 @@ function parseBotProfileCommands(commandsNode: BinaryNode | undefined): {
     readonly commandsDescription: string | null
 } {
     if (!commandsNode) return { commands: [], commandsDescription: null }
-    const commandsDescription = getNodeTextContent(findNodeChild(commandsNode, 'description')) || null
+    const commandsDescription =
+        getNodeTextContent(findNodeChild(commandsNode, 'description')) || null
     const commandNodes = getNodeChildrenByTag(commandsNode, 'command')
     const commands = new Array<WaBotProfileCommand>(commandNodes.length)
     let count = 0
@@ -216,9 +215,7 @@ function parseBotProfileCommands(commandsNode: BinaryNode | undefined): {
     return { commands, commandsDescription }
 }
 
-function parsePosingAsProfessional(
-    node: BinaryNode | undefined
-): WaBotPosingAsProfessional | null {
+function parsePosingAsProfessional(node: BinaryNode | undefined): WaBotPosingAsProfessional | null {
     if (!node) return null
     const type = node.attrs.type
     if (type === 'unknown' || type === 'yes' || type === 'no') {
@@ -254,14 +251,12 @@ function parseBotProfileUsync(result: BinaryNode): WaBotProfileResult | null {
                 attributes: getNodeTextContent(findNodeChild(profileNode, 'attributes')) || null,
                 description: getNodeTextContent(findNodeChild(profileNode, 'description')) || null,
                 category: getNodeTextContent(findNodeChild(profileNode, 'category')) || null,
-                isDefault:
-                    getNodeTextContent(findNodeChild(profileNode, 'default')) === 'true',
+                isDefault: getNodeTextContent(findNodeChild(profileNode, 'default')) === 'true',
                 prompts: parseBotProfilePrompts(findNodeChild(profileNode, 'prompts')),
                 personaId: (profileNode.attrs.persona_id as string | undefined) ?? null,
                 commands,
                 commandsDescription,
-                isMetaCreated:
-                    isMetaCreatedRaw === undefined ? null : isMetaCreatedRaw === 'true',
+                isMetaCreated: isMetaCreatedRaw === undefined ? null : isMetaCreatedRaw === 'true',
                 creatorName: creatorNode
                     ? getNodeTextContent(findNodeChild(creatorNode, 'name')) || null
                     : null,

--- a/src/client/coordinators/WaBotCoordinator.ts
+++ b/src/client/coordinators/WaBotCoordinator.ts
@@ -34,11 +34,25 @@ import {
 import { isBotJid, toUserJid } from '@protocol/jid'
 import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
 import type { WaMessageStore } from '@store/contracts/message.store'
-import { buildBotListIq } from '@transport/node/builders/bot'
-import { findNodeChild, getNodeChildrenByTag } from '@transport/node/helpers'
+import {
+    buildBotListIq,
+    buildBotProfileUsyncUserNodeContent,
+    buildGetBotProfileUsyncQueryNode
+} from '@transport/node/builders/bot'
+import {
+    buildUsyncIq,
+    iterateUsyncUsers,
+    parseUsyncResultEnvelope
+} from '@transport/node/builders/usync'
+import {
+    findNodeChild,
+    getNodeChildrenByTag,
+    getNodeTextContent
+} from '@transport/node/helpers'
 import { assertIqResult } from '@transport/node/query'
+import { logUsyncProtocolErrors } from '@transport/node/usync'
 import type { BinaryNode } from '@transport/types'
-import { toError } from '@util/primitives'
+import { parseOptionalInt, toError } from '@util/primitives'
 
 export interface WaBotInfo {
     readonly jid: string
@@ -47,6 +61,38 @@ export interface WaBotInfo {
     readonly isDefault: boolean
     readonly section?: string
     readonly count?: number
+}
+
+export interface WaBotProfilePrompt {
+    readonly emoji: string
+    readonly text: string
+}
+
+export interface WaBotProfileCommand {
+    readonly name: string
+    readonly description: string
+}
+
+export type WaBotPosingAsProfessional = 'unknown' | 'yes' | 'no'
+
+export interface WaBotProfileResult {
+    readonly name: string | null
+    readonly attributes: string | null
+    readonly description: string | null
+    readonly category: string | null
+    readonly isDefault: boolean
+    readonly prompts: readonly WaBotProfilePrompt[]
+    readonly personaId: string | null
+    readonly commands: readonly WaBotProfileCommand[]
+    readonly commandsDescription: string | null
+    readonly isMetaCreated: boolean | null
+    readonly creatorName: string | null
+    readonly creatorProfileUrl: string | null
+    readonly posingAsProfessional: WaBotPosingAsProfessional | null
+}
+
+export interface WaGetBotProfileOptions {
+    readonly personaId?: string
 }
 
 export interface WaBotPromptOptions extends WaSendMessageOptions {
@@ -64,6 +110,10 @@ export interface WaBotPromptOptions extends WaSendMessageOptions {
 
 export interface WaBotCoordinator {
     readonly listBots: () => Promise<readonly WaBotInfo[]>
+    readonly getBotProfile: (
+        jid: string,
+        options?: WaGetBotProfileOptions
+    ) => Promise<WaBotProfileResult | null>
     readonly sendPrompt: (
         to: string,
         content: WaSendMessageContent,
@@ -90,6 +140,7 @@ interface WaBotCoordinatorOptions {
     readonly messageSecretStore: WaMessageSecretStore
     readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly emitBotChunk: (event: WaIncomingBotChunkEvent) => void
+    readonly generateSid: () => Promise<string>
 }
 
 function deriveFbidJid(jid: string, personaId: string): string {
@@ -116,19 +167,114 @@ function parseBotListResult(result: BinaryNode): readonly WaBotInfo[] {
             const jid = node.attrs.jid
             const personaId = node.attrs.persona_id
             if (typeof jid !== 'string' || typeof personaId !== 'string') continue
-            const countAttr = node.attrs.count
-            const count = typeof countAttr === 'string' ? Number.parseInt(countAttr, 10) : undefined
             out.push({
                 jid,
                 fbidJid: deriveFbidJid(jid, personaId),
                 personaId,
                 isDefault: defaultJid !== undefined && jid === defaultJid,
                 section: sectionName,
-                count: Number.isSafeInteger(count) ? count : undefined
+                count: parseOptionalInt(node.attrs.count)
             })
         }
     }
     return out
+}
+
+function parseBotProfilePrompts(promptsNode: BinaryNode | undefined): readonly WaBotProfilePrompt[] {
+    if (!promptsNode) return []
+    const children = getNodeChildrenByTag(promptsNode, 'prompt')
+    const out = new Array<WaBotProfilePrompt>(children.length)
+    let count = 0
+    for (let i = 0; i < children.length; i += 1) {
+        const promptNode = children[i]
+        const emoji = getNodeTextContent(findNodeChild(promptNode, 'emoji')) ?? ''
+        const text = getNodeTextContent(findNodeChild(promptNode, 'text')) ?? ''
+        out[count] = { emoji, text }
+        count += 1
+    }
+    out.length = count
+    return out
+}
+
+function parseBotProfileCommands(commandsNode: BinaryNode | undefined): {
+    readonly commands: readonly WaBotProfileCommand[]
+    readonly commandsDescription: string | null
+} {
+    if (!commandsNode) return { commands: [], commandsDescription: null }
+    const commandsDescription = getNodeTextContent(findNodeChild(commandsNode, 'description')) || null
+    const commandNodes = getNodeChildrenByTag(commandsNode, 'command')
+    const commands = new Array<WaBotProfileCommand>(commandNodes.length)
+    let count = 0
+    for (let i = 0; i < commandNodes.length; i += 1) {
+        const cmdNode = commandNodes[i]
+        const name = getNodeTextContent(findNodeChild(cmdNode, 'name')) ?? ''
+        const description = getNodeTextContent(findNodeChild(cmdNode, 'description')) ?? ''
+        commands[count] = { name, description }
+        count += 1
+    }
+    commands.length = count
+    return { commands, commandsDescription }
+}
+
+function parsePosingAsProfessional(
+    node: BinaryNode | undefined
+): WaBotPosingAsProfessional | null {
+    if (!node) return null
+    const type = node.attrs.type
+    if (type === 'unknown' || type === 'yes' || type === 'no') {
+        return type
+    }
+    return null
+}
+
+function parseBotProfileUsync(result: BinaryNode): WaBotProfileResult | null {
+    const userNodes = iterateUsyncUsers(result) ?? []
+    for (let i = 0; i < userNodes.length; i += 1) {
+        const userNode = userNodes[i]
+        const userContent = userNode.content
+        if (!Array.isArray(userContent)) continue
+        for (let j = 0; j < userContent.length; j += 1) {
+            const botNode = userContent[j]
+            if (botNode.tag !== WA_NODE_TAGS.BOT) continue
+            const errorNode = findNodeChild(botNode, WA_NODE_TAGS.ERROR)
+            if (errorNode) return null
+            const profileNode = findNodeChild(botNode, 'profile')
+            if (!profileNode) return null
+
+            const isMetaCreatedRaw = getNodeTextContent(
+                findNodeChild(profileNode, 'is_meta_created')
+            )
+            const creatorNode = findNodeChild(profileNode, 'creator')
+            const { commands, commandsDescription } = parseBotProfileCommands(
+                findNodeChild(profileNode, 'commands')
+            )
+
+            return {
+                name: getNodeTextContent(findNodeChild(profileNode, 'name')) || null,
+                attributes: getNodeTextContent(findNodeChild(profileNode, 'attributes')) || null,
+                description: getNodeTextContent(findNodeChild(profileNode, 'description')) || null,
+                category: getNodeTextContent(findNodeChild(profileNode, 'category')) || null,
+                isDefault:
+                    getNodeTextContent(findNodeChild(profileNode, 'default')) === 'true',
+                prompts: parseBotProfilePrompts(findNodeChild(profileNode, 'prompts')),
+                personaId: (profileNode.attrs.persona_id as string | undefined) ?? null,
+                commands,
+                commandsDescription,
+                isMetaCreated:
+                    isMetaCreatedRaw === undefined ? null : isMetaCreatedRaw === 'true',
+                creatorName: creatorNode
+                    ? getNodeTextContent(findNodeChild(creatorNode, 'name')) || null
+                    : null,
+                creatorProfileUrl: creatorNode
+                    ? getNodeTextContent(findNodeChild(creatorNode, 'profile_url')) || null
+                    : null,
+                posingAsProfessional: parsePosingAsProfessional(
+                    findNodeChild(profileNode, 'posing_as_professional')
+                )
+            }
+        }
+    }
+    return null
 }
 
 function normalizeBotJidToFbid(botJid: string): string {
@@ -148,7 +294,8 @@ export function createBotCoordinator(options: WaBotCoordinatorOptions): WaBotCoo
         messageStore,
         messageSecretStore,
         getCurrentCredentials,
-        emitBotChunk
+        emitBotChunk,
+        generateSid
     } = options
 
     return {
@@ -157,6 +304,26 @@ export function createBotCoordinator(options: WaBotCoordinatorOptions): WaBotCoo
             const result = await queryWithContext('bot.listBots', node)
             assertIqResult(result, 'bot.listBots')
             return parseBotListResult(result)
+        },
+
+        getBotProfile: async (jid, opts) => {
+            const sid = await generateSid()
+            const usyncNode = buildUsyncIq({
+                sid,
+                queryProtocolNodes: [buildGetBotProfileUsyncQueryNode()],
+                users: [
+                    {
+                        jid,
+                        content: buildBotProfileUsyncUserNodeContent(opts?.personaId)
+                    }
+                ]
+            })
+            const result = await queryWithContext('bot.getBotProfile', usyncNode, undefined, {
+                jid
+            })
+            assertIqResult(result, 'bot.getBotProfile')
+            logUsyncProtocolErrors(parseUsyncResultEnvelope(result), logger, 'bot.getBotProfile')
+            return parseBotProfileUsync(result)
         },
 
         sendPrompt: async (to, content, opts = {}) => {

--- a/src/client/coordinators/WaBusinessCoordinator.ts
+++ b/src/client/coordinators/WaBusinessCoordinator.ts
@@ -10,6 +10,7 @@ import type { Logger } from '@infra/log/types'
 import { PPS_UPLOAD_PATHS } from '@media/constants'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import type { WaMediaConn } from '@media/types'
+import { WA_NODE_TAGS } from '@protocol/nodes'
 import { WA_BUSINESS_NOTIFICATION_TAGS } from '@protocol/notification'
 import {
     buildCoverPhotoIq,
@@ -92,8 +93,8 @@ function parseUsyncVerifiedNames(result: BinaryNode): readonly WaVerifiedNameBat
         const userNode = userNodes[i]
         const jid = userNode.attrs.jid as string | undefined
         if (!jid) continue
-        const businessNode = findNodeChild(userNode, 'business')
-        const errorNode = businessNode ? findNodeChild(businessNode, 'error') : undefined
+        const businessNode = findNodeChild(userNode, WA_NODE_TAGS.BUSINESS)
+        const errorNode = businessNode ? findNodeChild(businessNode, WA_NODE_TAGS.ERROR) : undefined
         const vnNode =
             businessNode && !errorNode
                 ? findNodeChild(businessNode, WA_BUSINESS_NOTIFICATION_TAGS.VERIFIED_NAME)

--- a/src/client/coordinators/WaBusinessCoordinator.ts
+++ b/src/client/coordinators/WaBusinessCoordinator.ts
@@ -15,12 +15,24 @@ import {
     buildCoverPhotoIq,
     buildEditBusinessProfileIq,
     buildGetBusinessProfileIq,
+    buildGetBusinessUsyncQueryNode,
     buildGetVerifiedNameIq,
     type WaEditBusinessProfileInput
 } from '@transport/node/builders/business'
+import {
+    buildUsyncIq,
+    iterateUsyncUsers,
+    parseUsyncResultEnvelope
+} from '@transport/node/builders/usync'
 import { findNodeChild, getNodeChildren } from '@transport/node/helpers'
 import { assertIqResult } from '@transport/node/query'
+import { logUsyncProtocolErrors } from '@transport/node/usync'
 import type { BinaryNode } from '@transport/types'
+
+export interface WaVerifiedNameBatchEntry {
+    readonly jid: string
+    readonly verifiedName: WaVerifiedNameResult | null
+}
 
 export interface WaBusinessCoordinator {
     readonly getBusinessProfile: (
@@ -28,6 +40,9 @@ export interface WaBusinessCoordinator {
     ) => Promise<readonly WaBusinessProfileResult[]>
     readonly editBusinessProfile: (input: WaEditBusinessProfileInput) => Promise<void>
     readonly getVerifiedName: (jid: string) => Promise<WaVerifiedNameResult | null>
+    readonly getVerifiedNames: (
+        jids: readonly string[]
+    ) => Promise<readonly WaVerifiedNameBatchEntry[]>
     readonly updateCoverPhoto: (media: WaUploadMediaSource) => Promise<void>
     readonly deleteCoverPhoto: (id: string) => Promise<void>
 }
@@ -42,6 +57,7 @@ interface WaBusinessCoordinatorOptions {
     readonly mediaTransfer: WaMediaTransferClient
     readonly getMediaConn: () => Promise<WaMediaConn>
     readonly logger: Logger
+    readonly generateSid: () => Promise<string>
 }
 
 function parseBusinessProfiles(result: BinaryNode): readonly WaBusinessProfileResult[] {
@@ -68,10 +84,40 @@ function parseVerifiedName(result: BinaryNode): WaVerifiedNameResult | null {
     return parseVerifiedNameNode(vnNode)
 }
 
+function parseUsyncVerifiedNames(result: BinaryNode): readonly WaVerifiedNameBatchEntry[] {
+    const userNodes = iterateUsyncUsers(result) ?? []
+    const out = new Array<WaVerifiedNameBatchEntry>(userNodes.length)
+    let count = 0
+    for (let i = 0; i < userNodes.length; i += 1) {
+        const userNode = userNodes[i]
+        const jid = userNode.attrs.jid as string | undefined
+        if (!jid) continue
+        const businessNode = findNodeChild(userNode, 'business')
+        if (!businessNode) continue
+        const errorNode = findNodeChild(businessNode, 'error')
+        if (errorNode) {
+            out[count] = { jid, verifiedName: null }
+            count += 1
+            continue
+        }
+        const vnNode = findNodeChild(
+            businessNode,
+            WA_BUSINESS_NOTIFICATION_TAGS.VERIFIED_NAME
+        )
+        out[count] = {
+            jid,
+            verifiedName: vnNode ? parseVerifiedNameNode(vnNode) : null
+        }
+        count += 1
+    }
+    out.length = count
+    return out
+}
+
 export function createBusinessCoordinator(
     options: WaBusinessCoordinatorOptions
 ): WaBusinessCoordinator {
-    const { queryWithContext, mediaTransfer, getMediaConn, logger } = options
+    const { queryWithContext, mediaTransfer, getMediaConn, logger, generateSid } = options
 
     return {
         getBusinessProfile: async (jids) => {
@@ -97,6 +143,29 @@ export function createBusinessCoordinator(
             })
             assertIqResult(result, 'business.getVerifiedName')
             return parseVerifiedName(result)
+        },
+
+        getVerifiedNames: async (jids) => {
+            if (jids.length === 0) return []
+            const sid = await generateSid()
+            const usyncNode = buildUsyncIq({
+                sid,
+                queryProtocolNodes: [buildGetBusinessUsyncQueryNode()],
+                users: jids.map((jid) => ({ jid }))
+            })
+            const result = await queryWithContext(
+                'business.getVerifiedNames',
+                usyncNode,
+                undefined,
+                { count: jids.length }
+            )
+            assertIqResult(result, 'business.getVerifiedNames')
+            logUsyncProtocolErrors(
+                parseUsyncResultEnvelope(result),
+                logger,
+                'business.getVerifiedNames'
+            )
+            return parseUsyncVerifiedNames(result)
         },
 
         updateCoverPhoto: async (media) => {

--- a/src/client/coordinators/WaBusinessCoordinator.ts
+++ b/src/client/coordinators/WaBusinessCoordinator.ts
@@ -93,14 +93,11 @@ function parseUsyncVerifiedNames(result: BinaryNode): readonly WaVerifiedNameBat
         const jid = userNode.attrs.jid as string | undefined
         if (!jid) continue
         const businessNode = findNodeChild(userNode, 'business')
-        if (!businessNode) continue
-        const errorNode = findNodeChild(businessNode, 'error')
-        if (errorNode) {
-            out[count] = { jid, verifiedName: null }
-            count += 1
-            continue
-        }
-        const vnNode = findNodeChild(businessNode, WA_BUSINESS_NOTIFICATION_TAGS.VERIFIED_NAME)
+        const errorNode = businessNode ? findNodeChild(businessNode, 'error') : undefined
+        const vnNode =
+            businessNode && !errorNode
+                ? findNodeChild(businessNode, WA_BUSINESS_NOTIFICATION_TAGS.VERIFIED_NAME)
+                : undefined
         out[count] = {
             jid,
             verifiedName: vnNode ? parseVerifiedNameNode(vnNode) : null

--- a/src/client/coordinators/WaBusinessCoordinator.ts
+++ b/src/client/coordinators/WaBusinessCoordinator.ts
@@ -100,10 +100,7 @@ function parseUsyncVerifiedNames(result: BinaryNode): readonly WaVerifiedNameBat
             count += 1
             continue
         }
-        const vnNode = findNodeChild(
-            businessNode,
-            WA_BUSINESS_NOTIFICATION_TAGS.VERIFIED_NAME
-        )
+        const vnNode = findNodeChild(businessNode, WA_BUSINESS_NOTIFICATION_TAGS.VERIFIED_NAME)
         out[count] = {
             jid,
             verifiedName: vnNode ? parseVerifiedNameNode(vnNode) : null

--- a/src/client/coordinators/WaProfileCoordinator.ts
+++ b/src/client/coordinators/WaProfileCoordinator.ts
@@ -162,7 +162,7 @@ function parseUsyncProfiles(result: BinaryNode): readonly WaProfileInfo[] {
                 if (pictureId !== undefined) {
                     info.pictureId = pictureId
                 }
-            } else if (child.tag === 'status') {
+            } else if (child.tag === WA_NODE_TAGS.STATUS) {
                 const code = child.attrs.code as string | undefined
                 if (parseOptionalInt(code) === 401) {
                     info.status = ''
@@ -191,7 +191,7 @@ function parseUsyncDisappearingModes(result: BinaryNode): readonly WaDisappearin
 
         for (let j = 0; j < userContent.length; j += 1) {
             const child = userContent[j]
-            if (child.tag !== 'disappearing_mode') continue
+            if (child.tag !== WA_NODE_TAGS.DISAPPEARING_MODE) continue
 
             const errorNode = findNodeChild(child, WA_NODE_TAGS.ERROR)
             if (errorNode) continue
@@ -234,7 +234,7 @@ function parseUsyncTextStatuses(result: BinaryNode): readonly WaTextStatusResult
             lastUpdateTime: null
         }
 
-        const textStatusNode = findNodeChild(userNode, 'text_status')
+        const textStatusNode = findNodeChild(userNode, WA_NODE_TAGS.TEXT_STATUS)
         if (textStatusNode && !findNodeChild(textStatusNode, WA_NODE_TAGS.ERROR)) {
             const emojiNode = findNodeChild(textStatusNode, 'emoji')
             entry = {
@@ -268,7 +268,7 @@ function parseUsyncUsernames(result: BinaryNode): readonly WaUsernameResult[] {
         const jid = userNode.attrs.jid as string | undefined
         if (!jid) continue
 
-        const usernameNode = findNodeChild(userNode, 'username')
+        const usernameNode = findNodeChild(userNode, WA_NODE_TAGS.USERNAME)
         const hasUsernameError =
             usernameNode && findNodeChild(usernameNode, WA_NODE_TAGS.ERROR) !== undefined
         const username =

--- a/src/client/coordinators/WaProfileCoordinator.ts
+++ b/src/client/coordinators/WaProfileCoordinator.ts
@@ -96,9 +96,7 @@ export interface WaProfileCoordinator {
     readonly getDisappearingMode: (
         jids: readonly string[]
     ) => Promise<readonly WaDisappearingModeResult[]>
-    readonly getTextStatuses: (
-        jids: readonly string[]
-    ) => Promise<readonly WaTextStatusResult[]>
+    readonly getTextStatuses: (jids: readonly string[]) => Promise<readonly WaTextStatusResult[]>
     readonly setTextStatus: (input: WaSetTextStatusInput) => Promise<void>
     readonly getUsernames: (jids: readonly string[]) => Promise<readonly WaUsernameResult[]>
     readonly getOwnUsername: () => Promise<WaOwnUsernameResult>
@@ -451,12 +449,9 @@ export function createProfileCoordinator(
                 queryProtocolNodes: [buildGetTextStatusUsyncQueryNode()],
                 users: jids.map((jid) => ({ jid }))
             })
-            const result = await queryWithContext(
-                'profile.getTextStatuses',
-                usyncNode,
-                undefined,
-                { count: jids.length }
-            )
+            const result = await queryWithContext('profile.getTextStatuses', usyncNode, undefined, {
+                count: jids.length
+            })
             assertIqResult(result, 'profile.getTextStatuses')
             logUsyncProtocolErrors(
                 parseUsyncResultEnvelope(result),
@@ -483,18 +478,11 @@ export function createProfileCoordinator(
                 queryProtocolNodes: [buildGetUsernameUsyncQueryNode()],
                 users: jids.map((jid) => ({ jid }))
             })
-            const result = await queryWithContext(
-                'profile.getUsernames',
-                usyncNode,
-                undefined,
-                { count: jids.length }
-            )
+            const result = await queryWithContext('profile.getUsernames', usyncNode, undefined, {
+                count: jids.length
+            })
             assertIqResult(result, 'profile.getUsernames')
-            logUsyncProtocolErrors(
-                parseUsyncResultEnvelope(result),
-                logger,
-                'profile.getUsernames'
-            )
+            logUsyncProtocolErrors(parseUsyncResultEnvelope(result), logger, 'profile.getUsernames')
             return parseUsyncUsernames(result)
         },
 

--- a/src/client/coordinators/WaProfileCoordinator.ts
+++ b/src/client/coordinators/WaProfileCoordinator.ts
@@ -1,18 +1,28 @@
+import type { Logger } from '@infra/log/types'
 import { WA_NODE_TAGS } from '@protocol/nodes'
 import {
     buildDeleteProfilePictureIq,
     buildGetDisappearingModeUsyncQueryNode,
     buildGetProfilePictureIq,
     buildGetStatusUsyncQueryNodes,
+    buildGetTextStatusUsyncQueryNode,
+    buildGetUsernameUsyncQueryNode,
     buildSetProfilePictureIq,
     buildSetStatusIq,
     type WaProfilePictureType
 } from '@transport/node/builders/profile'
-import { buildUsyncIq, iterateUsyncUsers } from '@transport/node/builders/usync'
-import { findNodeChild } from '@transport/node/helpers'
+import {
+    buildUsyncIq,
+    iterateUsyncUsers,
+    parseUsyncResultEnvelope
+} from '@transport/node/builders/usync'
+import { findNodeChild, getNodeTextContent } from '@transport/node/helpers'
+import { dispatchMexQuery, type WaMexQuerySocket } from '@transport/node/mex/client'
+import { WA_MEX_PERSIST_IDS } from '@transport/node/mex/persist-ids'
 import { assertIqResult } from '@transport/node/query'
+import { logUsyncProtocolErrors } from '@transport/node/usync'
 import type { BinaryNode } from '@transport/types'
-import { TEXT_DECODER } from '@util/bytes'
+import { parseOptionalInt, parseOptionalSignedInt } from '@util/primitives'
 
 export interface WaProfilePictureResult {
     readonly url?: string
@@ -37,6 +47,38 @@ export interface WaDisappearingModeResult {
     readonly ephemeralityDisabled?: boolean
 }
 
+export interface WaTextStatusResult {
+    readonly jid: string
+    readonly text: string | null
+    readonly emoji: string | null
+    readonly ephemeralDurationSec: number | null
+    readonly lastUpdateTime: number | null
+}
+
+export interface WaSetTextStatusInput {
+    readonly text?: string | null
+    readonly emoji?: string | null
+    readonly ephemeralDurationSec?: number | null
+}
+
+export interface WaUsernameResult {
+    readonly jid: string
+    readonly username: string | null
+}
+
+export interface WaOwnUsernameResult {
+    readonly username: string | null
+    readonly state: string | null
+    readonly pin: string | null
+}
+
+export interface WaSetUsernameInput {
+    readonly username: string
+    readonly reserved?: boolean
+    readonly sessionId?: string
+    readonly source?: string
+}
+
 export interface WaProfileCoordinator {
     readonly getProfilePicture: (
         jid: string,
@@ -54,6 +96,14 @@ export interface WaProfileCoordinator {
     readonly getDisappearingMode: (
         jids: readonly string[]
     ) => Promise<readonly WaDisappearingModeResult[]>
+    readonly getTextStatuses: (
+        jids: readonly string[]
+    ) => Promise<readonly WaTextStatusResult[]>
+    readonly setTextStatus: (input: WaSetTextStatusInput) => Promise<void>
+    readonly getUsernames: (jids: readonly string[]) => Promise<readonly WaUsernameResult[]>
+    readonly getOwnUsername: () => Promise<WaOwnUsernameResult>
+    readonly setUsername: (input: WaSetUsernameInput) => Promise<boolean>
+    readonly deleteUsername: () => Promise<boolean>
 }
 
 interface WaProfileCoordinatorOptions {
@@ -65,6 +115,8 @@ interface WaProfileCoordinatorOptions {
         options?: { readonly useSystemId?: boolean }
     ) => Promise<BinaryNode>
     readonly generateSid: () => Promise<string>
+    readonly mexSocket: WaMexQuerySocket
+    readonly logger: Logger
 }
 
 function parseProfilePicture(result: BinaryNode): WaProfilePictureResult {
@@ -108,27 +160,16 @@ function parseUsyncProfiles(result: BinaryNode): readonly WaProfileInfo[] {
         for (let j = 0; j < userContent.length; j += 1) {
             const child = userContent[j]
             if (child.tag === WA_NODE_TAGS.PICTURE) {
-                const idAttr = child.attrs.id as string | undefined
-                if (idAttr) {
-                    const parsed = Number.parseInt(idAttr, 10)
-                    if (Number.isSafeInteger(parsed)) {
-                        info.pictureId = parsed
-                    }
+                const pictureId = parseOptionalInt(child.attrs.id as string | undefined)
+                if (pictureId !== undefined) {
+                    info.pictureId = pictureId
                 }
             } else if (child.tag === 'status') {
                 const code = child.attrs.code as string | undefined
-                if (code !== undefined && Number.parseInt(code, 10) === 401) {
+                if (parseOptionalInt(code) === 401) {
                     info.status = ''
                 } else {
-                    const content = child.content
-                    if (content instanceof Uint8Array) {
-                        const decoded = TEXT_DECODER.decode(content)
-                        info.status = decoded.length > 0 ? decoded : null
-                    } else if (typeof content === 'string') {
-                        info.status = content.length > 0 ? content : null
-                    } else {
-                        info.status = null
-                    }
+                    info.status = getNodeTextContent(child) || null
                 }
             }
         }
@@ -157,8 +198,8 @@ function parseUsyncDisappearingModes(result: BinaryNode): readonly WaDisappearin
             const errorNode = findNodeChild(child, WA_NODE_TAGS.ERROR)
             if (errorNode) continue
 
-            const duration = Number.parseInt((child.attrs.duration as string) ?? '0', 10)
-            const timestamp = Number.parseInt((child.attrs.t as string) ?? '0', 10)
+            const duration = parseOptionalInt(child.attrs.duration as string | undefined) ?? 0
+            const timestamp = parseOptionalInt(child.attrs.t as string | undefined) ?? 0
             const entry: {
                 duration: number
                 timestamp: number
@@ -177,6 +218,105 @@ function parseUsyncDisappearingModes(result: BinaryNode): readonly WaDisappearin
     return results
 }
 
+function parseUsyncTextStatuses(result: BinaryNode): readonly WaTextStatusResult[] {
+    const userNodes = iterateUsyncUsers(result) ?? []
+    const results = new Array<WaTextStatusResult>(userNodes.length)
+    let count = 0
+
+    for (let i = 0; i < userNodes.length; i += 1) {
+        const userNode = userNodes[i]
+        const jid = userNode.attrs.jid as string | undefined
+        if (!jid) continue
+
+        const userContent = userNode.content
+        if (!Array.isArray(userContent)) continue
+
+        for (let j = 0; j < userContent.length; j += 1) {
+            const child = userContent[j]
+            if (child.tag !== 'text_status') continue
+
+            const errorNode = findNodeChild(child, WA_NODE_TAGS.ERROR)
+            if (errorNode) continue
+
+            const emojiNode = findNodeChild(child, 'emoji')
+
+            results[count] = {
+                jid,
+                text: (child.attrs.text as string | undefined) ?? null,
+                emoji: emojiNode?.attrs.content ?? null,
+                ephemeralDurationSec:
+                    parseOptionalSignedInt(
+                        child.attrs.ephemeral_duration_sec as string | undefined
+                    ) ?? null,
+                lastUpdateTime:
+                    parseOptionalInt(child.attrs.last_update_time as string | undefined) ?? null
+            }
+            count += 1
+        }
+    }
+    results.length = count
+    return results
+}
+
+function parseUsyncUsernames(result: BinaryNode): readonly WaUsernameResult[] {
+    const userNodes = iterateUsyncUsers(result) ?? []
+    const results = new Array<WaUsernameResult>(userNodes.length)
+    let count = 0
+
+    for (let i = 0; i < userNodes.length; i += 1) {
+        const userNode = userNodes[i]
+        const jid = userNode.attrs.jid as string | undefined
+        if (!jid) continue
+
+        const userContent = userNode.content
+        if (!Array.isArray(userContent)) continue
+
+        for (let j = 0; j < userContent.length; j += 1) {
+            const child = userContent[j]
+            if (child.tag !== 'username') continue
+
+            const errorNode = findNodeChild(child, WA_NODE_TAGS.ERROR)
+            if (errorNode) continue
+
+            const username = getNodeTextContent(child) || null
+
+            results[count] = { jid, username }
+            count += 1
+        }
+    }
+    results.length = count
+    return results
+}
+
+function parseOwnUsernameMexResponse(data: unknown): WaOwnUsernameResult {
+    const root = (data ?? {}) as {
+        readonly xwa2_username_get?: {
+            readonly username_info?: {
+                readonly username?: string | null
+                readonly state?: string | null
+                readonly pin?: string | null
+            } | null
+        } | null
+    }
+    const info = root.xwa2_username_get?.username_info
+    return {
+        username: info?.username ?? null,
+        state: info?.state ?? null,
+        pin: info?.pin ?? null
+    }
+}
+
+function isMexSetUsernameSuccess(data: unknown): boolean {
+    const root = (data ?? {}) as {
+        readonly xwa2_username_set?: { readonly result?: string | null } | null
+    }
+    return root.xwa2_username_set?.result === 'SUCCESS'
+}
+
+function isMexNotFoundError(error: unknown): boolean {
+    return error instanceof Error && /\berrors?:\s*404\b/.test(error.message)
+}
+
 function parseUsyncStatus(result: BinaryNode): WaProfileStatusResult {
     const profiles = parseUsyncProfiles(result)
     if (profiles.length === 0) {
@@ -185,10 +325,28 @@ function parseUsyncStatus(result: BinaryNode): WaProfileStatusResult {
     return { status: profiles[0].status ?? null }
 }
 
+function buildTextStatusMutationInput(input: WaSetTextStatusInput): {
+    readonly text: string | null
+    readonly emoji: { readonly content: string } | undefined
+    readonly ephemeral_duration_sec: number
+} {
+    const text = input.text === '' ? null : (input.text ?? null)
+    const emoji = input.emoji ?? null
+    let ephemeralDurationSec = input.ephemeralDurationSec ?? 0
+    if (text === null && emoji === null && ephemeralDurationSec !== 0) {
+        ephemeralDurationSec = 0
+    }
+    return {
+        text,
+        emoji: emoji !== null ? { content: emoji } : undefined,
+        ephemeral_duration_sec: ephemeralDurationSec
+    }
+}
+
 export function createProfileCoordinator(
     options: WaProfileCoordinatorOptions
 ): WaProfileCoordinator {
-    const { queryWithContext, generateSid } = options
+    const { queryWithContext, generateSid, mexSocket, logger } = options
 
     return {
         getProfilePicture: async (jid, type, existingId) => {
@@ -231,6 +389,7 @@ export function createProfileCoordinator(
                 jid
             })
             assertIqResult(result, 'profile.getStatus')
+            logUsyncProtocolErrors(parseUsyncResultEnvelope(result), logger, 'profile.getStatus')
             return parseUsyncStatus(result)
         },
 
@@ -257,6 +416,7 @@ export function createProfileCoordinator(
                 count: jids.length
             })
             assertIqResult(result, 'profile.getProfiles')
+            logUsyncProtocolErrors(parseUsyncResultEnvelope(result), logger, 'profile.getProfiles')
             return parseUsyncProfiles(result)
         },
 
@@ -275,7 +435,109 @@ export function createProfileCoordinator(
                 { count: jids.length }
             )
             assertIqResult(result, 'profile.getDisappearingMode')
+            logUsyncProtocolErrors(
+                parseUsyncResultEnvelope(result),
+                logger,
+                'profile.getDisappearingMode'
+            )
             return parseUsyncDisappearingModes(result)
+        },
+
+        getTextStatuses: async (jids) => {
+            if (jids.length === 0) return []
+            const sid = await generateSid()
+            const usyncNode = buildUsyncIq({
+                sid,
+                queryProtocolNodes: [buildGetTextStatusUsyncQueryNode()],
+                users: jids.map((jid) => ({ jid }))
+            })
+            const result = await queryWithContext(
+                'profile.getTextStatuses',
+                usyncNode,
+                undefined,
+                { count: jids.length }
+            )
+            assertIqResult(result, 'profile.getTextStatuses')
+            logUsyncProtocolErrors(
+                parseUsyncResultEnvelope(result),
+                logger,
+                'profile.getTextStatuses'
+            )
+            return parseUsyncTextStatuses(result)
+        },
+
+        setTextStatus: async (input) => {
+            await dispatchMexQuery(mexSocket, {
+                docId: WA_MEX_PERSIST_IDS.UpdateTextStatus.docId,
+                clientDocId: WA_MEX_PERSIST_IDS.UpdateTextStatus.clientDocId,
+                opName: 'profile.setTextStatus',
+                variables: { input: buildTextStatusMutationInput(input) }
+            })
+        },
+
+        getUsernames: async (jids) => {
+            if (jids.length === 0) return []
+            const sid = await generateSid()
+            const usyncNode = buildUsyncIq({
+                sid,
+                queryProtocolNodes: [buildGetUsernameUsyncQueryNode()],
+                users: jids.map((jid) => ({ jid }))
+            })
+            const result = await queryWithContext(
+                'profile.getUsernames',
+                usyncNode,
+                undefined,
+                { count: jids.length }
+            )
+            assertIqResult(result, 'profile.getUsernames')
+            logUsyncProtocolErrors(
+                parseUsyncResultEnvelope(result),
+                logger,
+                'profile.getUsernames'
+            )
+            return parseUsyncUsernames(result)
+        },
+
+        getOwnUsername: async () => {
+            try {
+                const { data } = await dispatchMexQuery(mexSocket, {
+                    docId: WA_MEX_PERSIST_IDS.GetUsername.docId,
+                    clientDocId: WA_MEX_PERSIST_IDS.GetUsername.clientDocId,
+                    opName: 'profile.getOwnUsername',
+                    variables: {}
+                })
+                return parseOwnUsernameMexResponse(data)
+            } catch (error) {
+                if (isMexNotFoundError(error)) {
+                    return { username: null, state: null, pin: null }
+                }
+                throw error
+            }
+        },
+
+        setUsername: async (input) => {
+            const { data } = await dispatchMexQuery(mexSocket, {
+                docId: WA_MEX_PERSIST_IDS.SetUsername.docId,
+                clientDocId: WA_MEX_PERSIST_IDS.SetUsername.clientDocId,
+                opName: 'profile.setUsername',
+                variables: {
+                    input: input.username,
+                    reserved: input.reserved ?? false,
+                    session_id: input.sessionId ?? '',
+                    source: input.source ?? 'USER_INPUT'
+                }
+            })
+            return isMexSetUsernameSuccess(data)
+        },
+
+        deleteUsername: async () => {
+            const { data } = await dispatchMexQuery(mexSocket, {
+                docId: WA_MEX_PERSIST_IDS.SetUsername.docId,
+                clientDocId: WA_MEX_PERSIST_IDS.SetUsername.clientDocId,
+                opName: 'profile.deleteUsername',
+                variables: {}
+            })
+            return isMexSetUsernameSuccess(data)
         }
     }
 }

--- a/src/client/coordinators/WaProfileCoordinator.ts
+++ b/src/client/coordinators/WaProfileCoordinator.ts
@@ -226,31 +226,33 @@ function parseUsyncTextStatuses(result: BinaryNode): readonly WaTextStatusResult
         const jid = userNode.attrs.jid as string | undefined
         if (!jid) continue
 
-        const userContent = userNode.content
-        if (!Array.isArray(userContent)) continue
+        let entry: WaTextStatusResult = {
+            jid,
+            text: null,
+            emoji: null,
+            ephemeralDurationSec: null,
+            lastUpdateTime: null
+        }
 
-        for (let j = 0; j < userContent.length; j += 1) {
-            const child = userContent[j]
-            if (child.tag !== 'text_status') continue
-
-            const errorNode = findNodeChild(child, WA_NODE_TAGS.ERROR)
-            if (errorNode) continue
-
-            const emojiNode = findNodeChild(child, 'emoji')
-
-            results[count] = {
+        const textStatusNode = findNodeChild(userNode, 'text_status')
+        if (textStatusNode && !findNodeChild(textStatusNode, WA_NODE_TAGS.ERROR)) {
+            const emojiNode = findNodeChild(textStatusNode, 'emoji')
+            entry = {
                 jid,
-                text: (child.attrs.text as string | undefined) ?? null,
+                text: (textStatusNode.attrs.text as string | undefined) ?? null,
                 emoji: emojiNode?.attrs.content ?? null,
                 ephemeralDurationSec:
                     parseOptionalSignedInt(
-                        child.attrs.ephemeral_duration_sec as string | undefined
+                        textStatusNode.attrs.ephemeral_duration_sec as string | undefined
                     ) ?? null,
                 lastUpdateTime:
-                    parseOptionalInt(child.attrs.last_update_time as string | undefined) ?? null
+                    parseOptionalInt(textStatusNode.attrs.last_update_time as string | undefined) ??
+                    null
             }
-            count += 1
         }
+
+        results[count] = entry
+        count += 1
     }
     results.length = count
     return results
@@ -266,21 +268,14 @@ function parseUsyncUsernames(result: BinaryNode): readonly WaUsernameResult[] {
         const jid = userNode.attrs.jid as string | undefined
         if (!jid) continue
 
-        const userContent = userNode.content
-        if (!Array.isArray(userContent)) continue
+        const usernameNode = findNodeChild(userNode, 'username')
+        const hasUsernameError =
+            usernameNode && findNodeChild(usernameNode, WA_NODE_TAGS.ERROR) !== undefined
+        const username =
+            usernameNode && !hasUsernameError ? getNodeTextContent(usernameNode) || null : null
 
-        for (let j = 0; j < userContent.length; j += 1) {
-            const child = userContent[j]
-            if (child.tag !== 'username') continue
-
-            const errorNode = findNodeChild(child, WA_NODE_TAGS.ERROR)
-            if (errorNode) continue
-
-            const username = getNodeTextContent(child) || null
-
-            results[count] = { jid, username }
-            count += 1
-        }
+        results[count] = { jid, username }
+        count += 1
     }
     results.length = count
     return results

--- a/src/client/coordinators/__tests__/bot-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/bot-coordinator.test.ts
@@ -16,7 +16,8 @@ const decryptDepsStub = {
     messageStore: null as unknown as WaMessageStore,
     messageSecretStore: null as unknown as WaMessageSecretStore,
     getCurrentCredentials: () => null,
-    emitBotChunk: () => undefined
+    emitBotChunk: () => undefined,
+    generateSid: async () => 'test-sid'
 }
 
 function createIqResult(content?: readonly BinaryNode[]): BinaryNode {
@@ -368,4 +369,235 @@ test('bot coordinator sendPrompt mention path injects mention metadata into imag
     assert.equal(inner.imageMessage.caption, '@867051314767696 olha isso')
     assert.deepEqual(inner.imageMessage.contextInfo?.mentionedJid, [META_AI_FBID])
     assert.equal(inner.imageMessage.contextInfo?.botMessageSharingInfo?.botEntryPointOrigin, 30)
+})
+
+test('bot coordinator getBotProfile parses full profile node via usync', async () => {
+    const calls: BinaryNode[] = []
+    const coordinator = createBotCoordinator({
+        ...decryptDepsStub,
+        queryWithContext: async (_context, node) => {
+            calls.push(node)
+            return createIqResult([
+                {
+                    tag: 'usync',
+                    attrs: {},
+                    content: [
+                        { tag: 'result', attrs: {} },
+                        {
+                            tag: 'list',
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: 'user',
+                                    attrs: { jid: '13135550002@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: 'bot',
+                                            attrs: {},
+                                            content: [
+                                                {
+                                                    tag: 'profile',
+                                                    attrs: { persona_id: 'persona-1' },
+                                                    content: [
+                                                        { tag: 'name', attrs: {}, content: 'Meta AI' },
+                                                        {
+                                                            tag: 'attributes',
+                                                            attrs: {},
+                                                            content: 'attr-bytes'
+                                                        },
+                                                        {
+                                                            tag: 'description',
+                                                            attrs: {},
+                                                            content: 'AI assistant'
+                                                        },
+                                                        {
+                                                            tag: 'category',
+                                                            attrs: {},
+                                                            content: 'assistant'
+                                                        },
+                                                        { tag: 'default', attrs: {}, content: 'true' },
+                                                        {
+                                                            tag: 'prompts',
+                                                            attrs: {},
+                                                            content: [
+                                                                {
+                                                                    tag: 'prompt',
+                                                                    attrs: {},
+                                                                    content: [
+                                                                        {
+                                                                            tag: 'emoji',
+                                                                            attrs: {},
+                                                                            content: '✨'
+                                                                        },
+                                                                        {
+                                                                            tag: 'text',
+                                                                            attrs: {},
+                                                                            content: 'Tell me a story'
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            tag: 'commands',
+                                                            attrs: {},
+                                                            content: [
+                                                                {
+                                                                    tag: 'description',
+                                                                    attrs: {},
+                                                                    content: 'top-level desc'
+                                                                },
+                                                                {
+                                                                    tag: 'command',
+                                                                    attrs: {},
+                                                                    content: [
+                                                                        {
+                                                                            tag: 'name',
+                                                                            attrs: {},
+                                                                            content: 'imagine'
+                                                                        },
+                                                                        {
+                                                                            tag: 'description',
+                                                                            attrs: {},
+                                                                            content: 'generate image'
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            tag: 'is_meta_created',
+                                                            attrs: {},
+                                                            content: 'true'
+                                                        },
+                                                        {
+                                                            tag: 'creator',
+                                                            attrs: {},
+                                                            content: [
+                                                                {
+                                                                    tag: 'name',
+                                                                    attrs: {},
+                                                                    content: 'Meta'
+                                                                },
+                                                                {
+                                                                    tag: 'profile_url',
+                                                                    attrs: {},
+                                                                    content: 'https://meta.com'
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            tag: 'posing_as_professional',
+                                                            attrs: { type: 'no' }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+        },
+        buildMessageContent: async () => ({ message: {} }),
+        sendMessage: noopSendMessage
+    })
+
+    const result = await coordinator.getBotProfile('13135550002@s.whatsapp.net')
+
+    assert.ok(result)
+    assert.equal(result.name, 'Meta AI')
+    assert.equal(result.description, 'AI assistant')
+    assert.equal(result.category, 'assistant')
+    assert.equal(result.isDefault, true)
+    assert.deepEqual(result.prompts, [{ emoji: '✨', text: 'Tell me a story' }])
+    assert.equal(result.personaId, 'persona-1')
+    assert.deepEqual(result.commands, [{ name: 'imagine', description: 'generate image' }])
+    assert.equal(result.commandsDescription, 'top-level desc')
+    assert.equal(result.isMetaCreated, true)
+    assert.equal(result.creatorName, 'Meta')
+    assert.equal(result.creatorProfileUrl, 'https://meta.com')
+    assert.equal(result.posingAsProfessional, 'no')
+
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].attrs.xmlns, 'usync')
+})
+
+test('bot coordinator getBotProfile returns null when server replies with bot error', async () => {
+    const coordinator = createBotCoordinator({
+        ...decryptDepsStub,
+        queryWithContext: async () =>
+            createIqResult([
+                {
+                    tag: 'usync',
+                    attrs: {},
+                    content: [
+                        { tag: 'result', attrs: {} },
+                        {
+                            tag: 'list',
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: 'user',
+                                    attrs: { jid: '5511920387975@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: 'bot',
+                                            attrs: {},
+                                            content: [
+                                                {
+                                                    tag: 'error',
+                                                    attrs: { code: '400', text: 'bad-request' }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]),
+        buildMessageContent: async () => ({ message: {} }),
+        sendMessage: noopSendMessage
+    })
+
+    const result = await coordinator.getBotProfile('5511920387975@s.whatsapp.net')
+    assert.equal(result, null)
+})
+
+test('bot coordinator getBotProfile sends persona_id in user element when provided', async () => {
+    const captured: BinaryNode[] = []
+    const coordinator = createBotCoordinator({
+        ...decryptDepsStub,
+        queryWithContext: async (_context, node) => {
+            captured.push(node)
+            return createIqResult([
+                {
+                    tag: 'usync',
+                    attrs: {},
+                    content: [
+                        { tag: 'result', attrs: {} },
+                        { tag: 'list', attrs: {} }
+                    ]
+                }
+            ])
+        },
+        buildMessageContent: async () => ({ message: {} }),
+        sendMessage: noopSendMessage
+    })
+
+    await coordinator.getBotProfile('x@bot', { personaId: 'p-meta' })
+
+    const usyncNode = (captured[0].content as readonly BinaryNode[])[0]
+    const listNode = (usyncNode.content as readonly BinaryNode[]).find((n) => n.tag === 'list')!
+    const userNode = (listNode.content as readonly BinaryNode[])[0]
+    const userBotNode = (userNode.content as readonly BinaryNode[])[0]
+    assert.equal(userBotNode.tag, 'bot')
+    const profileNode = (userBotNode.content as readonly BinaryNode[])[0]
+    assert.equal(profileNode.tag, 'profile')
+    assert.equal(profileNode.attrs.persona_id, 'p-meta')
 })

--- a/src/client/coordinators/__tests__/bot-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/bot-coordinator.test.ts
@@ -399,7 +399,11 @@ test('bot coordinator getBotProfile parses full profile node via usync', async (
                                                     tag: 'profile',
                                                     attrs: { persona_id: 'persona-1' },
                                                     content: [
-                                                        { tag: 'name', attrs: {}, content: 'Meta AI' },
+                                                        {
+                                                            tag: 'name',
+                                                            attrs: {},
+                                                            content: 'Meta AI'
+                                                        },
                                                         {
                                                             tag: 'attributes',
                                                             attrs: {},
@@ -415,7 +419,11 @@ test('bot coordinator getBotProfile parses full profile node via usync', async (
                                                             attrs: {},
                                                             content: 'assistant'
                                                         },
-                                                        { tag: 'default', attrs: {}, content: 'true' },
+                                                        {
+                                                            tag: 'default',
+                                                            attrs: {},
+                                                            content: 'true'
+                                                        },
                                                         {
                                                             tag: 'prompts',
                                                             attrs: {},
@@ -432,7 +440,8 @@ test('bot coordinator getBotProfile parses full profile node via usync', async (
                                                                         {
                                                                             tag: 'text',
                                                                             attrs: {},
-                                                                            content: 'Tell me a story'
+                                                                            content:
+                                                                                'Tell me a story'
                                                                         }
                                                                     ]
                                                                 }
@@ -459,7 +468,8 @@ test('bot coordinator getBotProfile parses full profile node via usync', async (
                                                                         {
                                                                             tag: 'description',
                                                                             attrs: {},
-                                                                            content: 'generate image'
+                                                                            content:
+                                                                                'generate image'
                                                                         }
                                                                     ]
                                                                 }

--- a/src/client/coordinators/__tests__/business-profile-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/business-profile-coordinator.test.ts
@@ -31,6 +31,7 @@ function makeBusinessCoordinator(overrides: Partial<CoordinatorDeps> = {}) {
             throw new Error('getMediaConn not stubbed in this test')
         },
         logger: createNoopLogger('error'),
+        generateSid: async () => 'test-sid',
         ...overrides
     })
 }
@@ -378,6 +379,104 @@ test('business coordinator returns null for missing verified name', async () => 
 
     const result = await coordinator.getVerifiedName('5511@s.whatsapp.net')
     assert.equal(result, null)
+})
+
+test('business coordinator gets verified names in batch via usync', async () => {
+    const certBytes = buildVerifiedNameCertBytes({
+        serial: 99,
+        issuer: 'smb:wa',
+        verifiedName: 'Acme Co'
+    })
+
+    const calls: Array<{ readonly context: string; readonly node: BinaryNode }> = []
+    const coordinator = makeBusinessCoordinator({
+        queryWithContext: async (context, node) => {
+            calls.push({ context, node })
+            return createIqResult([
+                {
+                    tag: 'usync',
+                    attrs: {},
+                    content: [
+                        { tag: 'result', attrs: {} },
+                        {
+                            tag: 'list',
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: 'user',
+                                    attrs: { jid: 'a@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: 'business',
+                                            attrs: {},
+                                            content: [
+                                                {
+                                                    tag: 'verified_name',
+                                                    attrs: { verified_level: 'high' },
+                                                    content: certBytes
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    tag: 'user',
+                                    attrs: { jid: 'b@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: 'business',
+                                            attrs: {},
+                                            content: [
+                                                {
+                                                    tag: 'error',
+                                                    attrs: { code: '404', text: 'not-found' }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    tag: 'user',
+                                    attrs: { jid: 'c@s.whatsapp.net' },
+                                    content: [{ tag: 'business', attrs: {} }]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+        }
+    })
+
+    const result = await coordinator.getVerifiedNames([
+        'a@s.whatsapp.net',
+        'b@s.whatsapp.net',
+        'c@s.whatsapp.net'
+    ])
+
+    assert.equal(result.length, 3)
+    assert.equal(result[0].jid, 'a@s.whatsapp.net')
+    assert.equal(result[0].verifiedName?.name, 'Acme Co')
+    assert.equal(result[0].verifiedName?.serial, '99')
+    assert.deepEqual(result[1], { jid: 'b@s.whatsapp.net', verifiedName: null })
+    assert.deepEqual(result[2], { jid: 'c@s.whatsapp.net', verifiedName: null })
+
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].context, 'business.getVerifiedNames')
+    assert.equal(calls[0].node.attrs.xmlns, 'usync')
+})
+
+test('business coordinator returns empty array for empty jids batch', async () => {
+    const calls: string[] = []
+    const coordinator = makeBusinessCoordinator({
+        queryWithContext: async (context) => {
+            calls.push(context)
+            return createIqResult()
+        }
+    })
+    const result = await coordinator.getVerifiedNames([])
+    assert.equal(result.length, 0)
+    assert.equal(calls.length, 0)
 })
 
 test('business coordinator uploads cover photo bytes and finalizes via IQ', async () => {

--- a/src/client/coordinators/__tests__/profile-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/profile-coordinator.test.ts
@@ -551,7 +551,7 @@ test('profile coordinator gets text statuses via usync', async () => {
     assert.equal(calls[0].node.attrs.xmlns, 'usync')
 })
 
-test('profile coordinator skips text_status entries with error nodes', async () => {
+test('profile coordinator emits null text_status entry on error nodes', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
@@ -591,7 +591,15 @@ test('profile coordinator skips text_status entries with error nodes', async () 
     })
 
     const results = await coordinator.getTextStatuses(['a@s.whatsapp.net'])
-    assert.equal(results.length, 0)
+    assert.deepEqual(results, [
+        {
+            jid: 'a@s.whatsapp.net',
+            text: null,
+            emoji: null,
+            ephemeralDurationSec: null,
+            lastUpdateTime: null
+        }
+    ])
 })
 
 test('profile coordinator returns empty text statuses for empty jids', async () => {
@@ -767,9 +775,10 @@ test('profile coordinator gets usernames via usync', async () => {
         'c@s.whatsapp.net'
     ])
 
-    assert.equal(results.length, 2)
+    assert.equal(results.length, 3)
     assert.deepEqual(results[0], { jid: 'a@s.whatsapp.net', username: 'alice' })
     assert.deepEqual(results[1], { jid: 'b@s.whatsapp.net', username: null })
+    assert.deepEqual(results[2], { jid: 'c@s.whatsapp.net', username: null })
     assert.equal(calls.length, 1)
     assert.equal(calls[0].context, 'profile.getUsernames')
 })

--- a/src/client/coordinators/__tests__/profile-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/profile-coordinator.test.ts
@@ -529,10 +529,7 @@ test('profile coordinator gets text statuses via usync', async () => {
         }
     })
 
-    const results = await coordinator.getTextStatuses([
-        'a@s.whatsapp.net',
-        'b@s.whatsapp.net'
-    ])
+    const results = await coordinator.getTextStatuses(['a@s.whatsapp.net', 'b@s.whatsapp.net'])
 
     assert.equal(results.length, 2)
     assert.deepEqual(results[0], {

--- a/src/client/coordinators/__tests__/profile-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/profile-coordinator.test.ts
@@ -2,9 +2,10 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import { createProfileCoordinator } from '@client/coordinators/WaProfileCoordinator'
+import { createNoopLogger } from '@infra/log/types'
 import { WA_XMLNS } from '@protocol/constants'
 import type { BinaryNode } from '@transport/types'
-import { TEXT_ENCODER } from '@util/bytes'
+import { TEXT_DECODER, TEXT_ENCODER } from '@util/bytes'
 
 function createIqResult(content?: readonly BinaryNode[]): BinaryNode {
     return {
@@ -23,6 +24,8 @@ test('profile coordinator gets profile picture url', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node, _timeoutMs, contextData) => {
             calls.push({ context, node, contextData })
             return createIqResult([
@@ -61,6 +64,8 @@ test('profile coordinator gets profile picture url', async () => {
 test('profile coordinator returns empty result when no picture node', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async () => createIqResult()
     })
 
@@ -76,6 +81,8 @@ test('profile coordinator gets full image picture with existing id', async () =>
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node) => {
             calls.push({ context, node })
             return createIqResult([
@@ -109,6 +116,8 @@ test('profile coordinator sets profile picture and returns id', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node, _timeoutMs, contextData) => {
             calls.push({ context, node, contextData })
             return createIqResult([
@@ -140,6 +149,8 @@ test('profile coordinator sets group profile picture with target jid', async () 
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (_context, node) => {
             calls.push({ node })
             return createIqResult([{ tag: 'picture', attrs: { id: '111' } }])
@@ -159,6 +170,8 @@ test('profile coordinator deletes profile picture', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node) => {
             calls.push({ context, node })
             return createIqResult()
@@ -182,6 +195,8 @@ test('profile coordinator gets status via usync', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node) => {
             calls.push({ context, node })
             return createIqResult([
@@ -224,6 +239,8 @@ test('profile coordinator gets status via usync', async () => {
 test('profile coordinator returns null status when no content', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async () =>
             createIqResult([
                 {
@@ -254,6 +271,8 @@ test('profile coordinator returns null status when no content', async () => {
 test('profile coordinator returns empty string for status code 401', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async () =>
             createIqResult([
                 {
@@ -289,6 +308,8 @@ test('profile coordinator gets multiple profiles via usync', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node) => {
             calls.push({ context, node })
             return createIqResult([
@@ -350,6 +371,8 @@ test('profile coordinator sets status text', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node) => {
             calls.push({ context, node })
             return createIqResult()
@@ -370,6 +393,8 @@ test('profile coordinator sets status text', async () => {
 test('profile coordinator gets disappearing mode via usync', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async () =>
             createIqResult([
                 {
@@ -427,6 +452,8 @@ test('profile coordinator returns empty disappearing mode for empty jids', async
     const calls: string[] = []
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context) => {
             calls.push(context)
             return createIqResult()
@@ -438,11 +465,543 @@ test('profile coordinator returns empty disappearing mode for empty jids', async
     assert.equal(calls.length, 0)
 })
 
+test('profile coordinator gets text statuses via usync', async () => {
+    const calls: Array<{
+        readonly context: string
+        readonly node: BinaryNode
+    }> = []
+
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
+        queryWithContext: async (context, node) => {
+            calls.push({ context, node })
+            return createIqResult([
+                {
+                    tag: 'usync',
+                    attrs: {},
+                    content: [
+                        { tag: 'result', attrs: {} },
+                        {
+                            tag: 'list',
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: 'user',
+                                    attrs: { jid: 'a@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: 'text_status',
+                                            attrs: {
+                                                text: 'feeling great',
+                                                ephemeral_duration_sec: '3600',
+                                                last_update_time: '1700000000'
+                                            },
+                                            content: [
+                                                {
+                                                    tag: 'emoji',
+                                                    attrs: { content: '🚀' }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    tag: 'user',
+                                    attrs: { jid: 'b@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: 'text_status',
+                                            attrs: {
+                                                text: ' ',
+                                                ephemeral_duration_sec: '-1',
+                                                last_update_time: '1776181230'
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+        }
+    })
+
+    const results = await coordinator.getTextStatuses([
+        'a@s.whatsapp.net',
+        'b@s.whatsapp.net'
+    ])
+
+    assert.equal(results.length, 2)
+    assert.deepEqual(results[0], {
+        jid: 'a@s.whatsapp.net',
+        text: 'feeling great',
+        emoji: '🚀',
+        ephemeralDurationSec: 3600,
+        lastUpdateTime: 1700000000
+    })
+    assert.deepEqual(results[1], {
+        jid: 'b@s.whatsapp.net',
+        text: ' ',
+        emoji: null,
+        ephemeralDurationSec: -1,
+        lastUpdateTime: 1776181230
+    })
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].context, 'profile.getTextStatuses')
+    assert.equal(calls[0].node.attrs.xmlns, 'usync')
+})
+
+test('profile coordinator skips text_status entries with error nodes', async () => {
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
+        queryWithContext: async () =>
+            createIqResult([
+                {
+                    tag: 'usync',
+                    attrs: {},
+                    content: [
+                        { tag: 'result', attrs: {} },
+                        {
+                            tag: 'list',
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: 'user',
+                                    attrs: { jid: 'a@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: 'text_status',
+                                            attrs: {},
+                                            content: [
+                                                {
+                                                    tag: 'error',
+                                                    attrs: { code: '404', text: 'not-found' }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+    })
+
+    const results = await coordinator.getTextStatuses(['a@s.whatsapp.net'])
+    assert.equal(results.length, 0)
+})
+
+test('profile coordinator returns empty text statuses for empty jids', async () => {
+    const calls: string[] = []
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
+        queryWithContext: async (context) => {
+            calls.push(context)
+            return createIqResult()
+        }
+    })
+
+    const results = await coordinator.getTextStatuses([])
+    assert.equal(results.length, 0)
+    assert.equal(calls.length, 0)
+})
+
+test('profile coordinator sets text status via mex', async () => {
+    const captured: BinaryNode[] = []
+    const mexSocket = {
+        query: async (node: BinaryNode): Promise<BinaryNode> => {
+            captured.push(node)
+            return {
+                tag: 'iq',
+                attrs: { type: 'result' },
+                content: [
+                    {
+                        tag: 'result',
+                        attrs: {},
+                        content: TEXT_ENCODER.encode(
+                            JSON.stringify({
+                                data: { xwa2_update_text_status: { result: 'OK' } }
+                            })
+                        )
+                    }
+                ]
+            }
+        }
+    }
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        queryWithContext: async () => createIqResult(),
+        mexSocket
+    })
+
+    await coordinator.setTextStatus({
+        text: 'feeling great',
+        emoji: '🚀',
+        ephemeralDurationSec: 3600
+    })
+
+    assert.equal(captured.length, 1)
+    assert.equal(captured[0].attrs.xmlns, 'w:mex')
+    const queryNode = (captured[0].content as readonly BinaryNode[])[0]
+    assert.equal(queryNode.tag, 'query')
+    assert.equal(queryNode.attrs.query_id, '9152604461510864')
+    const body = JSON.parse(
+        typeof queryNode.content === 'string'
+            ? queryNode.content
+            : TEXT_DECODER.decode(queryNode.content as Uint8Array)
+    )
+    assert.deepEqual(body.variables, {
+        input: {
+            text: 'feeling great',
+            emoji: { content: '🚀' },
+            ephemeral_duration_sec: 3600
+        }
+    })
+})
+
+test('profile coordinator setTextStatus normalizes empty inputs to clear payload', async () => {
+    const captured: BinaryNode[] = []
+    const mexSocket = {
+        query: async (node: BinaryNode): Promise<BinaryNode> => {
+            captured.push(node)
+            return {
+                tag: 'iq',
+                attrs: { type: 'result' },
+                content: [
+                    {
+                        tag: 'result',
+                        attrs: {},
+                        content: TEXT_ENCODER.encode(JSON.stringify({ data: null }))
+                    }
+                ]
+            }
+        }
+    }
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        queryWithContext: async () => createIqResult(),
+        mexSocket
+    })
+
+    await coordinator.setTextStatus({ text: '', ephemeralDurationSec: 3600 })
+
+    const queryNode = (captured[0].content as readonly BinaryNode[])[0]
+    const body = JSON.parse(
+        typeof queryNode.content === 'string'
+            ? queryNode.content
+            : TEXT_DECODER.decode(queryNode.content as Uint8Array)
+    )
+    assert.deepEqual(body.variables, {
+        input: { text: null, ephemeral_duration_sec: 0 }
+    })
+})
+
+test('profile coordinator gets usernames via usync', async () => {
+    const calls: Array<{ readonly context: string; readonly node: BinaryNode }> = []
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
+        queryWithContext: async (context, node) => {
+            calls.push({ context, node })
+            return createIqResult([
+                {
+                    tag: 'usync',
+                    attrs: {},
+                    content: [
+                        { tag: 'result', attrs: {} },
+                        {
+                            tag: 'list',
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: 'user',
+                                    attrs: { jid: 'a@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: 'username',
+                                            attrs: {},
+                                            content: TEXT_ENCODER.encode('alice')
+                                        }
+                                    ]
+                                },
+                                {
+                                    tag: 'user',
+                                    attrs: { jid: 'b@s.whatsapp.net' },
+                                    content: [{ tag: 'username', attrs: {} }]
+                                },
+                                {
+                                    tag: 'user',
+                                    attrs: { jid: 'c@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: 'username',
+                                            attrs: {},
+                                            content: [
+                                                {
+                                                    tag: 'error',
+                                                    attrs: { code: '404', text: 'not-found' }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+        }
+    })
+
+    const results = await coordinator.getUsernames([
+        'a@s.whatsapp.net',
+        'b@s.whatsapp.net',
+        'c@s.whatsapp.net'
+    ])
+
+    assert.equal(results.length, 2)
+    assert.deepEqual(results[0], { jid: 'a@s.whatsapp.net', username: 'alice' })
+    assert.deepEqual(results[1], { jid: 'b@s.whatsapp.net', username: null })
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].context, 'profile.getUsernames')
+})
+
+test('profile coordinator returns empty usernames for empty jids', async () => {
+    const calls: string[] = []
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
+        queryWithContext: async (context) => {
+            calls.push(context)
+            return createIqResult()
+        }
+    })
+    const results = await coordinator.getUsernames([])
+    assert.equal(results.length, 0)
+    assert.equal(calls.length, 0)
+})
+
+test('profile coordinator getOwnUsername parses mex payload', async () => {
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        queryWithContext: async () => createIqResult(),
+        mexSocket: {
+            query: async (): Promise<BinaryNode> => ({
+                tag: 'iq',
+                attrs: { type: 'result' },
+                content: [
+                    {
+                        tag: 'result',
+                        attrs: {},
+                        content: TEXT_ENCODER.encode(
+                            JSON.stringify({
+                                data: {
+                                    xwa2_username_get: {
+                                        username_info: {
+                                            username: 'me',
+                                            state: 'OWNED',
+                                            pin: '1234'
+                                        }
+                                    }
+                                }
+                            })
+                        )
+                    }
+                ]
+            })
+        }
+    })
+    const result = await coordinator.getOwnUsername()
+    assert.deepEqual(result, { username: 'me', state: 'OWNED', pin: '1234' })
+})
+
+test('profile coordinator getOwnUsername swallows 404 GraphQL errors', async () => {
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        queryWithContext: async () => createIqResult(),
+        mexSocket: {
+            query: async (): Promise<BinaryNode> => ({
+                tag: 'iq',
+                attrs: { type: 'result' },
+                content: [
+                    {
+                        tag: 'result',
+                        attrs: {},
+                        content: TEXT_ENCODER.encode(
+                            JSON.stringify({
+                                errors: [
+                                    {
+                                        message: 'Not Found',
+                                        path: ['xwa2_username_get'],
+                                        extensions: { error_code: 404 }
+                                    }
+                                ]
+                            })
+                        )
+                    }
+                ]
+            })
+        }
+    })
+    const result = await coordinator.getOwnUsername()
+    assert.deepEqual(result, { username: null, state: null, pin: null })
+})
+
+test('profile coordinator getOwnUsername returns nulls when info missing', async () => {
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        queryWithContext: async () => createIqResult(),
+        mexSocket: {
+            query: async (): Promise<BinaryNode> => ({
+                tag: 'iq',
+                attrs: { type: 'result' },
+                content: [
+                    {
+                        tag: 'result',
+                        attrs: {},
+                        content: TEXT_ENCODER.encode(
+                            JSON.stringify({ data: { xwa2_username_get: { username_info: null } } })
+                        )
+                    }
+                ]
+            })
+        }
+    })
+    const result = await coordinator.getOwnUsername()
+    assert.deepEqual(result, { username: null, state: null, pin: null })
+})
+
+test('profile coordinator setUsername sends mex variables with defaults', async () => {
+    const captured: BinaryNode[] = []
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        queryWithContext: async () => createIqResult(),
+        mexSocket: {
+            query: async (node: BinaryNode): Promise<BinaryNode> => {
+                captured.push(node)
+                return {
+                    tag: 'iq',
+                    attrs: { type: 'result' },
+                    content: [
+                        {
+                            tag: 'result',
+                            attrs: {},
+                            content: TEXT_ENCODER.encode(
+                                JSON.stringify({
+                                    data: { xwa2_username_set: { result: 'SUCCESS' } }
+                                })
+                            )
+                        }
+                    ]
+                }
+            }
+        }
+    })
+
+    const ok = await coordinator.setUsername({ username: 'newhandle' })
+    assert.equal(ok, true)
+    const queryNode = (captured[0].content as readonly BinaryNode[])[0]
+    assert.equal(queryNode.attrs.query_id, '25757341163897635')
+    const body = JSON.parse(
+        typeof queryNode.content === 'string'
+            ? queryNode.content
+            : TEXT_DECODER.decode(queryNode.content as Uint8Array)
+    )
+    assert.deepEqual(body.variables, {
+        input: 'newhandle',
+        reserved: false,
+        session_id: '',
+        source: 'USER_INPUT'
+    })
+})
+
+test('profile coordinator setUsername returns false on non-SUCCESS result', async () => {
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        queryWithContext: async () => createIqResult(),
+        mexSocket: {
+            query: async (): Promise<BinaryNode> => ({
+                tag: 'iq',
+                attrs: { type: 'result' },
+                content: [
+                    {
+                        tag: 'result',
+                        attrs: {},
+                        content: TEXT_ENCODER.encode(
+                            JSON.stringify({ data: { xwa2_username_set: { result: 'TAKEN' } } })
+                        )
+                    }
+                ]
+            })
+        }
+    })
+    assert.equal(await coordinator.setUsername({ username: 'x' }), false)
+})
+
+test('profile coordinator deleteUsername sends empty variables', async () => {
+    const captured: BinaryNode[] = []
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        queryWithContext: async () => createIqResult(),
+        mexSocket: {
+            query: async (node: BinaryNode): Promise<BinaryNode> => {
+                captured.push(node)
+                return {
+                    tag: 'iq',
+                    attrs: { type: 'result' },
+                    content: [
+                        {
+                            tag: 'result',
+                            attrs: {},
+                            content: TEXT_ENCODER.encode(
+                                JSON.stringify({
+                                    data: { xwa2_username_set: { result: 'SUCCESS' } }
+                                })
+                            )
+                        }
+                    ]
+                }
+            }
+        }
+    })
+
+    const ok = await coordinator.deleteUsername()
+    assert.equal(ok, true)
+    const queryNode = (captured[0].content as readonly BinaryNode[])[0]
+    assert.equal(queryNode.attrs.query_id, '25757341163897635')
+    const body = JSON.parse(
+        typeof queryNode.content === 'string'
+            ? queryNode.content
+            : TEXT_DECODER.decode(queryNode.content as Uint8Array)
+    )
+    assert.deepEqual(body.variables, {})
+})
+
 test('profile coordinator returns empty array for empty jids list', async () => {
     const calls: Array<{ readonly context: string }> = []
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context) => {
             calls.push({ context })
             return createIqResult()

--- a/src/client/events/business.ts
+++ b/src/client/events/business.ts
@@ -22,7 +22,7 @@ import {
     getNodeTextContent
 } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
-import { longToNumber, parseOptionalInt } from '@util/primitives'
+import { parseOptionalInt } from '@util/primitives'
 
 interface WaParseBusinessNotificationResult {
     readonly events: readonly WaBusinessEvent[]
@@ -43,7 +43,7 @@ function parseCertificateContent(
             name: details.verifiedName ?? undefined,
             serial:
                 details.serial !== null && details.serial !== undefined
-                    ? String(longToNumber(details.serial))
+                    ? details.serial.toString()
                     : undefined,
             isApi: details.issuer === VN_ISSUER_API,
             isSmb: details.issuer === VN_ISSUER_SMB

--- a/src/client/events/business.ts
+++ b/src/client/events/business.ts
@@ -278,7 +278,7 @@ function parseCollectionUpdates(catalogNode: BinaryNode): readonly WaBusinessCol
         } = { id }
         const statusInfo = findNodeChild(collection, 'status_info')
         if (statusInfo) {
-            const statusNode = findNodeChild(statusInfo, 'status')
+            const statusNode = findNodeChild(statusInfo, WA_NODE_TAGS.STATUS)
             if (statusNode) {
                 const text = getNodeTextContent(statusNode)
                 if (text) entry.reviewStatus = text

--- a/src/client/events/devices.ts
+++ b/src/client/events/devices.ts
@@ -2,6 +2,7 @@ import { parseSignalAddressFromJid } from '@protocol/jid'
 import { WA_NODE_TAGS } from '@protocol/nodes'
 import { findNodeChild, getNodeChildrenByTag } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
+import { parseOptionalInt } from '@util/primitives'
 
 export const DEVICE_NOTIFICATION_ACTIONS = Object.freeze({
     ADD: 'add',
@@ -72,15 +73,7 @@ export function parseDeviceNotification(node: BinaryNode): DeviceNotification | 
                 continue
             }
 
-            const keyIndexAttr = deviceNode.attrs['key-index']
-            const parsedKeyIndex =
-                keyIndexAttr === undefined ? null : Number.parseInt(keyIndexAttr, 10)
-            const keyIndex =
-                parsedKeyIndex !== null &&
-                Number.isSafeInteger(parsedKeyIndex) &&
-                parsedKeyIndex >= 0
-                    ? parsedKeyIndex
-                    : null
+            const keyIndex = parseOptionalInt(deviceNode.attrs['key-index']) ?? null
 
             devices[devices.length] = {
                 deviceId,

--- a/src/client/events/dirty.ts
+++ b/src/client/events/dirty.ts
@@ -371,11 +371,7 @@ async function runSyncQuery(
         args.contextData
     )
     assertIqResult(response, args.assertContext ?? args.queryContext)
-    logUsyncProtocolErrors(
-        parseUsyncResultEnvelope(response),
-        runtime.logger,
-        args.queryContext
-    )
+    logUsyncProtocolErrors(parseUsyncResultEnvelope(response), runtime.logger, args.queryContext)
     runtime.logger.debug(args.logMessage, args.contextData)
 }
 

--- a/src/client/events/dirty.ts
+++ b/src/client/events/dirty.ts
@@ -19,10 +19,12 @@ import {
     buildNewsletterMetadataSyncIq
 } from '@transport/node/builders/account-sync'
 import { buildGetPrivacySettingsIq } from '@transport/node/builders/privacy'
+import { parseUsyncResultEnvelope } from '@transport/node/builders/usync'
 import { getNodeChildrenTags } from '@transport/node/helpers'
 import { assertIqResult, parseIqError } from '@transport/node/query'
+import { logUsyncProtocolErrors } from '@transport/node/usync'
 import type { BinaryNode } from '@transport/types'
-import { toError } from '@util/primitives'
+import { parseOptionalInt, toError } from '@util/primitives'
 
 export interface WaDirtyBit {
     readonly type: string
@@ -50,8 +52,8 @@ const ACCOUNT_SYNC_PROTOCOL_SET = new Set<string>(WA_ACCOUNT_SYNC_PROTOCOLS)
 
 function parseDirtyBitNode(node: BinaryNode, logger: Logger): WaDirtyBit | null {
     const type = node.attrs.type
-    const timestamp = Number.parseInt(node.attrs.timestamp ?? '', 10)
-    if (!type || !Number.isFinite(timestamp)) {
+    const timestamp = parseOptionalInt(node.attrs.timestamp)
+    if (!type || timestamp === undefined) {
         logger.warn('received invalid dirty bit node', {
             type,
             timestamp: node.attrs.timestamp
@@ -369,6 +371,11 @@ async function runSyncQuery(
         args.contextData
     )
     assertIqResult(response, args.assertContext ?? args.queryContext)
+    logUsyncProtocolErrors(
+        parseUsyncResultEnvelope(response),
+        runtime.logger,
+        args.queryContext
+    )
     runtime.logger.debug(args.logMessage, args.contextData)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,10 +155,7 @@ export type {
 } from '@client/coordinators/WaProfileCoordinator'
 export type { WaProfilePictureType } from '@transport/node/builders/profile'
 export { parseUsyncResultEnvelope } from '@transport/node/builders/usync'
-export type {
-    WaUsyncProtocolError,
-    WaUsyncResultEnvelope
-} from '@transport/node/builders/usync'
+export type { WaUsyncProtocolError, WaUsyncResultEnvelope } from '@transport/node/builders/usync'
 export type {
     WaSendStatusInput,
     WaStatusCoordinator

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,13 +63,21 @@ export type {
 export type {
     WaBotCoordinator,
     WaBotInfo,
-    WaBotPromptOptions
+    WaBotPosingAsProfessional,
+    WaBotProfileCommand,
+    WaBotProfilePrompt,
+    WaBotProfileResult,
+    WaBotPromptOptions,
+    WaGetBotProfileOptions
 } from '@client/coordinators/WaBotCoordinator'
 export type {
     WaBroadcastListCoordinator,
     WaSendBroadcastListMessageInput
 } from '@client/coordinators/WaBroadcastListCoordinator'
-export type { WaBusinessCoordinator } from '@client/coordinators/WaBusinessCoordinator'
+export type {
+    WaBusinessCoordinator,
+    WaVerifiedNameBatchEntry
+} from '@client/coordinators/WaBusinessCoordinator'
 export type { WaUploadMediaSource } from '@client/media'
 export type { WaEditBusinessProfileInput } from '@transport/node/builders/business'
 export type {
@@ -135,12 +143,22 @@ export type {
 } from '@client/coordinators/WaPrivacyCoordinator'
 export type {
     WaDisappearingModeResult,
+    WaOwnUsernameResult,
     WaProfileCoordinator,
     WaProfileInfo,
     WaProfilePictureResult,
-    WaProfileStatusResult
+    WaProfileStatusResult,
+    WaSetTextStatusInput,
+    WaSetUsernameInput,
+    WaTextStatusResult,
+    WaUsernameResult
 } from '@client/coordinators/WaProfileCoordinator'
 export type { WaProfilePictureType } from '@transport/node/builders/profile'
+export { parseUsyncResultEnvelope } from '@transport/node/builders/usync'
+export type {
+    WaUsyncProtocolError,
+    WaUsyncResultEnvelope
+} from '@transport/node/builders/usync'
 export type {
     WaSendStatusInput,
     WaStatusCoordinator

--- a/src/media/transfer/conn.ts
+++ b/src/media/transfer/conn.ts
@@ -3,6 +3,7 @@ import { WA_NODE_TAGS } from '@protocol/constants'
 import { findNodeChild, getNodeChildrenByTag } from '@transport/node/helpers'
 import { assertIqResult } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
+import { parseOptionalInt } from '@util/primitives'
 
 export function parseMediaConnResponse(node: BinaryNode, nowMs: number): WaMediaConn {
     assertIqResult(node, 'media_conn')
@@ -16,8 +17,8 @@ export function parseMediaConnResponse(node: BinaryNode, nowMs: number): WaMedia
     if (!auth) {
         throw new Error('media_conn response is missing auth')
     }
-    const ttlRaw = Number.parseInt(mediaConnNode.attrs.ttl ?? '0', 10)
-    if (!Number.isFinite(ttlRaw) || ttlRaw <= 0) {
+    const ttlRaw = parseOptionalInt(mediaConnNode.attrs.ttl) ?? 0
+    if (ttlRaw <= 0) {
         throw new Error('media_conn response has invalid ttl')
     }
 

--- a/src/protocol/nodes.ts
+++ b/src/protocol/nodes.ts
@@ -72,7 +72,12 @@ export const WA_NODE_TAGS = Object.freeze({
     INTERACTIVE: 'interactive',
     NATIVE_FLOW: 'native_flow',
     BOT: 'bot',
-    META: 'meta'
+    META: 'meta',
+    STATUS: 'status',
+    USERNAME: 'username',
+    TEXT_STATUS: 'text_status',
+    DISAPPEARING_MODE: 'disappearing_mode',
+    BUSINESS: 'business'
 } as const)
 
 export const WA_IQ_TYPES = Object.freeze({

--- a/src/signal/api/SignalDeviceSyncApi.ts
+++ b/src/signal/api/SignalDeviceSyncApi.ts
@@ -3,10 +3,18 @@ import { PromiseDedup } from '@infra/perf/PromiseDedup'
 import { WA_DEFAULTS, WA_NODE_TAGS, WA_USYNC_CONTEXTS } from '@protocol/constants'
 import { buildDeviceJid, isHostedDeviceId, splitJid, toUserJid } from '@protocol/jid'
 import type { WaDeviceListStore } from '@store/contracts/device-list.store'
-import { buildUsyncIq, iterateUsyncUsers } from '@transport/node/builders/usync'
+import {
+    buildUsyncIq,
+    iterateUsyncUsers,
+    parseUsyncResultEnvelope
+} from '@transport/node/builders/usync'
 import { findNodeChild, getNodeChildrenByTag } from '@transport/node/helpers'
 import { assertIqResult } from '@transport/node/query'
-import { createUsyncSidGenerator, type WaUsyncSidGenerator } from '@transport/node/usync'
+import {
+    createUsyncSidGenerator,
+    logUsyncProtocolErrors,
+    type WaUsyncSidGenerator
+} from '@transport/node/usync'
 import type { BinaryNode } from '@transport/types'
 
 interface SignalDeviceSyncApiOptions {
@@ -277,6 +285,7 @@ export class SignalDeviceSyncApi {
         requestedUsers: readonly string[]
     ): readonly { readonly jid: string; readonly deviceJids: readonly string[] }[] {
         assertIqResult(node, 'signal device sync')
+        logUsyncProtocolErrors(parseUsyncResultEnvelope(node), this.logger, 'signal.deviceSync')
         const userNodes = iterateUsyncUsers(node)
         if (!userNodes) {
             throw new Error('signal device sync response missing usync envelope')
@@ -318,6 +327,7 @@ export class SignalDeviceSyncApi {
         readonly exists: boolean
     }[] {
         assertIqResult(node, 'signal lid sync')
+        logUsyncProtocolErrors(parseUsyncResultEnvelope(node), this.logger, 'signal.lidSync')
         const userNodes = iterateUsyncUsers(node)
         if (!userNodes) {
             throw new Error('signal lid sync response missing usync envelope')

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -82,7 +82,11 @@ import {
     buildTcTokenMessageNode
 } from '@transport/node/builders/privacy-token'
 import { buildRetryReceiptNode } from '@transport/node/builders/retry'
-import { buildUsyncIq, buildUsyncUserNode } from '@transport/node/builders/usync'
+import {
+    buildUsyncIq,
+    buildUsyncUserNode,
+    parseUsyncResultEnvelope
+} from '@transport/node/builders/usync'
 import type { BinaryNode } from '@transport/types'
 
 test('presence and offline builders generate expected lightweight nodes', () => {
@@ -236,6 +240,94 @@ test('usync builder composes query/list nodes with defaults and overrides', () =
             }),
         /must include at least one protocol node/
     )
+})
+
+test('parseUsyncResultEnvelope extracts per-protocol errors with backoff', () => {
+    const response: BinaryNode = {
+        tag: 'iq',
+        attrs: { type: 'result' },
+        content: [
+            {
+                tag: 'usync',
+                attrs: {},
+                content: [
+                    {
+                        tag: 'result',
+                        attrs: {},
+                        content: [
+                            {
+                                tag: 'bot',
+                                attrs: {},
+                                content: [
+                                    {
+                                        tag: 'error',
+                                        attrs: {
+                                            code: '400',
+                                            text: 'bad-request',
+                                            backoff: '598'
+                                        }
+                                    }
+                                ]
+                            },
+                            { tag: 'contact', attrs: { refresh: '3600' } },
+                            { tag: 'status', attrs: {} }
+                        ]
+                    },
+                    { tag: 'list', attrs: {} }
+                ]
+            }
+        ]
+    }
+
+    const envelope = parseUsyncResultEnvelope(response)
+    assert.deepEqual(envelope.errors, {
+        bot: { code: 400, text: 'bad-request', backoffSeconds: 598 }
+    })
+    assert.deepEqual(envelope.refresh, { contact: 3600 })
+})
+
+test('parseUsyncResultEnvelope returns empty envelope when usync or result missing', () => {
+    const noUsync: BinaryNode = { tag: 'iq', attrs: { type: 'result' } }
+    assert.deepEqual(parseUsyncResultEnvelope(noUsync), { errors: {}, refresh: {} })
+
+    const noResult: BinaryNode = {
+        tag: 'iq',
+        attrs: { type: 'result' },
+        content: [{ tag: 'usync', attrs: {} }]
+    }
+    assert.deepEqual(parseUsyncResultEnvelope(noResult), { errors: {}, refresh: {} })
+})
+
+test('parseUsyncResultEnvelope falls back to null fields when error attrs missing', () => {
+    const response: BinaryNode = {
+        tag: 'iq',
+        attrs: { type: 'result' },
+        content: [
+            {
+                tag: 'usync',
+                attrs: {},
+                content: [
+                    {
+                        tag: 'result',
+                        attrs: {},
+                        content: [
+                            {
+                                tag: 'feature',
+                                attrs: {},
+                                content: [{ tag: 'error', attrs: {} }]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    const envelope = parseUsyncResultEnvelope(response)
+    assert.deepEqual(envelope.errors, {
+        feature: { code: null, text: null, backoffSeconds: null }
+    })
+    assert.deepEqual(envelope.refresh, {})
 })
 
 test('account sync builders generate expected iq structure', () => {

--- a/src/transport/node/builders/bot.ts
+++ b/src/transport/node/builders/bot.ts
@@ -13,3 +13,31 @@ export function buildBotListIq(version: string = BOT_LIST_VERSION): BinaryNode {
         }
     ])
 }
+
+export function buildGetBotProfileUsyncQueryNode(): BinaryNode {
+    return {
+        tag: WA_NODE_TAGS.BOT,
+        attrs: {},
+        content: [
+            {
+                tag: 'profile',
+                attrs: { v: '1' }
+            }
+        ]
+    }
+}
+
+export function buildBotProfileUsyncUserNodeContent(personaId?: string): readonly BinaryNode[] {
+    return [
+        {
+            tag: WA_NODE_TAGS.BOT,
+            attrs: {},
+            content: [
+                {
+                    tag: 'profile',
+                    attrs: personaId ? { persona_id: personaId } : {}
+                }
+            ]
+        }
+    ]
+}

--- a/src/transport/node/builders/business.ts
+++ b/src/transport/node/builders/business.ts
@@ -1,5 +1,5 @@
-import { WA_BUSINESS_NOTIFICATION_TAGS } from '@protocol/notification'
 import { WA_DEFAULTS, WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
+import { WA_BUSINESS_NOTIFICATION_TAGS } from '@protocol/notification'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 

--- a/src/transport/node/builders/business.ts
+++ b/src/transport/node/builders/business.ts
@@ -145,6 +145,14 @@ export type BuildCoverPhotoIqInput =
           readonly id: string
       }
 
+export function buildGetBusinessUsyncQueryNode(): BinaryNode {
+    return {
+        tag: 'business',
+        attrs: {},
+        content: [{ tag: 'verified_name', attrs: {} }]
+    }
+}
+
 export function buildCoverPhotoIq(input: BuildCoverPhotoIqInput): BinaryNode {
     const attrs: Record<string, string> =
         input.op === 'update'

--- a/src/transport/node/builders/business.ts
+++ b/src/transport/node/builders/business.ts
@@ -1,4 +1,5 @@
-import { WA_DEFAULTS, WA_IQ_TYPES, WA_XMLNS } from '@protocol/constants'
+import { WA_BUSINESS_NOTIFICATION_TAGS } from '@protocol/notification'
+import { WA_DEFAULTS, WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
@@ -147,9 +148,9 @@ export type BuildCoverPhotoIqInput =
 
 export function buildGetBusinessUsyncQueryNode(): BinaryNode {
     return {
-        tag: 'business',
+        tag: WA_NODE_TAGS.BUSINESS,
         attrs: {},
-        content: [{ tag: 'verified_name', attrs: {} }]
+        content: [{ tag: WA_BUSINESS_NOTIFICATION_TAGS.VERIFIED_NAME, attrs: {} }]
     }
 }
 

--- a/src/transport/node/builders/profile.ts
+++ b/src/transport/node/builders/profile.ts
@@ -69,7 +69,7 @@ export function buildDeleteProfilePictureIq(targetJid?: string): BinaryNode {
 export function buildSetStatusIq(text: string): BinaryNode {
     return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.STATUS, [
         {
-            tag: 'status',
+            tag: WA_NODE_TAGS.STATUS,
             attrs: {},
             content: text
         }
@@ -78,21 +78,21 @@ export function buildSetStatusIq(text: string): BinaryNode {
 
 export function buildGetDisappearingModeUsyncQueryNode(): BinaryNode {
     return {
-        tag: 'disappearing_mode',
+        tag: WA_NODE_TAGS.DISAPPEARING_MODE,
         attrs: {}
     }
 }
 
 export function buildGetTextStatusUsyncQueryNode(): BinaryNode {
     return {
-        tag: 'text_status',
+        tag: WA_NODE_TAGS.TEXT_STATUS,
         attrs: {}
     }
 }
 
 export function buildGetUsernameUsyncQueryNode(): BinaryNode {
     return {
-        tag: 'username',
+        tag: WA_NODE_TAGS.USERNAME,
         attrs: {}
     }
 }
@@ -104,7 +104,7 @@ export function buildGetStatusUsyncQueryNodes(): readonly BinaryNode[] {
             attrs: {}
         },
         {
-            tag: 'status',
+            tag: WA_NODE_TAGS.STATUS,
             attrs: {}
         },
         {

--- a/src/transport/node/builders/profile.ts
+++ b/src/transport/node/builders/profile.ts
@@ -83,6 +83,20 @@ export function buildGetDisappearingModeUsyncQueryNode(): BinaryNode {
     }
 }
 
+export function buildGetTextStatusUsyncQueryNode(): BinaryNode {
+    return {
+        tag: 'text_status',
+        attrs: {}
+    }
+}
+
+export function buildGetUsernameUsyncQueryNode(): BinaryNode {
+    return {
+        tag: 'username',
+        attrs: {}
+    }
+}
+
 export function buildGetStatusUsyncQueryNodes(): readonly BinaryNode[] {
     return [
         {

--- a/src/transport/node/builders/tos.ts
+++ b/src/transport/node/builders/tos.ts
@@ -2,6 +2,7 @@ import { WA_DEFAULTS } from '@protocol/defaults'
 import { WA_IQ_TYPES, WA_XMLNS } from '@protocol/nodes'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
+import { parseOptionalInt } from '@util/primitives'
 
 function noticeNodes(noticeIds: readonly string[]): BinaryNode[] {
     return noticeIds.map((id) => ({
@@ -53,8 +54,7 @@ export function parseTosQueryResponse(node: BinaryNode): WaTosQueryResult {
     if (!tosNode) {
         throw new Error('tos response missing <tos> node')
     }
-    const refreshAttr = tosNode.attrs.refresh
-    const refreshSeconds = refreshAttr ? Number.parseInt(refreshAttr, 10) : 0
+    const refreshSeconds = parseOptionalInt(tosNode.attrs.refresh) ?? 0
     const notices: WaTosNoticeState[] = []
     if (Array.isArray(tosNode.content)) {
         for (const child of tosNode.content) {

--- a/src/transport/node/builders/usync.ts
+++ b/src/transport/node/builders/usync.ts
@@ -10,6 +10,7 @@ import {
 import { findNodeChild, getNodeChildrenByTag } from '@transport/node/helpers'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
+import { parseOptionalInt } from '@util/primitives'
 
 export type WaUsyncMode = (typeof WA_USYNC_MODES)[keyof typeof WA_USYNC_MODES]
 export type WaUsyncContext = (typeof WA_USYNC_CONTEXTS)[keyof typeof WA_USYNC_CONTEXTS]
@@ -48,6 +49,52 @@ export function iterateUsyncUsers(result: BinaryNode): readonly BinaryNode[] | n
     const listNode = findNodeChild(usyncNode, WA_NODE_TAGS.LIST)
     if (!listNode) return null
     return getNodeChildrenByTag(listNode, WA_NODE_TAGS.USER)
+}
+
+export interface WaUsyncProtocolError {
+    readonly code: number | null
+    readonly text: string | null
+    readonly backoffSeconds: number | null
+}
+
+export interface WaUsyncResultEnvelope {
+    readonly errors: Readonly<Record<string, WaUsyncProtocolError>>
+    readonly refresh: Readonly<Record<string, number>>
+}
+
+const EMPTY_USYNC_RESULT_ENVELOPE: WaUsyncResultEnvelope = Object.freeze({
+    errors: Object.freeze({}),
+    refresh: Object.freeze({})
+})
+
+export function parseUsyncResultEnvelope(result: BinaryNode): WaUsyncResultEnvelope {
+    const usyncNode = findNodeChild(result, WA_NODE_TAGS.USYNC)
+    if (!usyncNode) return EMPTY_USYNC_RESULT_ENVELOPE
+    const resultNode = findNodeChild(usyncNode, 'result')
+    if (!resultNode) return EMPTY_USYNC_RESULT_ENVELOPE
+    if (!Array.isArray(resultNode.content)) return EMPTY_USYNC_RESULT_ENVELOPE
+
+    const errors: Record<string, WaUsyncProtocolError> = {}
+    const refresh: Record<string, number> = {}
+
+    for (let i = 0; i < resultNode.content.length; i += 1) {
+        const protoNode = resultNode.content[i]
+        const errorNode = findNodeChild(protoNode, WA_NODE_TAGS.ERROR)
+        if (errorNode) {
+            errors[protoNode.tag] = {
+                code: parseOptionalInt(errorNode.attrs.code) ?? null,
+                text: (errorNode.attrs.text as string | undefined) ?? null,
+                backoffSeconds: parseOptionalInt(errorNode.attrs.backoff) ?? null
+            }
+            continue
+        }
+        const refreshSeconds = parseOptionalInt(protoNode.attrs.refresh)
+        if (refreshSeconds !== undefined) {
+            refresh[protoNode.tag] = refreshSeconds
+        }
+    }
+
+    return { errors, refresh }
 }
 
 export function buildUsyncIq(input: BuildUsyncIqInput): BinaryNode {

--- a/src/transport/node/mex/persist-ids.ts
+++ b/src/transport/node/mex/persist-ids.ts
@@ -135,5 +135,17 @@ export const WA_MEX_PERSIST_IDS = Object.freeze({
     CommunityFetchAllSubgroups: Object.freeze({
         docId: '9935467776504344',
         clientDocId: '9935467776504344'
+    }),
+    UpdateTextStatus: Object.freeze({
+        docId: '9152604461510864',
+        clientDocId: '9152604461510864'
+    }),
+    GetUsername: Object.freeze({
+        docId: '25347099718279209',
+        clientDocId: '25347099718279209'
+    }),
+    SetUsername: Object.freeze({
+        docId: '25757341163897635',
+        clientDocId: '25757341163897635'
     })
 }) satisfies Readonly<Record<string, WaMexPersistId>>

--- a/src/transport/node/usync.ts
+++ b/src/transport/node/usync.ts
@@ -1,3 +1,6 @@
+import type { Logger } from '@infra/log/types'
+
+import type { WaUsyncResultEnvelope } from './builders/usync'
 import { createNodeIdGenerator } from './helpers'
 
 export type WaUsyncSidGenerator = () => Promise<string>
@@ -5,4 +8,21 @@ export type WaUsyncSidGenerator = () => Promise<string>
 export function createUsyncSidGenerator(): WaUsyncSidGenerator {
     const generatorPromise = createNodeIdGenerator()
     return async () => (await generatorPromise).next()
+}
+
+export function logUsyncProtocolErrors(
+    envelope: WaUsyncResultEnvelope,
+    logger: Logger,
+    context: string
+): void {
+    for (const protocol of Object.keys(envelope.errors)) {
+        const err = envelope.errors[protocol]
+        logger.warn('usync protocol error', {
+            context,
+            protocol,
+            code: err.code,
+            text: err.text,
+            backoffSeconds: err.backoffSeconds
+        })
+    }
 }

--- a/src/util/primitives.ts
+++ b/src/util/primitives.ts
@@ -1,4 +1,5 @@
 const DIGITS_ONLY_RE = /^\d+$/
+const SIGNED_DIGITS_RE = /^-?\d+$/
 
 export function toError(value: unknown): Error {
     if (value instanceof Error) return value
@@ -59,4 +60,11 @@ function parseStrictUnsignedInt(value: string): number | undefined {
 export function parseOptionalInt(value: string | undefined): number | undefined {
     if (!value) return undefined
     return parseStrictUnsignedInt(value)
+}
+
+export function parseOptionalSignedInt(value: string | undefined): number | undefined {
+    if (!value) return undefined
+    if (!SIGNED_DIGITS_RE.test(value)) return undefined
+    const parsed = Number(value)
+    return Number.isSafeInteger(parsed) ? parsed : undefined
 }


### PR DESCRIPTION
- profile coordinator: getTextStatuses / setTextStatus (mex), getUsernames (batch usync), getOwnUsername / setUsername / deleteUsername (mex), now receives a logger to surface per-protocol errors
- bot coordinator: getBotProfile via usync (name, prompts, commands, persona, posing-as-professional) with persona_id user-element support
- business coordinator: getVerifiedNames batch via usync
- transport/usync: parseUsyncResultEnvelope captures per-protocol error + refresh hints from <result>; logUsyncProtocolErrors wired in profile/bot/ business coordinators, SignalDeviceSyncApi and runSyncQuery
- fix(business): parseCertificateContent silently lost name/serial when certificate serial exceeded MAX_SAFE_INTEGER (longToNumber threw inside the silent catch); switch to Long.toString() to preserve precision
- util/primitives: parseOptionalSignedInt for ephemeral_duration_sec (-1)
- refactor: dedupe inline parseInt+isSafeInteger blocks (abprops, dirty, devices, bot list count, media-conn ttl, tos refresh, appstate version, status 401 check) via parseOptionalInt; dedupe inline Uint8Array/string content decode via getNodeTextContent in profile/bot parsers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bot profile retrieval API; batched business verified-name lookup; profile text-status and username management (get/set/delete).

* **Improvements**
  * Better parsing for numeric fields and TTLs; improved usync result envelope parsing and protocol-error logging.

* **Tests**
  * Expanded unit tests covering bot profiles, verified-name batches, text-status, username flows, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->