### PR TITLE
feat(mex): expand coverage + adopt lenient parsers

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -761,7 +761,8 @@ export function buildWaClientDependencies(input: {
         messageStore: sessionStore.messages,
         messageSecretStore: sessionStore.messageSecret,
         trustedContactToken,
-        emitAddon: (event) => runtime.emitEvent('message_addon', event)
+        emitAddon: (event) => runtime.emitEvent('message_addon', event),
+        mexSocket: { query: runtime.query }
     })
 
     const presenceCoordinator = createPresenceCoordinator({

--- a/src/client/coordinators/WaGroupCoordinator.ts
+++ b/src/client/coordinators/WaGroupCoordinator.ts
@@ -1,6 +1,8 @@
 import { parseParticipants as parseGroupEventParticipants } from '@client/events/group'
+import type { WaMexOperationResponses } from '@mex'
 import { WA_DEFAULTS } from '@protocol/defaults'
 import { WA_GROUP_PARTICIPANT_TYPES, type WaGroupSetting } from '@protocol/group'
+import { parseJidFull } from '@protocol/jid'
 import { WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
 import { WA_GROUP_NOTIFICATION_TAGS } from '@protocol/notification'
 import { buildListParticipatingGroupsIq } from '@transport/node/builders/account-sync'
@@ -29,6 +31,7 @@ import {
 import { runMexQuery, type WaMexQuerySocket } from '@transport/node/mex/client'
 import { assertIqResult, buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
+import { tryAsNumber, tryAsRecord, tryAsString } from '@util/coercion'
 
 export interface WaGroupParticipant {
     readonly jid: string
@@ -135,10 +138,28 @@ export interface WaCommunitySubGroup {
     readonly pendingMembershipRequests: number
 }
 
+export interface WaCommunitySubGroupSuggestion {
+    readonly jid: string
+    readonly subject: string | null
+    readonly description: string | null
+    readonly creator: string | null
+    readonly creationTime: number | null
+    readonly participantCount: number | null
+    readonly isExistingGroup: boolean
+    readonly hiddenGroup: boolean
+}
+
 export interface WaCommunitySubGroupsResult {
     readonly communityJid: string
     readonly announcementGroup: WaCommunitySubGroup | null
     readonly subGroups: readonly WaCommunitySubGroup[]
+}
+
+export interface WaGroupSuspensionAppealResult {
+    readonly success: boolean
+    readonly responseCode: string | null
+    readonly errorMessage: string | null
+    readonly appealCreationTime: number | null
 }
 
 interface WaGroupCoordinatorOptions {
@@ -228,6 +249,19 @@ export interface WaGroupCoordinator {
         subGroupJid: string,
         options?: { readonly type?: string }
     ) => Promise<BinaryNode>
+    readonly isInternalGroup: (groupJid: string) => Promise<boolean>
+    readonly transferCommunityOwnership: (
+        communityJid: string,
+        newOwnerJid: string
+    ) => Promise<void>
+    readonly fetchSubgroupSuggestions: (
+        communityJid: string,
+        hintSubgroupJid: string
+    ) => Promise<readonly WaCommunitySubGroupSuggestion[]>
+    readonly submitGroupSuspensionAppeal: (
+        groupJid: string,
+        options?: { readonly reason?: string | null; readonly debugInfo?: string }
+    ) => Promise<WaGroupSuspensionAppealResult>
 }
 
 type WaGroupParticipantChangeAction = 'add' | 'remove' | 'promote' | 'demote'
@@ -414,37 +448,77 @@ const SETTING_TAGS: Readonly<
     }
 }
 
-interface MexSubGroupNode {
-    readonly id?: string
-    readonly subject?: { readonly value?: string; readonly creation_time?: string | number }
-    readonly properties?: {
-        readonly general_chat?: boolean | null
-        readonly membership_approval_mode_enabled?: boolean | null
-        readonly hidden_group?: boolean | null
-    } | null
-    readonly membership_approval_requests?: { readonly total_count?: string | number } | null
-}
-
-interface MexFetchAllSubgroupsResult {
-    readonly xwa2_group_query_by_id?: {
-        readonly default_sub_group?: MexSubGroupNode | null
-        readonly sub_groups?: { readonly edges?: readonly { readonly node?: MexSubGroupNode }[] }
-    } | null
-}
-
-function parseSubGroupNode(node: MexSubGroupNode, defaultSubgroup: boolean): WaCommunitySubGroup {
-    const totalCount = node.membership_approval_requests?.total_count
-    const creationTime = node.subject?.creation_time
+function parseSubGroupNode(node: unknown, defaultSubgroup: boolean): WaCommunitySubGroup {
+    const n = tryAsRecord(node)
+    const subject = tryAsRecord(n?.subject)
+    const properties = tryAsRecord(n?.properties)
+    const approvals = tryAsRecord(n?.membership_approval_requests)
     return {
-        jid: node.id ?? '',
-        subject: node.subject?.value,
-        subjectTime: creationTime !== undefined ? Number(creationTime) : undefined,
+        jid: tryAsString(n?.id) ?? '',
+        subject: tryAsString(subject?.value) ?? undefined,
+        subjectTime: tryAsNumber(subject?.creation_time) ?? undefined,
         defaultSubgroup,
-        generalSubgroup: node.properties?.general_chat === true,
-        hiddenSubgroup: node.properties?.hidden_group === true,
-        membershipApprovalEnabled: node.properties?.membership_approval_mode_enabled === true,
-        pendingMembershipRequests: totalCount !== undefined ? Number(totalCount) : 0
+        generalSubgroup: properties?.general_chat === true,
+        hiddenSubgroup: properties?.hidden_group === true,
+        membershipApprovalEnabled: properties?.membership_approval_mode_enabled === true,
+        pendingMembershipRequests: tryAsNumber(approvals?.total_count) ?? 0
     }
+}
+
+function parseGroupIsInternalMexResponse(
+    data: WaMexOperationResponses['FetchGroupIsInternal'] | null
+): boolean {
+    return data?.xwa2_group_query_by_id?.properties?.internal === true
+}
+
+function parseGroupSuspensionAppealMexResponse(
+    data: WaMexOperationResponses['GroupSuspensionAppeal'] | null
+): WaGroupSuspensionAppealResult {
+    const root = data?.wa_create_group_suspension_appeal
+    const responseCode = tryAsString(root?.response_code)
+    return {
+        success: responseCode === 'SUCCESS' || responseCode === 'APPEAL_ALREADY_EXISTS',
+        responseCode,
+        errorMessage: tryAsString(root?.error_message),
+        appealCreationTime: tryAsNumber(root?.appeal_creation_time)
+    }
+}
+
+// Spec types `edges` as a single object, but at runtime it's an array — narrow inline.
+function parseSubGroupSuggestionsMexResponse(
+    data: WaMexOperationResponses['FetchSubgroupSuggestions'] | null
+): readonly WaCommunitySubGroupSuggestion[] {
+    type Edge = NonNullable<
+        NonNullable<
+            NonNullable<
+                WaMexOperationResponses['FetchSubgroupSuggestions']['xwa2_group_query_by_id']
+            >['sub_group_suggestions']
+        >['edges']
+    >
+    const edges = (data?.xwa2_group_query_by_id?.sub_group_suggestions?.edges ?? []) as
+        | readonly Edge[]
+        | Edge
+    const list = Array.isArray(edges) ? edges : []
+    const results: WaCommunitySubGroupSuggestion[] = []
+    for (const edge of list) {
+        const node = edge?.node
+        if (!node || typeof node.id !== 'string') continue
+        results.push({
+            jid: node.id,
+            subject: typeof node.subject?.value === 'string' ? node.subject.value : null,
+            description:
+                typeof node.description?.value === 'string' ? node.description.value : null,
+            creator: typeof node.creator?.id === 'string' ? node.creator.id : null,
+            creationTime: typeof node.creation_time === 'number' ? node.creation_time : null,
+            participantCount:
+                typeof node.total_participants_count === 'number'
+                    ? node.total_participants_count
+                    : null,
+            isExistingGroup: node.is_existing_group === true,
+            hiddenGroup: node.hidden_group === true
+        })
+    }
+    return results
 }
 
 export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGroupCoordinator {
@@ -690,13 +764,13 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
                 query_context: 'INTERACTIVE',
                 sub_group_hint_id: undefined
             })
-            const envelope = (data ?? {}) as MexFetchAllSubgroupsResult
-            const groupQuery = envelope.xwa2_group_query_by_id
-            const announcementNode = groupQuery?.default_sub_group
-            const announcementGroup = announcementNode
-                ? parseSubGroupNode(announcementNode, true)
+            const groupQuery = data?.xwa2_group_query_by_id
+            const announcementGroup = groupQuery?.default_sub_group
+                ? parseSubGroupNode(groupQuery.default_sub_group, true)
                 : null
-            const edges = groupQuery?.sub_groups?.edges ?? []
+            const edges = (groupQuery?.sub_groups?.edges ?? []) as readonly {
+                readonly node?: unknown
+            }[]
             const subGroups: WaCommunitySubGroup[] = []
             for (const edge of edges) {
                 if (!edge?.node) continue
@@ -739,6 +813,52 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
             const result = await queryWithContext('community.joinLinkedGroup', node)
             assertIqResult(result, 'community.joinLinkedGroup')
             return result
+        },
+
+        isInternalGroup: async (groupJid) => {
+            if (!mexSocket) {
+                throw new Error('group.isInternalGroup requires a mex transport')
+            }
+            const data = await runMexQuery(mexSocket, 'FetchGroupIsInternal', { id: groupJid })
+            return parseGroupIsInternalMexResponse(data)
+        },
+
+        transferCommunityOwnership: async (communityJid, newOwnerJid) => {
+            if (!mexSocket) {
+                throw new Error('community.transferOwnership requires a mex transport')
+            }
+            await runMexQuery(mexSocket, 'TransferCommunityOwnership', {
+                input: {
+                    group_id: communityJid,
+                    role_updates: [{ new_role: 'SUPERADMIN_MEMBER', user_jid: newOwnerJid }]
+                }
+            })
+        },
+
+        fetchSubgroupSuggestions: async (communityJid, hintSubgroupJid) => {
+            if (!mexSocket) {
+                throw new Error('community.fetchSubgroupSuggestions requires a mex transport')
+            }
+            const data = await runMexQuery(mexSocket, 'FetchSubgroupSuggestions', {
+                group_id: communityJid,
+                query_context: 'INTERACTIVE',
+                sub_group_hint_id: hintSubgroupJid
+            })
+            return parseSubGroupSuggestionsMexResponse(data)
+        },
+
+        submitGroupSuspensionAppeal: async (groupJid, options) => {
+            if (!mexSocket) {
+                throw new Error('group.submitSuspensionAppeal requires a mex transport')
+            }
+            const data = await runMexQuery(mexSocket, 'GroupSuspensionAppeal', {
+                input: {
+                    group_jid: parseJidFull(groupJid).address.user,
+                    appeal_reason: options?.reason ?? null,
+                    debug_info: options?.debugInfo ?? '{}'
+                }
+            })
+            return parseGroupSuspensionAppealMexResponse(data)
         }
     }
 }

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -30,11 +30,14 @@ import type {
     WaSendReceiptInput,
     WaSendReceiptOptions
 } from '@message/types'
+import type { WaMexOperationResponses } from '@mex'
 import type { Proto } from '@proto'
 import { applyDeviceToJid } from '@protocol/jid'
 import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
 import type { WaMessageStore } from '@store/contracts/message.store'
+import { runMexQuery, type WaMexQuerySocket } from '@transport/node/mex/client'
 import { readAllBytes } from '@util/bytes'
+import { tryAsNumber, tryAsString } from '@util/coercion'
 import { toError } from '@util/primitives'
 
 export interface WaMessageCoordinatorDeps {
@@ -45,6 +48,53 @@ export interface WaMessageCoordinatorDeps {
     readonly messageSecretStore: WaMessageSecretStore
     readonly trustedContactToken: WaTrustedContactTokenCoordinator
     readonly emitAddon: (event: WaIncomingAddonEvent) => void
+    readonly mexSocket: WaMexQuerySocket
+}
+
+export interface WaReachoutTimelock {
+    readonly isActive: boolean
+    readonly enforcementType: string | null
+    readonly enforcementEndsAt: number | null
+}
+
+export type WaMessageCappingType = 'INDIVIDUAL_NEW_CHAT_THREAD' | (string & {})
+
+export interface WaMessageCappingInfo {
+    readonly totalQuota: number | null
+    readonly usedQuota: number | null
+    readonly cycleStartAt: number | null
+    readonly cycleEndAt: number | null
+    readonly serverSentAt: number | null
+    readonly oteStatus: string | null
+    readonly mvStatus: string | null
+    readonly cappingStatus: string | null
+}
+
+function parseReachoutTimelockMexResponse(
+    data: WaMexOperationResponses['FetchReachoutTimelock'] | null
+): WaReachoutTimelock {
+    const root = data?.xwa2_fetch_account_reachout_timelock
+    return {
+        isActive: root?.is_active === true,
+        enforcementType: tryAsString(root?.enforcement_type),
+        enforcementEndsAt: tryAsNumber(root?.time_enforcement_ends)
+    }
+}
+
+function parseMessageCappingMexResponse(
+    data: WaMexOperationResponses['FetchNewChatMessageCappingInfo'] | null
+): WaMessageCappingInfo {
+    const root = data?.xwa2_message_capping_info
+    return {
+        totalQuota: tryAsNumber(root?.total_quota),
+        usedQuota: tryAsNumber(root?.used_quota),
+        cycleStartAt: tryAsNumber(root?.cycle_start_timestamp),
+        cycleEndAt: tryAsNumber(root?.cycle_end_timestamp),
+        serverSentAt: tryAsNumber(root?.server_sent_timestamp),
+        oteStatus: tryAsString(root?.ote_status),
+        mvStatus: tryAsString(root?.mv_status),
+        cappingStatus: tryAsString(root?.capping_status)
+    }
 }
 
 export class WaMessageCoordinator {
@@ -55,6 +105,7 @@ export class WaMessageCoordinator {
     private readonly messageSecretStore: WaMessageSecretStore
     private readonly trustedContactToken: WaTrustedContactTokenCoordinator
     private readonly emitAddon: (event: WaIncomingAddonEvent) => void
+    private readonly mexSocket: WaMexQuerySocket
 
     public constructor(deps: WaMessageCoordinatorDeps) {
         this.messageDispatch = deps.messageDispatch
@@ -64,6 +115,21 @@ export class WaMessageCoordinator {
         this.messageSecretStore = deps.messageSecretStore
         this.trustedContactToken = deps.trustedContactToken
         this.emitAddon = deps.emitAddon
+        this.mexSocket = deps.mexSocket
+    }
+
+    public async getReachoutTimelock(): Promise<WaReachoutTimelock> {
+        const data = await runMexQuery(this.mexSocket, 'FetchReachoutTimelock', {})
+        return parseReachoutTimelockMexResponse(data)
+    }
+
+    public async getNewChatMessageCapping(
+        type: WaMessageCappingType = 'INDIVIDUAL_NEW_CHAT_THREAD'
+    ): Promise<WaMessageCappingInfo> {
+        const data = await runMexQuery(this.mexSocket, 'FetchNewChatMessageCappingInfo', {
+            input: { type }
+        })
+        return parseMessageCappingMexResponse(data)
     }
 
     public async syncSignalSession(jid: string, reasonIdentity = false): Promise<void> {

--- a/src/client/coordinators/WaProfileCoordinator.ts
+++ b/src/client/coordinators/WaProfileCoordinator.ts
@@ -1,4 +1,6 @@
 import type { Logger } from '@infra/log/types'
+import type { WaMexOperationResponses } from '@mex'
+import { parseJidFull } from '@protocol/jid'
 import { WA_NODE_TAGS } from '@protocol/nodes'
 import {
     buildDeleteProfilePictureIq,
@@ -21,6 +23,7 @@ import { runMexQuery, type WaMexQuerySocket } from '@transport/node/mex/client'
 import { assertIqResult } from '@transport/node/query'
 import { logUsyncProtocolErrors } from '@transport/node/usync'
 import type { BinaryNode } from '@transport/types'
+import { tryAsRecord, tryAsString } from '@util/coercion'
 import { parseOptionalInt, parseOptionalSignedInt } from '@util/primitives'
 
 export interface WaProfilePictureResult {
@@ -78,6 +81,11 @@ export interface WaSetUsernameInput {
     readonly source?: string
 }
 
+export interface WaUsernameAvailabilityResult {
+    readonly available: boolean
+    readonly suggestions: readonly string[]
+}
+
 export interface WaProfileCoordinator {
     readonly getProfilePicture: (
         jid: string,
@@ -101,6 +109,9 @@ export interface WaProfileCoordinator {
     readonly getOwnUsername: () => Promise<WaOwnUsernameResult>
     readonly setUsername: (input: WaSetUsernameInput) => Promise<boolean>
     readonly deleteUsername: () => Promise<boolean>
+    readonly getAboutStatus: (jid: string) => Promise<string | null>
+    readonly checkUsernameAvailability: (username: string) => Promise<WaUsernameAvailabilityResult>
+    readonly setUsernameKey: (pin: string) => Promise<boolean>
 }
 
 interface WaProfileCoordinatorOptions {
@@ -280,29 +291,47 @@ function parseUsyncUsernames(result: BinaryNode): readonly WaUsernameResult[] {
     return results
 }
 
-function parseOwnUsernameMexResponse(data: unknown): WaOwnUsernameResult {
-    const root = (data ?? {}) as {
-        readonly xwa2_username_get?: {
-            readonly username_info?: {
-                readonly username?: string | null
-                readonly state?: string | null
-                readonly pin?: string | null
-            } | null
-        } | null
-    }
-    const info = root.xwa2_username_get?.username_info
+function parseOwnUsernameMexResponse(
+    data: WaMexOperationResponses['GetUsername'] | null
+): WaOwnUsernameResult {
+    const info = tryAsRecord(tryAsRecord(data?.xwa2_username_get)?.username_info)
     return {
-        username: info?.username ?? null,
-        state: info?.state ?? null,
-        pin: info?.pin ?? null
+        username: tryAsString(info?.username),
+        state: tryAsString(info?.state),
+        pin: tryAsString(info?.pin)
     }
 }
 
-function isMexSetUsernameSuccess(data: unknown): boolean {
-    const root = (data ?? {}) as {
-        readonly xwa2_username_set?: { readonly result?: string | null } | null
-    }
-    return root.xwa2_username_set?.result === 'SUCCESS'
+function isMexSetUsernameSuccess(data: WaMexOperationResponses['SetUsername'] | null): boolean {
+    return data?.xwa2_username_set?.result === 'SUCCESS'
+}
+
+// The spec types leaves as `unknown` and lists xwa2_users_updates_since /
+// updates as single objects, but at runtime both are arrays — narrow inline.
+function parseAboutStatusMexResponse(
+    data: WaMexOperationResponses['FetchAboutStatus'] | null
+): string | null {
+    const updates = data?.xwa2_users_updates_since as
+        | ReadonlyArray<{ readonly updates?: ReadonlyArray<{ readonly text?: unknown }> }>
+        | undefined
+    const text = updates?.[0]?.updates?.[0]?.text
+    return typeof text === 'string' ? text : null
+}
+
+function parseUsernameAvailabilityMexResponse(
+    data: WaMexOperationResponses['UsernameAvailability'] | null
+): WaUsernameAvailabilityResult {
+    const check = data?.xwa2_username_check
+    const suggestions = (
+        Array.isArray(check?.suggestions) ? (check.suggestions as readonly unknown[]) : []
+    ).filter((s): s is string => typeof s === 'string')
+    return { available: check?.result === 'SUCCESS', suggestions }
+}
+
+function isMexUsernameKeySetSuccess(
+    data: WaMexOperationResponses['SetUsernameKey'] | null
+): boolean {
+    return data?.xwa2_username_pin_set?.result === 'SUCCESS'
 }
 
 function isMexNotFoundError(error: unknown): boolean {
@@ -502,6 +531,25 @@ export function createProfileCoordinator(
         deleteUsername: async () => {
             const data = await runMexQuery(mexSocket, 'SetUsername', {})
             return isMexSetUsernameSuccess(data)
+        },
+
+        getAboutStatus: async (jid) => {
+            const data = await runMexQuery(mexSocket, 'FetchAboutStatus', {
+                user: { user_id: parseJidFull(jid).address.user }
+            })
+            return parseAboutStatusMexResponse(data)
+        },
+
+        checkUsernameAvailability: async (username) => {
+            const data = await runMexQuery(mexSocket, 'UsernameAvailability', {
+                input: username
+            })
+            return parseUsernameAvailabilityMexResponse(data)
+        },
+
+        setUsernameKey: async (pin) => {
+            const data = await runMexQuery(mexSocket, 'SetUsernameKey', { pin })
+            return isMexUsernameKeySetSuccess(data)
         }
     }
 }

--- a/src/client/newsletter/admin.ts
+++ b/src/client/newsletter/admin.ts
@@ -5,7 +5,6 @@ import {
     type WaNewsletterMexDeps
 } from '@client/newsletter/mex'
 import {
-    type MexNewsletterEnvelope,
     parseAdminCapabilities,
     parseAdminInfo,
     parseAdminInviteResult,
@@ -95,7 +94,7 @@ export function createAdminOps(deps: WaNewsletterMexDeps): WaNewsletterAdminOps 
             if (!data?.xwa2_newsletter_create) {
                 throw new Error('newsletter create returned no envelope')
             }
-            return parseNewsletterMetadata(data.xwa2_newsletter_create as MexNewsletterEnvelope)
+            return parseNewsletterMetadata(data.xwa2_newsletter_create)
         },
         update: async (newsletterJid, input) => {
             const updates: Record<string, unknown> = {}
@@ -114,7 +113,7 @@ export function createAdminOps(deps: WaNewsletterMexDeps): WaNewsletterAdminOps 
             if (!data?.xwa2_newsletter_update) {
                 throw new Error('newsletter update returned no envelope')
             }
-            return parseNewsletterMetadata(data.xwa2_newsletter_update as MexNewsletterEnvelope)
+            return parseNewsletterMetadata(data.xwa2_newsletter_update)
         },
         delete: async (newsletterJid) => {
             await runMex(deps, 'DeleteNewsletter', { newsletter_id: newsletterJid })

--- a/src/client/newsletter/discovery.ts
+++ b/src/client/newsletter/discovery.ts
@@ -1,6 +1,5 @@
 import { runMex, runMexEnvelope, type WaNewsletterMexDeps } from '@client/newsletter/mex'
 import {
-    type MexNewsletterEnvelope,
     parseDehydratedMetadata,
     parseDirectoryCategoriesPreview,
     parseDirectoryList,
@@ -82,7 +81,7 @@ export function createDiscoveryOps(deps: WaNewsletterMexDeps): WaNewsletterDisco
         if (!data?.xwa2_newsletter) {
             throw new Error('newsletter fetch returned no envelope')
         }
-        return parseNewsletterMetadata(data.xwa2_newsletter as MexNewsletterEnvelope)
+        return parseNewsletterMetadata(data.xwa2_newsletter)
     }
 
     return {
@@ -94,8 +93,9 @@ export function createDiscoveryOps(deps: WaNewsletterMexDeps): WaNewsletterDisco
                 fetch_wamo_sub: opts?.fetchWamoSub ?? false,
                 fetch_status_metadata: false
             })
-            const list = (data?.xwa2_newsletter_subscribed ??
-                []) as readonly MexNewsletterEnvelope[]
+            const list = Array.isArray(data?.xwa2_newsletter_subscribed)
+                ? (data.xwa2_newsletter_subscribed as readonly unknown[])
+                : []
             return list.map(parseNewsletterMetadata)
         },
         searchDirectory: async (opts) => {

--- a/src/client/newsletter/parse.ts
+++ b/src/client/newsletter/parse.ts
@@ -21,407 +21,279 @@ import {
     type WaNewsletterRole,
     type WaNewsletterStateType
 } from '@protocol/newsletter'
+import { tryAsNumber, tryAsRecord, tryAsString } from '@util/coercion'
 
-interface RawPicture {
-    readonly id?: string
-    readonly direct_path?: string
+function asUndef<T>(value: T | null): T | undefined {
+    return value === null ? undefined : value
 }
 
-export interface MexNewsletterEnvelope {
-    readonly id?: string
-    readonly state?: { readonly type?: WaNewsletterStateType }
-    readonly thread_metadata?: {
-        readonly creation_time?: string | number
-        readonly name?: { readonly text?: string; readonly update_time?: string | number }
-        readonly description?: {
-            readonly text?: string
-            readonly update_time?: string | number
-        }
-        readonly picture?: RawPicture
-        readonly preview?: RawPicture
-        readonly invite?: string
-        readonly handle?: string
-        readonly subscribers_count?: string | number
-        readonly verification?: string
-    }
-    readonly viewer_metadata?: {
-        readonly role?: WaNewsletterRole
-        readonly settings?: readonly { readonly type?: string; readonly value?: string }[]
-    }
+function asArray(value: unknown): readonly unknown[] {
+    return Array.isArray(value) ? value : []
 }
 
-interface RawAdminProfile {
-    readonly id?: string
-    readonly name?: string
-    readonly picture?: RawPicture
+function parsePicture(raw: unknown): WaNewsletterPicture | undefined {
+    const r = tryAsRecord(raw)
+    if (!r) return undefined
+    const id = tryAsString(r.id)
+    const directPath = tryAsString(r.direct_path)
+    if (!id && !directPath) return undefined
+    return { id: asUndef(id), directPath: asUndef(directPath) }
 }
 
-interface RawFollowerEdge {
-    readonly admin_profile?: RawAdminProfile
-    readonly follow_time?: string | number
-    readonly role?: string
-    readonly node?: {
-        readonly id?: string
-        readonly pn?: string
-        readonly display_name?: string
-        readonly username_info?: { readonly username?: string }
-    }
-}
-
-interface RawPageInfo {
-    readonly hasNextPage?: boolean
-    readonly hasPreviousPage?: boolean
-    readonly startCursor?: string
-    readonly endCursor?: string
-}
-
-function toNumber(value: string | number | null | undefined): number | undefined {
-    if (value === null || value === undefined) return undefined
-    if (typeof value === 'number') return value
-    const parsed = Number.parseInt(value, 10)
-    return Number.isFinite(parsed) ? parsed : undefined
-}
-
-function parsePicture(raw: RawPicture | undefined): WaNewsletterPicture | undefined {
-    if (!raw) return undefined
-    if (!raw.id && !raw.direct_path) return undefined
+function parseAdminProfile(raw: unknown): WaNewsletterAdminProfile | null {
+    const r = tryAsRecord(raw)
+    const name = tryAsString(r?.name)
+    if (!name) return null
+    const picture = tryAsRecord(r?.picture)
     return {
-        id: raw.id,
-        directPath: raw.direct_path
+        id: asUndef(tryAsString(r?.id)),
+        name,
+        pictureId: asUndef(tryAsString(picture?.id)),
+        pictureDirectPath: asUndef(tryAsString(picture?.direct_path))
     }
 }
 
-function parseAdminProfile(raw: RawAdminProfile | undefined): WaNewsletterAdminProfile | null {
-    if (!raw || !raw.name) return null
+function parsePageInfo(raw: unknown): WaPageInfo | undefined {
+    const r = tryAsRecord(raw)
+    if (!r) return undefined
     return {
-        id: raw.id,
-        name: raw.name,
-        pictureId: raw.picture?.id,
-        pictureDirectPath: raw.picture?.direct_path
+        hasNextPage: typeof r.hasNextPage === 'boolean' ? r.hasNextPage : undefined,
+        hasPreviousPage: typeof r.hasPreviousPage === 'boolean' ? r.hasPreviousPage : undefined,
+        startCursor: asUndef(tryAsString(r.startCursor)),
+        endCursor: asUndef(tryAsString(r.endCursor))
     }
 }
 
-function parsePageInfo(raw: RawPageInfo | undefined): WaPageInfo | undefined {
-    if (!raw) return undefined
-    return {
-        hasNextPage: raw.hasNextPage,
-        hasPreviousPage: raw.hasPreviousPage,
-        startCursor: raw.startCursor,
-        endCursor: raw.endCursor
-    }
-}
-
-export function parseNewsletterMetadata(envelope: MexNewsletterEnvelope): WaNewsletterMetadata {
-    const meta = envelope.thread_metadata
-    const viewer = envelope.viewer_metadata
-    const settings = viewer?.settings ?? []
+export function parseNewsletterMetadata(envelope: unknown): WaNewsletterMetadata {
+    const env = tryAsRecord(envelope)
+    const meta = tryAsRecord(env?.thread_metadata)
+    const viewer = tryAsRecord(env?.viewer_metadata)
+    const state = tryAsRecord(env?.state)
+    const name = tryAsRecord(meta?.name)
+    const description = tryAsRecord(meta?.description)
 
     let mutedAdmin: boolean | undefined
     let mutedFollower: boolean | undefined
-    for (const setting of settings) {
-        if (setting.type === WA_NEWSLETTER_MUTE_TYPES.ADMIN_ACTIVITY) {
-            mutedAdmin = setting.value === WA_NEWSLETTER_MUTE_VALUES.ON
-        } else if (setting.type === WA_NEWSLETTER_MUTE_TYPES.FOLLOWER_ACTIVITY) {
-            mutedFollower = setting.value === WA_NEWSLETTER_MUTE_VALUES.ON
+    for (const settingRaw of asArray(viewer?.settings)) {
+        const setting = tryAsRecord(settingRaw)
+        const type = tryAsString(setting?.type)
+        const value = tryAsString(setting?.value)
+        if (type === WA_NEWSLETTER_MUTE_TYPES.ADMIN_ACTIVITY) {
+            mutedAdmin = value === WA_NEWSLETTER_MUTE_VALUES.ON
+        } else if (type === WA_NEWSLETTER_MUTE_TYPES.FOLLOWER_ACTIVITY) {
+            mutedFollower = value === WA_NEWSLETTER_MUTE_VALUES.ON
         }
     }
 
     return {
-        jid: envelope.id ?? '',
-        state: envelope.state?.type ?? WA_NEWSLETTER_STATE_TYPES.ACTIVE,
-        creationTime: toNumber(meta?.creation_time),
-        name: meta?.name?.text,
-        nameUpdateTime: toNumber(meta?.name?.update_time),
-        description: meta?.description?.text,
-        descriptionUpdateTime: toNumber(meta?.description?.update_time),
+        jid: tryAsString(env?.id) ?? '',
+        state:
+            (tryAsString(state?.type) as WaNewsletterStateType | null) ??
+            WA_NEWSLETTER_STATE_TYPES.ACTIVE,
+        creationTime: asUndef(tryAsNumber(meta?.creation_time)),
+        name: asUndef(tryAsString(name?.text)),
+        nameUpdateTime: asUndef(tryAsNumber(name?.update_time)),
+        description: asUndef(tryAsString(description?.text)),
+        descriptionUpdateTime: asUndef(tryAsNumber(description?.update_time)),
         picture: parsePicture(meta?.picture),
         preview: parsePicture(meta?.preview),
-        invite: meta?.invite,
-        handle: meta?.handle,
-        subscribersCount: toNumber(meta?.subscribers_count),
-        verification: meta?.verification,
-        viewerRole: viewer?.role,
+        invite: asUndef(tryAsString(meta?.invite)),
+        handle: asUndef(tryAsString(meta?.handle)),
+        subscribersCount: asUndef(tryAsNumber(meta?.subscribers_count)),
+        verification: asUndef(tryAsString(meta?.verification)),
+        viewerRole: (tryAsString(viewer?.role) as WaNewsletterRole | null) ?? undefined,
         mutedAdmin,
         mutedFollower
     }
 }
 
 export function parseAdminInfo(envelope: WaNewsletterMexEnvelope): WaNewsletterAdminInfo {
-    const admin = (envelope as { readonly xwa2_newsletter_admin?: unknown }).xwa2_newsletter_admin
-    if (!admin || typeof admin !== 'object') {
-        return { adminProfile: null }
-    }
-    const node = admin as {
-        readonly admin_count?: number
-        readonly admin_profile?: RawAdminProfile
-    }
+    const admin = tryAsRecord(envelope.xwa2_newsletter_admin)
+    if (!admin) return { adminProfile: null }
     return {
-        adminCount: node.admin_count,
-        adminProfile: parseAdminProfile(node.admin_profile)
+        adminCount: asUndef(tryAsNumber(admin.admin_count)),
+        adminProfile: parseAdminProfile(admin.admin_profile)
     }
 }
 
 export function parseAdminCapabilities(envelope: WaNewsletterMexEnvelope): ReadonlySet<string> {
-    const admin = (envelope as { readonly xwa2_newsletter_admin?: unknown }).xwa2_newsletter_admin
-    if (!admin || typeof admin !== 'object') return new Set()
-    const capabilities = (admin as { readonly capabilities?: readonly string[] }).capabilities
-    return new Set(Array.isArray(capabilities) ? capabilities : [])
+    const admin = tryAsRecord(envelope.xwa2_newsletter_admin)
+    const result = new Set<string>()
+    for (const cap of asArray(admin?.capabilities)) {
+        const s = tryAsString(cap)
+        if (s) result.add(s)
+    }
+    return result
 }
 
 export function parsePendingInvites(envelope: WaNewsletterMexEnvelope): readonly string[] {
-    const admin = (envelope as { readonly xwa2_newsletter_admin?: unknown }).xwa2_newsletter_admin
-    if (!admin || typeof admin !== 'object') return []
-    const invites = (
-        admin as {
-            readonly pending_admin_invites?: readonly {
-                readonly user?: { readonly id?: string; readonly pn?: string }
-            }[]
-        }
-    ).pending_admin_invites
-    if (!Array.isArray(invites)) return []
+    const admin = tryAsRecord(envelope.xwa2_newsletter_admin)
     const result: string[] = []
-    for (const invite of invites) {
-        const user = invite?.user
-        const id = user?.pn ?? user?.id
+    for (const inviteRaw of asArray(admin?.pending_admin_invites)) {
+        const user = tryAsRecord(tryAsRecord(inviteRaw)?.user)
+        const id = tryAsString(user?.pn) ?? tryAsString(user?.id)
         if (id) result.push(id)
     }
     return result
 }
 
 export function parseFollowers(envelope: WaNewsletterMexEnvelope): WaNewsletterFollowersPage {
-    const root = (envelope as { readonly xwa2_newsletter_followers?: unknown })
-        .xwa2_newsletter_followers
-    if (!root || typeof root !== 'object') {
-        return { followers: [] }
-    }
-    const followersWrap = (
-        root as {
-            readonly followers?: {
-                readonly edges?: readonly RawFollowerEdge[]
-                readonly page_info?: RawPageInfo
-            }
-        }
-    ).followers
-    const edges = followersWrap?.edges ?? []
+    const root = tryAsRecord(envelope.xwa2_newsletter_followers)
+    const followersWrap = tryAsRecord(root?.followers)
     const followers: WaNewsletterFollower[] = []
-    for (const edge of edges) {
-        const id = edge.node?.id
+    for (const edgeRaw of asArray(followersWrap?.edges)) {
+        const edge = tryAsRecord(edgeRaw)
+        const node = tryAsRecord(edge?.node)
+        const id = tryAsString(node?.id)
         if (!id) continue
         followers.push({
             id,
-            displayName: edge.node?.display_name,
-            role: edge.role as WaNewsletterRole | undefined,
-            phoneJid: edge.node?.pn,
-            username: edge.node?.username_info?.username,
-            followTime: toNumber(edge.follow_time),
-            adminProfile: parseAdminProfile(edge.admin_profile)
+            displayName: asUndef(tryAsString(node?.display_name)),
+            role: (tryAsString(edge?.role) as WaNewsletterRole | null) ?? undefined,
+            phoneJid: asUndef(tryAsString(node?.pn)),
+            username: asUndef(tryAsString(tryAsRecord(node?.username_info)?.username)),
+            followTime: asUndef(tryAsNumber(edge?.follow_time)),
+            adminProfile: parseAdminProfile(edge?.admin_profile)
         })
     }
     return { followers, pageInfo: parsePageInfo(followersWrap?.page_info) }
 }
 
-interface RawDirectoryResponse {
-    readonly result?: readonly MexNewsletterEnvelope[]
-    readonly page_info?: RawPageInfo
+function parseDirectoryResponse(root: unknown): WaNewsletterDirectoryResults {
+    const r = tryAsRecord(root)
+    return {
+        results: asArray(r?.result).map(parseNewsletterMetadata),
+        pageInfo: parsePageInfo(r?.page_info)
+    }
 }
 
 export function parseDirectorySearch(
     envelope: WaNewsletterMexEnvelope
 ): WaNewsletterDirectoryResults {
-    const root = (envelope as { readonly xwa2_newsletters_directory_search?: RawDirectoryResponse })
-        .xwa2_newsletters_directory_search
-    return {
-        results: (root?.result ?? []).map(parseNewsletterMetadata),
-        pageInfo: parsePageInfo(root?.page_info)
-    }
+    return parseDirectoryResponse(envelope.xwa2_newsletters_directory_search)
 }
 
 export function parseDirectoryList(
     envelope: WaNewsletterMexEnvelope
 ): WaNewsletterDirectoryResults {
-    const root = (
-        envelope as { readonly xwa2_newsletters_directory_list_v2?: RawDirectoryResponse }
-    ).xwa2_newsletters_directory_list_v2
-    return {
-        results: (root?.result ?? []).map(parseNewsletterMetadata),
-        pageInfo: parsePageInfo(root?.page_info)
-    }
+    return parseDirectoryResponse(envelope.xwa2_newsletters_directory_list_v2)
 }
 
 export function parseRecommended(
     envelope: WaNewsletterMexEnvelope
 ): readonly WaNewsletterMetadata[] {
-    const root = (envelope as { readonly xwa2_recommended_newsletters?: RawDirectoryResponse })
-        .xwa2_recommended_newsletters
-    return (root?.result ?? []).map(parseNewsletterMetadata)
+    return parseDirectoryResponse(envelope.xwa2_recommended_newsletters).results
 }
 
 export function parseSimilar(envelope: WaNewsletterMexEnvelope): readonly WaNewsletterMetadata[] {
-    const root = (envelope as { readonly xwa2_newsletters_similar?: RawDirectoryResponse })
-        .xwa2_newsletters_similar
-    return (root?.result ?? []).map(parseNewsletterMetadata)
+    return parseDirectoryResponse(envelope.xwa2_newsletters_similar).results
 }
 
 export function parseDomainsPreviewable(
     envelope: WaNewsletterMexEnvelope
 ): ReadonlyMap<string, boolean> {
-    const root = (
-        envelope as {
-            readonly xwa2_newsletter_message_integrity?: {
-                readonly url_previews?: readonly {
-                    readonly url_domain?: string
-                    readonly is_previewable?: boolean
-                }[]
-            }
-        }
-    ).xwa2_newsletter_message_integrity
-    const previews = root?.url_previews ?? []
+    const root = tryAsRecord(envelope.xwa2_newsletter_message_integrity)
     const map = new Map<string, boolean>()
-    for (const preview of previews) {
-        if (preview.url_domain) {
-            map.set(preview.url_domain, preview.is_previewable === true)
+    for (const previewRaw of asArray(root?.url_previews)) {
+        const preview = tryAsRecord(previewRaw)
+        const domain = tryAsString(preview?.url_domain)
+        if (domain) {
+            map.set(domain, preview?.is_previewable === true)
         }
     }
     return map
 }
 
-interface RawDirectoryCategoryPreviewEntry {
-    readonly category?: string
-    readonly category_title?: string
-    readonly newsletters?: readonly MexNewsletterEnvelope[]
-}
-
 export function parseDirectoryCategoriesPreview(
     envelope: WaNewsletterMexEnvelope
 ): readonly WaNewsletterDirectoryCategoryPreview[] {
-    const root = (
-        envelope as {
-            readonly xwa2_newsletters_directory_category_preview?: {
-                readonly result?: readonly RawDirectoryCategoryPreviewEntry[]
-            }
-        }
-    ).xwa2_newsletters_directory_category_preview
-    const entries = root?.result ?? []
+    const root = tryAsRecord(envelope.xwa2_newsletters_directory_category_preview)
     const result: WaNewsletterDirectoryCategoryPreview[] = []
-    for (const entry of entries) {
-        if (!entry.category) continue
+    for (const entryRaw of asArray(root?.result)) {
+        const entry = tryAsRecord(entryRaw)
+        const category = tryAsString(entry?.category)
+        if (!category) continue
         result.push({
-            category: entry.category,
-            categoryTitle: entry.category_title,
-            newsletters: (entry.newsletters ?? []).map(parseNewsletterMetadata)
+            category,
+            categoryTitle: asUndef(tryAsString(entry?.category_title)),
+            newsletters: asArray(entry?.newsletters).map(parseNewsletterMetadata)
         })
     }
     return result
 }
 
-interface RawDehydratedNewsletter {
-    readonly id?: string
-    readonly thread_metadata?: {
-        readonly subscribers_count?: string | number
-        readonly verification?: string
-        readonly settings?: { readonly reaction_codes?: { readonly value?: string } }
-        readonly wamo_sub?: { readonly plan_id?: string }
-    }
-    readonly viewer_metadata?: { readonly wamo_sub_status?: string }
-}
-
 export function parseDehydratedMetadata(
     envelope: WaNewsletterMexEnvelope
 ): WaNewsletterDehydratedMetadata {
-    const node = (envelope as { readonly xwa2_newsletter?: RawDehydratedNewsletter })
-        .xwa2_newsletter
-    const meta = node?.thread_metadata
+    const node = tryAsRecord(envelope.xwa2_newsletter)
+    const meta = tryAsRecord(node?.thread_metadata)
+    const reactionCodes = tryAsRecord(tryAsRecord(meta?.settings)?.reaction_codes)
+    const wamoSub = tryAsRecord(meta?.wamo_sub)
+    const viewer = tryAsRecord(node?.viewer_metadata)
     return {
-        jid: node?.id ?? '',
-        subscribersCount: toNumber(meta?.subscribers_count),
-        verification: meta?.verification,
-        reactionCodesSetting: meta?.settings?.reaction_codes?.value,
-        wamoSubPlanId: meta?.wamo_sub?.plan_id,
-        wamoSubStatus: node?.viewer_metadata?.wamo_sub_status
+        jid: tryAsString(node?.id) ?? '',
+        subscribersCount: asUndef(tryAsNumber(meta?.subscribers_count)),
+        verification: asUndef(tryAsString(meta?.verification)),
+        reactionCodesSetting: asUndef(tryAsString(reactionCodes?.value)),
+        wamoSubPlanId: asUndef(tryAsString(wamoSub?.plan_id)),
+        wamoSubStatus: asUndef(tryAsString(viewer?.wamo_sub_status))
     }
 }
 
 export function parseAdminInviteResult(
     envelope: WaNewsletterMexEnvelope
 ): WaNewsletterAdminInviteResult {
-    const root = (
-        envelope as {
-            readonly xwa2_newsletter_admin_invite_create?: {
-                readonly id?: string
-                readonly invite_expiration_time?: string | number
-            }
-        }
-    ).xwa2_newsletter_admin_invite_create
+    const root = tryAsRecord(envelope.xwa2_newsletter_admin_invite_create)
     return {
-        inviteId: root?.id,
-        expirationTime: toNumber(root?.invite_expiration_time)
-    }
-}
-
-interface RawReactionEntry {
-    readonly reaction_code?: string
-    readonly sender_list?: {
-        readonly edges?: readonly {
-            readonly node?: { readonly id?: string; readonly profile_pic_direct_path?: string }
-        }[]
+        inviteId: asUndef(tryAsString(root?.id)),
+        expirationTime: asUndef(tryAsNumber(root?.invite_expiration_time))
     }
 }
 
 export function parseReactionSenders(
     envelope: WaNewsletterMexEnvelope
 ): readonly WaNewsletterReactionSenders[] {
-    const root = (
-        envelope as {
-            readonly xwa2_newsletters_reaction_sender_list?: {
-                readonly reactions?: readonly RawReactionEntry[]
-            }
+    const root = tryAsRecord(envelope.xwa2_newsletters_reaction_sender_list)
+    return asArray(root?.reactions).map((entryRaw) => {
+        const entry = tryAsRecord(entryRaw)
+        const senderList = tryAsRecord(entry?.sender_list)
+        const senders: { readonly id: string; readonly profileUrl?: string }[] = []
+        for (const edgeRaw of asArray(senderList?.edges)) {
+            const node = tryAsRecord(tryAsRecord(edgeRaw)?.node)
+            const id = tryAsString(node?.id)
+            if (!id) continue
+            senders.push({
+                id,
+                profileUrl: asUndef(tryAsString(node?.profile_pic_direct_path))
+            })
         }
-    ).xwa2_newsletters_reaction_sender_list
-    const reactions = root?.reactions ?? []
-    return reactions.map((entry) => ({
-        reactionCode: entry.reaction_code ?? '',
-        senders: (entry.sender_list?.edges ?? [])
-            .map((edge) => ({
-                id: edge.node?.id ?? '',
-                profileUrl: edge.node?.profile_pic_direct_path
-            }))
-            .filter((sender) => sender.id.length > 0)
-    }))
-}
-
-interface RawVotesGroup {
-    readonly vote_hash?: string
-    readonly voter_list?: {
-        readonly edges?: readonly {
-            readonly node?: { readonly id?: string }
-            readonly action_time?: string | number
-        }[]
-    }
+        return { reactionCode: tryAsString(entry?.reaction_code) ?? '', senders }
+    })
 }
 
 export function parsePollVoters(
     envelope: WaNewsletterMexEnvelope
 ): ReadonlyMap<string, readonly WaNewsletterPollVoter[]> {
-    const root = (
-        envelope as {
-            readonly voter_list?: { readonly votes?: readonly RawVotesGroup[] }
-        }
-    ).voter_list
-    const votes = root?.votes ?? []
+    const root = tryAsRecord(envelope.voter_list)
     const map = new Map<string, readonly WaNewsletterPollVoter[]>()
-    for (const group of votes) {
-        if (!group.vote_hash) continue
+    for (const groupRaw of asArray(root?.votes)) {
+        const group = tryAsRecord(groupRaw)
+        const voteHash = tryAsString(group?.vote_hash)
+        if (!voteHash) continue
+        const voterList = tryAsRecord(group?.voter_list)
         const voters: WaNewsletterPollVoter[] = []
-        for (const edge of group.voter_list?.edges ?? []) {
-            const id = edge.node?.id
+        for (const edgeRaw of asArray(voterList?.edges)) {
+            const edge = tryAsRecord(edgeRaw)
+            const node = tryAsRecord(edge?.node)
+            const id = tryAsString(node?.id)
             if (!id) continue
-            const time = toNumber(edge.action_time)
+            const time = tryAsNumber(edge?.action_time)
             voters.push({
                 id,
-                time: time !== undefined ? Math.floor(time / 1_000_000) : undefined
+                time: time !== null ? Math.floor(time / 1_000_000) : undefined
             })
         }
-        map.set(group.vote_hash, voters)
+        map.set(voteHash, voters)
     }
     return map
 }


### PR DESCRIPTION
Add 9 typed mex methods:

- group.isInternalGroup
- group.transferCommunityOwnership
- group.fetchSubgroupSuggestions
- group.submitGroupSuspensionAppeal
- profile.getAboutStatus
- profile.checkUsernameAvailability
- profile.setUsernameKey
- message.getReachoutTimelock
- message.getNewChatMessageCapping

Refactor existing parsers to use WaMexOperationResponses['<Op>'] + tryAsRecord/tryAsString/tryAsNumber from @util/coercion. Drops the local Mex*Result interfaces and inline shape casts across newsletter/parse.ts, admin.ts, discovery.ts, WaProfileCoordinator and WaGroupCoordinator — net ~150 fewer lines of cast ceremony.

Wire mexSocket through WaClientFactory for WaMessageCoordinator so the new message-quota methods have transport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added community ownership transfer capability.
  * Added subgroup suggestion and suspension appeal features for group management.
  * Added account reachout timelock and message capping information retrieval.
  * Added username availability checking and profile management features including about status and username key settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->