### PR TITLE
feat(store-sqlite): accept externally-owned WaSqliteConnection

### DIFF
--- a/packages/store-sqlite/README.md
+++ b/packages/store-sqlite/README.md
@@ -44,16 +44,41 @@ const client = new WaClient({ store, sessionId: 'default' })
 
 `createSqliteStore(config)` accepts:
 
-| Field        | Description                                                                           |
-| ------------ | ------------------------------------------------------------------------------------- |
-| `path`       | Database file path. Use `':memory:'` for an ephemeral DB.                             |
-| `driver`     | `'auto'` (default) / `'better-sqlite3'` / `'bun'`.                                    |
-| `pragmas`    | Extra `PRAGMA` statements merged on top of defaults.                                  |
-| `tableNames` | Per-domain table name overrides.                                                      |
-| `batchSizes` | Per-domain bulk-read batch sizes.                                                     |
-| `cacheTtlMs` | TTLs for the cache domains (`retry`, `groupMetadata`, `deviceList`, `messageSecret`). |
+| Field        | Description                                                                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `path`       | Database file path. Use `':memory:'` for an ephemeral DB. Mutually exclusive with `connection`.                                             |
+| `connection` | Pre-opened `WaSqliteConnection` to reuse instead of opening a new one. Caller owns the lifecycle (per-store `destroy()` does not close it). |
+| `driver`     | `'auto'` (default) / `'better-sqlite3'` / `'bun'`. Ignored when `connection` is set.                                                        |
+| `pragmas`    | Extra `PRAGMA` statements merged on top of defaults. Ignored when `connection` is set.                                                      |
+| `tableNames` | Per-domain table name overrides. Ignored when `connection` is set.                                                                          |
+| `batchSizes` | Per-domain bulk-read batch sizes.                                                                                                           |
+| `cacheTtlMs` | TTLs for the cache domains (`retry`, `groupMetadata`, `deviceList`, `messageSecret`).                                                       |
 
 The returned object is shaped as a `WaStoreBackend` (`{ stores, caches }`) - feed it to `createStore({ backends: { sqlite: ... } })` and reference it by name in `providers`/`cacheProviders`.
+
+### Bring your own connection
+
+To share a single SQLite connection with the rest of your application, open it yourself with `openSqliteConnection` and pass it through `connection`:
+
+```ts
+import { createSqliteStore, openSqliteConnection } from '@zapo-js/store-sqlite'
+
+const connection = await openSqliteConnection({
+    path: 'app.sqlite',
+    sessionId: 'shared',
+    pragmas: { journal_mode: 'WAL', synchronous: 'NORMAL' }
+})
+
+const store = createStore({
+    backends: { sqlite: createSqliteStore({ connection }) },
+    providers: { auth: 'sqlite', signal: 'sqlite', senderKey: 'sqlite', appState: 'sqlite' }
+})
+
+// ... use connection elsewhere in your app ...
+
+await store.destroy()
+connection.close() // you opened it, you close it
+```
 
 ## Notes
 

