### PR TITLE
feat(call): typed call events + outbound receipt/ack

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -346,6 +346,7 @@ function createIncomingNodeRuntime(input: {
         emitIncomingPresence: (event) => emitEvent('presence', event),
         emitIncomingChatstate: (event) => emitEvent('chatstate', event),
         emitIncomingCall: (event) => emitEvent('call', event),
+        getCurrentCredentials,
         emitIncomingFailure: (event) => emitEvent('stream_failure', event),
         emitIncomingErrorStanza: (event) => emitEvent('stanza_error', event),
         emitIncomingNotification: (event) => emitEvent('debug_notification', event),

--- a/src/client/__tests__/incoming.test.ts
+++ b/src/client/__tests__/incoming.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
     createIncomingBusinessNotificationHandler,
+    createIncomingCallHandler,
     createIncomingFailureHandler,
     createIncomingNotificationHandler,
     createIncomingReceiptHandler,
@@ -11,6 +12,7 @@ import {
 import type {
     WaAccountTakeoverNoticeEvent,
     WaBusinessEvent,
+    WaIncomingCallEvent,
     WaIncomingUnhandledStanzaEvent,
     WaRegistrationCodeEvent
 } from '@client/types'
@@ -459,4 +461,167 @@ test('failure handler maps disconnect-only reasons without clearing credentials'
             code: 409
         }
     ])
+})
+
+const ME_PN = '5511999999999:2@s.whatsapp.net'
+const ME_LID = '50062877036657:68@lid'
+
+function createCallTestHarness(credentials: { meJid?: string; meLid?: string } | null = null) {
+    const sent: BinaryNode[] = []
+    const emitted: WaIncomingCallEvent[] = []
+    const handler = createIncomingCallHandler({
+        logger: createNoopLogger(),
+        sendNode: async (node) => {
+            sent.push(node)
+        },
+        emitIncomingCall: (event) => {
+            emitted.push(event)
+        },
+        getCurrentCredentials: () => (credentials ? (credentials as never) : null)
+    })
+    return { sent, emitted, handler }
+}
+
+test('call handler sends typed receipt for offer to PN peer (from=meJid user-form)', async () => {
+    const { sent, emitted, handler } = createCallTestHarness({ meJid: ME_PN, meLid: ME_LID })
+
+    await handler({
+        tag: 'call',
+        attrs: { id: 'CALL1', from: '5511@s.whatsapp.net', t: '1700000000' },
+        content: [
+            {
+                tag: 'offer',
+                attrs: { 'call-id': 'CID-1', 'call-creator': '5511:1@s.whatsapp.net' }
+            }
+        ]
+    })
+
+    assert.equal(emitted.length, 1)
+    assert.equal(emitted[0].type, 'offer')
+    assert.equal(emitted[0].callId, 'CID-1')
+
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].tag, 'receipt')
+    assert.equal(sent[0].attrs.to, '5511@s.whatsapp.net')
+    assert.equal(sent[0].attrs.id, 'CALL1')
+    assert.equal(sent[0].attrs.from, '5511999999999@s.whatsapp.net')
+    assert.equal('class' in sent[0].attrs, false)
+    assert.ok(Array.isArray(sent[0].content) && sent[0].content.length === 1)
+    const child = (sent[0].content as BinaryNode[])[0]
+    assert.equal(child.tag, 'offer')
+    assert.deepEqual(child.attrs, {
+        'call-id': 'CID-1',
+        'call-creator': '5511:1@s.whatsapp.net'
+    })
+})
+
+test('call handler sends typed receipt for LID peer (from=meLid device-form)', async () => {
+    const { sent, handler } = createCallTestHarness({ meJid: ME_PN, meLid: ME_LID })
+
+    await handler({
+        tag: 'call',
+        attrs: { id: 'CALL2', from: '53979165777985@lid' },
+        content: [
+            {
+                tag: 'offer',
+                attrs: { 'call-id': 'CID-2', 'call-creator': '53979165777985@lid' }
+            }
+        ]
+    })
+
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].tag, 'receipt')
+    assert.equal(sent[0].attrs.from, ME_LID)
+})
+
+test('call handler sends receipt for accept/reject/enc_rekey payload tags', async () => {
+    for (const tag of ['accept', 'reject', 'enc_rekey'] as const) {
+        const { sent, handler } = createCallTestHarness({ meJid: ME_PN })
+        await handler({
+            tag: 'call',
+            attrs: { id: 'X', from: '5511@s.whatsapp.net' },
+            content: [{ tag, attrs: { 'call-id': 'C', 'call-creator': '5511:1@s.whatsapp.net' } }]
+        })
+        assert.equal(sent.length, 1, `expected receipt for ${tag}`)
+        assert.equal(sent[0].tag, 'receipt', `expected <receipt> for ${tag}`)
+        const child = (sent[0].content as BinaryNode[])[0]
+        assert.equal(child.tag, tag)
+    }
+})
+
+test('call handler sends class=call ack for other recognized payload tags', async () => {
+    for (const tag of ['terminate', 'transport', 'mute', 'preaccept', 'video_state'] as const) {
+        const { sent, handler } = createCallTestHarness()
+        await handler({
+            tag: 'call',
+            attrs: { id: 'X', from: '5511@s.whatsapp.net' },
+            content: [{ tag, attrs: { 'call-id': 'C', 'call-creator': '5511:1@s.whatsapp.net' } }]
+        })
+        assert.equal(sent.length, 1, `expected ack for ${tag}`)
+        assert.equal(sent[0].tag, 'ack')
+        assert.equal(sent[0].attrs.class, 'call')
+        assert.equal(sent[0].attrs.type, tag)
+        assert.equal(sent[0].attrs.to, '5511@s.whatsapp.net')
+        assert.equal(sent[0].attrs.id, 'X')
+    }
+})
+
+test('call handler sends class=call ack for unknown payload tag (preserves raw tag in type)', async () => {
+    const { sent, emitted, handler } = createCallTestHarness()
+    await handler({
+        tag: 'call',
+        attrs: { id: 'RL1', from: '5511@s.whatsapp.net' },
+        content: [
+            {
+                tag: 'relaylatency',
+                attrs: { 'call-id': 'C', 'call-creator': '5511:1@s.whatsapp.net' }
+            }
+        ]
+    })
+    assert.equal(emitted[0].type, 'unknown')
+    assert.equal(emitted[0].payloadTag, 'relaylatency')
+    assert.equal(sent[0].tag, 'ack')
+    assert.equal(sent[0].attrs.class, 'call')
+    assert.equal(sent[0].attrs.type, 'relaylatency')
+})
+
+test('call handler omits from on receipt when credentials are missing', async () => {
+    const { sent, handler } = createCallTestHarness(null)
+    await handler({
+        tag: 'call',
+        attrs: { id: 'X', from: '5511@s.whatsapp.net' },
+        content: [
+            { tag: 'offer', attrs: { 'call-id': 'C', 'call-creator': '5511:1@s.whatsapp.net' } }
+        ]
+    })
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].tag, 'receipt')
+    assert.equal('from' in sent[0].attrs, false)
+})
+
+test('call handler omits from on receipt when meJid is malformed instead of throwing', async () => {
+    const { sent, handler } = createCallTestHarness({ meJid: 'not-a-jid' })
+    await handler({
+        tag: 'call',
+        attrs: { id: 'X', from: '5511@s.whatsapp.net' },
+        content: [
+            { tag: 'offer', attrs: { 'call-id': 'C', 'call-creator': '5511:1@s.whatsapp.net' } }
+        ]
+    })
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].tag, 'receipt')
+    assert.equal('from' in sent[0].attrs, false)
+})
+
+test('call handler emits event but sends nothing when call stanza lacks id or from', async () => {
+    const { sent, emitted, handler } = createCallTestHarness()
+    await handler({
+        tag: 'call',
+        attrs: {},
+        content: [
+            { tag: 'offer', attrs: { 'call-id': 'C', 'call-creator': '5511:1@s.whatsapp.net' } }
+        ]
+    })
+    assert.equal(emitted.length, 1)
+    assert.equal(sent.length, 0)
 })

