### PR TITLE
refactor(newsletter)!: unify per-message updates into newsletter_message_update event

### DIFF
--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -231,7 +231,7 @@ const ALL_EVENT_NAMES = [
     'message_protocol',
     'receipt',
     'newsletter',
-    'newsletter_reaction',
+    'newsletter_message_update',
     'presence',
     'chatstate',
     'call',

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -83,6 +83,7 @@ import type { Logger } from '@infra/log/types'
 import { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import type { WaMediaConn } from '@media/types'
 import { createDefaultLinkPreviewFetcher } from '@message/addons/link-preview/fetcher'
+import { processNewsletterLiveUpdates } from '@message/kinds/newsletter'
 import { handleIncomingMessageAck } from '@message/primitives/incoming'
 import {
     createPeerDataOperationRequester,
@@ -956,7 +957,8 @@ export function buildWaClientDependencies(input: {
                 .handleIncomingMessageEvent(event)
                 .catch((err) => runtime.handleError(toError(err)))
         },
-        emitNewsletterReaction: (event) => runtime.emitEvent('newsletter_reaction', event),
+        emitNewsletterMessageUpdate: (event) =>
+            runtime.emitEvent('newsletter_message_update', event),
         emitUnhandledStanza: (event: WaIncomingUnhandledStanzaEvent) =>
             runtime.emitEvent('debug_unhandled_stanza', event)
     }
@@ -1031,6 +1033,15 @@ export function buildWaClientDependencies(input: {
                 action,
                 subType: childTag
             })
+            if (action === 'live_updates') {
+                processNewsletterLiveUpdates(node, {
+                    logger,
+                    emitIncomingMessage: incomingMessageAckOptions.emitIncomingMessage,
+                    emitNewsletterMessageUpdate:
+                        incomingMessageAckOptions.emitNewsletterMessageUpdate,
+                    emitUnhandledStanza: incomingMessageAckOptions.emitUnhandledStanza
+                })
+            }
             return false
         }
     })

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -536,11 +536,41 @@ export interface WaIncomingErrorStanzaEvent extends WaIncomingBaseEvent {
     readonly text?: string
 }
 