--- a/packages/store-sqlite/src/BaseSqliteStore.ts
+++ b/packages/store-sqlite/src/BaseSqliteStore.ts
@@ -18,7 +18,18 @@ export abstract class BaseSqliteStore {
 
     protected async getConnection(): Promise<WaSqliteConnection> {
         if (!this.connectionPromise) {
-            this.connectionPromise = openSqliteConnection(this.options).then((connection) =>
+            const supplied = this.options.connection
+            const path = this.options.path
+            if (supplied && path) {
+                throw new Error('sqlite store accepts only one of "path" or "connection"')
+            }
+            if (!supplied && !path) {
+                throw new Error('sqlite store requires either "path" or "connection"')
+            }
+            const open: Promise<WaSqliteConnection> = supplied
+                ? Promise.resolve(supplied)
+                : openSqliteConnection(this.options)
+            this.connectionPromise = open.then((connection) =>
                 ensureSqliteMigrations(connection, this.migrationDomains).then(() => connection)
             )
         }
@@ -36,6 +47,9 @@ export abstract class BaseSqliteStore {
         const connectionPromise = this.connectionPromise
         this.connectionPromise = null
         if (!connectionPromise) {
+            return
+        }
+        if (this.options.connection) {
             return
         }
         const connection = await connectionPromise

--- a/packages/store-sqlite/src/__tests__/sqlite-providers.test.ts
+++ b/packages/store-sqlite/src/__tests__/sqlite-providers.test.ts
@@ -6,6 +6,7 @@ import test from 'node:test'
 
 import { WaAuthSqliteStore } from '../auth.store'
 import { openSqliteConnection } from '../connection'
+import { createSqliteStore } from '../createSqliteStore'
 import { WaMessageSqliteStore } from '../message.store'
 import { WaPrivacyTokenSqliteStore } from '../privacy-token.store'
 import { WaThreadSqliteStore } from '../thread.store'
@@ -305,6 +306,113 @@ test('sqlite connection rejects invalid custom table names', async () => {
             /unsupported sqlite tableNames key/
         )
     } finally {
+        await rm(dir, { recursive: true, force: true })
+    }
+})
+
+test('sqlite store reuses externally-owned connection and does not close it on destroy', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zapo-sqlite-shared-conn-'))
+    const connection = await openSqliteConnection({
+        path: join(dir, 'state.sqlite'),
+        sessionId: 'shared',
+        driver: 'better-sqlite3'
+    })
+
+    try {
+        const store = new WaAuthSqliteStore({ connection, sessionId: 'shared' })
+        const credentials = createCredentials()
+        await store.save(credentials)
+        await store.destroy()
+
+        const row = connection.get<{ readonly me_jid: string }>(
+            'SELECT me_jid FROM auth_credentials WHERE session_id = ?',
+            ['shared']
+        )
+        assert.equal(row?.me_jid, credentials.meJid)
+
+        const reopened = new WaAuthSqliteStore({ connection, sessionId: 'shared' })
+        const loaded = await reopened.load()
+        assert.ok(loaded)
+        assert.equal(loaded.meJid, credentials.meJid)
+        await reopened.destroy()
+    } finally {
+        connection.close()
+        await rm(dir, { recursive: true, force: true })
+    }
+})
+
+test('sqlite store rejects invalid path/connection combinations', async () => {
+    await assert.rejects(async () => {
+        const store = new WaAuthSqliteStore({ sessionId: 'x' })
+        await store.load()
+    }, /requires either "path" or "connection"/)
+
+    const dir = await mkdtemp(join(tmpdir(), 'zapo-sqlite-conflict-'))
+    const connection = await openSqliteConnection({
+        path: join(dir, 'state.sqlite'),
+        sessionId: 'x',
+        driver: 'better-sqlite3'
+    })
+    try {
+        await assert.rejects(async () => {
+            const store = new WaAuthSqliteStore({
+                sessionId: 'x',
+                path: join(dir, 'state.sqlite'),
+                connection
+            })
+            await store.load()
+        }, /accepts only one of "path" or "connection"/)
+    } finally {
+        connection.close()
+        await rm(dir, { recursive: true, force: true })
+    }
+})
+
+test('createSqliteStore accepts an externally-owned connection', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zapo-sqlite-create-conn-'))
+    const connection = await openSqliteConnection({
+        path: join(dir, 'state.sqlite'),
+        sessionId: 'shared',
+        driver: 'better-sqlite3'
+    })
+
+    try {
+        const bundle = createSqliteStore({ connection })
+        const authStore = bundle.stores.auth('session-a')
+        const credentials = createCredentials()
+        await authStore.save(credentials)
+        await authStore.destroy()
+
+        const row = connection.get<{ readonly me_jid: string }>(
+            'SELECT me_jid FROM auth_credentials WHERE session_id = ?',
+            ['session-a']
+        )
+        assert.equal(row?.me_jid, credentials.meJid)
+    } finally {
+        connection.close()
+        await rm(dir, { recursive: true, force: true })
+    }
+})
+
+test('createSqliteStore rejects missing or duplicated connection source', async () => {
+    assert.throws(
+        () => createSqliteStore({}),
+        /createSqliteStore requires exactly one of "path" or "connection"/
+    )
+
+    const dir = await mkdtemp(join(tmpdir(), 'zapo-sqlite-create-conflict-'))
+    const connection = await openSqliteConnection({
+        path: join(dir, 'state.sqlite'),
+        sessionId: 'shared',
+        driver: 'better-sqlite3'
+    })
+    try {
+        assert.throws(
+            () => createSqliteStore({ path: join(dir, 'state.sqlite'), connection }),
+            /createSqliteStore requires exactly one of "path" or "connection"/
+        )
+    } finally {
+        connection.close()
         await rm(dir, { recursive: true, force: true })
     }
 })