--- a/src/client/coordinators/WaIncomingNodeCoordinator.ts
+++ b/src/client/coordinators/WaIncomingNodeCoordinator.ts
@@ -1,4 +1,4 @@
-import type { WaSuccessPersistAttributes } from '@auth/types'
+import type { WaAuthCredentials, WaSuccessPersistAttributes } from '@auth/types'
 import type { WaOfflineResumeCoordinator } from '@client/coordinators/WaOfflineResumeCoordinator'
 import { parseChatstateNode } from '@client/events/chatstate'
 import type { WaDirtyBit } from '@client/events/dirty'
@@ -6,6 +6,7 @@ import {
     buildInboundAck,
     createIncomingBaseEvent,
     createIncomingBusinessNotificationHandler,
+    createIncomingCallHandler,
     createIncomingFailureHandler,
     createIncomingGroupNotificationHandler,
     createIncomingNotificationHandler,
@@ -81,6 +82,7 @@ interface WaIncomingNodeRuntime {
     readonly emitIncomingPresence: (event: WaIncomingPresenceEvent) => void
     readonly emitIncomingChatstate: (event: WaIncomingChatstateEvent) => void
     readonly emitIncomingCall: (event: WaIncomingCallEvent) => void
+    readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly emitIncomingFailure: (event: WaIncomingFailureEvent) => void
     readonly emitIncomingErrorStanza: (event: WaIncomingErrorStanzaEvent) => void
     readonly emitIncomingNotification: (event: WaIncomingNotificationEvent) => void
@@ -407,12 +409,13 @@ export class WaIncomingNodeCoordinator {
             }
         })
         this.registerIncomingHandler({
-            tag: 'call',
-            // eslint-disable-next-line @typescript-eslint/require-await
-            handler: async (node) => {
-                runtime.emitIncomingCall(createIncomingBaseEvent(node))
-                return true
-            }
+            tag: WA_NODE_TAGS.CALL,
+            handler: createIncomingCallHandler({
+                logger: this.logger,
+                sendNode: runtime.sendNode,
+                emitIncomingCall: runtime.emitIncomingCall,
+                getCurrentCredentials: runtime.getCurrentCredentials
+            })
         })
         this.registerIncomingHandler({
             tag: 'failure',

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -58,6 +58,7 @@ function createIncomingRuntime() {
             emitIncomingPresence: () => undefined,
             emitIncomingChatstate: () => undefined,
             emitIncomingCall: () => undefined,
+            getCurrentCredentials: () => null,
             emitIncomingFailure: () => undefined,
             emitIncomingErrorStanza: () => undefined,
             emitIncomingNotification: () => undefined,

--- a/src/client/events/__tests__/events.test.ts
+++ b/src/client/events/__tests__/events.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import { parseAppStateMutationEvent } from '@client/events/appstate-mutation'
 import { parseBusinessNotificationEvents } from '@client/events/business'
+import { parseCallNode } from '@client/events/call'
 import { parseChatstateNode } from '@client/events/chatstate'
 import { parseGroupNotificationEvents } from '@client/events/group'
 import { parseMexNotification } from '@client/events/mex-notification'
@@ -1030,4 +1031,158 @@ test('parseMexNotification: returns null when JSON parses to a non-object', () =
             `expected null for JSON payload ${literal}`
         )
     }
+})
+
+test('parseCallNode: extracts offer payload with video and caller metadata', () => {
+    const parsed = parseCallNode({
+        tag: 'call',
+        attrs: {
+            id: 'CALL1',
+            from: '5511@s.whatsapp.net',
+            t: '1700000000',
+            e: '1700000060',
+            platform: 'web',
+            version: '2.3000.0'
+        },
+        content: [
+            {
+                tag: 'offer',
+                attrs: {
+                    'call-id': 'CID-1',
+                    'call-creator': '5511:1@s.whatsapp.net',
+                    caller_pn: '5511@s.whatsapp.net',
+                    username: 'alice',
+                    caller_country_code: '55',
+                    notify: 'Alice'
+                },
+                content: [
+                    { tag: 'video', attrs: {} },
+                    { tag: 'silence', attrs: { reason: 'vc_wave_all' } }
+                ]
+            }
+        ]
+    })
+
+    assert.equal(parsed.type, 'offer')
+    assert.equal(parsed.payloadTag, 'offer')
+    assert.equal(parsed.callId, 'CID-1')
+    assert.equal(parsed.callCreatorJid, '5511:1@s.whatsapp.net')
+    assert.equal(parsed.callerPnJid, '5511@s.whatsapp.net')
+    assert.equal(parsed.callerUsername, 'alice')
+    assert.equal(parsed.callerCountryCode, '55')
+    assert.equal(parsed.callerPushName, 'Alice')
+    assert.equal(parsed.peerPlatform, 'web')
+    assert.equal(parsed.peerAppVersion, '2.3000.0')
+    assert.equal(parsed.timestampSeconds, 1_700_000_000)
+    assert.equal(parsed.endTimestampSeconds, 1_700_000_060)
+    assert.equal(parsed.isVideo, true)
+    assert.equal(parsed.silenceReason, 'vc_wave_all')
+    assert.equal(parsed.groupInfo, undefined)
+})
+
+test('parseCallNode: extracts group_info participants and sender_lid', () => {
+    const parsed = parseCallNode({
+        tag: 'call',
+        attrs: {
+            id: 'CALL2',
+            from: '5511@s.whatsapp.net',
+            sender_lid: '99:1@lid'
+        },
+        content: [
+            {
+                tag: 'offer',
+                attrs: {
+                    'call-id': 'CID-2',
+                    'call-creator': '5511:1@s.whatsapp.net',
+                    'group-jid': '120@g.us'
+                },
+                content: [
+                    {
+                        tag: 'group_info',
+                        attrs: {},
+                        content: [
+                            {
+                                tag: 'participant',
+                                attrs: {
+                                    jid: '5522:0@lid',
+                                    user_pn: '5522@s.whatsapp.net',
+                                    username: 'bob',
+                                    guest_name: 'Bob G.'
+                                }
+                            },
+                            { tag: 'participant', attrs: { jid: '5533:0@lid' } }
+                        ]
+                    }
+                ]
+            }
+        ]
+    })
+
+    assert.equal(parsed.type, 'offer')
+    assert.equal(parsed.senderLidJid, '99:1@lid')
+    assert.equal(parsed.groupJid, '120@g.us')
+    assert.equal(parsed.isVideo, false)
+    assert.equal(parsed.groupInfo?.length, 2)
+    assert.deepEqual(parsed.groupInfo?.[0], {
+        jid: '5522:0@lid',
+        userPnJid: '5522@s.whatsapp.net',
+        username: 'bob',
+        guestName: 'Bob G.'
+    })
+    assert.deepEqual(parsed.groupInfo?.[1], {
+        jid: '5533:0@lid',
+        userPnJid: undefined,
+        username: undefined,
+        guestName: undefined
+    })
+})
+
+test('parseCallNode: maps recognized payload tags to typed discriminator', () => {
+    const tags = [
+        'accept',
+        'reject',
+        'terminate',
+        'transport',
+        'mute',
+        'preaccept',
+        'video_state',
+        'enc_rekey',
+        'peer_state',
+        'flow_control',
+        'web_client',
+        'group_update',
+        'offer_notice'
+    ] as const
+
+    for (const tag of tags) {
+        const parsed = parseCallNode({
+            tag: 'call',
+            attrs: { id: 'X', from: '5511@s.whatsapp.net' },
+            content: [{ tag, attrs: { 'call-id': 'C', 'call-creator': '5511:1@s.whatsapp.net' } }]
+        })
+        assert.equal(parsed.type, tag)
+        assert.equal(parsed.payloadTag, tag)
+        assert.equal(parsed.callId, 'C')
+    }
+})
+
+test('parseCallNode: returns unknown type for unrecognized or empty payload', () => {
+    const unknownTag = parseCallNode({
+        tag: 'call',
+        attrs: { id: 'X', from: '5511@s.whatsapp.net' },
+        content: [{ tag: 'frobnicate', attrs: { 'call-id': 'C' } }]
+    })
+    assert.equal(unknownTag.type, 'unknown')
+    assert.equal(unknownTag.payloadTag, 'frobnicate')
+    assert.equal(unknownTag.callId, 'C')
+
+    const empty = parseCallNode({
+        tag: 'call',
+        attrs: { id: 'X', from: '5511@s.whatsapp.net' },
+        content: []
+    })
+    assert.equal(empty.type, 'unknown')
+    assert.equal(empty.payloadTag, undefined)
+    assert.equal(empty.callId, undefined)
+    assert.equal(empty.isVideo, false)
 })

