### PR TITLE
feat(store): add WaAuthMemoryStore and default providers.auth to memory

### DIFF
--- a/packages/fake-server/bench/messaging.bench.ts
+++ b/packages/fake-server/bench/messaging.bench.ts
@@ -53,14 +53,7 @@ import * as inspector from 'node:inspector/promises'
 import { resolve as resolvePath } from 'node:path'
 import { performance } from 'node:perf_hooks'
 
-import {
-    createStore,
-    type Logger,
-    type WaAuthCredentials,
-    type WaAuthStore,
-    WaClient,
-    type WaClientEventMap
-} from 'zapo-js'
+import { createStore, type Logger, WaClient, type WaClientEventMap } from 'zapo-js'
 
 import type { FakePeer } from '../src/api/FakePeer'
 import { FakeWaServer, type WaFakeConnectionPipeline } from '../src/api/FakeWaServer'
@@ -115,47 +108,6 @@ const NOOP_LOGGER: Logger = {
         if (process.env.ZAPO_BENCH_VERBOSE) console.error('[lib error]', ...args)
     }
 }
-
-class InMemoryAuthStore implements WaAuthStore {
-    private credentials: WaAuthCredentials | null = null
-    public async load(): Promise<WaAuthCredentials | null> {
-        return this.credentials
-    }
-    public async save(credentials: WaAuthCredentials): Promise<void> {
-        this.credentials = credentials
-    }
-    public async clear(): Promise<void> {
-        this.credentials = null
-    }
-}
-
-function noopStore(): never {
-    throw new Error('unexpected store call – bench harness should not reach this slot')
-}
-
-const AUTH_BACKEND = (
-    authStore: WaAuthStore
-): { readonly stores: object; readonly caches: object } => ({
-    stores: {
-        auth: () => authStore,
-        signal: noopStore,
-        preKey: noopStore,
-        session: noopStore,
-        identity: noopStore,
-        senderKey: noopStore,
-        appState: noopStore,
-        messages: noopStore,
-        threads: noopStore,
-        contacts: noopStore,
-        privacyToken: noopStore
-    },
-    caches: {
-        retry: noopStore,
-        participants: noopStore,
-        deviceList: noopStore,
-        messageSecret: noopStore
-    }
-})
 
 // ─── Profiler ─────────────────────────────────────────────────────────
 