--- a/packages/store-sqlite/src/connection.ts
+++ b/packages/store-sqlite/src/connection.ts
@@ -293,7 +293,7 @@ function closeDatabaseSafely(db: SqliteDatabaseLike): void {
 }
 
 async function openBetterSqlite(
-    options: WaSqliteStorageOptions,
+    path: string,
     resolveSql: (sql: string) => string,
     pragmas: NormalizedSqlitePragmas
 ): Promise<WaSqliteConnection> {
@@ -307,7 +307,7 @@ async function openBetterSqlite(
     }
 
     const Database = asConstructor(loaded)
-    const db = new Database(options.path)
+    const db = new Database(path)
     try {
         applyPragmas(db, pragmas)
     } catch (error) {
@@ -319,7 +319,7 @@ async function openBetterSqlite(
 }
 
 async function openBunSqlite(
-    options: WaSqliteStorageOptions,
+    path: string,
     resolveSql: (sql: string) => string,
     pragmas: NormalizedSqlitePragmas
 ): Promise<WaSqliteConnection> {
@@ -340,7 +340,7 @@ async function openBunSqlite(
         throw new Error('invalid bun sqlite module export')
     }
 
-    const db = new (ctor as new (path: string) => SqliteDatabaseLike)(options.path)
+    const db = new (ctor as new (path: string) => SqliteDatabaseLike)(path)
     try {
         applyPragmas(db, pragmas)
     } catch (error) {
@@ -426,17 +426,15 @@ function createConnectionHandle(
 export async function openSqliteConnection(
     options: WaSqliteStorageOptions
 ): Promise<WaSqliteConnection> {
+    const { path } = options
+    if (!path) {
+        throw new Error('openSqliteConnection requires options.path')
+    }
     const driver = resolveDriver(options.driver)
     const resolvedTableNames = resolveSqliteTableNames(options.tableNames)
     const resolveSql = createSqliteTableNameSqlResolver(resolvedTableNames)
     const normalizedPragmas = normalizePragmas(options.pragmas)
-    const normalizedOptions: WaSqliteStorageOptions = {
-        ...options,
-        driver,
-        pragmas: normalizedPragmas,
-        tableNames: resolvedTableNames
-    }
-    const cacheKey = `${driver}|${options.path}|${Object.entries(normalizedPragmas)
+    const cacheKey = `${driver}|${path}|${Object.entries(normalizedPragmas)
         .sort(([left], [right]) => left.localeCompare(right))
         .map(([key, value]) => `${key}=${String(value)}`)
         .join(';')}|${serializeSqliteTableNames(resolvedTableNames)}`
@@ -444,8 +442,8 @@ export async function openSqliteConnection(
     if (!entry) {
         const createdConnection =
             driver === 'bun'
-                ? openBunSqlite(normalizedOptions, resolveSql, normalizedPragmas)
-                : openBetterSqlite(normalizedOptions, resolveSql, normalizedPragmas)
+                ? openBunSqlite(path, resolveSql, normalizedPragmas)
+                : openBetterSqlite(path, resolveSql, normalizedPragmas)
         const createdEntry: SqliteConnectionCacheEntry = {
             connection: null,
             connectionPromise: Promise.resolve(null as never),

--- a/packages/store-sqlite/src/createSqliteStore.ts
+++ b/packages/store-sqlite/src/createSqliteStore.ts
@@ -1,5 +1,6 @@
 import { WaAppStateSqliteStore } from './appstate.store'
 import { WaAuthSqliteStore } from './auth.store'
+import type { WaSqliteConnection } from './connection'
 import { WaContactSqliteStore } from './contact.store'
 import { WaDeviceListSqliteStore } from './device-list.store'
 import { WaGroupMetadataSqliteStore } from './group-metadata.store'
@@ -25,24 +26,38 @@ export interface WaSqliteStoreConfig {
      * Filesystem path to the SQLite database file. Use `':memory:'` for an
      * in-process ephemeral database (handy in tests). The file is created
      * on first use; migrations run lazily the first time each domain is
-     * touched.
+     * touched. Mutually exclusive with {@link connection}.
      */
-    readonly path: string
+    readonly path?: string
+    /**
+     * Pre-opened {@link WaSqliteConnection} the stores should reuse instead
+     * of opening their own. Mutually exclusive with {@link path}. The
+     * caller owns the lifecycle - per-store `destroy()` does not close it,
+     * so call `connection.close()` (or your wrapper's dispose) when
+     * tearing the app down. Use this to share a single SQLite connection
+     * across `zapo-js` and the rest of your application.
+     */
+    readonly connection?: WaSqliteConnection
     /**
      * SQLite driver selection. Defaults to `'auto'` which prefers
      * `better-sqlite3` on Node and falls back to `bun:sqlite` on Bun.
-     * Override only when you need to pin the driver for testing.
+     * Override only when you need to pin the driver for testing. Ignored
+     * when {@link connection} is set.
      */
     readonly driver?: WaSqliteDriver
     /**
      * Extra `PRAGMA` statements applied right after open (e.g.
      * `journal_mode = WAL`, `synchronous = NORMAL`, custom `cache_size`).
-     * Library defaults are merged with these on top.
+     * Library defaults are merged with these on top. Ignored when
+     * {@link connection} is set - apply pragmas yourself before passing
+     * the connection in.
      */
     readonly pragmas?: Readonly<Record<string, string | number>>
     /**
      * Per-domain table name overrides. Use to share a single SQLite file
      * with another application that already owns the default table names.
+     * Ignored when {@link connection} is set - the connection's own
+     * table-name resolver is used.
      */
     readonly tableNames?: WaSqliteTableNameOverrides
     /**
@@ -93,19 +108,44 @@ export interface WaSqliteStoreResult {
  * `messageSecret`. Feed the result into `createStore({ backends: { sqlite:
  * createSqliteStore(...) }, providers: { ... } })` from `zapo-js`.
  *
+ * Pass `path` for the library to open and own a connection (closed by
+ * per-store `destroy()` via the shared ref-counted cache), or `connection`
+ * to reuse one you already opened (you keep the lifecycle).
+ *
+ * @throws if neither or both of `path` / `connection` are set.
+ *
  * @example
  * ```ts
  * import { createStore, WaClient } from 'zapo-js'
  * import { createSqliteStore } from '@zapo-js/store-sqlite'
  *
+ * // Library-owned connection (most common)
  * const store = createStore({
  *     backends: { sqlite: createSqliteStore({ path: '.auth/state.sqlite' }) },
  *     providers: { auth: 'sqlite', signal: 'sqlite', senderKey: 'sqlite', appState: 'sqlite' }
  * })
  * const client = new WaClient({ store, sessionId: 'default' })
  * ```
+ *
+ * @example
+ * ```ts
+ * // Bring your own connection - shared with the rest of your app
+ * import { createSqliteStore, openSqliteConnection } from '@zapo-js/store-sqlite'
+ *
+ * const connection = await openSqliteConnection({ path: 'app.sqlite', sessionId: 'shared' })
+ * const store = createStore({
+ *     backends: { sqlite: createSqliteStore({ connection }) },
+ *     providers: { auth: 'sqlite', signal: 'sqlite', senderKey: 'sqlite', appState: 'sqlite' }
+ * })
+ * // ... use store + connection elsewhere ...
+ * await store.destroy()
+ * connection.close() // you own it
+ * ```
  */
 export function createSqliteStore(config: WaSqliteStoreConfig): WaSqliteStoreResult {
+    if (!config.path === !config.connection) {
+        throw new Error('createSqliteStore requires exactly one of "path" or "connection"')
+    }
     const retryTtlMs = config.cacheTtlMs?.retryMs
     const groupMetadataTtlMs = config.cacheTtlMs?.groupMetadataMs
     const deviceListTtlMs = config.cacheTtlMs?.deviceListMs
@@ -113,8 +153,9 @@ export function createSqliteStore(config: WaSqliteStoreConfig): WaSqliteStoreRes
     const batchSizes = config.batchSizes
 
     const opts = (sessionId: string): WaSqliteStorageOptions => ({
-        path: config.path,
         sessionId,
+        path: config.path,
+        connection: config.connection,
         driver: config.driver,
         pragmas: config.pragmas,
         tableNames: config.tableNames

--- a/packages/store-sqlite/src/types.ts
+++ b/packages/store-sqlite/src/types.ts
@@ -1,3 +1,5 @@
+import type { WaSqliteConnection } from './connection'
+
 export type WaSqliteDriver = 'auto' | 'better-sqlite3' | 'bun'
 
 export type WaSqliteTableName =
@@ -27,8 +29,20 @@ export type WaSqliteTableName =
 export type WaSqliteTableNameOverrides = Readonly<Partial<Record<WaSqliteTableName, string>>>
 
 export interface WaSqliteStorageOptions {
-    readonly path: string
     readonly sessionId: string
+    /**
+     * Filesystem path to the SQLite database. Mutually exclusive with
+     * {@link connection}. When set, the store opens (and ref-counts) its
+     * own connection and closes it on `destroy()`.
+     */
+    readonly path?: string
+    /**
+     * Pre-opened {@link WaSqliteConnection} the store should reuse instead
+     * of opening its own. Mutually exclusive with {@link path}. When set,
+     * `destroy()` does not close the connection - the caller owns its
+     * lifecycle. Migrations still run on first access (idempotent).
+     */
+    readonly connection?: WaSqliteConnection
     readonly driver?: WaSqliteDriver
     readonly pragmas?: Readonly<Record<string, string | number>>
     readonly tableNames?: WaSqliteTableNameOverrides


### PR DESCRIPTION
Brings sqlite to parity with pg/mysql/mongo/redis backends, which already accept either a connection-descriptor or a live instance. Lets users share one sqlite handle with the rest of their app and keep its lifecycle (per-store destroy skips close when externally owned).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for externally-managed SQLite connections, enabling shared database access across multiple store instances.

* **Documentation**
  * Expanded configuration guide with TypeScript examples for both library-managed and user-provided connection patterns.

* **Tests**
  * Comprehensive test coverage for connection lifecycle management and configuration validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->