--- a/src/client/events/call.ts
+++ b/src/client/events/call.ts
@@ -1,0 +1,99 @@
+import {
+    WA_CALL_CHILD_TAGS,
+    WA_CALL_NODE_ATTRS,
+    WA_CALL_PAYLOAD_TAGS,
+    type WaCallPayloadTag
+} from '@protocol/call'
+import {
+    findNodeChild,
+    getFirstNodeChild,
+    getNodeChildren,
+    hasNodeChild
+} from '@transport/node/helpers'
+import type { BinaryNode } from '@transport/types'
+import { parseOptionalInt } from '@util/primitives'
+
+export type WaCallType = WaCallPayloadTag | 'unknown'
+
+const KNOWN_CALL_PAYLOAD_TAGS: ReadonlySet<string> = new Set(Object.values(WA_CALL_PAYLOAD_TAGS))
+
+export interface WaCallGroupParticipant {
+    readonly jid: string
+    readonly userPnJid?: string
+    readonly username?: string
+    readonly guestName?: string
+}
+
+export interface ParsedCall {
+    readonly type: WaCallType
+    readonly payloadTag?: string
+    readonly callId?: string
+    readonly callCreatorJid?: string
+    readonly senderLidJid?: string
+    readonly callerPnJid?: string
+    readonly groupJid?: string
+    readonly isVideo: boolean
+    readonly callerUsername?: string
+    readonly callerCountryCode?: string
+    readonly callerPushName?: string
+    readonly peerPlatform?: string
+    readonly peerAppVersion?: string
+    readonly timestampSeconds?: number
+    readonly endTimestampSeconds?: number
+    readonly silenceReason?: string
+    readonly groupInfo?: readonly WaCallGroupParticipant[]
+}
+
+function parseGroupInfo(node: BinaryNode): readonly WaCallGroupParticipant[] | undefined {
+    const children = getNodeChildren(node)
+    if (children.length === 0) {
+        return undefined
+    }
+    const out: WaCallGroupParticipant[] = []
+    for (let i = 0; i < children.length; i += 1) {
+        const child = children[i]
+        const jid = child.attrs.jid
+        if (!jid) continue
+        out.push({
+            jid,
+            userPnJid: child.attrs[WA_CALL_NODE_ATTRS.USER_PN],
+            username: child.attrs[WA_CALL_NODE_ATTRS.USERNAME],
+            guestName: child.attrs[WA_CALL_NODE_ATTRS.GUEST_NAME]
+        })
+    }
+    return out.length > 0 ? out : undefined
+}
+
+export function parseCallNode(node: BinaryNode): ParsedCall {
+    const payload = getFirstNodeChild(node)
+    if (!payload) {
+        return { type: 'unknown', isVideo: false }
+    }
+    const payloadTag = payload.tag
+    const type: WaCallType = KNOWN_CALL_PAYLOAD_TAGS.has(payloadTag)
+        ? (payloadTag as WaCallPayloadTag)
+        : 'unknown'
+
+    const groupInfoNode = findNodeChild(payload, WA_CALL_CHILD_TAGS.GROUP_INFO)
+    const silenceNode = findNodeChild(payload, WA_CALL_CHILD_TAGS.SILENCE)
+
+    return {
+        type,
+        payloadTag,
+        callId: payload.attrs[WA_CALL_NODE_ATTRS.CALL_ID],
+        callCreatorJid: payload.attrs[WA_CALL_NODE_ATTRS.CALL_CREATOR],
+        senderLidJid: node.attrs[WA_CALL_NODE_ATTRS.SENDER_LID],
+        callerPnJid: payload.attrs[WA_CALL_NODE_ATTRS.CALLER_PN],
+        groupJid: payload.attrs[WA_CALL_NODE_ATTRS.GROUP_JID],
+        isVideo: hasNodeChild(payload, WA_CALL_CHILD_TAGS.VIDEO),
+        callerUsername: payload.attrs[WA_CALL_NODE_ATTRS.USERNAME],
+        callerCountryCode: payload.attrs[WA_CALL_NODE_ATTRS.CALLER_COUNTRY_CODE],
+        callerPushName: payload.attrs[WA_CALL_NODE_ATTRS.NOTIFY],
+        peerPlatform: node.attrs[WA_CALL_NODE_ATTRS.PLATFORM],
+        peerAppVersion: node.attrs[WA_CALL_NODE_ATTRS.VERSION],
+        timestampSeconds: parseOptionalInt(node.attrs.t),
+        endTimestampSeconds: parseOptionalInt(node.attrs.e),
+        silenceReason: silenceNode?.attrs[WA_CALL_NODE_ATTRS.REASON],
+        groupInfo: groupInfoNode ? parseGroupInfo(groupInfoNode) : undefined
+    }
+}