-export interface WaIncomingNewsletterReactionEvent extends WaIncomingBaseEvent {
+export interface WaNewsletterPollVoteEntry {
+    readonly optionHash: Uint8Array
+    readonly count?: number
+}
+
+export interface WaNewsletterReactionEntry {
+    readonly code: string
+    readonly count?: number
+}
+
+export type WaNewsletterMessageUpdate =
+    | {
+          readonly kind: 'reaction'
+          readonly isSender: boolean
+          readonly revoked: boolean
+          readonly reactions: ReadonlyArray<WaNewsletterReactionEntry>
+      }
+    | { readonly kind: 'revoke' }
+    | { readonly kind: 'edit'; readonly plaintext: Uint8Array; readonly message: Proto.IMessage }
+    | {
+          readonly kind: 'poll_vote'
+          readonly isSender: boolean
+          readonly votes: ReadonlyArray<WaNewsletterPollVoteEntry>
+      }
+    | {
+          readonly kind: 'counters'
+          readonly views?: number
+          readonly forwards?: number
+          readonly responses?: number
+      }
+
+export interface WaIncomingNewsletterMessageUpdateEvent extends WaIncomingBaseEvent {
     readonly timestampSeconds?: number
     readonly parentMessageServerId?: number
-    readonly reactionCode?: string
-    readonly revoked: boolean
+    readonly update: WaNewsletterMessageUpdate
 }
 
 export type WaNewsletterEventAction =
@@ -821,7 +851,7 @@ export interface WaClientEventMap {
     readonly message_protocol: (event: WaIncomingProtocolMessageEvent) => void
     readonly receipt: (event: WaIncomingReceiptEvent) => void
     readonly newsletter: (event: WaIncomingNewsletterEvent) => void
-    readonly newsletter_reaction: (event: WaIncomingNewsletterReactionEvent) => void
+    readonly newsletter_message_update: (event: WaIncomingNewsletterMessageUpdateEvent) => void
     readonly presence: (event: WaIncomingPresenceEvent) => void
     readonly chatstate: (event: WaIncomingChatstateEvent) => void
     readonly call: (event: WaIncomingCallEvent) => void

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -542,7 +542,7 @@ export interface WaNewsletterPollVoteEntry {
 }
 
 export interface WaNewsletterReactionEntry {
-    readonly code: string
+    readonly code?: string
     readonly count?: number
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export type {
     WaIncomingFailureEvent,
     WaIncomingMessageEvent,
     WaIncomingNewsletterEvent,
-    WaIncomingNewsletterReactionEvent,
+    WaIncomingNewsletterMessageUpdateEvent,
     WaIncomingNodeHandler,
     WaIncomingNodeHandlerRegistration,
     WaIncomingNotificationEvent,
@@ -63,7 +63,10 @@ export type {
     WaSendMessageOptions,
     WaVerifiedNameResult,
     WaAddonKind,
-    WaNewsletterEventAction
+    WaNewsletterEventAction,
+    WaNewsletterMessageUpdate,
+    WaNewsletterPollVoteEntry,
+    WaNewsletterReactionEntry
 } from '@client/types'
 export type {
     WaAppStateMutationCoordinator,

--- a/src/message/__tests__/message.test.ts
+++ b/src/message/__tests__/message.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test'
 
 import type {
     WaIncomingMessageEvent,
-    WaIncomingNewsletterReactionEvent,
+    WaIncomingNewsletterMessageUpdateEvent,
     WaIncomingUnhandledStanzaEvent
 } from '@client/types'
 import { createNoopLogger } from '@infra/log/types'
@@ -39,7 +39,10 @@ import {
     extractInvokedBotJid,
     genBotMsgSecret
 } from '@message/kinds/bot'
-import { processIncomingNewsletterMessage } from '@message/kinds/newsletter'
+import {
+    processIncomingNewsletterMessage,
+    processNewsletterLiveUpdates
+} from '@message/kinds/newsletter'
 import {
     describeAckNode,
     isAckOrReceiptNode,
@@ -47,6 +50,7 @@ import {
     isRetryableNegativeAck
 } from '@message/primitives/ack'
 import { proto } from '@proto'
+import type { BinaryNode } from '@transport/types'
 
 test('ack helpers classify receipt and retryability correctly', () => {
     const ackNode = { tag: 'ack', attrs: { id: '1', type: 'error', code: '500' } }
@@ -719,7 +723,7 @@ test('processIncomingNewsletterMessage emits unhandled when plaintext is missing
     )
 })
 
-test('processIncomingNewsletterMessage emits reaction event with parent server_id', () => {
+test('processIncomingNewsletterMessage emits reaction update with parent server_id', () => {
     const node = {
         tag: 'message',
         attrs: {
@@ -737,23 +741,67 @@ test('processIncomingNewsletterMessage emits reaction event with parent server_i
         ]
     }
 
-    let reactionEvent: WaIncomingNewsletterReactionEvent | null = null
+    let updateEvent: WaIncomingNewsletterMessageUpdateEvent | null = null
     processIncomingNewsletterMessage(node, {
         logger: NEWSLETTER_LOGGER,
-        emitNewsletterReaction: (event) => {
-            reactionEvent = event
+        emitNewsletterMessageUpdate: (event) => {
+            updateEvent = event
         }
     })
 
-    assert.ok(reactionEvent)
-    const event = reactionEvent as unknown as WaIncomingNewsletterReactionEvent
+    assert.ok(updateEvent)
+    const event = updateEvent as unknown as WaIncomingNewsletterMessageUpdateEvent
     assert.equal(event.parentMessageServerId, 42)
-    assert.equal(event.reactionCode, '1f44d')
-    assert.equal(event.revoked, false)
     assert.equal(event.timestampSeconds, 1700000000)
+    assert.equal(event.update.kind, 'reaction')
+    if (event.update.kind === 'reaction') {
+        assert.equal(event.update.isSender, false)
+        assert.equal(event.update.revoked, false)
+        assert.equal(event.update.reactions.length, 1)
+        assert.equal(event.update.reactions[0].code, '1f44d')
+        assert.equal(event.update.reactions[0].count, undefined)
+    }
 })
 
-test('processIncomingNewsletterMessage emits reaction_revoke with revoked flag', () => {
+test('processIncomingNewsletterMessage emits reaction aggregate via <reactions> envelope', () => {
+    const node: BinaryNode = {
+        tag: 'message',
+        attrs: { id: 'REAGG', from: '120363025343298869@newsletter', server_id: '42' },
+        content: [
+            {
+                tag: 'reactions',
+                attrs: {},
+                content: [
+                    { tag: 'reaction', attrs: { code: '🔥', count: '3' } },
+                    { tag: 'reaction', attrs: { code: '👍', count: '1' } }
+                ]
+            }
+        ]
+    }
+
+    let updateEvent: WaIncomingNewsletterMessageUpdateEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            updateEvent = event
+        }
+    })
+
+    assert.ok(updateEvent)
+    const event = updateEvent as unknown as WaIncomingNewsletterMessageUpdateEvent
+    assert.equal(event.update.kind, 'reaction')
+    if (event.update.kind === 'reaction') {
+        assert.equal(event.update.isSender, false)
+        assert.equal(event.update.revoked, false)
+        assert.equal(event.update.reactions.length, 2)
+        assert.equal(event.update.reactions[0].code, '🔥')
+        assert.equal(event.update.reactions[0].count, 3)
+        assert.equal(event.update.reactions[1].code, '👍')
+        assert.equal(event.update.reactions[1].count, 1)
+    }
+})
+
+test('processIncomingNewsletterMessage emits reaction revoke via type=reaction_revoke', () => {
     const node = {
         tag: 'message',
         attrs: {
@@ -770,16 +818,397 @@ test('processIncomingNewsletterMessage emits reaction_revoke with revoked flag',
         ]
     }
 
-    let reactionEvent: WaIncomingNewsletterReactionEvent | null = null
+    let updateEvent: WaIncomingNewsletterMessageUpdateEvent | null = null
     processIncomingNewsletterMessage(node, {
         logger: NEWSLETTER_LOGGER,
-        emitNewsletterReaction: (event) => {
-            reactionEvent = event
+        emitNewsletterMessageUpdate: (event) => {
+            updateEvent = event
         }
     })
 
-    assert.ok(reactionEvent)
-    assert.equal((reactionEvent as unknown as WaIncomingNewsletterReactionEvent).revoked, true)
+    assert.ok(updateEvent)
+    const event = updateEvent as unknown as WaIncomingNewsletterMessageUpdateEvent
+    assert.equal(event.update.kind, 'reaction')
+    if (event.update.kind === 'reaction') {
+        assert.equal(event.update.revoked, true)
+    }
+})
+
+test('processIncomingNewsletterMessage emits reaction revoke via edit=7', () => {
+    const node = {
+        tag: 'message',
+        attrs: {
+            id: 'REACT3',
+            from: '120363025343298869@newsletter',
+            type: 'reaction',
+            edit: '7',
+            server_id: '42'
+        },
+        content: [{ tag: 'reaction', attrs: {} }]
+    }
+
+    let updateEvent: WaIncomingNewsletterMessageUpdateEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            updateEvent = event
+        }
+    })
+
+    assert.ok(updateEvent)
+    const event = updateEvent as unknown as WaIncomingNewsletterMessageUpdateEvent
+    assert.equal(event.update.kind, 'reaction')
+    if (event.update.kind === 'reaction') {
+        assert.equal(event.update.revoked, true)
+    }
+})
+
+test('processIncomingNewsletterMessage emits poll_vote with aggregated counts (isSender=false)', () => {
+    const hashA = new Uint8Array(32).fill(0xaa)
+    const hashB = new Uint8Array(32).fill(0xbb)
+    const node: BinaryNode = {
+        tag: 'message',
+        attrs: {
+            id: 'POLL1',
+            from: '120363025343298869@newsletter',
+            type: 'poll',
+            server_id: '77',
+            t: '1700000001'
+        },
+        content: [
+            {
+                tag: 'votes',
+                attrs: {},
+                content: [
+                    { tag: 'vote', attrs: { count: '3' }, content: hashA },
+                    { tag: 'vote', attrs: { count: '1' }, content: hashB }
+                ]
+            },
+            { tag: 'meta', attrs: { polltype: 'vote' } }
+        ]
+    }
+
+    let updateEvent: WaIncomingNewsletterMessageUpdateEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            updateEvent = event
+        }
+    })
+
+    assert.ok(updateEvent)
+    const event = updateEvent as unknown as WaIncomingNewsletterMessageUpdateEvent
+    assert.equal(event.parentMessageServerId, 77)
+    assert.equal(event.update.kind, 'poll_vote')
+    if (event.update.kind === 'poll_vote') {
+        assert.equal(event.update.isSender, false)
+        assert.equal(event.update.votes.length, 2)
+        assert.deepEqual(event.update.votes[0].optionHash, hashA)
+        assert.equal(event.update.votes[0].count, 3)
+        assert.deepEqual(event.update.votes[1].optionHash, hashB)
+        assert.equal(event.update.votes[1].count, 1)
+    }
+})
+
+test('processIncomingNewsletterMessage emits poll_vote echo (isSender=true, no counts)', () => {
+    const hashA = new Uint8Array(32).fill(0x11)
+    const hashB = new Uint8Array(32).fill(0x22)
+    const node: BinaryNode = {
+        tag: 'message',
+        attrs: {
+            id: 'POLL_ECHO',
+            from: '120363025343298869@newsletter',
+            type: 'poll',
+            server_id: '77',
+            is_sender: 'true'
+        },
+        content: [
+            {
+                tag: 'votes',
+                attrs: {},
+                content: [
+                    { tag: 'vote', attrs: {}, content: hashA },
+                    { tag: 'vote', attrs: {}, content: hashB }
+                ]
+            },
+            { tag: 'meta', attrs: { polltype: 'vote' } }
+        ]
+    }
+
+    let updateEvent: WaIncomingNewsletterMessageUpdateEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            updateEvent = event
+        }
+    })
+
+    assert.ok(updateEvent)
+    const event = updateEvent as unknown as WaIncomingNewsletterMessageUpdateEvent
+    assert.equal(event.update.kind, 'poll_vote')
+    if (event.update.kind === 'poll_vote') {
+        assert.equal(event.update.isSender, true)
+        assert.equal(event.update.votes.length, 2)
+        assert.deepEqual(event.update.votes[0].optionHash, hashA)
+        assert.equal(event.update.votes[0].count, undefined)
+        assert.deepEqual(event.update.votes[1].optionHash, hashB)
+        assert.equal(event.update.votes[1].count, undefined)
+    }
+})
+
+test('processIncomingNewsletterMessage rejects poll_vote mixing count and no-count entries', () => {
+    const node: BinaryNode = {
+        tag: 'message',
+        attrs: { id: 'POLL_MIX', from: '120363025343298869@newsletter', type: 'poll' },
+        content: [
+            {
+                tag: 'votes',
+                attrs: {},
+                content: [
+                    { tag: 'vote', attrs: { count: '2' }, content: new Uint8Array(32).fill(1) },
+                    { tag: 'vote', attrs: {}, content: new Uint8Array(32).fill(2) }
+                ]
+            }
+        ]
+    }
+
+    let updateEvent: WaIncomingNewsletterMessageUpdateEvent | null = null
+    let unhandled: WaIncomingUnhandledStanzaEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            updateEvent = event
+        },
+        emitUnhandledStanza: (event) => {
+            unhandled = event
+        }
+    })
+
+    assert.equal(updateEvent, null)
+    assert.ok(unhandled)
+    assert.equal(
+        (unhandled as unknown as WaIncomingUnhandledStanzaEvent).reason,
+        'newsletter.invalid_votes'
+    )
+})
+
+test('processIncomingNewsletterMessage rejects poll_vote with wrong hash size', () => {
+    const node = {
+        tag: 'message',
+        attrs: { id: 'POLL2', from: '120363025343298869@newsletter', type: 'poll' },
+        content: [
+            {
+                tag: 'votes',
+                attrs: {},
+                content: [{ tag: 'vote', attrs: { count: '1' }, content: new Uint8Array(16) }]
+            }
+        ]
+    }
+
+    let updateEvent: WaIncomingNewsletterMessageUpdateEvent | null = null
+    let unhandled: WaIncomingUnhandledStanzaEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            updateEvent = event
+        },
+        emitUnhandledStanza: (event) => {
+            unhandled = event
+        }
+    })
+
+    assert.equal(updateEvent, null)
+    assert.ok(unhandled)
+    assert.equal(
+        (unhandled as unknown as WaIncomingUnhandledStanzaEvent).reason,
+        'newsletter.invalid_votes'
+    )
+})
+
+test('processIncomingNewsletterMessage emits counters from views/forwards/responses', () => {
+    const node: BinaryNode = {
+        tag: 'message',
+        attrs: { id: 'MTR', from: '120363025343298869@newsletter', server_id: '42' },
+        content: [
+            { tag: 'views_count', attrs: { count: '5' } },
+            { tag: 'forwards_count', attrs: { count: '2' } },
+            { tag: 'responses_count', attrs: { count: '1' } }
+        ]
+    }
+
+    const emitted: WaIncomingNewsletterMessageUpdateEvent[] = []
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            emitted.push(event)
+        }
+    })
+
+    assert.equal(emitted.length, 1)
+    assert.equal(emitted[0].update.kind, 'counters')
+    if (emitted[0].update.kind === 'counters') {
+        assert.equal(emitted[0].update.views, 5)
+        assert.equal(emitted[0].update.forwards, 2)
+        assert.equal(emitted[0].update.responses, 1)
+    }
+})
+
+test('processIncomingNewsletterMessage emits both reaction and counters from same stanza', () => {
+    const node: BinaryNode = {
+        tag: 'message',
+        attrs: { id: 'COMBO', from: '120363025343298869@newsletter', server_id: '42' },
+        content: [
+            {
+                tag: 'reactions',
+                attrs: {},
+                content: [{ tag: 'reaction', attrs: { code: '🔥', count: '4' } }]
+            },
+            { tag: 'views_count', attrs: { count: '12' } }
+        ]
+    }
+
+    const kinds: string[] = []
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            kinds.push(event.update.kind)
+        }
+    })
+
+    assert.deepEqual(kinds, ['reaction', 'counters'])
+})
+
+test('processNewsletterLiveUpdates fans aggregated poll_vote inside live_updates envelope', () => {
+    const hashA = new Uint8Array(32).fill(0x33)
+    const hashB = new Uint8Array(32).fill(0x44)
+    const notification: BinaryNode = {
+        tag: 'notification',
+        attrs: {
+            from: '120363025343298869@newsletter',
+            type: 'newsletter',
+            id: 'NOTIF1',
+            t: '1700000099'
+        },
+        content: [
+            {
+                tag: 'live_updates',
+                attrs: {},
+                content: [
+                    {
+                        tag: 'messages',
+                        attrs: { t: '1700000099' },
+                        content: [
+                            {
+                                tag: 'message',
+                                attrs: { server_id: '128' },
+                                content: [
+                                    {
+                                        tag: 'votes',
+                                        attrs: {},
+                                        content: [
+                                            {
+                                                tag: 'vote',
+                                                attrs: { count: '4' },
+                                                content: hashA
+                                            },
+                                            {
+                                                tag: 'vote',
+                                                attrs: { count: '1' },
+                                                content: hashB
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            // bare message announcement — should be skipped
+                            { tag: 'message', attrs: { server_id: '129' } }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    const emitted: WaIncomingNewsletterMessageUpdateEvent[] = []
+    processNewsletterLiveUpdates(notification, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            emitted.push(event)
+        }
+    })
+
+    assert.equal(emitted.length, 1)
+    const event = emitted[0]
+    assert.equal(event.parentMessageServerId, 128)
+    assert.equal(event.chatJid, '120363025343298869@newsletter')
+    assert.equal(event.timestampSeconds, 1700000099)
+    assert.equal(event.update.kind, 'poll_vote')
+    if (event.update.kind === 'poll_vote') {
+        assert.equal(event.update.isSender, false)
+        assert.equal(event.update.votes.length, 2)
+        assert.deepEqual(event.update.votes[0].optionHash, hashA)
+        assert.equal(event.update.votes[0].count, 4)
+        assert.deepEqual(event.update.votes[1].optionHash, hashB)
+        assert.equal(event.update.votes[1].count, 1)
+    }
+})
+
+test('processIncomingNewsletterMessage emits revoke on edit=8', () => {
+    const node = {
+        tag: 'message',
+        attrs: {
+            id: 'REV1',
+            from: '120363025343298869@newsletter',
+            type: 'text',
+            edit: '8',
+            server_id: '99'
+        },
+        content: [{ tag: 'plaintext', attrs: {} }]
+    }
+
+    let updateEvent: WaIncomingNewsletterMessageUpdateEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            updateEvent = event
+        }
+    })
+
+    assert.ok(updateEvent)
+    const event = updateEvent as unknown as WaIncomingNewsletterMessageUpdateEvent
+    assert.equal(event.parentMessageServerId, 99)
+    assert.equal(event.update.kind, 'revoke')
+})
+
+test('processIncomingNewsletterMessage emits edit on edit=3 with new plaintext', () => {
+    const newMessage = proto.Message.encode({ conversation: 'edited content' }).finish()
+    const node = {
+        tag: 'message',
+        attrs: {
+            id: 'EDIT1',
+            from: '120363025343298869@newsletter',
+            type: 'text',
+            edit: '3',
+            server_id: '55'
+        },
+        content: [{ tag: 'plaintext', attrs: {}, content: newMessage }]
+    }
+
+    let updateEvent: WaIncomingNewsletterMessageUpdateEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            updateEvent = event
+        }
+    })
+
+    assert.ok(updateEvent)
+    const event = updateEvent as unknown as WaIncomingNewsletterMessageUpdateEvent
+    assert.equal(event.parentMessageServerId, 55)
+    assert.equal(event.update.kind, 'edit')
+    if (event.update.kind === 'edit') {
+        assert.equal(event.update.message.conversation, 'edited content')
+    }
 })
 
 test('processIncomingNewsletterMessage emits unhandled on decode failure', () => {

--- a/src/message/__tests__/message.test.ts
+++ b/src/message/__tests__/message.test.ts
@@ -801,6 +801,120 @@ test('processIncomingNewsletterMessage emits reaction aggregate via <reactions> 
     }
 })
 
+test('processIncomingNewsletterMessage omits code when reaction revoke has no code attr', () => {
+    const node = {
+        tag: 'message',
+        attrs: {
+            id: 'REACT_NO_CODE',
+            from: '120363025343298869@newsletter',
+            type: 'reaction',
+            edit: '7',
+            server_id: '42'
+        },
+        content: [{ tag: 'reaction', attrs: {} }]
+    }
+
+    let updateEvent: WaIncomingNewsletterMessageUpdateEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            updateEvent = event
+        }
+    })
+
+    assert.ok(updateEvent)
+    const event = updateEvent as unknown as WaIncomingNewsletterMessageUpdateEvent
+    if (event.update.kind === 'reaction') {
+        assert.equal(event.update.revoked, true)
+        assert.equal(event.update.reactions.length, 1)
+        assert.equal(event.update.reactions[0].code, undefined)
+    }
+})
+
+test('processIncomingNewsletterMessage rejects poll_vote with empty votes envelope', () => {
+    const node: BinaryNode = {
+        tag: 'message',
+        attrs: { id: 'POLL_EMPTY', from: '120363025343298869@newsletter', type: 'poll' },
+        content: [{ tag: 'votes', attrs: {}, content: [] }]
+    }
+
+    let updateEvent: WaIncomingNewsletterMessageUpdateEvent | null = null
+    let unhandled: WaIncomingUnhandledStanzaEvent | null = null
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            updateEvent = event
+        },
+        emitUnhandledStanza: (event) => {
+            unhandled = event
+        }
+    })
+
+    assert.equal(updateEvent, null)
+    assert.ok(unhandled)
+    assert.equal(
+        (unhandled as unknown as WaIncomingUnhandledStanzaEvent).reason,
+        'newsletter.invalid_votes'
+    )
+})
+
+test('processIncomingNewsletterMessage preserves counters with zero values', () => {
+    const node: BinaryNode = {
+        tag: 'message',
+        attrs: { id: 'CTR_ZERO', from: '120363025343298869@newsletter', server_id: '42' },
+        content: [{ tag: 'views_count', attrs: { count: '0' } }]
+    }
+
+    const emitted: WaIncomingNewsletterMessageUpdateEvent[] = []
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            emitted.push(event)
+        }
+    })
+
+    assert.equal(emitted.length, 1)
+    if (emitted[0].update.kind === 'counters') {
+        assert.equal(emitted[0].update.views, 0)
+        assert.equal(emitted[0].update.forwards, undefined)
+    }
+})
+
+test('processIncomingNewsletterMessage skips counters when count attr is invalid', () => {
+    const node: BinaryNode = {
+        tag: 'message',
+        attrs: {
+            id: 'CTR_BAD',
+            from: '120363025343298869@newsletter',
+            server_id: '42',
+            type: 'text'
+        },
+        content: [
+            { tag: 'views_count', attrs: { count: 'abc' } },
+            {
+                tag: 'plaintext',
+                attrs: {},
+                content: proto.Message.encode({ conversation: 'x' }).finish()
+            }
+        ]
+    }
+
+    const emitted: WaIncomingNewsletterMessageUpdateEvent[] = []
+    let incoming = 0
+    processIncomingNewsletterMessage(node, {
+        logger: NEWSLETTER_LOGGER,
+        emitNewsletterMessageUpdate: (event) => {
+            emitted.push(event)
+        },
+        emitIncomingMessage: () => {
+            incoming += 1
+        }
+    })
+
+    assert.equal(emitted.length, 0)
+    assert.equal(incoming, 1)
+})
+
 test('processIncomingNewsletterMessage emits reaction revoke via type=reaction_revoke', () => {
     const node = {
         tag: 'message',

--- a/src/message/kinds/newsletter.ts
+++ b/src/message/kinds/newsletter.ts
@@ -1,11 +1,15 @@
 import type {
     WaIncomingMessageEvent,
-    WaIncomingNewsletterReactionEvent,
-    WaIncomingUnhandledStanzaEvent
+    WaIncomingNewsletterMessageUpdateEvent,
+    WaIncomingUnhandledStanzaEvent,
+    WaNewsletterMessageUpdate,
+    WaNewsletterPollVoteEntry,
+    WaNewsletterReactionEntry
 } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import { proto } from '@proto'
 import { WA_NODE_TAGS } from '@protocol/constants'
+import { WA_EDIT_ATTRS } from '@protocol/message'
 import { decodeNodeContentBase64OrBytes, findNodeChild } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
 import { parseOptionalInt, toError } from '@util/primitives'
@@ -13,62 +17,124 @@ import { parseOptionalInt, toError } from '@util/primitives'
 interface ProcessNewsletterMessageOptions {
     readonly logger: Logger
     readonly emitIncomingMessage?: (event: WaIncomingMessageEvent) => void
-    readonly emitNewsletterReaction?: (event: WaIncomingNewsletterReactionEvent) => void
+    readonly emitNewsletterMessageUpdate?: (event: WaIncomingNewsletterMessageUpdateEvent) => void
     readonly emitUnhandledStanza?: (event: WaIncomingUnhandledStanzaEvent) => void
+}
+
+export function processNewsletterLiveUpdates(
+    notification: BinaryNode,
+    options: ProcessNewsletterMessageOptions
+): void {
+    const liveUpdates = findNodeChild(notification, 'live_updates')
+    if (!liveUpdates) return
+    const messagesNode = findNodeChild(liveUpdates, 'messages')
+    if (!messagesNode || !Array.isArray(messagesNode.content)) return
+    const from = notification.attrs.from
+    const outerId = notification.attrs.id
+    const messagesT = messagesNode.attrs.t ?? notification.attrs.t
+    for (const inner of messagesNode.content) {
+        if (inner.tag !== 'message') continue
+        if (!Array.isArray(inner.content) || inner.content.length === 0) {
+            continue
+        }
+        const synth: BinaryNode = {
+            tag: 'message',
+            attrs: {
+                ...(from ? { from } : {}),
+                ...(outerId ? { id: outerId } : {}),
+                ...(messagesT ? { t: messagesT } : {}),
+                ...inner.attrs
+            },
+            content: inner.content
+        }
+        processIncomingNewsletterMessage(synth, options)
+    }
 }
 
 export function processIncomingNewsletterMessage(
     node: BinaryNode,
     options: ProcessNewsletterMessageOptions
 ): void {
-    const chatJid = node.attrs.from
     const messageType = node.attrs.type
+    const editAttr = node.attrs.edit
+    let emittedAggregate = false
 
-    if (messageType === 'reaction') {
-        emitReactionEvent(node, options, false)
+    const reactionsEnvelope = findNodeChild(node, 'reactions')
+    if (reactionsEnvelope) {
+        const reactions = parseReactionAggregate(reactionsEnvelope)
+        if (reactions === null) {
+            emitUnhandled(node, options, 'newsletter.invalid_reactions')
+            return
+        }
+        emitUpdate(node, options, {
+            kind: 'reaction',
+            isSender: node.attrs.is_sender === 'true',
+            revoked: false,
+            reactions
+        })
+        emittedAggregate = true
+    } else {
+        const reactionNode = findNodeChild(node, 'reaction')
+        if (reactionNode) {
+            const revoked =
+                editAttr === WA_EDIT_ATTRS.SENDER_REVOKE || messageType === 'reaction_revoke'
+            emitUpdate(node, options, {
+                kind: 'reaction',
+                isSender: node.attrs.is_sender === 'true',
+                revoked,
+                reactions: [{ code: reactionNode.attrs.code ?? '' }]
+            })
+            emittedAggregate = true
+        }
+    }
+
+    const votesNode = findNodeChild(node, 'votes')
+    if (votesNode) {
+        const votes = parsePollVotes(votesNode)
+        if (votes === null) {
+            emitUnhandled(node, options, 'newsletter.invalid_votes')
+            return
+        }
+        emitUpdate(node, options, {
+            kind: 'poll_vote',
+            isSender: node.attrs.is_sender === 'true',
+            votes
+        })
+        emittedAggregate = true
+    }
+
+    const counters = parseCounters(node)
+    if (counters) {
+        emitUpdate(node, options, counters)
+        emittedAggregate = true
+    }
+
+    if (emittedAggregate) return
+
+    if (editAttr === WA_EDIT_ATTRS.ADMIN_REVOKE) {
+        emitUpdate(node, options, { kind: 'revoke' })
         return
     }
-    if (messageType === 'reaction_revoke') {
-        emitReactionEvent(node, options, true)
-        return
-    }
 
-    const plaintextNode = findNodeChild(node, WA_NODE_TAGS.PLAINTEXT)
-    if (!plaintextNode) {
-        options.emitUnhandledStanza?.({
-            rawNode: node,
-            stanzaId: node.attrs.id,
-            chatJid,
-            stanzaType: messageType,
-            offline: node.attrs.offline !== undefined,
-            reason: 'newsletter.missing_plaintext'
+    if (editAttr === WA_EDIT_ATTRS.NEWSLETTER_EDIT) {
+        const decoded = decodePlaintext(node, options)
+        if (decoded === null) {
+            return
+        }
+        emitUpdate(node, options, {
+            kind: 'edit',
+            plaintext: decoded.plaintext,
+            message: decoded.message
         })
         return
     }
 
-    let plaintext: Uint8Array
-    let message: proto.IMessage
-    try {
-        plaintext = decodeNodeContentBase64OrBytes(plaintextNode.content, 'newsletter.plaintext')
-        message = proto.Message.decode(plaintext)
-    } catch (error) {
-        options.logger.warn('failed to decode newsletter plaintext message', {
-            id: node.attrs.id,
-            from: chatJid,
-            type: messageType,
-            message: toError(error).message
-        })
-        options.emitUnhandledStanza?.({
-            rawNode: node,
-            stanzaId: node.attrs.id,
-            chatJid,
-            stanzaType: messageType,
-            offline: node.attrs.offline !== undefined,
-            reason: 'newsletter.decode_failed'
-        })
+    const decoded = decodePlaintext(node, options)
+    if (decoded === null) {
         return
     }
 
+    const chatJid = node.attrs.from
     options.emitIncomingMessage?.({
         rawNode: node,
         stanzaId: node.attrs.id,
@@ -83,38 +149,128 @@ export function processIncomingNewsletterMessage(
         isNewsletterChat: true,
         serverId: parseOptionalInt(node.attrs.server_id),
         isSender: node.attrs.is_sender === 'true',
-        plaintext,
-        message
+        plaintext: decoded.plaintext,
+        message: decoded.message
     })
 }
 
-function emitReactionEvent(
+function emitUpdate(
     node: BinaryNode,
     options: ProcessNewsletterMessageOptions,
-    revoked: boolean
+    update: WaNewsletterMessageUpdate
 ): void {
-    const chatJid = node.attrs.from
-    const reactionNode = findNodeChild(node, 'reaction')
-    if (!reactionNode) {
-        options.emitUnhandledStanza?.({
-            rawNode: node,
-            stanzaId: node.attrs.id,
-            chatJid,
-            stanzaType: node.attrs.type,
-            offline: node.attrs.offline !== undefined,
-            reason: 'newsletter.missing_reaction'
-        })
-        return
-    }
-    options.emitNewsletterReaction?.({
+    options.emitNewsletterMessageUpdate?.({
         rawNode: node,
         stanzaId: node.attrs.id,
-        chatJid,
+        chatJid: node.attrs.from,
         stanzaType: node.attrs.type,
         offline: node.attrs.offline !== undefined,
         timestampSeconds: parseOptionalInt(node.attrs.t),
         parentMessageServerId: parseOptionalInt(node.attrs.server_id),
-        reactionCode: reactionNode.attrs.code,
-        revoked
+        update
     })
+}
+
+function emitUnhandled(
+    node: BinaryNode,
+    options: ProcessNewsletterMessageOptions,
+    reason: string
+): void {
+    options.emitUnhandledStanza?.({
+        rawNode: node,
+        stanzaId: node.attrs.id,
+        chatJid: node.attrs.from,
+        stanzaType: node.attrs.type,
+        offline: node.attrs.offline !== undefined,
+        reason
+    })
+}
+
+function decodePlaintext(
+    node: BinaryNode,
+    options: ProcessNewsletterMessageOptions
+): { readonly plaintext: Uint8Array; readonly message: proto.IMessage } | null {
+    const plaintextNode = findNodeChild(node, WA_NODE_TAGS.PLAINTEXT)
+    if (!plaintextNode) {
+        emitUnhandled(node, options, 'newsletter.missing_plaintext')
+        return null
+    }
+    try {
+        const plaintext = decodeNodeContentBase64OrBytes(
+            plaintextNode.content,
+            'newsletter.plaintext'
+        )
+        const message = proto.Message.decode(plaintext)
+        return { plaintext, message }
+    } catch (error) {
+        options.logger.warn('failed to decode newsletter plaintext message', {
+            id: node.attrs.id,
+            from: node.attrs.from,
+            type: node.attrs.type,
+            message: toError(error).message
+        })
+        emitUnhandled(node, options, 'newsletter.decode_failed')
+        return null
+    }
+}
+
+function parsePollVotes(votesNode: BinaryNode): WaNewsletterPollVoteEntry[] | null {
+    if (!Array.isArray(votesNode.content)) {
+        return null
+    }
+    const entries: WaNewsletterPollVoteEntry[] = []
+    let withCount = 0
+    let withoutCount = 0
+    for (const child of votesNode.content) {
+        if (child.tag !== 'vote') continue
+        if (!(child.content instanceof Uint8Array) || child.content.byteLength !== 32) {
+            return null
+        }
+        if (child.attrs.count === undefined) {
+            entries.push({ optionHash: child.content })
+            withoutCount += 1
+            continue
+        }
+        const count = parseOptionalInt(child.attrs.count)
+        if (count === undefined || count < 1) {
+            return null
+        }
+        entries.push({ optionHash: child.content, count })
+        withCount += 1
+    }
+    if (withCount > 0 && withoutCount > 0) {
+        return null
+    }
+    return entries
+}
+
+function parseCounters(
+    node: BinaryNode
+): (WaNewsletterMessageUpdate & { kind: 'counters' }) | null {
+    const viewsNode = findNodeChild(node, 'views_count')
+    const forwardsNode = findNodeChild(node, 'forwards_count')
+    const responsesNode = findNodeChild(node, 'responses_count')
+    if (!viewsNode && !forwardsNode && !responsesNode) return null
+    const update: WaNewsletterMessageUpdate & { kind: 'counters' } = {
+        kind: 'counters',
+        ...(viewsNode ? { views: parseOptionalInt(viewsNode.attrs.count) } : {}),
+        ...(forwardsNode ? { forwards: parseOptionalInt(forwardsNode.attrs.count) } : {}),
+        ...(responsesNode ? { responses: parseOptionalInt(responsesNode.attrs.count) } : {})
+    }
+    return update
+}
+
+function parseReactionAggregate(envelope: BinaryNode): WaNewsletterReactionEntry[] | null {
+    if (!Array.isArray(envelope.content)) return null
+    const out: WaNewsletterReactionEntry[] = []
+    for (const child of envelope.content) {
+        if (child.tag !== 'reaction') continue
+        const code = child.attrs.code
+        if (typeof code !== 'string' || code.length === 0) return null
+        const count = parseOptionalInt(child.attrs.count)
+        if (count === undefined || count < 1) return null
+        out.push({ code, count })
+    }
+    if (out.length === 0) return null
+    return out
 }

--- a/src/message/kinds/newsletter.ts
+++ b/src/message/kinds/newsletter.ts
@@ -82,7 +82,7 @@ export function processIncomingNewsletterMessage(
                 kind: 'reaction',
                 isSender: node.attrs.is_sender === 'true',
                 revoked,
-                reactions: [{ code: reactionNode.attrs.code ?? '' }]
+                reactions: [reactionNode.attrs.code ? { code: reactionNode.attrs.code } : {}]
             })
             emittedAggregate = true
         }
@@ -241,23 +241,30 @@ function parsePollVotes(votesNode: BinaryNode): WaNewsletterPollVoteEntry[] | nu
     if (withCount > 0 && withoutCount > 0) {
         return null
     }
+    if (entries.length === 0) {
+        return null
+    }
     return entries
 }
 
 function parseCounters(
     node: BinaryNode
 ): (WaNewsletterMessageUpdate & { kind: 'counters' }) | null {
-    const viewsNode = findNodeChild(node, 'views_count')
-    const forwardsNode = findNodeChild(node, 'forwards_count')
-    const responsesNode = findNodeChild(node, 'responses_count')
-    if (!viewsNode && !forwardsNode && !responsesNode) return null
-    const update: WaNewsletterMessageUpdate & { kind: 'counters' } = {
+    const views = parseCounterAttr(findNodeChild(node, 'views_count'))
+    const forwards = parseCounterAttr(findNodeChild(node, 'forwards_count'))
+    const responses = parseCounterAttr(findNodeChild(node, 'responses_count'))
+    if (views === undefined && forwards === undefined && responses === undefined) return null
+    return {
         kind: 'counters',
-        ...(viewsNode ? { views: parseOptionalInt(viewsNode.attrs.count) } : {}),
-        ...(forwardsNode ? { forwards: parseOptionalInt(forwardsNode.attrs.count) } : {}),
-        ...(responsesNode ? { responses: parseOptionalInt(responsesNode.attrs.count) } : {})
+        ...(views !== undefined ? { views } : {}),
+        ...(forwards !== undefined ? { forwards } : {}),
+        ...(responses !== undefined ? { responses } : {})
     }
-    return update
+}
+
+function parseCounterAttr(node: BinaryNode | undefined): number | undefined {
+    if (!node) return undefined
+    return parseOptionalInt(node.attrs.count)
 }
 
 function parseReactionAggregate(envelope: BinaryNode): WaNewsletterReactionEntry[] | null {

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -1,6 +1,6 @@
 import type {
     WaIncomingMessageEvent,
-    WaIncomingNewsletterReactionEvent,
+    WaIncomingNewsletterMessageUpdateEvent,
     WaIncomingUnhandledStanzaEvent
 } from '@client/types'
 import type { Logger } from '@infra/log/types'
@@ -37,7 +37,7 @@ interface WaIncomingMessageAckHandlerOptions {
         error: unknown
     ) => Promise<boolean>
     readonly emitIncomingMessage?: (event: WaIncomingMessageEvent) => void
-    readonly emitNewsletterReaction?: (event: WaIncomingNewsletterReactionEvent) => void
+    readonly emitNewsletterMessageUpdate?: (event: WaIncomingNewsletterMessageUpdateEvent) => void
     readonly emitUnhandledStanza?: (event: WaIncomingUnhandledStanzaEvent) => void
 }
 
@@ -594,7 +594,7 @@ async function handleIncomingNewsletterMessage(
     processIncomingNewsletterMessage(node, {
         logger: options.logger,
         emitIncomingMessage: options.emitIncomingMessage,
-        emitNewsletterReaction: options.emitNewsletterReaction,
+        emitNewsletterMessageUpdate: options.emitNewsletterMessageUpdate,
         emitUnhandledStanza: options.emitUnhandledStanza
     })
 


### PR DESCRIPTION
Replaces newsletter_reaction with a single discriminated event carrying reaction, revoke, edit, poll_vote and counters kinds. Adds aggregate fanout for live_updates notifications so per-message addons (reaction counts, poll vote totals, view/forward/response counters) are parsed and emitted through the same path used for direct stanzas.

- types: new WaNewsletterMessageUpdate union with isSender + count entries
- parser: processNewsletterLiveUpdates fans inner messages with grafted attrs
- emits multiple updates per stanza when aggregates co-exist
- removes newsletter_reaction event (breaking)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified newsletter updates: reactions, edits, revokes, poll votes, and counters are delivered as a single message-update event.
  * Support for processing live newsletter update envelopes so updates appear in real time.

* **Breaking Changes**
  * Newsletter event key changed from newsletter_reaction to newsletter_message_update with an expanded payload.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->