### PR TITLE
feat(client)!: type group result parsers + flip 3 opinionated defaults

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -122,12 +122,13 @@ export class WaClient extends EventEmitter {
         )
 
         if (
-            this.options.addons?.autoDecrypt &&
+            this.options.addons?.autoDecrypt !== false &&
             this.stores.messageSecret === NOOP_MESSAGE_SECRET_STORE
         ) {
             this.logger.warn(
-                'addons.autoDecrypt is enabled but messageSecret cache is noop – ' +
-                    'addon decryption will only work if secrets are in the message store'
+                'addons.autoDecrypt is on (default) but messageSecret cache is noop – ' +
+                    'addon decryption will only work if secrets are in the message store. ' +
+                    'Set addons.autoDecrypt: false to silence this warning.'
             )
         }
 
@@ -284,7 +285,7 @@ export class WaClient extends EventEmitter {
                 messageSecretStore: this.stores.messageSecret,
                 event
             })
-            if (this.options.addons?.autoDecrypt && event.message) {
+            if (this.options.addons?.autoDecrypt !== false && event.message) {
                 void this.deps.messageCoordinator.tryDecryptAddon(event).catch((err) => {
                     this.logger.warn('addon auto-decrypt failed', {
                         id: event.stanzaId,
@@ -332,7 +333,10 @@ export class WaClient extends EventEmitter {
             }
 
             if (protocolType === proto.Message.ProtocolMessage.Type.HISTORY_SYNC_NOTIFICATION) {
-                if (this.options.history?.enabled && protocolMessage.historySyncNotification) {
+                if (
+                    this.options.history?.enabled !== false &&
+                    protocolMessage.historySyncNotification
+                ) {
                     await runHistorySyncNotification(
                         {
                             logger: this.logger,
@@ -591,8 +595,13 @@ export class WaClient extends EventEmitter {
         }
 
         const s = this.options.logoutStoreClear
-        const shouldClear = (key: keyof NonNullable<typeof s>): boolean =>
-            s === undefined || s[key] !== false
+        const isMailbox = (key: keyof NonNullable<typeof s>): boolean =>
+            key === 'messages' || key === 'threads' || key === 'contacts'
+        const shouldClear = (key: keyof NonNullable<typeof s>): boolean => {
+            const explicit = s?.[key]
+            if (explicit !== undefined) return explicit
+            return !isMailbox(key)
+        }
 
         if (shouldClear('auth')) await this.deps.authClient.clearStoredCredentials()
         if (shouldClear('appState')) await this.stores.appState.clear()

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -1314,7 +1314,7 @@ export function buildWaClientDependencies(input: {
             receiptQueue,
             getCurrentCredentials,
             abPropsCoordinator,
-            markOnlineOnConnect: options.markOnlineOnConnect ?? true
+            markOnlineOnConnect: options.markOnlineOnConnect ?? false
         }),
         mobilePrimary: options.mobileTransport !== undefined,
         appStateSync

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -485,6 +485,25 @@ test('buildWaClientDependencies wires trusted contact token AB prop overrides', 
     assert.equal(config.senderNumBuckets, 4)
 })
 
+test('default option resolution: autoDecrypt on, history on, markOnlineOnConnect off', () => {
+    const opts: WaClientOptions = { store: {} as never, sessionId: 's' }
+
+    assert.equal(opts.addons?.autoDecrypt !== false, true)
+    assert.equal(opts.history?.enabled !== false, true)
+    assert.equal(opts.markOnlineOnConnect ?? false, false)
+
+    const optedOut: WaClientOptions = {
+        store: {} as never,
+        sessionId: 's',
+        addons: { autoDecrypt: false },
+        history: { enabled: false },
+        markOnlineOnConnect: true
+    }
+    assert.equal(optedOut.addons?.autoDecrypt !== false, false)
+    assert.equal(optedOut.history?.enabled !== false, false)
+    assert.equal(optedOut.markOnlineOnConnect ?? false, true)
+})
+
 function getClearStoredStateMethod() {
     return (
         WaClient.prototype as unknown as {
@@ -610,15 +629,13 @@ function createClearStoredStateHarness(logoutStoreClear?: {
     return { fakeClient, cleared }
 }
 
-test('clearStoredState clears every store domain by default', async () => {
+test('clearStoredState clears non-mailbox domains by default and preserves mailbox archive', async () => {
     const { fakeClient, cleared } = createClearStoredStateHarness()
     await getClearStoredStateMethod().call(fakeClient)
 
     assert.deepEqual(cleared, [
         'auth',
         'appState',
-        'contacts',
-        'messages',
         'messageSecret',
         'groupMetadata',
         'deviceList',
@@ -628,9 +645,21 @@ test('clearStoredState clears every store domain by default', async () => {
         'session',
         'identity',
         'senderKey',
-        'threads',
         'privacyToken'
     ])
+})
+
+test('clearStoredState wipes mailbox when explicitly opted in', async () => {
+    const { fakeClient, cleared } = createClearStoredStateHarness({
+        messages: true,
+        threads: true,
+        contacts: true
+    })
+    await getClearStoredStateMethod().call(fakeClient)
+
+    assert.ok(cleared.includes('messages'))
+    assert.ok(cleared.includes('threads'))
+    assert.ok(cleared.includes('contacts'))
 })
 
 test('WaClient exposes chat/group/privacy coordinator getters', () => {
@@ -660,8 +689,6 @@ test('clearStoredState respects logoutStoreClear domain toggles', async () => {
     await getClearStoredStateMethod().call(fakeClient)
 
     assert.deepEqual(cleared, [
-        'contacts',
-        'messages',
         'messageSecret',
         'groupMetadata',
         'deviceList',
@@ -669,8 +696,7 @@ test('clearStoredState respects logoutStoreClear domain toggles', async () => {
         'preKey',
         'session',
         'identity',
-        'senderKey',
-        'threads'
+        'senderKey'
     ])
 })
 

--- a/src/client/coordinators/WaGroupCoordinator.ts
+++ b/src/client/coordinators/WaGroupCoordinator.ts
@@ -58,10 +58,17 @@ export interface WaGroupMetadata {
     readonly subjectOwner?: string
     readonly subjectTime?: number
     readonly owner?: string
+    /** PN-form jid of the group creator when the group is LID-addressed (`creator_pn`). */
+    readonly ownerPhoneNumber?: string
+    /** Username handle of the group creator when set (`creator_username`). */
+    readonly ownerUsername?: string
+    /** ISO country code of the group creator when set (`creator_country_code`). */
+    readonly ownerCountryCode?: string
     readonly creation?: number
     readonly desc?: string
     readonly descId?: string
     readonly descOwner?: string
+    readonly descTime?: number
     readonly restrict: boolean
     readonly announce: boolean
     readonly ephemeral?: number
@@ -169,6 +176,55 @@ export interface WaGroupSuspensionAppealResult {
     readonly appealCreationTime: number | null
 }
 
+export interface WaGroupInviteParticipantSample {
+    readonly jid: string
+    readonly phoneNumber?: string
+    readonly type?: string
+}
+
+export interface WaGroupInviteInfo extends GroupCommons {
+    readonly hiddenGroup: boolean
+    readonly defaultSubgroup: boolean
+    readonly generalChat: boolean
+    readonly hasCapi: boolean
+    /**
+     * Sample of participants returned alongside the invite preview - WhatsApp
+     * trims this list (admins/recent members), it is not the full roster.
+     * Call {@link WaGroupCoordinator.queryGroupMetadata} after joining for
+     * the complete list.
+     */
+    readonly participants: readonly WaGroupInviteParticipantSample[]
+}
+
+export interface WaRevokeInviteResult {
+    readonly code: string
+    /**
+     * Participants that joined via the now-revoked code and that the server
+     * surfaced in the response (typically with `code: 404` meaning the
+     * invite they used is gone). Empty when nobody was affected.
+     */
+    readonly affectedParticipants: readonly WaParticipantActionResult[]
+}
+
+export type WaParticipantActionStatus = 'ok' | 'error'
+
+export interface WaParticipantActionResult {
+    readonly jid: string
+    readonly status: WaParticipantActionStatus
+    /** HTTP-style numeric code returned by the server (`200`, `403`, `409`, ...). */
+    readonly code: number
+    /** PN-form JID the server resolved for the participant (when addressing-mode is LID). */
+    readonly phoneNumber?: string
+    /** Username (handle) the server resolved for the participant, when set. */
+    readonly username?: string
+    /**
+     * Optional content children attached to the participant outcome. Some
+     * partial failures (`409: gone`, `408: not-allowed`, ...) carry extra
+     * tags that hint at how to recover.
+     */
+    readonly raw: BinaryNode
+}
+
 interface WaGroupCoordinatorOptions {
     readonly queryWithContext: (
         context: string,
@@ -191,20 +247,27 @@ export interface WaGroupCoordinator {
     readonly queryGroupMetadata: (groupJid: string) => Promise<WaGroupMetadata>
     /** Lists every group the current account participates in. */
     readonly queryAllGroups: () => Promise<readonly WaGroupMetadata[]>
-    /** Resolves the IQ result for a group invite `code` – returns the raw node. */
-    readonly queryGroupInviteInfo: (code: string) => Promise<BinaryNode>
+    /**
+     * Resolves a group invite `code` (the path segment of a
+     * `chat.whatsapp.com/<code>` URL) into a preview of the group: subject,
+     * size, ephemeral timer, description, and a trimmed participant sample.
+     * The sample is NOT the full roster - call {@link queryGroupMetadata}
+     * after joining for the complete list.
+     */
+    readonly queryGroupInviteInfo: (code: string) => Promise<WaGroupInviteInfo>
     /**
      * Creates a new group with `subject` and the given participant JIDs.
      * The creator is auto-added as admin; do **not** include your own JID
-     * in `participants`. Same partial-failure shape as
-     * {@link addParticipants} for individual invitees - inspect the result
-     * for `<participant ... error="..."/>` entries.
+     * in `participants`. The returned metadata includes the participant
+     * list - partial failures surface as participants with `type: 'error'`
+     * or are filtered out by the server; inspect against the original
+     * `participants` to spot rejections.
      */
     readonly createGroup: (
         subject: string,
         participants: readonly string[],
         options?: WaGroupCreateOptions
-    ) => Promise<BinaryNode>
+    ) => Promise<WaGroupMetadata>
     /** Renames the group. */
     readonly setSubject: (groupJid: string, subject: string) => Promise<void>
     /** Sets or clears the group description; pass `null` to remove it. */
@@ -254,47 +317,46 @@ export interface WaGroupCoordinator {
         trigger?: number
     ) => Promise<void>
     /**
-     * Adds the given participant JIDs to the group. Returns the raw IQ
-     * result - **per-participant outcome is encoded inside** as a list of
-     * `<participant jid="..." error="..."/>` children. The IQ as a whole
-     * succeeds even when some participants fail (e.g. blocked you, privacy
-     * settings disallow add); parse the children to surface partial errors.
+     * Adds the given participant JIDs to the group. The IQ as a whole
+     * succeeds even when some invitees fail (blocked you, privacy settings
+     * disallow add, already a member, etc.) - inspect the returned per-jid
+     * results: `status: 'ok'` (code 200) means the invite landed,
+     * everything else carries the server's HTTP-style `code`.
      */
     readonly addParticipants: (
         groupJid: string,
         participants: readonly string[]
-    ) => Promise<BinaryNode>
-    /** Removes the given participant JIDs. Same partial-failure shape as {@link addParticipants}. */
+    ) => Promise<readonly WaParticipantActionResult[]>
+    /** Removes the given participant JIDs. Same per-jid result shape as {@link addParticipants}. */
     readonly removeParticipants: (
         groupJid: string,
         participants: readonly string[]
-    ) => Promise<BinaryNode>
-    /** Promotes participants to admins. Same partial-failure shape as {@link addParticipants}. */
+    ) => Promise<readonly WaParticipantActionResult[]>
+    /** Promotes participants to admins. Same per-jid result shape as {@link addParticipants}. */
     readonly promoteParticipants: (
         groupJid: string,
         participants: readonly string[]
-    ) => Promise<BinaryNode>
-    /** Demotes admins back to regular participants. Same partial-failure shape as {@link addParticipants}. */
+    ) => Promise<readonly WaParticipantActionResult[]>
+    /** Demotes admins back to regular participants. Same per-jid result shape as {@link addParticipants}. */
     readonly demoteParticipants: (
         groupJid: string,
         participants: readonly string[]
-    ) => Promise<BinaryNode>
+    ) => Promise<readonly WaParticipantActionResult[]>
     /** Leaves one or more groups (batched in a single IQ). */
-    readonly leaveGroup: (groupJids: readonly string[]) => Promise<BinaryNode>
+    readonly leaveGroup: (groupJids: readonly string[]) => Promise<void>
     /**
      * Revokes the current invite link. The server rotates the code
      * immediately - every previously-shared `chat.whatsapp.com/<code>` link
-     * stops working, and the next call to {@link queryGroupInviteInfo}
-     * returns the new code.
+     * stops working. Returns the freshly-issued code.
      */
-    readonly revokeInvite: (groupJid: string) => Promise<BinaryNode>
+    readonly revokeInvite: (groupJid: string) => Promise<WaRevokeInviteResult>
     /**
      * Joins a group using its invite `code` (the path segment of a
      * `chat.whatsapp.com/<code>` URL). Throws if the code is expired,
      * revoked, the group is full, or the current account is already a
-     * member.
+     * member. Returns the joined group's metadata.
      */
-    readonly joinGroupViaInvite: (code: string) => Promise<BinaryNode>
+    readonly joinGroupViaInvite: (code: string) => Promise<WaGroupMetadata>
     /**
      * Creates a community (parent group). Defaults to request-required
      * membership unless `membershipApprovalMode === 'open'`.
@@ -344,12 +406,17 @@ export interface WaGroupCoordinator {
         groupJid: string,
         participantJids: readonly string[]
     ) => Promise<void>
-    /** Joins a linked sub-group of a community the account already belongs to. */
+    /**
+     * Joins a linked sub-group of a community the account already belongs
+     * to. The IQ result carries no group payload (wa-web only validates the
+     * envelope) - call {@link queryGroupMetadata} on `subGroupJid` after
+     * this resolves to get the full metadata for the newly-joined group.
+     */
     readonly joinLinkedGroup: (
         communityJid: string,
         subGroupJid: string,
         options?: { readonly type?: string }
-    ) => Promise<BinaryNode>
+    ) => Promise<void>
     /** Returns `true` when the group is flagged as an internal WhatsApp group. */
     readonly isInternalGroup: (groupJid: string) => Promise<boolean>
     /** Transfers community ownership to `newOwnerJid` (superadmin handoff). */
@@ -429,28 +496,43 @@ function parseMembershipApprovalRequests(node: BinaryNode): readonly WaMembershi
     return requests
 }
 
-function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
-    const groupNode =
-        node.tag === WA_NODE_TAGS.GROUP ? node : findNodeChild(node, WA_NODE_TAGS.GROUP)
-    const target = groupNode ?? node
+interface GroupCommons {
+    readonly jid: string
+    readonly subject: string
+    readonly size?: number
+    readonly creation?: number
+    readonly subjectOwner?: string
+    /** PN-form jid of the subject owner when the group is LID-addressed (`s_o_pn`). */
+    readonly subjectOwnerPhoneNumber?: string
+    /** Username handle of the subject owner when set (`s_o_username`). */
+    readonly subjectOwnerUsername?: string
+    readonly subjectTime?: number
+    readonly addressingMode?: 'lid' | 'pn'
+    readonly desc?: string
+    readonly descId?: string
+    readonly descOwner?: string
+    readonly descTime?: number
+    readonly ephemeral?: number
+    readonly ephemeralTrigger?: number
+    readonly linkedParentJid?: string
+    readonly membershipApprovalEnabled: boolean
+}
+
+function findGroupTarget(node: BinaryNode): BinaryNode {
+    return node.tag === WA_NODE_TAGS.GROUP
+        ? node
+        : (findNodeChild(node, WA_NODE_TAGS.GROUP) ?? node)
+}
+
+function parseGroupCommons(target: BinaryNode): GroupCommons {
     const attrs = target.attrs
 
     const descNode = findNodeChild(target, WA_NODE_TAGS.DESCRIPTION)
-    let desc: string | undefined
-    if (descNode) {
-        const bodyNode = findNodeChild(descNode, WA_NODE_TAGS.BODY)
-        if (bodyNode && typeof bodyNode.content === 'string') {
-            desc = bodyNode.content
-        }
-    }
+    const desc = descNode
+        ? getNodeTextContent(findNodeChild(descNode, WA_NODE_TAGS.BODY))
+        : undefined
 
     const ephemeralNode = findNodeChild(target, WA_NODE_TAGS.EPHEMERAL)
-    const ephemeral = ephemeralNode?.attrs.expiration
-        ? Number(ephemeralNode.attrs.expiration)
-        : undefined
-    const ephemeralTrigger = ephemeralNode?.attrs.trigger
-        ? Number(ephemeralNode.attrs.trigger)
-        : undefined
 
     const parentNode = findNodeChild(target, 'parent')
     const linkedParentNode = findNodeChild(target, 'linked_parent')
@@ -459,15 +541,6 @@ function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
     const groupJoinNode = membershipApprovalNode
         ? findNodeChild(membershipApprovalNode, WA_NODE_TAGS.GROUP_JOIN)
         : undefined
-
-    const growthLockedNode = findNodeChild(target, 'growth_locked')
-    const appealStatusNode = findNodeChild(target, 'appeal_status')
-    const appealStatusType = appealStatusNode?.attrs.type
-    const appealUpdateTimeNode = findNodeChild(target, 'appeal_update_time')
-    const evolutionVersionNode = findNodeChild(target, 'evolution_version')
-    const memberAddModeNode = findNodeChild(target, 'member_add_mode')
-    const memberLinkModeNode = findNodeChild(target, 'member_link_mode')
-    const memberShareNode = findNodeChild(target, 'member_share_group_history_mode')
 
     const addressingModeRaw = attrs.addressing_mode
     const addressingMode: 'lid' | 'pn' | undefined =
@@ -479,19 +552,51 @@ function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
     return {
         jid,
         subject: attrs.subject ?? '',
-        subjectOwner: attrs.s_o ?? attrs.subject_owner,
-        subjectTime: attrs.s_t ? Number(attrs.s_t) : undefined,
-        owner: attrs.creator ?? attrs.owner,
+        size: attrs.size ? Number(attrs.size) : undefined,
         creation: attrs.creation ? Number(attrs.creation) : undefined,
+        subjectOwner: attrs.s_o ?? attrs.subject_owner,
+        subjectOwnerPhoneNumber: attrs.s_o_pn,
+        subjectOwnerUsername: attrs.s_o_username,
+        subjectTime: attrs.s_t ? Number(attrs.s_t) : undefined,
+        addressingMode,
         desc,
         descId: descNode?.attrs.id,
         descOwner: descNode?.attrs.participant,
+        descTime: descNode?.attrs.t ? Number(descNode.attrs.t) : undefined,
+        ephemeral: ephemeralNode?.attrs.expiration
+            ? Number(ephemeralNode.attrs.expiration)
+            : undefined,
+        ephemeralTrigger: ephemeralNode?.attrs.trigger
+            ? Number(ephemeralNode.attrs.trigger)
+            : undefined,
+        linkedParentJid: linkedParentNode?.attrs.jid ?? parentNode?.attrs.jid,
+        membershipApprovalEnabled: groupJoinNode?.attrs.state === 'on'
+    }
+}
+
+function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
+    const target = findGroupTarget(node)
+    const attrs = target.attrs
+    const commons = parseGroupCommons(target)
+
+    const parentNode = findNodeChild(target, 'parent')
+    const growthLockedNode = findNodeChild(target, 'growth_locked')
+    const appealStatusNode = findNodeChild(target, 'appeal_status')
+    const appealStatusType = appealStatusNode?.attrs.type
+    const appealUpdateTimeNode = findNodeChild(target, 'appeal_update_time')
+    const evolutionVersionNode = findNodeChild(target, 'evolution_version')
+    const memberAddModeNode = findNodeChild(target, 'member_add_mode')
+    const memberLinkModeNode = findNodeChild(target, 'member_link_mode')
+    const memberShareNode = findNodeChild(target, 'member_share_group_history_mode')
+
+    return {
+        ...commons,
+        owner: attrs.creator ?? attrs.owner,
+        ownerPhoneNumber: attrs.creator_pn,
+        ownerUsername: attrs.creator_username,
+        ownerCountryCode: attrs.creator_country_code,
         restrict: hasNodeChild(target, WA_NODE_TAGS.LOCKED),
         announce: hasNodeChild(target, WA_NODE_TAGS.ANNOUNCEMENT),
-        ephemeral,
-        ephemeralTrigger,
-        size: attrs.size ? Number(attrs.size) : undefined,
-        addressingMode,
         isParentGroup: parentNode !== undefined,
         isClosedCommunity:
             parentNode?.attrs.default_membership_approval_mode === 'request_required',
@@ -499,7 +604,6 @@ function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
         generalSubgroup: hasNodeChild(target, 'general_chat'),
         hiddenSubgroup: hasNodeChild(target, 'hidden_group'),
         allowNonAdminSubGroupCreation: hasNodeChild(target, 'allow_non_admin_sub_group_creation'),
-        membershipApprovalEnabled: groupJoinNode?.attrs.state === 'on',
         noFrequentlyForwarded: hasNodeChild(target, 'no_frequently_forwarded'),
         support: hasNodeChild(target, 'support'),
         suspended: hasNodeChild(target, 'suspended'),
@@ -529,8 +633,70 @@ function parseGroupMetadata(node: BinaryNode): WaGroupMetadata {
         appealUpdateTime: appealUpdateTimeNode?.attrs.value
             ? Number(appealUpdateTimeNode.attrs.value)
             : undefined,
-        linkedParentJid: linkedParentNode?.attrs.jid ?? parentNode?.attrs.jid,
         participants: parseGroupParticipants(target)
+    }
+}
+
+function parseParticipantActionResult(p: BinaryNode): WaParticipantActionResult | null {
+    const jid = p.attrs.jid
+    if (!jid) return null
+    const errorCode = p.attrs.error
+    const code = errorCode ? Number(errorCode) : 200
+    return {
+        jid,
+        status: code >= 200 && code < 300 ? 'ok' : 'error',
+        code,
+        phoneNumber: p.attrs.phone_number,
+        username: p.attrs.username,
+        raw: p
+    }
+}
+
+function parseParticipantActionResults(
+    iqResult: BinaryNode,
+    action: WaGroupParticipantChangeAction
+): readonly WaParticipantActionResult[] {
+    const wrapper = findNodeChild(iqResult, action)
+    const target = wrapper ?? iqResult
+    const participantNodes = getNodeChildrenByTag(target, WA_NODE_TAGS.PARTICIPANT)
+    const results: WaParticipantActionResult[] = new Array(participantNodes.length)
+    let count = 0
+    for (const p of participantNodes) {
+        const parsed = parseParticipantActionResult(p)
+        if (!parsed) continue
+        results[count] = parsed
+        count += 1
+    }
+    results.length = count
+    return results
+}
+
+function parseGroupInviteInfo(node: BinaryNode): WaGroupInviteInfo {
+    const target = findGroupTarget(node)
+    const commons = parseGroupCommons(target)
+
+    const participantNodes = getNodeChildrenByTag(target, WA_NODE_TAGS.PARTICIPANT)
+    const participants: WaGroupInviteParticipantSample[] = new Array(participantNodes.length)
+    let participantCount = 0
+    for (const p of participantNodes) {
+        const jidAttr = p.attrs.jid
+        if (!jidAttr) continue
+        participants[participantCount] = {
+            jid: jidAttr,
+            phoneNumber: p.attrs.phone_number,
+            type: p.attrs.type
+        }
+        participantCount += 1
+    }
+    participants.length = participantCount
+
+    return {
+        ...commons,
+        hiddenGroup: hasNodeChild(target, 'hidden_group'),
+        defaultSubgroup: hasNodeChild(target, 'default_sub_group'),
+        generalChat: hasNodeChild(target, 'general_chat'),
+        hasCapi: hasNodeChild(target, 'capi'),
+        participants
     }
 }
 
@@ -634,7 +800,7 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
         action: WaGroupParticipantChangeAction,
         groupJid: string,
         participants: readonly string[]
-    ): Promise<BinaryNode> => {
+    ): Promise<readonly WaParticipantActionResult[]> => {
         const context = `group.${action}Participants`
         const node = buildGroupParticipantChangeIq({
             groupJid,
@@ -643,7 +809,7 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
         })
         const result = await queryWithContext(context, node)
         assertIqResult(result, context)
-        return result
+        return parseParticipantActionResults(result, action)
     }
 
     return {
@@ -676,7 +842,7 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
             ])
             const result = await queryWithContext('group.invite.info', node)
             assertIqResult(result, 'group.invite.info')
-            return result
+            return parseGroupInviteInfo(result)
         },
 
         createGroup: async (subject, participants, opts) => {
@@ -688,7 +854,7 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
             })
             const result = await queryWithContext('group.create', node)
             assertIqResult(result, 'group.create')
-            return result
+            return parseGroupMetadata(result)
         },
 
         setSubject: async (groupJid, subject) => {
@@ -810,7 +976,6 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
             const node = buildLeaveGroupIq(groupJids)
             const result = await queryWithContext('group.leave', node)
             assertIqResult(result, 'group.leave')
-            return result
         },
 
         revokeInvite: async (groupJid) => {
@@ -819,7 +984,24 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
             ])
             const result = await queryWithContext('group.revokeInvite', node)
             assertIqResult(result, 'group.revokeInvite')
-            return result
+            const inviteNode = findNodeChild(result, WA_NODE_TAGS.INVITE)
+            const code = inviteNode?.attrs.code
+            if (!code) {
+                throw new Error('group.revokeInvite: missing invite code in response')
+            }
+            const participantNodes = getNodeChildrenByTag(result, WA_NODE_TAGS.PARTICIPANT)
+            const affectedParticipants: WaParticipantActionResult[] = new Array(
+                participantNodes.length
+            )
+            let affectedCount = 0
+            for (const p of participantNodes) {
+                const parsed = parseParticipantActionResult(p)
+                if (!parsed) continue
+                affectedParticipants[affectedCount] = parsed
+                affectedCount += 1
+            }
+            affectedParticipants.length = affectedCount
+            return { code, affectedParticipants }
         },
 
         joinGroupViaInvite: async (code) => {
@@ -828,7 +1010,7 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
             ])
             const result = await queryWithContext('group.joinViaInvite', node)
             assertIqResult(result, 'group.joinViaInvite')
-            return result
+            return parseGroupMetadata(result)
         },
 
         createCommunity: async (subject, opts) => {
@@ -973,7 +1155,6 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
             })
             const result = await queryWithContext('community.joinLinkedGroup', node)
             assertIqResult(result, 'community.joinLinkedGroup')
-            return result
         },
 
         isInternalGroup: async (groupJid) => {

--- a/src/client/coordinators/WaGroupCoordinator.ts
+++ b/src/client/coordinators/WaGroupCoordinator.ts
@@ -519,9 +519,12 @@ interface GroupCommons {
 }
 
 function findGroupTarget(node: BinaryNode): BinaryNode {
-    return node.tag === WA_NODE_TAGS.GROUP
-        ? node
-        : (findNodeChild(node, WA_NODE_TAGS.GROUP) ?? node)
+    if (node.tag === WA_NODE_TAGS.GROUP) return node
+    const groupNode = findNodeChild(node, WA_NODE_TAGS.GROUP)
+    if (!groupNode) {
+        throw new Error(`expected <group> node in response, got <${node.tag}>`)
+    }
+    return groupNode
 }
 
 function parseGroupCommons(target: BinaryNode): GroupCommons {

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -437,8 +437,9 @@ export class WaMessageCoordinator {
      * `WaIncomingAddonEvent`. Silently returns when the parent message
      * secret is missing or the payload is not an addon.
      *
-     * Called automatically by the client when `options.addons.autoDecrypt`
-     * is `true` - you rarely need to invoke it directly. The parent secret
+     * Called automatically by the client unless `options.addons.autoDecrypt`
+     * is explicitly `false` - you rarely need to invoke it directly. The
+     * parent secret
      * is looked up in the in-memory `messageSecret` cache first, then in
      * the `messages` store; if both are `'none'`/missing, decryption fails
      * silently (and the event never fires).

--- a/src/client/coordinators/__tests__/group-community-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/group-community-coordinator.test.ts
@@ -234,6 +234,119 @@ test('setSetting toggles new group_history / allow_admin_reports / no_frequently
     ])
 })
 
+test('queryGroupInviteInfo parses subject/owner/ephemeral/description/participants', async () => {
+    const response: BinaryNode = iqResult([
+        {
+            tag: 'group',
+            attrs: {
+                id: '120363@g.us',
+                subject: 'TESTE',
+                size: '3',
+                creation: '1700000000',
+                s_o: 'owner@lid',
+                s_o_pn: 'owner@s.whatsapp.net',
+                s_t: '1710000000',
+                addressing_mode: 'lid'
+            },
+            content: [
+                { tag: 'ephemeral', attrs: { expiration: '86400' } },
+                {
+                    tag: 'participant',
+                    attrs: { jid: 'a@lid', phone_number: 'a@s.whatsapp.net', type: 'admin' }
+                },
+                {
+                    tag: 'description',
+                    attrs: { id: 'D1', t: '1715000000' },
+                    content: [{ tag: 'body', attrs: {}, content: new Uint8Array([114, 101, 103]) }]
+                }
+            ]
+        }
+    ])
+    const mock = createMockQuery([response])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    const info = await coordinator.queryGroupInviteInfo('CODE')
+
+    assert.equal(info.jid, '120363@g.us')
+    assert.equal(info.subject, 'TESTE')
+    assert.equal(info.size, 3)
+    assert.equal(info.creation, 1700000000)
+    assert.equal(info.subjectOwner, 'owner@lid')
+    assert.equal(info.subjectOwnerPhoneNumber, 'owner@s.whatsapp.net')
+    assert.equal(info.subjectTime, 1710000000)
+    assert.equal(info.addressingMode, 'lid')
+    assert.equal(info.ephemeral, 86400)
+    assert.equal(info.desc, 'reg')
+    assert.equal(info.descId, 'D1')
+    assert.equal(info.descTime, 1715000000)
+    assert.equal(info.participants.length, 1)
+    assert.equal(info.participants[0].jid, 'a@lid')
+    assert.equal(info.participants[0].phoneNumber, 'a@s.whatsapp.net')
+    assert.equal(info.participants[0].type, 'admin')
+})
+
+test('revokeInvite returns new code and any affected participants', async () => {
+    const responseWithAffected = iqResult([
+        { tag: 'invite', attrs: { code: 'NEW123' } },
+        {
+            tag: 'participant',
+            attrs: {
+                jid: 'evicted@lid',
+                error: '404',
+                phone_number: 'evicted@s.whatsapp.net'
+            }
+        }
+    ])
+    const responseEmpty = iqResult([{ tag: 'invite', attrs: { code: 'NEW456' } }])
+    const mock = createMockQuery([responseWithAffected, responseEmpty])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    const r1 = await coordinator.revokeInvite('120363@g.us')
+    assert.equal(r1.code, 'NEW123')
+    assert.equal(r1.affectedParticipants.length, 1)
+    assert.equal(r1.affectedParticipants[0].jid, 'evicted@lid')
+    assert.equal(r1.affectedParticipants[0].code, 404)
+    assert.equal(r1.affectedParticipants[0].status, 'error')
+    assert.equal(r1.affectedParticipants[0].phoneNumber, 'evicted@s.whatsapp.net')
+
+    const r2 = await coordinator.revokeInvite('120363@g.us')
+    assert.equal(r2.code, 'NEW456')
+    assert.deepEqual(r2.affectedParticipants, [])
+})
+
+test('participant action returns per-jid result with status/code/phoneNumber/username', async () => {
+    const response = iqResult([
+        {
+            tag: 'add',
+            attrs: {},
+            content: [
+                {
+                    tag: 'participant',
+                    attrs: {
+                        jid: 'ok@lid',
+                        phone_number: 'ok@s.whatsapp.net',
+                        username: 'maria'
+                    }
+                },
+                { tag: 'participant', attrs: { jid: 'fail@lid', error: '403' } }
+            ]
+        }
+    ])
+    const mock = createMockQuery([response])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    const results = await coordinator.addParticipants('120363@g.us', ['ok@lid', 'fail@lid'])
+    assert.equal(results.length, 2)
+    assert.equal(results[0].jid, 'ok@lid')
+    assert.equal(results[0].status, 'ok')
+    assert.equal(results[0].code, 200)
+    assert.equal(results[0].phoneNumber, 'ok@s.whatsapp.net')
+    assert.equal(results[0].username, 'maria')
+    assert.equal(results[1].jid, 'fail@lid')
+    assert.equal(results[1].status, 'error')
+    assert.equal(results[1].code, 403)
+})
+
 test('queryLinkedGroupsParticipants returns flattened participants', async () => {
     const response: BinaryNode = iqResult([
         {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -41,7 +41,7 @@ export interface WaClientProxyOptions {
  * - `messages`, `threads`, `contacts` → **preserved** (mailbox archive
  *   survives logout; the user keeps their history when re-pairing).
  * - everything else → **cleared** (credentials, Signal state, app-state,
- *   caches, privacy tokens — all need a clean slate for the new pair).
+ *   caches, privacy tokens: all need a clean slate for the new pair).
  *
  * Explicit `true`/`false` always wins. To wipe the mailbox too, pass
  * `{ messages: true, threads: true, contacts: true }`.
@@ -243,9 +243,10 @@ export interface WaAddonOptions {
      * Decrypt incoming addon ciphertexts (poll votes, reactions, message
      * edits, ...) and emit them as typed `message_addon` events. On by
      * default - set to `false` to receive the encrypted payload and
-     * decrypt yourself via `client.message.tryDecryptAddon(event)`. When
-     * on, the `messageSecret` cache must be a real store (the in-tree
-     * memory provider is the default; `'none'` defeats the cache).
+     * decrypt yourself via `client.message.tryDecryptAddon(event)`. The
+     * parent message secret is looked up in the `messageSecret` cache
+     * first, then in the `messages` store; setting both to `'none'`
+     * defeats addon decryption silently.
      */
     readonly autoDecrypt?: boolean
 }
@@ -1057,7 +1058,7 @@ export interface WaClientEventMap {
      * A decrypted addon (poll vote, reaction, edit, comment, ...) attached to
      * a previous message. Fires unless `addons.autoDecrypt` is explicitly
      * set to `false`, and the parent message secret is available in the
-     * cache.
+     * `messageSecret` cache or the `messages` store.
      */
     readonly message_addon: (event: WaIncomingAddonEvent) => void
     /**

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -34,6 +34,18 @@ export interface WaClientProxyOptions {
     readonly linkPreview?: WaProxyTransport
 }
 
+/**
+ * Per-domain control over what {@link WaClient.logout} wipes from the store.
+ *
+ * Defaults (when the domain is left `undefined`):
+ * - `messages`, `threads`, `contacts` → **preserved** (mailbox archive
+ *   survives logout; the user keeps their history when re-pairing).
+ * - everything else → **cleared** (credentials, Signal state, app-state,
+ *   caches, privacy tokens — all need a clean slate for the new pair).
+ *
+ * Explicit `true`/`false` always wins. To wipe the mailbox too, pass
+ * `{ messages: true, threads: true, contacts: true }`.
+ */
 export interface WaLogoutStoreClearOptions {
     readonly auth?: boolean
     readonly signal?: boolean
@@ -101,11 +113,11 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
     readonly messageRetryDelayMs?: number
     /**
      * Initial presence sent right after the post-connect passive task runs.
-     * - `true` (default): announce the client as online – matches the wa-web
-     *   behavior when the browser tab has focus at login time.
-     * - `false`: announce as unavailable – matches wa-web when the tab is not
-     *   focused (or the Windows app is minimized to tray) at login time. Useful
-     *   for bots/headless sessions that should not appear "online" on connect.
+     * - `false` (default): announce as unavailable – matches wa-web when the
+     *   tab is not focused (or the Windows app is minimized to tray) at login
+     *   time, and keeps headless bots/automation invisible by default.
+     * - `true`: announce the client as online – matches wa-web behavior when
+     *   the browser tab has focus at login time.
      */
     readonly markOnlineOnConnect?: boolean
     /**
@@ -122,8 +134,12 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
      */
     readonly writeBehind?: WaWriteBehindOptions
     /**
-     * History-sync behavior – enable initial history download, full vs.
-     * recent sync, and external blob handling.
+     * History-sync behavior. By default chunks pushed via
+     * `historySyncNotification` (both the initial bootstrap and the
+     * on-demand backfill triggered by `message.requestHistorySync`) are
+     * downloaded and emitted as `history_sync_chunk` events. Set
+     * `enabled: false` to drop them; `requireFullSync: true` asks the
+     * primary device for a full history download instead of just recent.
      */
     readonly history?: WaHistorySyncOptions
     /**
@@ -140,15 +156,17 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
      */
     readonly privacyToken?: WaPrivacyTokenOptions
     /**
-     * Addon behavior – set `autoDecrypt: true` to automatically decrypt
-     * encrypted addons (poll votes, reactions, ...) and emit them as typed
-     * `message_addon` events.
+     * Addon behavior. Encrypted addons (poll votes, reactions, ...) are
+     * decrypted automatically and emitted as typed `message_addon` events
+     * by default; set `autoDecrypt: false` to receive them encrypted and
+     * decrypt yourself via `client.message.tryDecryptAddon(event)`.
      */
     readonly addons?: WaAddonOptions
     /**
      * Per-domain control of what {@link WaClient.logout} clears from the
-     * store. Defaults to clearing everything; set a domain to `false` to
-     * preserve it across logout.
+     * store. By default the mailbox archive (`messages`, `threads`,
+     * `contacts`) is **preserved** and every other domain is cleared. See
+     * {@link WaLogoutStoreClearOptions} for the per-domain defaults.
      */
     readonly logoutStoreClear?: WaLogoutStoreClearOptions
     /**
@@ -221,6 +239,14 @@ export interface WaMediaOptions {
 }
 
 export interface WaAddonOptions {
+    /**
+     * Decrypt incoming addon ciphertexts (poll votes, reactions, message
+     * edits, ...) and emit them as typed `message_addon` events. On by
+     * default - set to `false` to receive the encrypted payload and
+     * decrypt yourself via `client.message.tryDecryptAddon(event)`. When
+     * on, the `messageSecret` cache must be a real store (the in-tree
+     * memory provider is the default; `'none'` defeats the cache).
+     */
     readonly autoDecrypt?: boolean
 }
 
@@ -239,6 +265,14 @@ export interface WaWriteBehindOptions {
 }
 
 export interface WaHistorySyncOptions {
+    /**
+     * Whether to process the `historySyncNotification` protocol messages
+     * that WhatsApp pushes on first connect (initial bootstrap) and via
+     * `message.requestHistorySync` (on-demand). On by default - set to
+     * `false` to drop the chunks silently (useful when you do not persist
+     * mailbox/threads/contacts and the conversation download would just
+     * burn bandwidth).
+     */
     readonly enabled?: boolean
     readonly requireFullSync?: boolean
 }
@@ -1021,8 +1055,9 @@ export interface WaClientEventMap {
     readonly message: (event: WaIncomingMessageEvent) => void
     /**
      * A decrypted addon (poll vote, reaction, edit, comment, ...) attached to
-     * a previous message. Fires only when `addons.autoDecrypt` is on **and**
-     * the parent message secret is available in the cache.
+     * a previous message. Fires unless `addons.autoDecrypt` is explicitly
+     * set to `false`, and the parent message secret is available in the
+     * cache.
      */
     readonly message_addon: (event: WaIncomingAddonEvent) => void
     /**
@@ -1075,9 +1110,11 @@ export interface WaClientEventMap {
      */
     readonly mutation: (event: WaAppStateMutationEvent) => void
     /**
-     * One chunk of history-sync data while the primary device is mirroring
-     * past chats. Multiple chunks per sync; track `event.progress` for
-     * completion. Only fires when `history.enabled` is set.
+     * One chunk of history-sync data, fired both during the initial
+     * bootstrap that the primary device pushes after pairing and for any
+     * on-demand backfill triggered by `message.requestHistorySync`.
+     * Multiple chunks per sync; track `event.progress` for completion.
+     * Skipped only when `history.enabled` is explicitly `false`.
      */
     readonly history_sync_chunk: (event: WaHistorySyncChunkEvent) => void
     /**


### PR DESCRIPTION
group coord:
- typed parsers for the 10 methods that used to return raw BinaryNode:
    * queryGroupInviteInfo -> WaGroupInviteInfo (subject, size, ephemeral, desc, sample participants, ...)
    * createGroup / joinGroupViaInvite -> WaGroupMetadata via the existing parseGroupMetadata, no more hand-rolled tag-walking by callers
    * revokeInvite -> { code, affectedParticipants[] }
    * leaveGroup -> void
    * joinLinkedGroup -> void (wa-web only validates the IQ envelope; call queryGroupMetadata after to get the joined sub-group's metadata)
    * addParticipants / removeParticipants / promoteParticipants / demoteParticipants -> WaParticipantActionResult[] with per-jid status/code/phoneNumber/username and the raw node for context
- pulled common <group>-node decoding into parseGroupCommons (jid, subject, size, creation, subjectOwner+pn+username, ephemeral, desc, linkedParent, membershipApprovalEnabled, ...). parseGroupMetadata and parseGroupInviteInfo now share it; WaGroupInviteInfo extends GroupCommons
- added previously-dropped owner/creator attrs to WaGroupMetadata (ownerPhoneNumber/creator_pn, ownerUsername/creator_username, ownerCountryCode/creator_country_code) and subjectOwnerUsername to commons. desc <body> now decodes via getNodeTextContent so it works when the server returns Uint8Array (not just string).

client options:
- addons.autoDecrypt defaults to true. Encrypted addons (poll votes, reactions, message edits, ...) reach apps as typed message_addon events out of the box. Set false to keep the encrypted payload and decrypt yourself via client.message.tryDecryptAddon.
- markOnlineOnConnect defaults to false. zapo is primarily used for bots/automation; the previous wa-web parity default made every bot silently appear online on connect.
- history.enabled defaults to true. The historySyncNotification chunks that WhatsApp pushes after pairing (and the on-demand backfill via message.requestHistorySync) are now processed by default - previously they were dropped silently unless the option was explicitly set.

BREAKING CHANGES:
- group coord methods listed above changed return type from BinaryNode to dedicated parsed shapes. Callers walking the raw tree need to switch to the typed fields.
- markOnlineOnConnect default flipped to false. Pass true to restore the previous behavior.
- addons.autoDecrypt and history.enabled defaults flipped to true. Pass false to restore the previous behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group operations now return structured, typed results with richer metadata and per-participant outcomes.

* **Improvements**
  * Defaults changed: addon auto-decryption and history sync are enabled unless explicitly disabled; online-presence no longer marks online by default on connect.
  * Logout now preserves mailbox-related data by default while clearing other stores.

* **Documentation**
  * Updated docs clarifying these behaviors and addon/history event semantics.

* **Tests**
  * Added tests covering the new defaults and group behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->