--- a/src/client/events/incoming.ts
+++ b/src/client/events/incoming.ts
@@ -1,4 +1,6 @@
+import type { WaAuthCredentials } from '@auth/types'
 import { parseBusinessNotificationEvents } from '@client/events/business'
+import { parseCallNode } from '@client/events/call'
 import { parseGroupNotificationEvents } from '@client/events/group'
 import { parseMexNotification } from '@client/events/mex-notification'
 import { parsePictureNotificationEvents } from '@client/events/picture'
@@ -8,6 +10,7 @@ import type {
     WaBusinessEvent,
     WaGroupEvent,
     WaIncomingBaseEvent,
+    WaIncomingCallEvent,
     WaIncomingFailureEvent,
     WaIncomingNotificationEvent,
     WaIncomingReceiptEvent,
@@ -19,14 +22,17 @@ import type {
 } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import {
+    WA_CALL_NODE_ATTRS,
+    WA_CALL_RECEIPT_PAYLOAD_TAGS,
     WA_DISCONNECT_REASONS,
     WA_MESSAGE_TAGS,
     WA_MESSAGE_TYPES,
     WA_NODE_TAGS,
     WA_NOTIFICATION_TYPES
 } from '@protocol/constants'
+import { isLidJid, normalizeDeviceJid, toUserJid } from '@protocol/jid'
 import type { WaConnectionCode, WaDisconnectReason } from '@protocol/stream'
-import { buildAckNode } from '@transport/node/builders/global'
+import { buildAckNode, buildReceiptNode } from '@transport/node/builders/global'
 import { getFirstNodeChild, getNodeChildrenNonEmptyAttrValuesByTag } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
 import { parseOptionalInt, toError } from '@util/primitives'
@@ -79,6 +85,11 @@ type IncomingPictureNotificationHandlerOptions = IncomingAckRuntime & {
 type IncomingRegistrationNotificationHandlerOptions = IncomingAckRuntime & {
     readonly emitRegistrationCode: (event: WaRegistrationCodeEvent) => void
     readonly emitAccountTakeoverNotice: (event: WaAccountTakeoverNoticeEvent) => void
+}
+
+type IncomingCallHandlerOptions = IncomingAckRuntime & {
+    readonly emitIncomingCall: (event: WaIncomingCallEvent) => void
+    readonly getCurrentCredentials: () => WaAuthCredentials | null
 }
 
 const FAILURE_REASON_TO_DISCONNECT: Readonly<Record<number, WaDisconnectReason>> = {
@@ -543,6 +554,71 @@ export function createIncomingPictureNotificationHandler(
         emit: options.emitPictureEvent,
         emitUnhandledStanza: options.emitUnhandledStanza
     })
+}
+
+export function createIncomingCallHandler(
+    options: IncomingCallHandlerOptions
+): (node: BinaryNode) => Promise<boolean> {
+    return async (node: BinaryNode): Promise<boolean> => {
+        const parsed = parseCallNode(node)
+        options.emitIncomingCall({
+            ...createIncomingBaseEvent(node),
+            ...parsed
+        })
+
+        const peerJid = node.attrs.from
+        const stanzaId = node.attrs.id
+        if (!peerJid || !stanzaId) {
+            options.logger.warn('incoming call missing required attrs for ack', {
+                hasFrom: peerJid !== undefined,
+                hasId: stanzaId !== undefined,
+                payloadTag: parsed.payloadTag
+            })
+            return true
+        }
+
+        const payloadTag = parsed.payloadTag
+        const isReceiptType =
+            parsed.type !== 'unknown' && WA_CALL_RECEIPT_PAYLOAD_TAGS.has(parsed.type)
+
+        let response: BinaryNode
+        if (isReceiptType && payloadTag && parsed.callId && parsed.callCreatorJid) {
+            const credentials = options.getCurrentCredentials()
+            const fromJid = isLidJid(peerJid)
+                ? credentials?.meLid && normalizeDeviceJid(credentials.meLid)
+                : credentials?.meJid && toUserJid(credentials.meJid)
+            const receiptAttrs: Record<string, string> = {
+                id: stanzaId,
+                to: peerJid
+            }
+            if (fromJid) {
+                receiptAttrs.from = fromJid
+            }
+            response = buildReceiptNode({
+                kind: 'custom',
+                attrs: receiptAttrs,
+                content: [
+                    {
+                        tag: payloadTag,
+                        attrs: {
+                            [WA_CALL_NODE_ATTRS.CALL_ID]: parsed.callId,
+                            [WA_CALL_NODE_ATTRS.CALL_CREATOR]: parsed.callCreatorJid
+                        }
+                    }
+                ]
+            })
+        } else {
+            response = buildAckNode({
+                kind: 'custom',
+                ackClass: WA_MESSAGE_TYPES.ACK_CLASS_CALL,
+                to: peerJid,
+                id: stanzaId,
+                type: payloadTag
+            })
+        }
+        await sendSafeAck(options.logger, options.sendNode, response)
+        return true
+    }
 }
 
 export function createInfoBulletinNotificationEvent(

--- a/src/client/events/incoming.ts
+++ b/src/client/events/incoming.ts
@@ -584,9 +584,24 @@ export function createIncomingCallHandler(
         let response: BinaryNode
         if (isReceiptType && payloadTag && parsed.callId && parsed.callCreatorJid) {
             const credentials = options.getCurrentCredentials()
-            const fromJid = isLidJid(peerJid)
-                ? credentials?.meLid && normalizeDeviceJid(credentials.meLid)
-                : credentials?.meJid && toUserJid(credentials.meJid)
+            let fromJid: string | undefined
+            try {
+                fromJid = isLidJid(peerJid)
+                    ? credentials?.meLid
+                        ? normalizeDeviceJid(credentials.meLid)
+                        : undefined
+                    : credentials?.meJid
+                      ? toUserJid(credentials.meJid)
+                      : undefined
+            } catch (error) {
+                options.logger.warn('failed to derive call receipt from jid', {
+                    peerJid,
+                    meLid: credentials?.meLid,
+                    meJid: credentials?.meJid,
+                    message: toError(error).message
+                })
+                fromJid = undefined
+            }
             const receiptAttrs: Record<string, string> = {
                 id: stanzaId,
                 to: peerJid

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -6,6 +6,7 @@ import type {
     WaAuthDangerousOptions,
     WaAuthSocketOptions
 } from '@auth/types'
+import type { WaCallGroupParticipant, WaCallType } from '@client/events/call'
 import type { IncomingPresenceType, PresenceLastSeen } from '@client/events/presence'
 import type { WaMediaProcessor } from '@media/processor'
 import type { WaLinkPreviewOptions } from '@message/addons/link-preview/types'
@@ -294,10 +295,37 @@ export interface WaIncomingChatstateEvent extends WaIncomingBaseEvent {
     readonly participantJid?: string
 }
 
-// TODO: populate with call-specific fields (offer id, call type, from device,
-// audio/video flag, etc.) and update WaIncomingNodeCoordinator's call handler
-// to parse them out of the <call> stanza instead of only passing the base node.
-export interface WaIncomingCallEvent extends WaIncomingBaseEvent {}
+export interface WaIncomingCallEvent extends WaIncomingBaseEvent {
+    /** Discriminator from the inner child tag (e.g. `offer`, `accept`, `terminate`). `unknown` when the child tag is missing or not recognized. */
+    readonly type: WaCallType
+    /** Original inner child tag, useful when `type === 'unknown'`. */
+    readonly payloadTag?: string
+    /** WhatsApp call identifier (from inner child `call-id`). */
+    readonly callId?: string
+    /** JID of the device that initiated the call. */
+    readonly callCreatorJid?: string
+    /** Sender LID of the call stanza, when present. */
+    readonly senderLidJid?: string
+    /** Phone-number JID of the caller, when present. */
+    readonly callerPnJid?: string
+    /** Group JID for group calls. */
+    readonly groupJid?: string
+    /** True when the call payload has a `<video/>` marker. */
+    readonly isVideo: boolean
+    readonly callerUsername?: string
+    readonly callerCountryCode?: string
+    readonly callerPushName?: string
+    readonly peerPlatform?: string
+    readonly peerAppVersion?: string
+    /** Stanza timestamp (`t` attr, seconds since epoch). */
+    readonly timestampSeconds?: number
+    /** Stanza end-of-validity timestamp (`e` attr, seconds since epoch). */
+    readonly endTimestampSeconds?: number
+    /** Optional silence reason (e.g. `vc_wave_all`). */
+    readonly silenceReason?: string
+    /** Group participant snapshot, when the stanza includes `<group_info>`. */
+    readonly groupInfo?: readonly WaCallGroupParticipant[]
+}
 
 export interface WaIncomingNotificationEvent extends WaIncomingBaseEvent {
     readonly notificationType?: string

--- a/src/protocol/call.ts
+++ b/src/protocol/call.ts
@@ -1,0 +1,53 @@
+export const WA_CALL_PAYLOAD_TAGS = Object.freeze({
+    OFFER: 'offer',
+    OFFER_NOTICE: 'offer_notice',
+    ACCEPT: 'accept',
+    PREACCEPT: 'preaccept',
+    REJECT: 'reject',
+    TERMINATE: 'terminate',
+    TRANSPORT: 'transport',
+    MUTE: 'mute',
+    VIDEO_STATE: 'video_state',
+    GROUP_INFO: 'group_info',
+    GROUP_UPDATE: 'group_update',
+    ENC_REKEY: 'enc_rekey',
+    PEER_STATE: 'peer_state',
+    FLOW_CONTROL: 'flow_control',
+    WEB_CLIENT: 'web_client'
+} as const)
+
+export type WaCallPayloadTag = (typeof WA_CALL_PAYLOAD_TAGS)[keyof typeof WA_CALL_PAYLOAD_TAGS]
+
+/**
+ * Payload tags that wa-web responds to with a `<receipt>` carrying a typed
+ * child node (`<offer call-id call-creator/>`, etc.) instead of a plain
+ * `<ack class="call"/>`. Source: `WAWebHandleVoipCall.js`.
+ */
+export const WA_CALL_RECEIPT_PAYLOAD_TAGS: ReadonlySet<WaCallPayloadTag> = new Set([
+    WA_CALL_PAYLOAD_TAGS.OFFER,
+    WA_CALL_PAYLOAD_TAGS.ACCEPT,
+    WA_CALL_PAYLOAD_TAGS.REJECT,
+    WA_CALL_PAYLOAD_TAGS.ENC_REKEY
+])
+
+export const WA_CALL_NODE_ATTRS = Object.freeze({
+    CALL_ID: 'call-id',
+    CALL_CREATOR: 'call-creator',
+    GROUP_JID: 'group-jid',
+    CALLER_PN: 'caller_pn',
+    CALLER_COUNTRY_CODE: 'caller_country_code',
+    USERNAME: 'username',
+    NOTIFY: 'notify',
+    SENDER_LID: 'sender_lid',
+    PLATFORM: 'platform',
+    VERSION: 'version',
+    REASON: 'reason',
+    USER_PN: 'user_pn',
+    GUEST_NAME: 'guest_name'
+} as const)
+
+export const WA_CALL_CHILD_TAGS = Object.freeze({
+    VIDEO: 'video',
+    SILENCE: 'silence',
+    GROUP_INFO: 'group_info'
+} as const)

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -18,6 +18,13 @@ export type {
 } from '@protocol/stream'
 export { WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
 export {
+    WA_CALL_CHILD_TAGS,
+    WA_CALL_NODE_ATTRS,
+    WA_CALL_PAYLOAD_TAGS,
+    WA_CALL_RECEIPT_PAYLOAD_TAGS
+} from '@protocol/call'
+export type { WaCallPayloadTag } from '@protocol/call'
+export {
     WA_EDIT_ATTRS,
     WA_ENC_MEDIA_TYPES,
     WA_EVENT_META_TYPES,

--- a/src/protocol/message.ts
+++ b/src/protocol/message.ts
@@ -12,6 +12,7 @@ export const WA_MESSAGE_TYPES = Object.freeze({
     ACK_TYPE_ERROR: 'error',
     ACK_CLASS_ERROR: 'error',
     ACK_CLASS_MESSAGE: 'message',
+    ACK_CLASS_CALL: 'call',
     RECEIPT_TYPE_DELIVERY: 'delivery',
     RECEIPT_TYPE_SENDER: 'sender',
     RECEIPT_TYPE_INACTIVE: 'inactive',

--- a/src/protocol/nodes.ts
+++ b/src/protocol/nodes.ts
@@ -66,6 +66,7 @@ export const WA_NODE_TAGS = Object.freeze({
     PLAINTEXT: 'plaintext',
     PRESENCE: 'presence',
     CHATSTATE: 'chatstate',
+    CALL: 'call',
     COMPOSING: 'composing',
     PAUSED: 'paused',
     BIZ: 'biz',


### PR DESCRIPTION
Populate WaIncomingCallEvent with payload-derived fields (type, callId, callCreator, caller PN/country/push, peer platform/version, isVideo, group_info participants, silence reason, timestamps) and emit through a dedicated createIncomingCallHandler that mirrors wa-web's response:

- offer/accept/reject/enc_rekey -> <receipt to=peer id=stanzaId from=<meLid device-form | mePn user-form>> with a typed <{tag} call-id call-creator/> child
- other recognized types -> <ack class="call" type=<tag>/>

Without the outbound receipt the server may replay the call stanza on future sessions (offline replay).

Constants live with their existing families: 'call' as WA_NODE_TAGS.CALL, ack class as WA_MESSAGE_TYPES.ACK_CLASS_CALL; call-specific tags/attrs go in a new src/protocol/call.ts (payload tags, receipt-payload set, node attrs, child tags).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incoming call events now include rich metadata: call type, video flag, identifiers, caller/creator info, timestamps, silence reason, and optional group participant snapshots.
  * Built-in parsing and handling for call stanzas: emits typed call events and sends appropriate ACKs/receipts (including call-class ACKs).

* **Runtime**
  * Runtime now surfaces current-credentials lookup for incoming-call handling.

* **Tests**
  * Added comprehensive tests covering call parsing, event emission, and ack/receipt behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->