### PR TITLE
fix(hosted): align group fanout, retry-keys, and sender_intent with wa-web

### DIFF
--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -47,6 +47,7 @@ import { WA_DEFAULTS, type WaStatusDistributionSetting } from '@protocol/constan
 import {
     isBotJid,
     isGroupJid,
+    isHostedDeviceJid,
     isLidJid,
     isNewsletterJid,
     normalizeDeviceJid,
@@ -506,10 +507,15 @@ export class WaMessageDispatchCoordinator {
             logTag: 'broadcast list',
             customize: ({ fanoutDeviceJids }) => {
                 const phashTargets = new Array<string>(fanoutDeviceJids.length + 1)
+                let phashTargetCount = 0
                 for (let i = 0; i < fanoutDeviceJids.length; i += 1) {
-                    phashTargets[i] = fanoutDeviceJids[i]
+                    const candidate = fanoutDeviceJids[i]
+                    if (isHostedDeviceJid(candidate)) continue
+                    phashTargets[phashTargetCount] = candidate
+                    phashTargetCount += 1
                 }
-                phashTargets[fanoutDeviceJids.length] = senderJid
+                phashTargets[phashTargetCount] = senderJid
+                phashTargets.length = phashTargetCount + 1
                 return Promise.resolve({ phash: computePhashV2(phashTargets) })
             }
         })
@@ -749,10 +755,15 @@ export class WaMessageDispatchCoordinator {
             }
         }
         const phashTargets = new Array<string>(resolvedFanoutTargets.length + 1)
+        let phashTargetCount = 0
         for (let index = 0; index < resolvedFanoutTargets.length; index += 1) {
-            phashTargets[index] = resolvedFanoutTargets[index].jid
+            const candidate = resolvedFanoutTargets[index].jid
+            if (isHostedDeviceJid(candidate)) continue
+            phashTargets[phashTargetCount] = candidate
+            phashTargetCount += 1
         }
