### PR TITLE
feat(store)!: require explicit providers when backends is set

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -65,12 +65,15 @@ async function main(): Promise<void> {
         providers: {
             auth: 'sqlite',
             signal: 'sqlite',
+            preKey: 'sqlite',
+            session: 'sqlite',
+            identity: 'sqlite',
             senderKey: 'sqlite',
             appState: 'sqlite',
+            privacyToken: 'sqlite',
             messages: 'sqlite',
             threads: 'sqlite',
-            contacts: 'sqlite',
-            privacyToken: 'sqlite'
+            contacts: 'sqlite'
         }
     })
 

--- a/packages/fake-server/src/__tests__/resume-handshake.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/resume-handshake.cross-check.test.ts
@@ -40,16 +40,16 @@ function buildClientFor(
         },
         providers: {
             auth: 'mem',
-            signal: 'mem',
-            preKey: 'mem',
-            session: 'mem',
-            identity: 'mem',
-            senderKey: 'mem',
-            appState: 'mem',
-            privacyToken: 'mem',
-            messages: 'mem',
-            threads: 'mem',
-            contacts: 'mem'
+            signal: 'memory',
+            preKey: 'memory',
+            session: 'memory',
+            identity: 'memory',
+            senderKey: 'memory',
+            appState: 'memory',
+            privacyToken: 'memory',
+            messages: 'none',
+            threads: 'none',
+            contacts: 'none'
         }
     })
     return new WaClient({

--- a/packages/fake-server/src/__tests__/resume-handshake.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/resume-handshake.cross-check.test.ts
@@ -38,7 +38,19 @@ function buildClientFor(
                 }
             }
         },
