### PR TITLE
feat(client): profile/group setters + on-demand history backfill

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -626,14 +626,6 @@ export function buildWaClientDependencies(input: {
         queryWithContext: runtime.queryWithContext
     })
 
-    const profileCoordinator = createProfileCoordinator({
-        queryWithContext: runtime.queryWithContext,
-        generateSid: generateUsyncSid,
-        mexSocket: { query: runtime.query },
-        queryLidsByPhoneJids: (phoneJids) => signalDeviceSync.queryLidsByPhoneJids(phoneJids),
-        logger
-    })
-
     const businessCoordinator = createBusinessCoordinator({
         queryWithContext: runtime.queryWithContext,
         mediaTransfer,
@@ -758,17 +750,6 @@ export function buildWaClientDependencies(input: {
         mobileMessageIdFormat: options.mobileTransport !== undefined
     })
 
-    const messageCoordinator = new WaMessageCoordinator({
-        messageDispatch,
-        mediaTransfer,
-        logger,
-        messageStore: sessionStore.messages,
-        messageSecretStore: sessionStore.messageSecret,
-        trustedContactToken,
-        emitAddon: (event) => runtime.emitEvent('message_addon', event),
-        mexSocket: { query: runtime.query }
-    })
-
     const presenceCoordinator = createPresenceCoordinator({
         sendNode: (node) => nodeOrchestrator.sendNode(node, false),
         getCurrentCredentials
@@ -781,6 +762,18 @@ export function buildWaClientDependencies(input: {
         getCurrentCredentials,
         generateOutgoingMessageId: () => messageDispatch.generateOutgoingMessageId(),
         subscribeToProtocolMessage: runtime.subscribeProtocolMessage
+    })
+
+    const messageCoordinator = new WaMessageCoordinator({
+        messageDispatch,
+        mediaTransfer,
+        logger,
+        messageStore: sessionStore.messages,
+        messageSecretStore: sessionStore.messageSecret,
+        trustedContactToken,
+        emitAddon: (event) => runtime.emitEvent('message_addon', event),
+        mexSocket: { query: runtime.query },
+        peerDataOperation
     })
 
     const retryCoordinator = new WaRetryCoordinator({
@@ -858,6 +851,15 @@ export function buildWaClientDependencies(input: {
         emitSnapshotMutations: options.chatEvents?.emitSnapshotMutations === true,
         emitMutation: (event) => runtime.emitEvent('mutation', event),
         nctSaltSink: (salt) => trustedContactToken.handleNctSaltSync(salt)
+    })
+
+    const profileCoordinator = createProfileCoordinator({
+        queryWithContext: runtime.queryWithContext,
+        generateSid: generateUsyncSid,
+        mexSocket: { query: runtime.query },
+        queryLidsByPhoneJids: (phoneJids) => signalDeviceSync.queryLidsByPhoneJids(phoneJids),
+        mutations: appStateMutations,
+        logger
     })
 
     const statusCoordinator = createStatusCoordinator({

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -117,6 +117,63 @@ test('history sync processor persists conversations and emits chunk event', asyn
     assert.equal((emitted[0] as { messagesCount: number }).messagesCount, 1)
 })
 
+test('history sync processor handles ON_DEMAND chunks (peer-data-operation response)', async () => {
+    const historySyncBytes = proto.HistorySync.encode({
+        chunkOrder: 0,
+        progress: 100,
+        conversations: [
+            {
+                id: 'thread@s.whatsapp.net',
+                messages: [
+                    {
+                        message: {
+                            key: { id: 'on-demand-msg', fromMe: false },
+                            messageTimestamp: 200,
+                            message: { conversation: 'older message' }
+                        }
+                    }
+                ]
+            }
+        ]
+    }).finish()
+    const zipped = gzipSync(historySyncBytes)
+
+    const emitted: { type: string; payload: unknown }[] = []
+    await processHistorySyncNotification(
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: {
+                downloadAndDecrypt: async () => {
+                    throw new Error('should not be called for inline payload')
+                }
+            } as never,
+            writeBehind: {
+                persistMessageAsync: async () => undefined,
+                persistThreadAsync: async () => undefined,
+                persistContactAsync: async () => undefined
+            } as never,
+            emitEvent: (type, payload) => {
+                emitted.push({ type, payload })
+            }
+        },
+        {
+            syncType: proto.Message.HistorySyncType.ON_DEMAND,
+            initialHistBootstrapInlinePayload: zipped
+        }
+    )
+
+    assert.equal(emitted.length, 1)
+    assert.equal(emitted[0].type, 'history_sync_chunk')
+    const event = emitted[0].payload as {
+        syncType: number
+        messagesCount: number
+        progress: number
+    }
+    assert.equal(event.syncType, proto.Message.HistorySyncType.ON_DEMAND)
+    assert.equal(event.messagesCount, 1)
+    assert.equal(event.progress, 100)
+})
+
 test('history sync processor does not emit chunk event when chunk persistence fails', async () => {
     const historySyncBytes = proto.HistorySync.encode({
         chunkOrder: 2,

--- a/src/client/coordinators/WaGroupCoordinator.ts
+++ b/src/client/coordinators/WaGroupCoordinator.ts
@@ -19,7 +19,14 @@ import {
     buildGroupParticipantChangeIq,
     buildJoinLinkedGroupIq,
     buildLeaveGroupIq,
-    buildMembershipRequestsActionIq
+    buildMembershipRequestsActionIq,
+    buildSetGroupEphemeralIq,
+    buildSetGroupMemberAddModeIq,
+    buildSetGroupMemberLinkModeIq,
+    buildSetGroupMemberShareGroupHistoryModeIq,
+    type WaGroupMemberAddMode,
+    type WaGroupMemberLinkMode,
+    type WaGroupMemberShareGroupHistoryMode
 } from '@transport/node/builders/group'
 import {
     findNodeChild,
@@ -211,6 +218,40 @@ export interface WaGroupCoordinator {
         groupJid: string,
         setting: WaGroupSetting,
         enabled: boolean
+    ) => Promise<void>
+    /**
+     * Sets who can add members to the group. `admin_add` restricts adds to
+     * admins; `all_member_add` lets any participant add. Group admin
+     * operation - non-admins receive a `403 not-authorized` error.
+     */
+    readonly setMemberAddMode: (groupJid: string, mode: WaGroupMemberAddMode) => Promise<void>
+    /**
+     * Sets who can share/forward the group invite link. `admin_link`
+     * restricts to admins; `all_member_link` lets any participant share.
+     * Group admin operation.
+     */
+    readonly setMemberLinkMode: (groupJid: string, mode: WaGroupMemberLinkMode) => Promise<void>
+    /**
+     * Sets whether new members see prior chat history. `admin_share` hides
+     * history; `all_member_share` exposes the message backlog when someone
+     * joins. Group admin operation.
+     */
+    readonly setMemberShareGroupHistoryMode: (
+        groupJid: string,
+        mode: WaGroupMemberShareGroupHistoryMode
+    ) => Promise<void>
+    /**
+     * Sets the per-group disappearing-message lifetime in seconds (`0`
+     * disables, `86400` = 24h, `604800` = 7d, `7776000` = 90d). Use this
+     * to pick a duration; `setSetting('ephemeral', false)` is the explicit
+     * disable path. `trigger` is the WhatsApp ephemeral-trigger code -
+     * leave unset unless you know the protocol value to pass through.
+     * Group admin operation.
+     */
+    readonly setEphemeralDuration: (
+        groupJid: string,
+        expirationSeconds: number,
+        trigger?: number
     ) => Promise<void>
     /**
      * Adds the given participant JIDs to the group. Returns the raw IQ
@@ -512,6 +553,18 @@ const SETTING_TAGS: Readonly<
     allow_non_admin_sub_group_creation: {
         on: WA_GROUP_NOTIFICATION_TAGS.ALLOW_NON_ADMIN_SUB_GROUP_CREATION,
         off: WA_GROUP_NOTIFICATION_TAGS.NOT_ALLOW_NON_ADMIN_SUB_GROUP_CREATION
+    },
+    group_history: {
+        on: WA_GROUP_NOTIFICATION_TAGS.GROUP_HISTORY,
+        off: WA_GROUP_NOTIFICATION_TAGS.NO_GROUP_HISTORY
+    },
+    allow_admin_reports: {
+        on: WA_GROUP_NOTIFICATION_TAGS.ALLOW_ADMIN_REPORTS,
+        off: WA_GROUP_NOTIFICATION_TAGS.NOT_ALLOW_ADMIN_REPORTS
+    },
+    no_frequently_forwarded: {
+        on: WA_GROUP_NOTIFICATION_TAGS.NO_FREQUENTLY_FORWARDED,
+        off: WA_GROUP_NOTIFICATION_TAGS.FREQUENTLY_FORWARDED_OK
     }
 }
 
@@ -663,6 +716,61 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
             ])
             const result = await queryWithContext('group.setDescription', node)
             assertIqResult(result, 'group.setDescription')
+        },
+
+        setMemberAddMode: async (groupJid, mode) => {
+            const node = buildSetGroupMemberAddModeIq({ groupJid, mode })
+            const result = await queryWithContext('group.setMemberAddMode', node, undefined, {
+                groupJid,
+                mode
+            })
+            assertIqResult(result, 'group.setMemberAddMode')
+        },
+
+        setMemberLinkMode: async (groupJid, mode) => {
+            const node = buildSetGroupMemberLinkModeIq({ groupJid, mode })
+            const result = await queryWithContext('group.setMemberLinkMode', node, undefined, {
+                groupJid,
+                mode
+            })
+            assertIqResult(result, 'group.setMemberLinkMode')
+        },
+
+        setMemberShareGroupHistoryMode: async (groupJid, mode) => {
+            const node = buildSetGroupMemberShareGroupHistoryModeIq({ groupJid, mode })
+            const result = await queryWithContext(
+                'group.setMemberShareGroupHistoryMode',
+                node,
+                undefined,
+                { groupJid, mode }
+            )
+            assertIqResult(result, 'group.setMemberShareGroupHistoryMode')
+        },
+
+        setEphemeralDuration: async (groupJid, expirationSeconds, trigger) => {
+            if (
+                !Number.isFinite(expirationSeconds) ||
+                !Number.isSafeInteger(expirationSeconds) ||
+                expirationSeconds < 0
+            ) {
+                throw new Error(`invalid expirationSeconds: ${expirationSeconds}`)
+            }
+            if (trigger !== undefined) {
+                if (!Number.isFinite(trigger) || !Number.isSafeInteger(trigger) || trigger < 0) {
+                    throw new Error(`invalid trigger: ${trigger}`)
+                }
+            }
+            const node = buildSetGroupEphemeralIq({
+                groupJid,
+                expirationSeconds,
+                ...(trigger === undefined ? {} : { trigger })
+            })
+            const result = await queryWithContext('group.setEphemeralDuration', node, undefined, {
+                groupJid,
+                expirationSeconds,
+                ...(trigger === undefined ? {} : { trigger })
+            })
+            assertIqResult(result, 'group.setEphemeralDuration')
         },
 
         setSetting: async (groupJid, setting, enabled) => {

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -23,6 +23,7 @@ import {
     shouldUseAddonAdditionalData
 } from '@message/crypto/addon-crypto'
 import { resolveMediaPayload } from '@message/encode/media-payload'
+import type { PeerDataOperationRequester } from '@message/primitives/peer-data-operation'
 import type {
     WaMessagePublishResult,
     WaSendMessageContent,
@@ -31,8 +32,8 @@ import type {
     WaSendReceiptOptions
 } from '@message/types'
 import type { WaMexOperationResponses } from '@mex'
-import type { Proto } from '@proto'
-import { applyDeviceToJid } from '@protocol/jid'
+import { proto, type Proto } from '@proto'
+import { applyDeviceToJid, normalizeRecipientJid } from '@protocol/jid'
 import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
 import type { WaMessageStore } from '@store/contracts/message.store'
 import { runMexQuery, type WaMexQuerySocket } from '@transport/node/mex/client'
@@ -49,6 +50,29 @@ export interface WaMessageCoordinatorDeps {
     readonly trustedContactToken: WaTrustedContactTokenCoordinator
     readonly emitAddon: (event: WaIncomingAddonEvent) => void
     readonly mexSocket: WaMexQuerySocket
+    readonly peerDataOperation: PeerDataOperationRequester
+}
+
+export interface WaRequestHistorySyncInput {
+    /** Chat the older messages should be fetched from. */
+    readonly chatJid: string
+    /**
+     * Id of the oldest message currently in the local view. The server
+     * pages backwards from this anchor. Omit to let the server pick its
+     * own anchor (rarely useful).
+     */
+    readonly oldestMsgId?: string
+    /** Whether {@link oldestMsgId} was sent by the current account. */
+    readonly oldestMsgFromMe?: boolean
+    /** Epoch ms of the oldest local message; pairs with {@link oldestMsgId}. */
+    readonly oldestMsgTimestampMs?: number
+    /**
+     * How many older messages to request. WhatsApp Web defaults to the
+     * server-side `history_sync_on_demand_message_count` AB-prop (~50);
+     * passing nothing here leaves the field unset so the server applies
+     * its own default.
+     */
+    readonly count?: number
 }
 
 export interface WaReachoutTimelock {
@@ -111,6 +135,7 @@ export class WaMessageCoordinator {
     private readonly trustedContactToken: WaTrustedContactTokenCoordinator
     private readonly emitAddon: (event: WaIncomingAddonEvent) => void
     private readonly mexSocket: WaMexQuerySocket
+    private readonly peerDataOperation: PeerDataOperationRequester
 
     public constructor(deps: WaMessageCoordinatorDeps) {
         this.messageDispatch = deps.messageDispatch
@@ -121,6 +146,61 @@ export class WaMessageCoordinator {
         this.trustedContactToken = deps.trustedContactToken
         this.emitAddon = deps.emitAddon
         this.mexSocket = deps.mexSocket
+        this.peerDataOperation = deps.peerDataOperation
+    }
+
+    /**
+     * Asks the server to backfill older messages for `chatJid` beyond what
+     * arrived in the initial history-sync. Implemented as a
+     * `PeerDataOperationRequestMessage` (type `HISTORY_SYNC_ON_DEMAND`)
+     * sent to this account's own user JID; the response arrives later as
+     * a `history_sync_chunk` event the same way the bootstrap chunks do -
+     * subscribe before calling if you need to react to the chunk.
+     *
+     * The method returns once the request is dispatched (with the protocol
+     * message id), **not** when the chunk arrives. Pair `oldestMsgId` +
+     * `oldestMsgTimestampMs` + `oldestMsgFromMe` from the topmost message
+     * currently visible to page backwards correctly.
+     */
+    public async requestHistorySync(
+        input: WaRequestHistorySyncInput
+    ): Promise<{ readonly messageId: string }> {
+        const chatJid = normalizeRecipientJid(input.chatJid)
+        if (input.count !== undefined) {
+            if (
+                !Number.isFinite(input.count) ||
+                !Number.isSafeInteger(input.count) ||
+                input.count <= 0
+            ) {
+                throw new Error(`invalid count: ${input.count}`)
+            }
+        }
+        if (input.oldestMsgTimestampMs !== undefined) {
+            if (
+                !Number.isFinite(input.oldestMsgTimestampMs) ||
+                !Number.isSafeInteger(input.oldestMsgTimestampMs) ||
+                input.oldestMsgTimestampMs < 0
+            ) {
+                throw new Error(`invalid oldestMsgTimestampMs: ${input.oldestMsgTimestampMs}`)
+            }
+        }
+        const historySyncOnDemandRequest: Proto.Message.PeerDataOperationRequestMessage.IHistorySyncOnDemandRequest =
+            {
+                chatJid,
+                supportInlineResponse: true,
+                ...(input.oldestMsgId === undefined ? {} : { oldestMsgId: input.oldestMsgId }),
+                ...(input.oldestMsgFromMe === undefined
+                    ? {}
+                    : { oldestMsgFromMe: input.oldestMsgFromMe }),
+                ...(input.oldestMsgTimestampMs === undefined
+                    ? {}
+                    : { oldestMsgTimestampMs: input.oldestMsgTimestampMs }),
+                ...(input.count === undefined ? {} : { onDemandMsgCount: input.count })
+            }
+        return this.peerDataOperation.send(
+            proto.Message.PeerDataOperationRequestType.HISTORY_SYNC_ON_DEMAND,
+            { historySyncOnDemandRequest }
+        )
     }
 
     /**

--- a/src/client/coordinators/WaProfileCoordinator.ts
+++ b/src/client/coordinators/WaProfileCoordinator.ts
@@ -1,3 +1,4 @@
+import type { WaAppStateMutationCoordinator } from '@client/coordinators/WaAppStateMutationCoordinator'
 import type { Logger } from '@infra/log/types'
 import type { WaMexOperationResponses } from '@mex'
 import { parseJidFull, parsePhoneJid } from '@protocol/jid'
@@ -10,6 +11,7 @@ import {
     buildGetStatusUsyncQueryNodes,
     buildGetTextStatusUsyncQueryNode,
     buildGetUsernameUsyncQueryNode,
+    buildSetDisappearingModeIq,
     buildSetProfilePictureIq,
     buildSetStatusIq,
     type WaProfilePictureType
@@ -117,12 +119,30 @@ export interface WaProfileCoordinator {
     readonly getStatus: (jid: string) => Promise<WaProfileStatusResult>
     /** Sets the current account's legacy "About" status. */
     readonly setStatus: (text: string) => Promise<void>
+    /**
+     * Sets the account's pushName - the display name broadcast to other
+     * users in chats and group participant lists. WhatsApp Web applies the
+     * change via a `SettingPushName` app-state mutation (collection
+     * `critical_block`); the new value reaches peers as their next
+     * incoming-message envelope from this account carries the updated
+     * `notify` attr. Empty strings are accepted but reset the display name
+     * to the device fingerprint default.
+     */
+    readonly setPushName: (name: string) => Promise<void>
     /** Batched usync fetch of picture id + status for many JIDs. */
     readonly getProfiles: (jids: readonly string[]) => Promise<readonly WaProfileInfo[]>
     /** Batched fetch of the disappearing-mode setting per JID. */
     readonly getDisappearingMode: (
         jids: readonly string[]
     ) => Promise<readonly WaDisappearingModeResult[]>
+    /**
+     * Sets the account-wide default disappearing-mode duration applied to
+     * **new** 1:1 chats started by this account. `durationSeconds` is the
+     * ephemeral message lifetime (`0` disables, `86400` = 24h, `604800` =
+     * 7d, `7776000` = 90d). Existing chats keep their per-chat setting -
+     * change that with a system `disappearing_mode` message instead.
+     */
+    readonly setDisappearingMode: (durationSeconds: number) => Promise<void>
     /** Batched fetch of the modern text-status (emoji + text) per JID. */
     readonly getTextStatuses: (jids: readonly string[]) => Promise<readonly WaTextStatusResult[]>
     /**
@@ -170,6 +190,13 @@ interface WaProfileCoordinatorOptions {
     readonly queryLidsByPhoneJids: (
         phoneJids: readonly string[]
     ) => Promise<readonly SignalLidSyncResult[]>
+    /**
+     * App-state mutation coordinator. {@link WaProfileCoordinator.setPushName}
+     * routes through `mutations.set({ schema: 'SettingPushName', ... })` so
+     * the pushName change shares the same flush pipeline as other queued
+     * mutations.
+     */
+    readonly mutations: WaAppStateMutationCoordinator
     readonly logger: Logger
 }
 
@@ -408,7 +435,8 @@ function buildTextStatusMutationInput(input: WaSetTextStatusInput): {
 export function createProfileCoordinator(
     options: WaProfileCoordinatorOptions
 ): WaProfileCoordinator {
-    const { queryWithContext, generateSid, mexSocket, queryLidsByPhoneJids, logger } = options
+    const { queryWithContext, generateSid, mexSocket, queryLidsByPhoneJids, mutations, logger } =
+        options
 
     return {
         getProfilePicture: async (jid, type, existingId) => {
@@ -463,6 +491,10 @@ export function createProfileCoordinator(
             assertIqResult(result, 'profile.setStatus')
         },
 
+        setPushName: async (name) => {
+            await mutations.set({ schema: 'SettingPushName', name })
+        },
+
         getProfiles: async (jids) => {
             if (jids.length === 0) {
                 return []
@@ -503,6 +535,21 @@ export function createProfileCoordinator(
                 'profile.getDisappearingMode'
             )
             return parseUsyncDisappearingModes(result)
+        },
+
+        setDisappearingMode: async (durationSeconds) => {
+            if (
+                !Number.isFinite(durationSeconds) ||
+                !Number.isSafeInteger(durationSeconds) ||
+                durationSeconds < 0
+            ) {
+                throw new Error(`invalid durationSeconds: ${durationSeconds}`)
+            }
+            const node = buildSetDisappearingModeIq(durationSeconds)
+            const result = await queryWithContext('profile.setDisappearingMode', node, undefined, {
+                durationSeconds
+            })
+            assertIqResult(result, 'profile.setDisappearingMode')
         },
 
         getTextStatuses: async (jids) => {

--- a/src/client/coordinators/__tests__/group-community-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/group-community-coordinator.test.ts
@@ -142,6 +142,98 @@ test('deactivateCommunity sends delete_parent', async () => {
     assert.equal(root.tag, 'delete_parent')
 })
 
+test('setMemberAddMode shapes member_add_mode IQ with text content', async () => {
+    const mock = createMockQuery([iqResult(), iqResult()])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    await coordinator.setMemberAddMode('120363@g.us', 'all_member_add')
+    await coordinator.setMemberAddMode('120363@g.us', 'admin_add')
+
+    assert.equal(mock.calls.length, 2)
+    assert.equal(mock.calls[0].context, 'group.setMemberAddMode')
+    assert.equal(mock.calls[0].node.attrs.to, '120363@g.us')
+    assert.equal(mock.calls[0].node.attrs.type, 'set')
+    assert.equal(mock.calls[0].node.attrs.xmlns, 'w:g2')
+    const firstChild = (mock.calls[0].node.content as BinaryNode[])[0]
+    assert.equal(firstChild.tag, 'member_add_mode')
+    assert.equal(firstChild.content, 'all_member_add')
+    const secondChild = (mock.calls[1].node.content as BinaryNode[])[0]
+    assert.equal(secondChild.content, 'admin_add')
+})
+
+test('setMemberLinkMode and setMemberShareGroupHistoryMode shape mode IQs', async () => {
+    const mock = createMockQuery([iqResult(), iqResult()])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    await coordinator.setMemberLinkMode('120363@g.us', 'admin_link')
+    await coordinator.setMemberShareGroupHistoryMode('120363@g.us', 'all_member_share')
+
+    assert.equal(mock.calls[0].context, 'group.setMemberLinkMode')
+    const linkChild = (mock.calls[0].node.content as BinaryNode[])[0]
+    assert.equal(linkChild.tag, 'member_link_mode')
+    assert.equal(linkChild.content, 'admin_link')
+
+    assert.equal(mock.calls[1].context, 'group.setMemberShareGroupHistoryMode')
+    const shareChild = (mock.calls[1].node.content as BinaryNode[])[0]
+    assert.equal(shareChild.tag, 'member_share_group_history_mode')
+    assert.equal(shareChild.content, 'all_member_share')
+})
+
+test('setEphemeralDuration shapes ephemeral IQ with expiration attr', async () => {
+    const mock = createMockQuery([iqResult(), iqResult()])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    await coordinator.setEphemeralDuration('120363@g.us', 86400)
+    await coordinator.setEphemeralDuration('120363@g.us', 604800, 1)
+
+    const first = (mock.calls[0].node.content as BinaryNode[])[0]
+    assert.equal(first.tag, 'ephemeral')
+    assert.equal(first.attrs.expiration, '86400')
+    assert.equal(first.attrs.trigger, undefined)
+
+    const second = (mock.calls[1].node.content as BinaryNode[])[0]
+    assert.equal(second.attrs.expiration, '604800')
+    assert.equal(second.attrs.trigger, '1')
+
+    await assert.rejects(
+        () => coordinator.setEphemeralDuration('120363@g.us', -1),
+        /invalid expirationSeconds/
+    )
+    await assert.rejects(
+        () => coordinator.setEphemeralDuration('120363@g.us', 86400, -1),
+        /invalid trigger/
+    )
+})
+
+test('setSetting toggles new group_history / allow_admin_reports / no_frequently_forwarded', async () => {
+    const mock = createMockQuery([
+        iqResult(),
+        iqResult(),
+        iqResult(),
+        iqResult(),
+        iqResult(),
+        iqResult()
+    ])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    await coordinator.setSetting('120363@g.us', 'group_history', true)
+    await coordinator.setSetting('120363@g.us', 'group_history', false)
+    await coordinator.setSetting('120363@g.us', 'allow_admin_reports', true)
+    await coordinator.setSetting('120363@g.us', 'allow_admin_reports', false)
+    await coordinator.setSetting('120363@g.us', 'no_frequently_forwarded', true)
+    await coordinator.setSetting('120363@g.us', 'no_frequently_forwarded', false)
+
+    const tags = mock.calls.map((c) => (c.node.content as BinaryNode[])[0].tag)
+    assert.deepEqual(tags, [
+        'group_history',
+        'no_group_history',
+        'allow_admin_reports',
+        'not_allow_admin_reports',
+        'no_frequently_forwarded',
+        'frequently_forwarded_ok'
+    ])
+})
+
 test('queryLinkedGroupsParticipants returns flattened participants', async () => {
     const response: BinaryNode = iqResult([
         {

--- a/src/client/coordinators/__tests__/message-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/message-coordinator.test.ts
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { WaMessageCoordinator } from '@client/coordinators/WaMessageCoordinator'
+import { createNoopLogger } from '@infra/log/types'
+import type { PeerDataOperationRequester } from '@message/primitives/peer-data-operation'
+import { proto, type Proto } from '@proto'
+
+interface RequestCall {
+    readonly type: Proto.Message.PeerDataOperationRequestType
+    readonly body: Proto.Message.IPeerDataOperationRequestMessage
+}
+
+function createFakePdo(): {
+    readonly requester: PeerDataOperationRequester
+    readonly sendCalls: RequestCall[]
+    readonly requestCalls: RequestCall[]
+} {
+    const sendCalls: RequestCall[] = []
+    const requestCalls: RequestCall[] = []
+    const requester: PeerDataOperationRequester = {
+        send: async (type, body) => {
+            sendCalls.push({ type, body })
+            return { messageId: `mid-${sendCalls.length}` }
+        },
+        request: async (type, body) => {
+            requestCalls.push({ type, body })
+            return []
+        }
+    }
+    return { requester, sendCalls, requestCalls }
+}
+
+function createCoordinator(peerDataOperation: PeerDataOperationRequester): WaMessageCoordinator {
+    return new WaMessageCoordinator({
+        messageDispatch: {} as never,
+        mediaTransfer: {} as never,
+        logger: createNoopLogger(),
+        messageStore: {} as never,
+        messageSecretStore: {} as never,
+        trustedContactToken: {} as never,
+        emitAddon: () => undefined,
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
+        peerDataOperation
+    })
+}
+
+test('requestHistorySync sends HISTORY_SYNC_ON_DEMAND PDO with normalized jid and anchor fields', async () => {
+    const pdo = createFakePdo()
+    const coordinator = createCoordinator(pdo.requester)
+
+    const result = await coordinator.requestHistorySync({
+        chatJid: '120363@g.us',
+        oldestMsgId: 'msgid-1',
+        oldestMsgFromMe: true,
+        oldestMsgTimestampMs: 1_700_000_000_000,
+        count: 25
+    })
+
+    assert.equal(result.messageId, 'mid-1')
+    assert.equal(pdo.sendCalls.length, 1)
+    const sent = pdo.sendCalls[0]
+    assert.equal(sent.type, proto.Message.PeerDataOperationRequestType.HISTORY_SYNC_ON_DEMAND)
+    const req = sent.body.historySyncOnDemandRequest
+    assert.ok(req)
+    assert.equal(req.chatJid, '120363@g.us')
+    assert.equal(req.oldestMsgId, 'msgid-1')
+    assert.equal(req.oldestMsgFromMe, true)
+    assert.equal(req.oldestMsgTimestampMs, 1_700_000_000_000)
+    assert.equal(req.onDemandMsgCount, 25)
+    assert.equal(req.supportInlineResponse, true)
+})
+
+test('requestHistorySync omits optional anchor fields when not provided', async () => {
+    const pdo = createFakePdo()
+    const coordinator = createCoordinator(pdo.requester)
+
+    await coordinator.requestHistorySync({ chatJid: '5511999999999@s.whatsapp.net' })
+
+    const req = pdo.sendCalls[0].body.historySyncOnDemandRequest
+    assert.ok(req)
+    assert.equal(req.oldestMsgId, undefined)
+    assert.equal(req.oldestMsgFromMe, undefined)
+    assert.equal(req.oldestMsgTimestampMs, undefined)
+    assert.equal(req.onDemandMsgCount, undefined)
+    assert.equal(req.supportInlineResponse, true)
+})
+
+test('requestHistorySync rejects invalid count and timestamp inputs', async () => {
+    const pdo = createFakePdo()
+    const coordinator = createCoordinator(pdo.requester)
+
+    await assert.rejects(
+        () => coordinator.requestHistorySync({ chatJid: 'a@g.us', count: 0 }),
+        /invalid count/
+    )
+    await assert.rejects(
+        () => coordinator.requestHistorySync({ chatJid: 'a@g.us', count: 1.5 }),
+        /invalid count/
+    )
+    await assert.rejects(
+        () =>
+            coordinator.requestHistorySync({
+                chatJid: 'a@g.us',
+                oldestMsgTimestampMs: -1
+            }),
+        /invalid oldestMsgTimestampMs/
+    )
+    assert.equal(pdo.sendCalls.length, 0)
+})

--- a/src/client/coordinators/__tests__/profile-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/profile-coordinator.test.ts
@@ -25,6 +25,7 @@ test('profile coordinator gets profile picture url', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node, _timeoutMs, contextData) => {
@@ -66,6 +67,7 @@ test('profile coordinator returns empty result when no picture node', async () =
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async () => createIqResult()
@@ -84,6 +86,7 @@ test('profile coordinator gets full image picture with existing id', async () =>
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node) => {
@@ -120,6 +123,7 @@ test('profile coordinator sets profile picture and returns id', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node, _timeoutMs, contextData) => {
@@ -154,6 +158,7 @@ test('profile coordinator sets group profile picture with target jid', async () 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (_context, node) => {
@@ -176,6 +181,7 @@ test('profile coordinator deletes profile picture', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node) => {
@@ -202,6 +208,7 @@ test('profile coordinator gets status via usync', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node) => {
@@ -247,6 +254,7 @@ test('profile coordinator returns null status when no content', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async () =>
@@ -280,6 +288,7 @@ test('profile coordinator returns empty string for status code 401', async () =>
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async () =>
@@ -318,6 +327,7 @@ test('profile coordinator gets multiple profiles via usync', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node) => {
@@ -382,6 +392,7 @@ test('profile coordinator sets status text', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node) => {
@@ -401,10 +412,70 @@ test('profile coordinator sets status text', async () => {
     assert.equal(statusNode.content, 'Hello World')
 })
 
+test('profile coordinator routes setPushName through mutations.set with SettingPushName schema', async () => {
+    const setCalls: unknown[] = []
+
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mutations: {
+            set: async (input: unknown) => {
+                setCalls.push(input)
+            }
+        } as never,
+        queryLidsByPhoneJids: async () => [],
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
+        queryWithContext: async () => createIqResult()
+    })
+
+    await coordinator.setPushName('Maria')
+    await coordinator.setPushName('')
+
+    assert.deepEqual(setCalls, [
+        { schema: 'SettingPushName', name: 'Maria' },
+        { schema: 'SettingPushName', name: '' }
+    ])
+})
+
+test('profile coordinator sets account default disappearing mode', async () => {
+    const calls: Array<{
+        readonly context: string
+        readonly node: BinaryNode
+        readonly contextData?: Readonly<Record<string, unknown>>
+    }> = []
+
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
+        queryLidsByPhoneJids: async () => [],
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
+        queryWithContext: async (context, node, _timeout, contextData) => {
+            calls.push({ context, node, contextData })
+            return createIqResult()
+        }
+    })
+
+    await coordinator.setDisappearingMode(86400)
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].context, 'profile.setDisappearingMode')
+    assert.equal(calls[0].node.attrs.type, 'set')
+    assert.equal(calls[0].node.attrs.xmlns, 'disappearing_mode')
+    assert.equal(calls[0].node.attrs.to, 's.whatsapp.net')
+    const child = (calls[0].node.content as readonly BinaryNode[])[0]
+    assert.equal(child.tag, 'disappearing_mode')
+    assert.equal(child.attrs.duration, '86400')
+    assert.deepEqual(calls[0].contextData, { durationSeconds: 86400 })
+
+    await assert.rejects(() => coordinator.setDisappearingMode(-1), /invalid durationSeconds/)
+    await assert.rejects(() => coordinator.setDisappearingMode(1.5), /invalid durationSeconds/)
+})
+
 test('profile coordinator gets disappearing mode via usync', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async () =>
@@ -465,6 +536,7 @@ test('profile coordinator returns empty disappearing mode for empty jids', async
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context) => {
@@ -487,6 +559,7 @@ test('profile coordinator gets text statuses via usync', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node) => {
@@ -569,6 +642,7 @@ test('profile coordinator emits null text_status entry on error nodes', async ()
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async () =>
@@ -622,6 +696,7 @@ test('profile coordinator returns empty text statuses for empty jids', async () 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context) => {
@@ -660,6 +735,7 @@ test('profile coordinator sets text status via mex', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         queryWithContext: async () => createIqResult(),
         mexSocket
@@ -711,6 +787,7 @@ test('profile coordinator setTextStatus normalizes empty inputs to clear payload
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         queryWithContext: async () => createIqResult(),
         mexSocket
@@ -734,6 +811,7 @@ test('profile coordinator gets usernames via usync', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context, node) => {
@@ -807,6 +885,7 @@ test('profile coordinator returns empty usernames for empty jids', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context) => {
@@ -823,6 +902,7 @@ test('profile coordinator getOwnUsername parses mex payload', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         queryWithContext: async () => createIqResult(),
         mexSocket: {
@@ -859,6 +939,7 @@ test('profile coordinator getOwnUsername swallows 404 GraphQL errors', async () 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         queryWithContext: async () => createIqResult(),
         mexSocket: {
@@ -893,6 +974,7 @@ test('profile coordinator getOwnUsername returns nulls when info missing', async
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         queryWithContext: async () => createIqResult(),
         mexSocket: {
@@ -920,6 +1002,7 @@ test('profile coordinator setUsername sends mex variables with defaults', async 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         queryWithContext: async () => createIqResult(),
         mexSocket: {
@@ -965,6 +1048,7 @@ test('profile coordinator setUsername returns false on non-SUCCESS result', asyn
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         queryWithContext: async () => createIqResult(),
         mexSocket: {
@@ -991,6 +1075,7 @@ test('profile coordinator deleteUsername sends empty variables', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         queryWithContext: async () => createIqResult(),
         mexSocket: {
@@ -1033,6 +1118,7 @@ test('profile coordinator returns empty array for empty jids list', async () => 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async (context) => {
@@ -1052,6 +1138,7 @@ test('profile coordinator resolves lids by phone numbers', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async () => createIqResult(),
         queryLidsByPhoneJids: async (phoneJids) => {
@@ -1084,6 +1171,7 @@ test('profile coordinator returns empty lid result without calling port', async 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
         queryWithContext: async () => createIqResult(),
         queryLidsByPhoneJids: async () => {

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -15,7 +15,8 @@ const HANDLED_SYNC_TYPES = new Set([
     proto.Message.HistorySyncType.INITIAL_BOOTSTRAP,
     proto.Message.HistorySyncType.RECENT,
     proto.Message.HistorySyncType.FULL,
-    proto.Message.HistorySyncType.PUSH_NAME
+    proto.Message.HistorySyncType.PUSH_NAME,
+    proto.Message.HistorySyncType.ON_DEMAND
 ])
 const HISTORY_SYNC_MAX_PENDING_WRITES = 1_024
 

--- a/src/protocol/group.ts
+++ b/src/protocol/group.ts
@@ -10,3 +10,6 @@ export type WaGroupSetting =
     | 'ephemeral'
     | 'membership_approval_mode'
     | 'allow_non_admin_sub_group_creation'
+    | 'group_history'
+    | 'allow_admin_reports'
+    | 'no_frequently_forwarded'

--- a/src/protocol/nodes.ts
+++ b/src/protocol/nodes.ts
@@ -107,5 +107,6 @@ export const WA_XMLNS = Object.freeze({
     WHATSAPP_PING: 'w:p',
     ABPROPS: 'abt',
     MEX: 'w:mex',
-    BOT: 'bot'
+    BOT: 'bot',
+    DISAPPEARING_MODE: 'disappearing_mode'
 } as const)

--- a/src/protocol/notification.ts
+++ b/src/protocol/notification.ts
@@ -72,5 +72,7 @@ export const WA_GROUP_NOTIFICATION_TAGS = Object.freeze({
     IS_CAPI_HOSTED_GROUP: 'is_capi_hosted_group',
     GROUP_SAFETY_CHECK: 'group_safety_check',
     LIMIT_SHARING_ENABLED: 'limit_sharing_enabled',
-    MISSING_PARTICIPANT_IDENTIFICATION: 'missing_participant_identification'
+    MISSING_PARTICIPANT_IDENTIFICATION: 'missing_participant_identification',
+    GROUP_HISTORY: 'group_history',
+    NO_GROUP_HISTORY: 'no_group_history'
 } as const)

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -48,7 +48,11 @@ import {
     buildGroupParticipantChangeIq,
     buildJoinLinkedGroupIq,
     buildLeaveGroupIq,
-    buildMembershipRequestsActionIq
+    buildMembershipRequestsActionIq,
+    buildSetGroupEphemeralIq,
+    buildSetGroupMemberAddModeIq,
+    buildSetGroupMemberLinkModeIq,
+    buildSetGroupMemberShareGroupHistoryModeIq
 } from '@transport/node/builders/group'
 import {
     buildButtonAddonNode,
@@ -81,6 +85,7 @@ import {
     buildPrivacyTokenIqNode,
     buildTcTokenMessageNode
 } from '@transport/node/builders/privacy-token'
+import { buildSetDisappearingModeIq } from '@transport/node/builders/profile'
 import { buildRetryReceiptNode } from '@transport/node/builders/retry'
 import {
     buildUsyncIq,
@@ -433,6 +438,78 @@ test('group builders support create participant updates and leave', () => {
     assert.equal(leave.attrs.type, 'set')
     assert.ok(Array.isArray(leave.content))
     assert.equal(leave.content[0].tag, 'leave')
+})
+
+test('buildSetGroupMemberAddModeIq shapes IQ with mode as text content', () => {
+    const adminAdd = buildSetGroupMemberAddModeIq({
+        groupJid: '120363@g.us',
+        mode: 'admin_add'
+    })
+    assert.equal(adminAdd.attrs.type, 'set')
+    assert.equal(adminAdd.attrs.to, '120363@g.us')
+    assert.equal(adminAdd.attrs.xmlns, WA_XMLNS.GROUPS)
+    const adminAddChild = (adminAdd.content as readonly BinaryNode[])[0]
+    assert.equal(adminAddChild.tag, 'member_add_mode')
+    assert.equal(adminAddChild.content, 'admin_add')
+
+    const allMember = buildSetGroupMemberAddModeIq({
+        groupJid: '120363@g.us',
+        mode: 'all_member_add'
+    })
+    const allMemberChild = (allMember.content as readonly BinaryNode[])[0]
+    assert.equal(allMemberChild.content, 'all_member_add')
+})
+
+test('buildSetGroupMemberLinkModeIq and ShareGroupHistoryMode shape mode IQs', () => {
+    const link = buildSetGroupMemberLinkModeIq({
+        groupJid: '120363@g.us',
+        mode: 'admin_link'
+    })
+    const linkChild = (link.content as readonly BinaryNode[])[0]
+    assert.equal(linkChild.tag, 'member_link_mode')
+    assert.equal(linkChild.content, 'admin_link')
+
+    const share = buildSetGroupMemberShareGroupHistoryModeIq({
+        groupJid: '120363@g.us',
+        mode: 'all_member_share'
+    })
+    const shareChild = (share.content as readonly BinaryNode[])[0]
+    assert.equal(shareChild.tag, 'member_share_group_history_mode')
+    assert.equal(shareChild.content, 'all_member_share')
+})
+
+test('buildSetGroupEphemeralIq shapes ephemeral IQ with expiration and optional trigger', () => {
+    const noTrigger = buildSetGroupEphemeralIq({
+        groupJid: '120363@g.us',
+        expirationSeconds: 86400
+    })
+    const noTriggerChild = (noTrigger.content as readonly BinaryNode[])[0]
+    assert.equal(noTriggerChild.tag, 'ephemeral')
+    assert.equal(noTriggerChild.attrs.expiration, '86400')
+    assert.equal(noTriggerChild.attrs.trigger, undefined)
+
+    const withTrigger = buildSetGroupEphemeralIq({
+        groupJid: '120363@g.us',
+        expirationSeconds: 604800,
+        trigger: 1
+    })
+    const withTriggerChild = (withTrigger.content as readonly BinaryNode[])[0]
+    assert.equal(withTriggerChild.attrs.expiration, '604800')
+    assert.equal(withTriggerChild.attrs.trigger, '1')
+})
+
+test('buildSetDisappearingModeIq shapes IQ with duration string attr', () => {
+    const node = buildSetDisappearingModeIq(86400)
+    assert.equal(node.attrs.type, 'set')
+    assert.equal(node.attrs.to, WA_DEFAULTS.HOST_DOMAIN)
+    assert.equal(node.attrs.xmlns, 'disappearing_mode')
+    const child = (node.content as readonly BinaryNode[])[0]
+    assert.equal(child.tag, 'disappearing_mode')
+    assert.equal(child.attrs.duration, '86400')
+
+    const disabled = buildSetDisappearingModeIq(0)
+    const disabledChild = (disabled.content as readonly BinaryNode[])[0]
+    assert.equal(disabledChild.attrs.duration, '0')
 })
 
 test('membership approval + join-linked-group builders shape iqs', () => {

--- a/src/transport/node/builders/group.ts
+++ b/src/transport/node/builders/group.ts
@@ -148,6 +148,71 @@ export function buildCancelMembershipRequestsIq(input: {
     ])
 }
 
+export type WaGroupMemberAddMode = 'admin_add' | 'all_member_add'
+export type WaGroupMemberLinkMode = 'admin_link' | 'all_member_link'
+export type WaGroupMemberShareGroupHistoryMode = 'admin_share' | 'all_member_share'
+
+function buildSetGroupMemberModeIq(input: {
+    readonly groupJid: string
+    readonly tag: string
+    readonly mode: string
+}): BinaryNode {
+    return buildIqNode(WA_IQ_TYPES.SET, input.groupJid, WA_XMLNS.GROUPS, [
+        {
+            tag: input.tag,
+            attrs: {},
+            content: input.mode
+        }
+    ])
+}
+
+export function buildSetGroupMemberAddModeIq(input: {
+    readonly groupJid: string
+    readonly mode: WaGroupMemberAddMode
+}): BinaryNode {
+    return buildSetGroupMemberModeIq({
+        groupJid: input.groupJid,
+        tag: 'member_add_mode',
+        mode: input.mode
+    })
+}
+
+export function buildSetGroupMemberLinkModeIq(input: {
+    readonly groupJid: string
+    readonly mode: WaGroupMemberLinkMode
+}): BinaryNode {
+    return buildSetGroupMemberModeIq({
+        groupJid: input.groupJid,
+        tag: 'member_link_mode',
+        mode: input.mode
+    })
+}
+
+export function buildSetGroupMemberShareGroupHistoryModeIq(input: {
+    readonly groupJid: string
+    readonly mode: WaGroupMemberShareGroupHistoryMode
+}): BinaryNode {
+    return buildSetGroupMemberModeIq({
+        groupJid: input.groupJid,
+        tag: 'member_share_group_history_mode',
+        mode: input.mode
+    })
+}
+
+export function buildSetGroupEphemeralIq(input: {
+    readonly groupJid: string
+    readonly expirationSeconds: number
+    readonly trigger?: number
+}): BinaryNode {
+    const attrs: Record<string, string> = { expiration: String(input.expirationSeconds) }
+    if (input.trigger !== undefined) {
+        attrs.trigger = String(input.trigger)
+    }
+    return buildIqNode(WA_IQ_TYPES.SET, input.groupJid, WA_XMLNS.GROUPS, [
+        { tag: 'ephemeral', attrs }
+    ])
+}
+
 export function buildJoinLinkedGroupIq(input: {
     readonly groupJid: string
     readonly subGroupJid: string

--- a/src/transport/node/builders/profile.ts
+++ b/src/transport/node/builders/profile.ts
@@ -83,6 +83,15 @@ export function buildGetDisappearingModeUsyncQueryNode(): BinaryNode {
     }
 }
 
+export function buildSetDisappearingModeIq(durationSeconds: number): BinaryNode {
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.DISAPPEARING_MODE, [
+        {
+            tag: WA_NODE_TAGS.DISAPPEARING_MODE,
+            attrs: { duration: String(durationSeconds) }
+        }
+    ])
+}
+
 export function buildGetTextStatusUsyncQueryNode(): BinaryNode {
     return {
         tag: WA_NODE_TAGS.TEXT_STATUS,


### PR DESCRIPTION
profile coord:
- setPushName routes through app-state mutations (SettingPushName / critical_block)
- setDisappearingMode for account-wide default ephemeral duration (IQ xmlns=disappearing_mode)

group coord:
- setMemberAddMode / setMemberLinkMode / setMemberShareGroupHistoryMode for admin_* vs all_member_* text-content mode IQs (xmlns=w:g2)
- setEphemeralDuration with explicit expiration attr (existing setSetting('ephemeral', enabled) only toggled on/off without picking 24h/7d/90d)
- setSetting extended with group_history, allow_admin_reports, no_frequently_forwarded (reuses the boolean-toggle infra)

message coord:
- requestHistorySync wraps HISTORY_SYNC_ON_DEMAND peer-data-operation for backfilling older messages on a chat

history-sync handler:
- ON_DEMAND added to HANDLED_SYNC_TYPES. Previously the chunk arrived via protocolMessage.historySyncNotification but was silently dropped because no caller exercised ON_DEMAND before requestHistorySync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Group admins can now control member permissions for joining, sharing links, and accessing group history
  * Group admins can set ephemeral message expiration durations for groups
  * Users can update their push name and configure personal disappearing message settings
  * Added support for on-demand message history synchronization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->