-        phashTargets[resolvedFanoutTargets.length] = senderForPhash
+        phashTargets[phashTargetCount] = senderForPhash
+        phashTargets.length = phashTargetCount + 1
         const localPhash = computePhashV2(phashTargets)
         const reportingArtifacts = await this.tryBuildReportingTokenArtifacts({
             message,
@@ -935,10 +946,15 @@ export class WaMessageDispatchCoordinator {
             }
         }
         const phashTargets = new Array<string>(fanoutDeviceJids.length + 1)
+        let phashTargetCount = 0
         for (let index = 0; index < fanoutDeviceJids.length; index += 1) {
-            phashTargets[index] = fanoutDeviceJids[index]
+            const candidate = fanoutDeviceJids[index]
+            if (isHostedDeviceJid(candidate)) continue
+            phashTargets[phashTargetCount] = candidate
+            phashTargetCount += 1
         }
-        phashTargets[fanoutDeviceJids.length] = senderJid
+        phashTargets[phashTargetCount] = senderJid
+        phashTargets.length = phashTargetCount + 1
         const localPhash = computePhashV2(phashTargets)
         const reportingArtifacts = await this.tryBuildReportingTokenArtifacts({
             message,

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -9,6 +9,7 @@ import { proto } from '@proto'
 import { WA_MESSAGE_TAGS, WA_MESSAGE_TYPES } from '@protocol/constants'
 import {
     isGroupOrBroadcastJid,
+    isHostedDeviceJid,
     normalizeDeviceJid,
     parseJidFull,
     parseSignalAddressFromJid,
@@ -270,11 +271,13 @@ export class WaRetryCoordinator {
                 delegatedToPlaceholderResend: true
             }
         }
+        const senderDeviceJid = context.participant ?? context.from
+        const forceKeysForHosted = senderDeviceJid ? isHostedDeviceJid(senderDeviceJid) : false
         return {
             registrationId: registrationInfo.registrationId,
             retryCount,
             retryKeys:
-                retryCount >= RETRY_KEYS_MIN_COUNT
+                forceKeysForHosted || retryCount >= RETRY_KEYS_MIN_COUNT
                     ? ((await this.buildRetryKeysSection(
                           registrationInfo.identityKeyPair.pubKey
                       )) ?? undefined)

--- a/src/client/messaging/__tests__/messaging.test.ts
+++ b/src/client/messaging/__tests__/messaging.test.ts
@@ -95,7 +95,7 @@ test('device fanout resolver keeps hosted devices in direct fanout', async () =>
     ])
 })
 
-test('device fanout resolver excludes hosted devices in group fanout', async () => {
+test('device fanout resolver keeps hosted devices in group fanout', async () => {
     const resolver = createDeviceFanoutResolver({
         signalDeviceSync: {
             syncDeviceList: async () => [
@@ -117,7 +117,12 @@ test('device fanout resolver excludes hosted devices in group fanout', async () 
         '6116570308623@lid',
         '551188888888@s.whatsapp.net'
     ])
-    assert.deepEqual(fanout, ['6116570308623:1@lid', '551188888888@s.whatsapp.net'])
+    assert.deepEqual(fanout, [
+        '6116570308623:1@lid',
+        '6116570308623:99@hosted.lid',
+        '551188888888@s.whatsapp.net',
+        '551188888888:99@hosted'
+    ])
 })
 
 test('group metadata cache mutates membership from events', async () => {

--- a/src/client/messaging/fanout.ts
+++ b/src/client/messaging/fanout.ts
@@ -1,7 +1,7 @@
 import type { WaAuthCredentials } from '@auth/types'
 import type { Logger } from '@infra/log/types'
 import { PromiseDedup } from '@infra/perf/PromiseDedup'
-import { isHostedDeviceJid, normalizeDeviceJid, splitJid, toUserJid } from '@protocol/jid'
+import { normalizeDeviceJid, splitJid, toUserJid } from '@protocol/jid'
 import type { SignalDeviceSyncApi } from '@signal/api/SignalDeviceSyncApi'
 import { toError } from '@util/primitives'
 
@@ -132,9 +132,6 @@ export function createDeviceFanoutResolver(options: {
 
                 for (const deviceJid of entry.deviceJids) {
                     const normalizedDeviceJid = normalizeDeviceJid(deviceJid)
-                    if (isHostedDeviceJid(normalizedDeviceJid)) {
-                        continue
-                    }
                     if (meDeviceJids.has(normalizedDeviceJid)) {
                         continue
                     }

--- a/src/retry/replay.ts
+++ b/src/retry/replay.ts
@@ -8,6 +8,7 @@ import { proto, type Proto } from '@proto'
 import { WA_DEFAULTS, WA_NODE_TAGS } from '@protocol/constants'
 import {
     isGroupOrBroadcastJid,
+    isHostedDeviceJid,
     isStatusBroadcastJid,
     normalizeDeviceJid,
     parseJidFull,
@@ -124,6 +125,9 @@ export class WaRetryReplayService {
         )
         const deviceIdentity =
             encrypted.type === 'pkmsg' ? this.resolveSignedDeviceIdentity('direct') : undefined
+        const metaNode = isHostedDeviceJid(requesterJid)
+            ? buildMetaNode({ sender_intent: 'hosted' })
+            : undefined
         await this.options.messageClient.sendEncrypted({
             to: requesterJid,
             encType: encrypted.type,
@@ -131,7 +135,8 @@ export class WaRetryReplayService {
             encCount: retryCount,
             id: outbound.messageId,
             type: payload.type,
-            deviceIdentity
+            deviceIdentity,
+            metaNode
         })
         return 'resent'
     }
@@ -241,9 +246,14 @@ export class WaRetryReplayService {
         }
 
         const isStatus = isStatusBroadcastJid(payload.to)
-        const metaNode = isStatus
-            ? buildMetaNode({ status_setting: payload.statusSetting ?? 'contacts' })
-            : undefined
+        const metaAttrs: Record<string, string> = {}
+        if (isStatus) {
+            metaAttrs.status_setting = payload.statusSetting ?? 'contacts'
+        }
+        if (isHostedDeviceJid(requesterJid)) {
+            metaAttrs.sender_intent = 'hosted'
+        }
+        const metaNode = Object.keys(metaAttrs).length > 0 ? buildMetaNode(metaAttrs) : undefined
         const retryNode = buildGroupRetryMessageNode({
             to: payload.to,
             type: payload.type,
@@ -281,6 +291,9 @@ export class WaRetryReplayService {
             payload.encType === 'pkmsg'
                 ? this.resolveSignedDeviceIdentity('encrypted_replay')
                 : undefined
+        const metaNode = isHostedDeviceJid(requesterJid)
+            ? buildMetaNode({ sender_intent: 'hosted' })
+            : undefined
         await this.options.messageClient.sendEncrypted({
             to: requesterJid,
             encType: payload.encType,
@@ -289,7 +302,8 @@ export class WaRetryReplayService {
             id: outbound.messageId,
             type: payload.type,
             participant: payload.participant,
-            deviceIdentity
+            deviceIdentity,
+            metaNode
         })
         return 'resent'
     }


### PR DESCRIPTION
- Include hosted devices in group sender-key and group-direct fanout; exclude them only from phash computation, matching WAWebSendGroupSkmsgJob behavior. Previously hosted peers received nothing on group sends.
- Force the <keys> bundle in retry receipts when the sender device is hosted, regardless of retry count — hosted devices are stateless and need the bundle on every retry.
- Emit <meta sender_intent='hosted'> on retried sends when the destination device is hosted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced device handling across message dispatch, retry coordination, and device resolution processes to improve messaging reliability and delivery performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->