-        providers: { auth: 'mem' }
+        providers: {
+            auth: 'mem',
+            signal: 'mem',
+            preKey: 'mem',
+            session: 'mem',
+            identity: 'mem',
+            senderKey: 'mem',
+            appState: 'mem',
+            privacyToken: 'mem',
+            messages: 'mem',
+            threads: 'mem',
+            contacts: 'mem'
+        }
     })
     return new WaClient({
         store,

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -68,7 +68,19 @@ const SYNC_RELATED_PROTOCOL_TYPES = new Set<WaIncomingProtocolType>([
  *
  * const store = createStore({
  *     backends: { sqlite: createSqliteStore({ path: '.auth/state.sqlite' }) },
- *     providers: { auth: 'sqlite', signal: 'sqlite', senderKey: 'sqlite', appState: 'sqlite' }
+ *     providers: {
+ *         auth: 'sqlite',
+ *         signal: 'sqlite',
+ *         preKey: 'sqlite',
+ *         session: 'sqlite',
+ *         identity: 'sqlite',
+ *         senderKey: 'sqlite',
+ *         appState: 'sqlite',
+ *         privacyToken: 'sqlite',
+ *         messages: 'sqlite',
+ *         threads: 'sqlite',
+ *         contacts: 'sqlite'
+ *     }
  * })
  *
  * const client = new WaClient(

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,7 @@ export type {
     WaAuthStore,
     WaContactStore,
     WaCreateStoreOptions,
+    WaCreateStoreOptionsStrict,
     WaDeviceListSnapshot,
     WaDeviceListStore,
     WaGroupMetadataSnapshot,

--- a/src/store/__tests__/create-store.test.ts
+++ b/src/store/__tests__/create-store.test.ts
@@ -90,6 +90,13 @@ test('createStore session lifecycle with backend + memory', async () => {
         backends: { mock: mockAuthBackend },
         providers: {
             auth: 'mock',
+            signal: 'memory',
+            preKey: 'memory',
+            session: 'memory',
+            identity: 'memory',
+            senderKey: 'memory',
+            appState: 'memory',
+            privacyToken: 'memory',
             messages: 'memory',
             threads: 'memory',
             contacts: 'memory'
@@ -118,8 +125,59 @@ test('createStore rejects unknown backend name', () => {
         () =>
             createStore({
                 backends: { db: mockAuthBackend },
-                providers: { auth: 'unknown' as 'db' }
+                providers: {
+                    auth: 'unknown' as 'db',
+                    signal: 'memory',
+                    preKey: 'memory',
+                    session: 'memory',
+                    identity: 'memory',
+                    senderKey: 'memory',
+                    appState: 'memory',
+                    privacyToken: 'memory',
+                    messages: 'none',
+                    threads: 'none',
+                    contacts: 'none'
+                }
             }).session('x'),
         /unknown backend/
     )
+})
+
+test('createStore throws when backends is set but providers omit persistence domains', () => {
+    // Type-system also catches this at compile time via the strict overload;
+    // we cast to bypass and assert the runtime guard is still in place for
+    // JS callers / `as any` users.
+    assert.throws(
+        () =>
+            createStore({
+                backends: { mock: mockAuthBackend },
+                providers: { auth: 'mock' }
+            } as never),
+        /Missing: providers\.signal.*providers\.preKey.*providers\.session.*providers\.identity.*providers\.senderKey.*providers\.appState.*providers\.messages.*providers\.threads.*providers\.contacts.*providers\.privacyToken/s
+    )
+})
+
+test('createStore allows omitting cacheProviders when backends is set (caches default to memory)', () => {
+    const store = createStore({
+        backends: { mock: mockAuthBackend },
+        providers: {
+            auth: 'mock',
+            signal: 'memory',
+            preKey: 'memory',
+            session: 'memory',
+            identity: 'memory',
+            senderKey: 'memory',
+            appState: 'memory',
+            privacyToken: 'memory',
+            messages: 'none',
+            threads: 'none',
+            contacts: 'none'
+        }
+        // cacheProviders intentionally omitted
+    })
+    const session = store.session('x')
+    assert.ok(session.retry)
+    assert.ok(session.groupMetadata)
+    assert.ok(session.deviceList)
+    assert.ok(session.messageSecret)
 })

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -54,6 +54,7 @@ import {
 } from '@store/noop.store'
 import type {
     WaCreateStoreOptions,
+    WaCreateStoreOptionsStrict,
     WaStore,
     WaStoreBackend,
     WaStoreMemoryLimitSelection,
@@ -71,6 +72,20 @@ const DEFAULT_CACHE_TTLS_MS = Object.freeze({
     deviceListMs: 5 * 60 * 1000,
     messageSecretMs: 30 * 60 * 1000
 } as const)
+
+const REQUIRED_PROVIDER_DOMAINS = [
+    'auth',
+    'signal',
+    'preKey',
+    'session',
+    'identity',
+    'senderKey',
+    'appState',
+    'messages',
+    'threads',
+    'contacts',
+    'privacyToken'
+] as const
 
 function hasDestroy(value: unknown): value is Destroyable {
     return (
@@ -111,11 +126,21 @@ function resolveStore<T>(
 /**
  * Builds a {@link WaStore} from the configured providers/backends. Each call
  * to `store.session(sessionId)` returns a cached, lock-wrapped per-domain
- * store bundle for that session – every domain defaults to `'memory'` (or
- * `'none'` for the mailbox domains), and the cache domains default to
- * bounded memory with the TTLs in `options.memory.cacheTtlMs`. `auth`
- * defaults to memory too, so the device re-pairs on every restart unless
- * you point it at a persistent backend.
+ * store bundle for that session. Cache domains default to bounded memory
+ * with the TTLs in `options.memory.cacheTtlMs`.
+ *
+ * **Defaults policy:**
+ * - With `backends` empty (or absent), every domain falls back to memory
+ *   (mailbox domains to `'none'`). The session lives only in memory and the
+ *   device re-pairs on every restart.
+ * - With `backends` set, **every persistence domain must be assigned
+ *   explicitly** in `providers` (auth/signal/preKey/session/identity/
+ *   senderKey/appState/privacyToken/messages/threads/contacts). The factory
+ *   throws listing the missing keys. Pass `'memory'` to keep the in-tree
+ *   memory provider for that domain, `'none'` to skip it, or the backend
+ *   name to persist. Cache domains (retry/groupMetadata/deviceList/
+ *   messageSecret) stay opt-in and default to memory - they are small,
+ *   hot, and cheap to rebuild.
  *
  * @example
  * ```ts
@@ -126,34 +151,54 @@ function resolveStore<T>(
  * const store = createStore({
  *     backends: { sqlite: createSqliteStore({ path: '.auth/state.sqlite' }) },
  *     providers: {
- *         auth: 'sqlite',        // pairing creds – persist in production
- *         signal: 'sqlite',      // signal sessions
- *         senderKey: 'sqlite',   // group sender keys
- *         appState: 'sqlite',    // app-state collections
- *         messages: 'sqlite',    // optional message archive
- *         threads: 'sqlite',
- *         contacts: 'sqlite'
+ *         auth: 'sqlite',
+ *         signal: 'sqlite',
+ *         preKey: 'sqlite',
+ *         session: 'sqlite',
+ *         identity: 'sqlite',
+ *         senderKey: 'sqlite',
+ *         appState: 'sqlite',
+ *         privacyToken: 'sqlite',
+ *         messages: 'sqlite',   // 'none' to skip the message archive
+ *         threads: 'sqlite',    // 'none' to skip
+ *         contacts: 'sqlite'    // 'none' to skip
  *     }
+ *     // cacheProviders omitted - retry/groupMetadata/deviceList/
+ *     // messageSecret default to memory
  * })
  *
- * // Memory-only (tests / ephemeral sessions – credentials lost on restart)
+ * // Memory-only (tests / ephemeral sessions - credentials lost on restart)
  * const memStore = createStore({})
- *
- * // Cache tuning
- * createStore({
- *     backends: { sqlite: createSqliteStore({ path: '.auth/state.sqlite' }) },
- *     providers: { auth: 'sqlite', signal: 'sqlite', senderKey: 'sqlite', appState: 'sqlite' },
- *     memory: {
- *         cacheTtlMs: { groupMetadataMs: 10 * 60_000, deviceListMs: 5 * 60_000 },
- *         limits: { groupMetadataGroups: 1024, deviceListUsers: 4096 }
- *     }
- * })
  * ```
  */
-export function createStore<B extends string>(options: WaCreateStoreOptions<B>): WaStore {
+export function createStore(
+    options?: Omit<WaCreateStoreOptions<never>, 'backends' | 'providers'> & {
+        readonly backends?: undefined
+        readonly providers?: undefined
+    }
+): WaStore
+export function createStore<B extends string>(options: WaCreateStoreOptionsStrict<B>): WaStore
+export function createStore<B extends string>(options?: WaCreateStoreOptions<B>): WaStore {
+    options = options ?? {}
     const backends = (options.backends ?? {}) as Readonly<Record<string, WaStoreBackend>>
     const providers = options.providers ?? {}
     const cacheProviders = options.cacheProviders ?? {}
+
+    if (Object.keys(backends).length > 0) {
+        const missingProviders = REQUIRED_PROVIDER_DOMAINS.filter(
+            (domain) => providers[domain] === undefined
+        )
+        if (missingProviders.length > 0) {
+            throw new Error(
+                `createStore: when backends is set, every persistence domain must be assigned ` +
+                    `explicitly via providers. Missing: ${missingProviders
+                        .map((d) => `providers.${d}`)
+                        .join(', ')}. Pass a backend name (e.g. 'sqlite'), 'memory' to use the ` +
+                    `in-tree memory provider, or 'none' to skip the domain. Cache providers ` +
+                    `(retry/groupMetadata/deviceList/messageSecret) stay opt-in and default to memory.`
+            )
+        }
+    }
     const cacheTtlsMs = Object.freeze({
         retry: resolvePositive(
             options.memory?.cacheTtlMs?.retryMs,

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -193,8 +193,10 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
                 `createStore: when backends is set, every persistence domain must be assigned ` +
                     `explicitly via providers. Missing: ${missingProviders
                         .map((d) => `providers.${d}`)
-                        .join(', ')}. Pass a backend name (e.g. 'sqlite'), 'memory' to use the ` +
-                    `in-tree memory provider, or 'none' to skip the domain. Cache providers ` +
+                        .join(', ')}. Pass a backend name (e.g. 'sqlite') to persist, or ` +
+                    `'memory' to use the in-tree memory provider. For the mailbox domains ` +
+                    `(messages/threads/contacts) 'none' skips the domain entirely; for the ` +
+                    `other domains 'none' falls back to memory. Cache providers ` +
                     `(retry/groupMetadata/deviceList/messageSecret) stay opt-in and default to memory.`
             )
         }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,6 @@
 export type {
     WaCreateStoreOptions,
+    WaCreateStoreOptionsStrict,
     WaStore,
     WaStoreBackend,
     WaCacheDomain,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -257,6 +257,20 @@ export interface WaCreateStoreOptions<B extends string = string> {
     }
 }
 
+/**
+ * Strict overload shape for {@link createStore} when at least one backend
+ * is registered. Every persistence domain in `providers` is `Required` -
+ * the compiler refuses partial coverage and the IDE highlights the missing
+ * keys. Cache domains stay opt-in (default `'memory'`).
+ */
+export interface WaCreateStoreOptionsStrict<B extends string> extends Omit<
+    WaCreateStoreOptions<B>,
+    'backends' | 'providers'
+> {
+    readonly backends: Readonly<Record<B, WaStoreBackend>>
+    readonly providers: Required<NonNullable<WaCreateStoreOptions<B>['providers']>>
+}
+
 export interface WaStoreMemoryLimitSelection {
     readonly appStateSyncKeys?: number
     readonly appStateCollectionEntries?: number


### PR DESCRIPTION
When createStore is called with at least one entry in backends, every persistence domain must now be assigned in providers (auth, signal, preKey, session, identity, senderKey, appState, privacyToken, messages, threads, contacts). Previously omitted domains silently fell back to 'memory', so a config like { backends: { sqlite }, providers: { auth: 'sqlite' } } would persist credentials but lose Signal state, app-state, mailbox, etc. on restart - a long-running footgun.

Two layers of enforcement:

- Type-level: new overload createStore<B>(WaCreateStoreOptionsStrict<B>) marks providers as Required<...> when backends is present. The IDE highlights missing keys without running the code. The leniant overload is still picked when backends is absent, so createStore({}) and tests using just memory keep working.
- Runtime: when backends is non-empty the factory throws listing the missing providers.X keys. Defense in depth for callers that bypass the types via as any / JS.

Cache providers (retry, groupMetadata, deviceList, messageSecret) stay opt-in and default to memory - they are derived state, cheap to rebuild, and persisting them is rarely worth it.

Callers and docs updated: WaClient JSDoc, examples/example.ts, the fake-server cross-check test, and the createStore tests. New tests cover both the runtime guard and the cache-opt-in behavior.

BREAKING CHANGE: any createStore call passing backends must now list every persistence domain in providers. Pass 'memory' to keep the in-tree provider, 'none' to skip the mailbox domains (messages/threads/contacts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced store creation with stricter validation requiring explicit provider configuration for all persistence domains.
  * New `WaCreateStoreOptionsStrict` type for improved type safety.

* **Documentation**
  * Updated store configuration examples with comprehensive provider setup.

* **Tests**
  * Expanded test coverage for provider validation and store creation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->