@@ -417,15 +369,7 @@ interface PairedFixture {
 
 async function bringUpPairedClient(): Promise<PairedFixture> {
     const server = await FakeWaServer.start()
-    const authStore = new InMemoryAuthStore()
     const store = createStore({
-        backends: { mem: AUTH_BACKEND(authStore) as never },
-        providers: {
-            auth: 'mem',
-            signal: 'memory',
-            senderKey: 'memory',
-            appState: 'memory'
-        },
         // The default in-memory prekey store caps at 4_096 entries.
         // The bench creates ~4000 fake peers and triggers ~5 prekey
         // refills (each generates 812 fresh keyIds), so the total
@@ -930,15 +874,7 @@ async function mainSeparateProcess(
         console.log('[server] profiling skipped (--no-server-prof)')
     }
 
-    const authStore = new InMemoryAuthStore()
     const store = createStore({
-        backends: { mem: AUTH_BACKEND(authStore) as never },
-        providers: {
-            auth: 'mem',
-            signal: 'memory',
-            senderKey: 'memory',
-            appState: 'memory'
-        },
         memory: { limits: { signalPreKeys: 16_384 } }
     })
 

--- a/packages/fake-server/src/__tests__/helpers/zapo-client.ts
+++ b/packages/fake-server/src/__tests__/helpers/zapo-client.ts
@@ -1,10 +1,4 @@
-import {
-    createStore,
-    type Logger,
-    type WaAuthCredentials,
-    type WaAuthStore,
-    WaClient
-} from 'zapo-js'
+import { createStore, type Logger, WaClient } from 'zapo-js'
 
 const NOOP_LOGGER: Logger = {
     level: 'error',
@@ -17,47 +11,6 @@ const NOOP_LOGGER: Logger = {
 
 import type { FakeWaServer } from '../../api/FakeWaServer'
 
-class InMemoryAuthStore implements WaAuthStore {
-    private credentials: WaAuthCredentials | null = null
-    public async load(): Promise<WaAuthCredentials | null> {
-        return this.credentials
-    }
-    public async save(credentials: WaAuthCredentials): Promise<void> {
-        this.credentials = credentials
-    }
-    public async clear(): Promise<void> {
-        this.credentials = null
-    }
-}
-
-function noopStore(): never {
-    throw new Error('unexpected store call – this slot should not be reached in cross-check tests')
-}
-
-const AUTH_BACKEND = (
-    authStore: WaAuthStore
-): { readonly stores: object; readonly caches: object } => ({
-    stores: {
-        auth: () => authStore,
-        signal: noopStore,
-        preKey: noopStore,
-        session: noopStore,
-        identity: noopStore,
-        senderKey: noopStore,
-        appState: noopStore,
-        messages: noopStore,
-        threads: noopStore,
-        contacts: noopStore,
-        privacyToken: noopStore
-    },
-    caches: {
-        retry: noopStore,
-        participants: noopStore,
-        deviceList: noopStore,
-        messageSecret: noopStore
-    }
-})
-
 export interface CreateZapoClientOptions {
     readonly sessionId?: string
     readonly connectTimeoutMs?: number
@@ -68,23 +21,13 @@ export interface CreateZapoClientOptions {
 
 export interface ZapoClientFixture {
     readonly client: WaClient
-    readonly authStore: WaAuthStore
 }
 
 export function createZapoClient(
     server: FakeWaServer,
     options: CreateZapoClientOptions = {}
 ): ZapoClientFixture {
-    const authStore = new InMemoryAuthStore()
-    const store = createStore({
-        backends: { mem: AUTH_BACKEND(authStore) as never },
-        providers: {
-            auth: 'mem',
-            signal: 'memory',
-            senderKey: 'memory',
-            appState: 'memory'
-        }
-    })
+    const store = createStore({})
 
     const client = new WaClient(
         {
@@ -105,5 +48,5 @@ export function createZapoClient(
         options.logger ?? NOOP_LOGGER
     )
 
-    return { client, authStore }
+    return { client }
 }

--- a/packages/fake-server/src/__tests__/resume-handshake.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/resume-handshake.cross-check.test.ts
@@ -1,37 +1,19 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import {
-    createStore,
-    type WaAuthCredentials,
-    type WaAuthStore,
-    WaClient,
-    type WaClientEventMap
-} from 'zapo-js'
+import { createStore, WaAuthMemoryStore, WaClient, type WaClientEventMap } from 'zapo-js'
 
 import { FakeWaServer } from '../api/FakeWaServer'
-
-class InMemoryAuthStore implements WaAuthStore {
-    private credentials: WaAuthCredentials | null = null
-    public async load(): Promise<WaAuthCredentials | null> {
-        return this.credentials
-    }
-    public async save(credentials: WaAuthCredentials): Promise<void> {
-        this.credentials = credentials
-    }
-    public async clear(): Promise<void> {
-        this.credentials = null
-    }
-    public peek(): WaAuthCredentials | null {
-        return this.credentials
-    }
-}
 
 function noopStore(): never {
     throw new Error('unexpected store call in resume cross-check')
 }
 
-function buildClientFor(server: FakeWaServer, authStore: WaAuthStore, sessionId: string): WaClient {
+function buildClientFor(
+    server: FakeWaServer,
+    authStore: WaAuthMemoryStore,
+    sessionId: string
+): WaClient {
     const store = createStore({
         backends: {
             mem: {
@@ -56,12 +38,7 @@ function buildClientFor(server: FakeWaServer, authStore: WaAuthStore, sessionId:
                 }
             }
         },
-        providers: {
-            auth: 'mem',
-            signal: 'memory',
-            senderKey: 'memory',
-            appState: 'memory'
-        }
+        providers: { auth: 'mem' }
     })
     return new WaClient({
         store,
@@ -91,7 +68,7 @@ function waitForEvent<K extends keyof WaClientEventMap>(
 
 test('resume handshake: second connection uses IK and reaches debug_connection_success', async () => {
     const server = await FakeWaServer.start()
-    const authStore = new InMemoryAuthStore()
+    const authStore = new WaAuthMemoryStore()
 
     try {
         const firstClient = buildClientFor(server, authStore, 'resume-1')
@@ -99,7 +76,7 @@ test('resume handshake: second connection uses IK and reaches debug_connection_s
         await firstClient.connect()
         await firstSuccess
 
-        const credsAfterXx = authStore.peek()
+        const credsAfterXx = await authStore.load()
         assert.ok(credsAfterXx, 'auth store should have credentials after first connect')
         assert.ok(
             credsAfterXx.serverStaticKey && credsAfterXx.serverStaticKey.byteLength === 32,

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,7 +227,7 @@ export { ConsoleLogger } from '@infra/log/ConsoleLogger'
 export { PinoLogger, createPinoLogger } from '@infra/log/PinoLogger'
 export type { PinoLoggerOptions } from '@infra/log/PinoLogger'
 export type { Logger, LogLevel } from '@infra/log/types'
-export { createStore } from '@store'
+export { createStore, WaAuthMemoryStore } from '@store'
 export type {
     WaAppStateCollectionStoreState,
     WaAppStateStore,

--- a/src/store/__tests__/create-store.test.ts
+++ b/src/store/__tests__/create-store.test.ts
@@ -59,8 +59,30 @@ const mockAuthBackend = {
     }
 } as const
 
-test('createStore requires providers.auth', () => {
-    assert.throws(() => createStore({}).session('default'), /providers.auth is required/)
+test('createStore defaults auth to in-memory when no provider is set', async () => {
+    const store = createStore({})
+    const session = store.session('default')
+    assert.equal(await session.auth.load(), null)
+
+    const credentials = {
+        noiseKeyPair: { pubKey: new Uint8Array(32), privKey: new Uint8Array(32) },
+        registrationInfo: {
+            registrationId: 1,
+            identityKeyPair: { pubKey: new Uint8Array(33), privKey: new Uint8Array(32) }
+        },
+        signedPreKey: {
+            keyId: 1,
+            keyPair: { pubKey: new Uint8Array(33), privKey: new Uint8Array(32) },
+            signature: new Uint8Array(64)
+        },
+        advSecretKey: new Uint8Array(32)
+    } as const
+    await session.auth.save(credentials)
+    assert.deepEqual(await session.auth.load(), credentials)
+    await session.auth.clear()
+    assert.equal(await session.auth.load(), null)
+
+    await store.destroy()
 })
 
 test('createStore session lifecycle with backend + memory', async () => {

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -29,6 +29,7 @@ import { withSessionLock } from '@store/locks/session.lock'
 import { withSignalLock } from '@store/locks/signal.lock'
 import { withThreadLock } from '@store/locks/thread.lock'
 import { WaAppStateMemoryStore } from '@store/memory/appstate.store'
+import { WaAuthMemoryStore } from '@store/memory/auth.store'
 import { WaContactMemoryStore } from '@store/memory/contact.store'
 import { WaDeviceListMemoryStore } from '@store/memory/device-list.store'
 import { WaGroupMetadataMemoryStore } from '@store/memory/group-metadata.store'
@@ -110,10 +111,11 @@ function resolveStore<T>(
 /**
  * Builds a {@link WaStore} from the configured providers/backends. Each call
  * to `store.session(sessionId)` returns a cached, lock-wrapped per-domain
- * store bundle for that session – `auth` is required (no default), the
- * Signal-protocol domains default to memory, mailbox domains (messages,
- * threads, contacts) default to noop, and the cache domains default to
- * bounded memory with the TTLs in `options.memory.cacheTtlMs`.
+ * store bundle for that session – every domain defaults to `'memory'` (or
+ * `'none'` for the mailbox domains), and the cache domains default to
+ * bounded memory with the TTLs in `options.memory.cacheTtlMs`. `auth`
+ * defaults to memory too, so the device re-pairs on every restart unless
+ * you point it at a persistent backend.
  *
  * @example
  * ```ts
@@ -124,7 +126,7 @@ function resolveStore<T>(
  * const store = createStore({
  *     backends: { sqlite: createSqliteStore({ path: '.auth/state.sqlite' }) },
  *     providers: {
- *         auth: 'sqlite',        // required – pairing creds live here
+ *         auth: 'sqlite',        // pairing creds – persist in production
  *         signal: 'sqlite',      // signal sessions
  *         senderKey: 'sqlite',   // group sender keys
  *         appState: 'sqlite',    // app-state collections
@@ -135,9 +137,7 @@ function resolveStore<T>(
  * })
  *
  * // Memory-only (tests / ephemeral sessions – credentials lost on restart)
- * const memStore = createStore({
- *     providers: { auth: 'memory' as never } // requires registering a memory auth backend yourself
- * })
+ * const memStore = createStore({})
  *
  * // Cache tuning
  * createStore({
@@ -196,14 +196,10 @@ export function createStore<B extends string>(options: WaCreateStoreOptions<B>):
             const rawAuth = resolveStore<WaAuthStore>(
                 id,
                 backends,
-                providers.auth,
+                providers.auth ?? 'memory',
                 'auth',
                 'stores',
-                () => {
-                    throw new Error(
-                        'providers.auth is required – register a backend or set providers.auth'
-                    )
-                }
+                () => new WaAuthMemoryStore()
             )
             const rawSignal = resolveStore<WaSignalStore>(
                 id,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -37,6 +37,7 @@ export type {
     WaStoredPrivacyTokenRecord
 } from '@store/contracts/privacy-token.store'
 export { WaAppStateMemoryStore } from '@store/memory/appstate.store'
+export { WaAuthMemoryStore } from '@store/memory/auth.store'
 export { WaSignalMemoryStore } from '@store/memory/signal.store'
 export { WaPreKeyMemoryStore } from '@store/memory/pre-key.store'
 export { WaSessionMemoryStore } from '@store/memory/session.store'

--- a/src/store/memory/__tests__/memory-providers.test.ts
+++ b/src/store/memory/__tests__/memory-providers.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import { WA_APP_STATE_COLLECTIONS } from '@protocol/constants'
 import { WaAppStateMemoryStore } from '@store/memory/appstate.store'
+import { WaAuthMemoryStore } from '@store/memory/auth.store'
 import { WaDeviceListMemoryStore } from '@store/memory/device-list.store'
 import { WaIdentityMemoryStore } from '@store/memory/identity.store'
 import { WaMessageSecretMemoryStore } from '@store/memory/message-secret.store'
@@ -13,6 +14,31 @@ import { WaRetryMemoryStore } from '@store/memory/retry.store'
 import { SenderKeyMemoryStore } from '@store/memory/sender-key.store'
 import { WaSessionMemoryStore } from '@store/memory/session.store'
 import { WaThreadMemoryStore } from '@store/memory/thread.store'
+
+test('memory auth store roundtrips credentials and clears', async () => {
+    const store = new WaAuthMemoryStore()
+    assert.equal(await store.load(), null)
+
+    const credentials = {
+        noiseKeyPair: { pubKey: new Uint8Array(32), privKey: new Uint8Array(32) },
+        registrationInfo: {
+            registrationId: 7,
+            identityKeyPair: { pubKey: new Uint8Array(33), privKey: new Uint8Array(32) }
+        },
+        signedPreKey: {
+            keyId: 11,
+            keyPair: { pubKey: new Uint8Array(33), privKey: new Uint8Array(32) },
+            signature: new Uint8Array(64)
+        },
+        advSecretKey: new Uint8Array(32),
+        meJid: '5511@s.whatsapp.net'
+    } as const
+    await store.save(credentials)
+    assert.deepEqual(await store.load(), credentials)
+
+    await store.clear()
+    assert.equal(await store.load(), null)
+})
 
 test('memory message/thread stores enforce limits and ordering', async () => {
     const messageStore = new WaMessageMemoryStore({ maxMessages: 2 })

--- a/src/store/memory/auth.store.ts
+++ b/src/store/memory/auth.store.ts
@@ -1,0 +1,28 @@
+import type { WaAuthCredentials } from '@auth/types'
+import type { WaAuthStore } from '@store/contracts/auth.store'
+
+/**
+ * In-memory {@link WaAuthStore} implementation. Holds a single
+ * {@link WaAuthCredentials} per instance in a field – nothing is persisted.
+ *
+ * @sensitive Holds private key material from {@link WaAuthCredentials} in
+ * RAM. Never log instances, never `JSON.stringify`. Pairing credentials are
+ * lost when the process exits, so the next connect will re-pair from scratch
+ * (QR/link-code). Prefer a persistent backend (e.g. `@zapo-js/store-sqlite`)
+ * for production.
+ */
+export class WaAuthMemoryStore implements WaAuthStore {
+    private credentials: WaAuthCredentials | null = null
+
+    public async load(): Promise<WaAuthCredentials | null> {
+        return this.credentials
+    }
+
+    public async save(credentials: WaAuthCredentials): Promise<void> {
+        this.credentials = credentials
+    }
+
+    public async clear(): Promise<void> {
+        this.credentials = null
+    }
+}

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -77,8 +77,8 @@ export interface WaCreateStoreOptions<B extends string = string> {
     readonly backends?: Readonly<Record<B, WaStoreBackend>>
     /**
      * Per-domain provider selection for the persistent (non-cache) stores.
-     * `auth` is required – every other domain falls back to `'memory'` (or
-     * `'none'` for the mailbox domains) when omitted.
+     * Every domain falls back to `'memory'` (or `'none'` for the mailbox
+     * domains) when omitted.
      */
     readonly providers?: {
         /**
@@ -86,8 +86,10 @@ export interface WaCreateStoreOptions<B extends string = string> {
          * identity, registration info, signed prekey, ADV secret, server
          * static key, routing info, account metadata. **This is what proves
          * "I am this paired device" to WhatsApp.** Lose it and the next
-         * connect has to re-pair from scratch (QR/link-code). No default  -
-         * pick a persistent backend in production.
+         * connect has to re-pair from scratch (QR/link-code). Default:
+         * `'memory'` – fine for tests / one-shot scripts, but persist it
+         * (e.g. `@zapo-js/store-sqlite`) in production so the device
+         * survives a process restart.
          */
         readonly auth?: B | 'memory'
         /**


### PR DESCRIPTION
Previously createStore() threw when providers.auth was omitted, forcing every consumer (incl. tests, benches, and the fake-server cross-check) to roll its own InMemoryAuthStore + backend wrapper. The contract is trivial (load/save/clear), so the in-tree memory provider now ships with it and auth falls back to it when no provider is set – matching every other domain. Credentials are still lost on process restart, so the JSDoc keeps the persist-in-production guidance.

Side cleanup: drop the local InMemoryAuthStore/AUTH_BACKEND duplicates in the fake-server bench, cross-check tests, and helper now that the default covers them. The resume-handshake test still keeps a backend wrapper since the two clients share auth across distinct sessionIds, but it consumes the lib's WaAuthMemoryStore instead of a private class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In-memory auth store is now publicly available for use.
  * Auth provisioning now defaults to in-memory storage when no custom backend is configured, eliminating the need for manual setup in simple scenarios.

* **Documentation**
  * Updated documentation to clarify default behavior and memory-based fallback mechanism for auth store provisioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->