### PR TITLE
feat(send)!: additionalAttributes on <message /> + unify coordinator send names

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -749,9 +749,10 @@ export function buildWaClientDependencies(input: {
             )
         },
         sendNewsletterMessage: (newsletterJid, content, sendOptions, contextInfo) =>
-            newsletterCoordinator.sendMessage(newsletterJid, content, {
+            newsletterCoordinator.send(newsletterJid, content, {
                 stanzaId: sendOptions.id,
-                contextInfo
+                contextInfo,
+                additionalAttributes: sendOptions.additionalAttributes
             }),
         getIcdcHashLength: () => abPropsCoordinator.getConfigValue('md_icdc_hash_length'),
         mobileMessageIdFormat: options.mobileTransport !== undefined

--- a/src/client/coordinators/WaBroadcastListCoordinator.ts
+++ b/src/client/coordinators/WaBroadcastListCoordinator.ts
@@ -31,9 +31,7 @@ export interface WaSendBroadcastListMessageInput {
 export interface WaBroadcastListCoordinator {
     readonly setList: (input: WaSetBroadcastListInput) => Promise<void>
     readonly removeList: (id: string) => Promise<void>
-    readonly sendMessage: (
-        input: WaSendBroadcastListMessageInput
-    ) => Promise<WaMessagePublishResult>
+    readonly send: (input: WaSendBroadcastListMessageInput) => Promise<WaMessagePublishResult>
 }
 
 export function createBroadcastListCoordinator(
@@ -42,7 +40,7 @@ export function createBroadcastListCoordinator(
     return {
         setList: (input) => options.appStateMutations.setBroadcastList(input),
         removeList: (id) => options.appStateMutations.removeBroadcastList(id),
-        sendMessage: async (input) => {
+        send: async (input) => {
             const built = await options.buildMessageContent(input.content)
             const published = await options.publishBroadcastListMessage({
                 listJid: input.listJid,

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -667,7 +667,8 @@ export class WaMessageDispatchCoordinator {
             deviceIdentity: shouldAttachDeviceIdentity
                 ? this.getEncodedSignedDeviceIdentity()
                 : undefined,
-            customNodes: extras.customNodes
+            customNodes: extras.customNodes,
+            additionalAttributes: sendOptions.additionalAttributes
         })
         const replayPayload: WaRetryReplayPayload = {
             mode: 'plaintext',
@@ -846,7 +847,8 @@ export class WaMessageDispatchCoordinator {
                 : undefined,
             customNodes: customNodes.length > 0 ? customNodes : undefined,
             mediatype,
-            decryptFail: envelope.decryptFail
+            decryptFail: envelope.decryptFail,
+            additionalAttributes: sendOptions.additionalAttributes
         })
         const replayPayload: WaRetryReplayPayload = {
             mode: 'plaintext',
@@ -1042,7 +1044,8 @@ export class WaMessageDispatchCoordinator {
             customNodes: customNodes.length > 0 ? customNodes : undefined,
             mediatype,
             decryptFail: envelope.decryptFail,
-            botParticipants: botSidecar ? [botSidecar] : undefined
+            botParticipants: botSidecar ? [botSidecar] : undefined,
+            additionalAttributes: sendOptions.additionalAttributes
         })
 
         const replayPayload: WaRetryReplayPayload = {
@@ -1518,7 +1521,8 @@ export class WaMessageDispatchCoordinator {
             deviceIdentity,
             customNodes: customNodes.length > 0 ? customNodes : undefined,
             mediatype,
-            decryptFail: envelope.decryptFail
+            decryptFail: envelope.decryptFail,
+            additionalAttributes: sendOptions.additionalAttributes
         })
 
         const replayPayload: WaRetryReplayPayload = {

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -679,7 +679,7 @@ export class WaMessageDispatchCoordinator {
         }
         const result = await this.deps.retryTracker.track(
             {
-                messageIdHint: sendOptions.id ?? messageNode.attrs.id,
+                messageIdHint: messageNode.attrs.id ?? sendOptions.id,
                 toJid: input.groupJid,
                 type: messageNode.attrs.type,
                 replayPayload,
@@ -858,7 +858,7 @@ export class WaMessageDispatchCoordinator {
         }
         const result = await this.deps.retryTracker.track(
             {
-                messageIdHint: sendOptions.id ?? messageNode.attrs.id,
+                messageIdHint: messageNode.attrs.id ?? sendOptions.id,
                 toJid: groupJid,
                 type,
                 replayPayload,
@@ -1056,7 +1056,7 @@ export class WaMessageDispatchCoordinator {
         }
         const result = await this.deps.retryTracker.track(
             {
-                messageIdHint: sendOptions.id ?? messageNode.attrs.id,
+                messageIdHint: messageNode.attrs.id ?? sendOptions.id,
                 toJid: groupJid,
                 type,
                 replayPayload,
@@ -1533,7 +1533,7 @@ export class WaMessageDispatchCoordinator {
         }
         const result = await this.deps.retryTracker.track(
             {
-                messageIdHint: sendOptions.id ?? messageNode.attrs.id,
+                messageIdHint: messageNode.attrs.id ?? sendOptions.id,
                 toJid: recipientJid,
                 type,
                 replayPayload,

--- a/src/client/coordinators/WaStatusCoordinator.ts
+++ b/src/client/coordinators/WaStatusCoordinator.ts
@@ -33,7 +33,7 @@ export interface WaSendStatusInput {
 export interface WaStatusCoordinator {
     readonly setPrivacy: (input: WaSetStatusPrivacyInput) => Promise<void>
     readonly setUserMuted: (jid: string, muted: boolean) => Promise<void>
-    readonly sendStatus: (input: WaSendStatusInput) => Promise<WaMessagePublishResult>
+    readonly send: (input: WaSendStatusInput) => Promise<WaMessagePublishResult>
     readonly revokeStatus: (input: {
         readonly messageId: string
         readonly recipients: readonly string[]
@@ -46,7 +46,7 @@ export function createStatusCoordinator(options: WaStatusCoordinatorOptions): Wa
     return {
         setPrivacy: (input) => options.appStateMutations.setStatusPrivacy(input),
         setUserMuted: (jid, muted) => options.appStateMutations.setUserStatusMute(jid, muted),
-        sendStatus: async (input) => {
+        send: async (input) => {
             const built = await options.buildMessageContent(input.content)
             const message =
                 built.message.conversation && !built.message.extendedTextMessage

--- a/src/client/coordinators/__tests__/broadcast-list-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/broadcast-list-coordinator.test.ts
@@ -67,7 +67,7 @@ test('broadcast list coordinator removeList delegates to app state mutations', a
     assert.deepEqual(appStateMutations.removeBroadcastListCalls, ['list-1'])
 })
 
-test('broadcast list coordinator sendMessage forwards built message + recipients', async () => {
+test('broadcast list coordinator send forwards built message + recipients', async () => {
     const sends: Array<{
         listJid: string
         message: Proto.IMessage
@@ -89,7 +89,7 @@ test('broadcast list coordinator sendMessage forwards built message + recipients
         }
     })
 
-    const result = await coordinator.sendMessage({
+    const result = await coordinator.send({
         listJid: 'list-1@broadcast',
         content: 'hello list',
         recipients: ['a@lid', 'b@lid']

--- a/src/client/coordinators/__tests__/newsletter-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/newsletter-coordinator.test.ts
@@ -204,12 +204,9 @@ test('coordinator mute toggles MUTE_FOLLOWER_ACTIVITY by default', async () => {
     assert.equal(adminBody.variables.input.value, WA_NEWSLETTER_MUTE_VALUES.OFF)
 })
 
-test('coordinator sendMessage(jid, "text") wraps as conversation proto', async () => {
+test('coordinator send(jid, "text") wraps as conversation proto', async () => {
     const env = createTestCoordinator({ resultData: null })
-    const result = await env.coordinator.sendMessage(
-        '120363025343298869@newsletter',
-        'hello channel'
-    )
+    const result = await env.coordinator.send('120363025343298869@newsletter', 'hello channel')
     assert.ok(result.id.startsWith('STANZA-'))
     assert.equal(result.upload, undefined)
     assert.equal(env.sendCalls.length, 1)
@@ -221,9 +218,9 @@ test('coordinator sendMessage(jid, "text") wraps as conversation proto', async (
     assert.ok(stanza.content[0].content instanceof Uint8Array)
 })
 
-test('coordinator sendMessage with explicit stanzaId honors caller id', async () => {
+test('coordinator send with explicit stanzaId honors caller id', async () => {
     const env = createTestCoordinator({ resultData: null })
-    const result = await env.coordinator.sendMessage('120363025343298869@newsletter', 'hello', {
+    const result = await env.coordinator.send('120363025343298869@newsletter', 'hello', {
         stanzaId: 'CUSTOM'
     })
     assert.equal(result.id, 'CUSTOM')
@@ -257,7 +254,7 @@ test('coordinator listSubscribed parses metadata array', async () => {
     assert.equal(list[1].viewerRole, 'OWNER')
 })
 
-test('coordinator sendMessage with media uploads plaintext blob and emits media stanza', async () => {
+test('coordinator send with media uploads plaintext blob and emits media stanza', async () => {
     const responseBody = new TextEncoder().encode(
         JSON.stringify({
             url: 'https://media.example/blob',
@@ -289,7 +286,7 @@ test('coordinator sendMessage with media uploads plaintext blob and emits media 
         }
     )
 
-    const result = await env.coordinator.sendMessage('120363025343298869@newsletter', {
+    const result = await env.coordinator.send('120363025343298869@newsletter', {
         type: 'image',
         media: new Uint8Array([7, 8, 9]),
         mimetype: 'image/jpeg',

--- a/src/client/coordinators/__tests__/status-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/status-coordinator.test.ts
@@ -63,7 +63,7 @@ test('status coordinator setUserMuted delegates to app state mutations', async (
     ])
 })
 
-test('status coordinator sendStatus converts conversation to extendedTextMessage', async () => {
+test('status coordinator send converts conversation to extendedTextMessage', async () => {
     const publishes: Array<{
         message: Proto.IMessage
         recipients: readonly string[]
@@ -85,7 +85,7 @@ test('status coordinator sendStatus converts conversation to extendedTextMessage
         }
     })
 
-    const result = await coordinator.sendStatus({
+    const result = await coordinator.send({
         content: 'hi status',
         recipients: ['5511000000000@lid'],
         statusSetting: 'denylist'
@@ -98,7 +98,7 @@ test('status coordinator sendStatus converts conversation to extendedTextMessage
     assert.equal(publishes[0].message.conversation, null)
 })
 
-test('status coordinator sendStatus passes a pre-built proto unchanged', async () => {
+test('status coordinator send passes a pre-built proto unchanged', async () => {
     let captured: Proto.IMessage | undefined
     const coordinator = createStatusCoordinator({
         appStateMutations: createFakeAppStateMutations(),
@@ -112,7 +112,7 @@ test('status coordinator sendStatus passes a pre-built proto unchanged', async (
     const proto1: Proto.IMessage = {
         extendedTextMessage: { text: 'already wrapped' }
     }
-    await coordinator.sendStatus({ content: proto1, recipients: ['5511000000000@lid'] })
+    await coordinator.send({ content: proto1, recipients: ['5511000000000@lid'] })
     assert.equal(captured?.extendedTextMessage?.text, 'already wrapped')
 })
 

--- a/src/client/newsletter/messaging.ts
+++ b/src/client/newsletter/messaging.ts
@@ -45,7 +45,7 @@ export interface WaNewsletterMessagingDeps extends WaNewsletterMexDeps {
 }
 
 export interface WaNewsletterMessagingOps {
-    readonly sendMessage: (
+    readonly send: (
         newsletterJid: string,
         content: WaSendMessageContent,
         options?: WaNewsletterSendOptions
@@ -114,7 +114,8 @@ function buildDispatchNode(
     newsletterJid: string,
     stanzaId: string,
     built: WaNewsletterBuiltContent,
-    edit: { readonly parentMessageId: string } | null
+    edit: { readonly parentMessageId: string } | null,
+    additionalAttributes?: Readonly<Record<string, string>>
 ): BinaryNode {
     if (built.kind === 'poll-creation') {
         if (edit) {
@@ -124,7 +125,8 @@ function buildDispatchNode(
             kind: 'poll-creation',
             to: newsletterJid,
             id: stanzaId,
-            plaintext: built.plaintext
+            plaintext: built.plaintext,
+            additionalAttributes
         })
     }
     if (built.kind === 'media') {
@@ -138,7 +140,8 @@ function buildDispatchNode(
                       to: newsletterJid,
                       parentMessageId: edit.parentMessageId,
                       plaintext: built.plaintext,
-                      mediaType: built.mediaType
+                      mediaType: built.mediaType,
+                      additionalAttributes
                   }
                 : {
                       kind: 'media',
@@ -146,7 +149,8 @@ function buildDispatchNode(
                       id: stanzaId,
                       plaintext: built.plaintext,
                       mediaType: built.mediaType,
-                      mediaHandle: built.upload?.handle
+                      mediaHandle: built.upload?.handle,
+                      additionalAttributes
                   }
         )
     }
@@ -156,13 +160,15 @@ function buildDispatchNode(
                   kind: 'edit-text',
                   to: newsletterJid,
                   parentMessageId: edit.parentMessageId,
-                  plaintext: built.plaintext
+                  plaintext: built.plaintext,
+                  additionalAttributes
               }
             : {
                   kind: 'text',
                   to: newsletterJid,
                   id: stanzaId,
-                  plaintext: built.plaintext
+                  plaintext: built.plaintext,
+                  additionalAttributes
               }
     )
 }
@@ -173,14 +179,16 @@ export function createMessagingOps(deps: WaNewsletterMessagingDeps): WaNewslette
     }
 
     return {
-        sendMessage: async (
-            newsletterJid,
-            content,
-            sendOptions
-        ): Promise<WaNewsletterSendResult> => {
+        send: async (newsletterJid, content, sendOptions): Promise<WaNewsletterSendResult> => {
             const stanzaId = await resolveStanzaId(sendOptions?.stanzaId)
             const built = await buildContent(deps, content, sendOptions?.contextInfo)
-            const node = buildDispatchNode(newsletterJid, stanzaId, built, null)
+            const node = buildDispatchNode(
+                newsletterJid,
+                stanzaId,
+                built,
+                null,
+                sendOptions?.additionalAttributes
+            )
             const result = await deps.publishMessageNode(node)
             return { ...result, upload: toUploadSummary(built) }
         },

--- a/src/client/newsletter/types.ts
+++ b/src/client/newsletter/types.ts
@@ -126,6 +126,12 @@ export interface WaNewsletterAdminInviteResult {
 export interface WaNewsletterSendOptions {
     readonly stanzaId?: string
     readonly contextInfo?: WaSendContextInfo | null
+    /**
+     * Extra attributes merged into the outgoing `<message>` stanza. Keys provided
+     * here override protocol-managed ones (`to`, `id`, `type`, `edit`, ...) —
+     * use with care: bad overrides can break the send.
+     */
+    readonly additionalAttributes?: Readonly<Record<string, string>>
 }
 
 export type WaNewsletterSendResult = WaMessagePublishResult

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -201,6 +201,12 @@ export interface WaSendMessageOptions extends WaMessagePublishOptions {
      * Use to share a known secret across follow-up addons or for deterministic tests.
      */
     readonly messageSecret?: Uint8Array
+    /**
+     * Extra attributes merged into the outgoing `<message>` stanza. Keys provided
+     * here override protocol-managed ones (`to`, `type`, `id`, `edit`, `phash`,
+     * `addressing_mode`) — use with care: bad overrides can break the send.
+     */
+    readonly additionalAttributes?: Readonly<Record<string, string>>
 }
 
 export interface WaClearChatOptions {

--- a/src/message/encode/content.ts
+++ b/src/message/encode/content.ts
@@ -233,7 +233,9 @@ export function resolveDecryptFailAttr(message: Proto.IMessage): 'hide' | undefi
     if (
         msg.reactionMessage ||
         msg.encReactionMessage ||
-        (msg.pollUpdateMessage && msg.pollUpdateMessage.vote != null) ||
+        (msg.pollUpdateMessage &&
+            msg.pollUpdateMessage.vote !== null &&
+            msg.pollUpdateMessage.vote !== undefined) ||
         msg.keepInChatMessage ||
         msg.editedMessage ||
         msg.pinInChatMessage ||

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -1062,6 +1062,39 @@ test('message builders cover group and inbound receipt branches', () => {
     assert.equal(nack.content[0].attrs.failure_reason, '12')
 })
 
+test('message builders merge additionalAttributes with user-wins semantics', () => {
+    const direct = buildDirectMessageFanoutNode({
+        to: '5511@s.whatsapp.net',
+        type: 'text',
+        id: 'm1',
+        participants: [
+            {
+                jid: '5511:2@s.whatsapp.net',
+                encType: 'msg',
+                ciphertext: new Uint8Array([1])
+            }
+        ],
+        additionalAttributes: { category: 'peer', type: 'media' }
+    })
+    assert.equal(direct.attrs.to, '5511@s.whatsapp.net')
+    assert.equal(direct.attrs.id, 'm1')
+    assert.equal(direct.attrs.category, 'peer')
+    // user-wins: additionalAttributes.type override the protocol type
+    assert.equal(direct.attrs.type, 'media')
+
+    const group = buildGroupSenderKeyMessageNode({
+        to: '123@g.us',
+        type: 'text',
+        id: 'g1',
+        groupCiphertext: new Uint8Array([2]),
+        participants: [],
+        additionalAttributes: { push_priority: 'high' }
+    })
+    assert.equal(group.attrs.push_priority, 'high')
+    assert.equal(group.attrs.to, '123@g.us')
+    assert.equal(group.attrs.type, 'text')
+})
+
 test('pairing builders generate link-code nodes and ack helpers', () => {
     const hello = buildCompanionHelloRequestNode({
         phoneJid: '5511999999999@s.whatsapp.net',
@@ -1613,6 +1646,34 @@ test('buildNewsletterMessageNode covers every message kind variant', async () =>
             }),
         /at least one item/
     )
+})
+
+test('buildNewsletterMessageNode merges additionalAttributes (user-wins)', async () => {
+    const { buildNewsletterMessageNode } = await import('@transport/node/builders/newsletter')
+    const to = '120363@newsletter'
+
+    const text = buildNewsletterMessageNode({
+        kind: 'text',
+        to,
+        id: 'S1',
+        plaintext: new Uint8Array([1]),
+        additionalAttributes: { category: 'peer', type: 'media' }
+    })
+    assert.equal(text.attrs.to, to)
+    assert.equal(text.attrs.id, 'S1')
+    assert.equal(text.attrs.category, 'peer')
+    assert.equal(text.attrs.type, 'media')
+
+    const media = buildNewsletterMessageNode({
+        kind: 'media',
+        to,
+        id: 'S2',
+        plaintext: new Uint8Array([2]),
+        mediaType: 'image',
+        additionalAttributes: { push_priority: 'high' }
+    })
+    assert.equal(media.attrs.push_priority, 'high')
+    assert.equal(media.attrs.type, 'media')
 })
 
 test('newsletter fetch IQs build the right history/update stanzas', async () => {

--- a/src/transport/node/builders/message.ts
+++ b/src/transport/node/builders/message.ts
@@ -18,6 +18,7 @@ type DirectMessageFanoutInput = {
     readonly customNodes?: readonly BinaryNode[]
     readonly mediatype?: string
     readonly decryptFail?: string
+    readonly additionalAttributes?: Readonly<Record<string, string>>
 }
 
 type GroupMessageFanoutInput = DirectMessageFanoutInput & {
@@ -77,6 +78,7 @@ function buildMessageAttrs(input: {
     readonly edit?: string
     readonly phash?: string
     readonly addressingMode?: string
+    readonly additionalAttributes?: Readonly<Record<string, string>>
 }): Record<string, string> {
     const attrs: Record<string, string> = {
         to: input.to,
@@ -93,6 +95,9 @@ function buildMessageAttrs(input: {
     }
     if (input.addressingMode) {
         attrs.addressing_mode = input.addressingMode
+    }
+    if (input.additionalAttributes) {
+        Object.assign(attrs, input.additionalAttributes)
     }
     return attrs
 }

--- a/src/transport/node/builders/newsletter.ts
+++ b/src/transport/node/builders/newsletter.ts
@@ -6,6 +6,7 @@ import type { BinaryNode } from '@transport/types'
 
 interface NewsletterMessageBaseInput {
     readonly to: string
+    readonly additionalAttributes?: Readonly<Record<string, string>>
 }
 
 interface NewsletterMessageNewInput extends NewsletterMessageBaseInput {
@@ -151,6 +152,10 @@ export function buildNewsletterMessageNode(input: BuildNewsletterMessageInput): 
                 pollMetaChild('vote', input.contentType)
             ]
             break
+    }
+
+    if (input.additionalAttributes) {
+        Object.assign(attrs, input.additionalAttributes)
     }
 
     return content === undefined ? { tag: 'message', attrs } : { tag: 'message', attrs, content }


### PR DESCRIPTION
Adds WaSendMessageOptions.additionalAttributes and WaNewsletterSendOptions.additionalAttributes (Record<string, string>), merged into the outgoing <message /> stanza attrs with user-wins semantics, extra keys land verbatim, and the user can also override protocol-managed attrs (to/type/id/edit/phash/addressing_mode) if they know what they are doing. Threaded through every encrypted send path (direct 1:1 fanout, group direct, group sender-key, status broadcast, broadcast list) and the newsletter send path, including the dispatch coordinator -> newsletter adapter in WaClientFactory.

BREAKING CHANGE: coordinator send entry points normalized to .send():
- client.broadcastList.sendMessage(...) -> client.broadcastList.send(...)
- client.status.sendStatus(...) -> client.status.send(...) (newsletter.send was already the canonical name.)

Also fixes an eqeqeq lint warning in resolveDecryptFailAttr by expanding != null into explicit !== null && !== undefined checks for the pollUpdateMessage vote branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom message attributes for direct, group, newsletter, status, broadcast, and builder flows so callers can include extra stanza attributes.

* **Bug Fixes**
  * Fixed poll-update visibility logic to more precisely determine when votes are hidden.

* **API Updates**
  * Unified send method names across coordinators for consistent usage.

* **Tests**
  * Added/updated tests covering attribute merging and coordinator send behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->