### PR TITLE
test(fake-server): add 8 bench suites with pluggable stores + separate-process mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ wa-mob
 coverage
 *.heap**
 *.cpuprofile
+bench-profiles/
+bench-profiles-*/
 /test/
 .claude
 *.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "name": "zapo-js",
             "version": "0.3.0",
             "hasInstallScript": true,
+            "license": "MIT",
             "workspaces": [
                 "packages/*"
             ],
@@ -9047,6 +9048,7 @@
         "packages/fake-server": {
             "name": "@zapo-js/fake-server",
             "version": "0.3.0",
+            "license": "MIT",
             "dependencies": {
                 "ws": "^8.18.0"
             },
@@ -9067,6 +9069,7 @@
         "packages/mcp-server": {
             "name": "@zapo-js/mcp-server",
             "version": "0.0.0",
+            "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0"
             },
@@ -9099,6 +9102,7 @@
         "packages/media-utils": {
             "name": "@zapo-js/media-utils",
             "version": "0.1.0",
+            "license": "MIT",
             "devDependencies": {
                 "sharp": "^0.33.0",
                 "zapo-js": "file:../.."
@@ -9114,6 +9118,7 @@
         "packages/store-mongo": {
             "name": "@zapo-js/store-mongo",
             "version": "0.3.0",
+            "license": "MIT",
             "devDependencies": {
                 "mongodb": "^6.16.0",
                 "zapo-js": "file:../.."
@@ -9134,6 +9139,7 @@
         "packages/store-mysql": {
             "name": "@zapo-js/store-mysql",
             "version": "0.3.0",
+            "license": "MIT",
             "devDependencies": {
                 "mysql2": "^3.14.0",
                 "zapo-js": "file:../.."
@@ -9154,6 +9160,7 @@
         "packages/store-postgres": {
             "name": "@zapo-js/store-postgres",
             "version": "0.3.0",
+            "license": "MIT",
             "devDependencies": {
                 "@types/pg": "^8.11.0",
                 "pg": "^8.14.1",
@@ -9175,6 +9182,7 @@
         "packages/store-redis": {
             "name": "@zapo-js/store-redis",
             "version": "0.3.0",
+            "license": "MIT",
             "devDependencies": {
                 "ioredis": "^5.6.1",
                 "zapo-js": "file:../.."
@@ -9195,6 +9203,7 @@
         "packages/store-sqlite": {
             "name": "@zapo-js/store-sqlite",
             "version": "0.3.0",
+            "license": "MIT",
             "devDependencies": {
                 "better-sqlite3": "^12.6.2",
                 "zapo-js": "file:../.."

--- a/packages/fake-server/bench/_common.ts
+++ b/packages/fake-server/bench/_common.ts
@@ -100,7 +100,7 @@ export function readProfilerOptions(args: ReadonlySet<string>): ProfilerOptions 
         snapshot: args.has('--snapshot'),
         perScenario: args.has('--per-scenario'),
         snapshotPerScenario: args.has('--snapshot-per-scenario'),
-        outDir: outDirArg ? outDirArg.split('=')[1] : process.cwd()
+        outDir: outDirArg ? outDirArg.slice('--out-dir='.length) : process.cwd()
     }
 }
 

--- a/packages/fake-server/bench/_common.ts
+++ b/packages/fake-server/bench/_common.ts
@@ -1,0 +1,439 @@
+/**
+ * Shared bench infrastructure for the fake-server bench suite.
+ *
+ * - {@link BenchProfiler}: V8 inspector wrapper that captures CPU profile,
+ *   heap allocation timeline, and heap snapshots (start/end and optional
+ *   per-scenario), saving to a configurable output directory.
+ * - {@link runScenario}: timed runner that wraps an operation with
+ *   process.cpuUsage + memory snapshot deltas.
+ * - format / env / GC helpers reused across every bench.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises'
+import * as inspector from 'node:inspector/promises'
+import { resolve as resolvePath } from 'node:path'
+import { performance } from 'node:perf_hooks'
+
+import type { Logger } from 'zapo-js'
+
+const BYTES_PER_MEBIBYTE = 1_048_576
+
+export function formatFixed(value: number, fractionDigits = 2): string {
+    if (!Number.isFinite(value)) return value.toString()
+    return value.toFixed(fractionDigits)
+}
+
+export function formatMiB(bytes: number): string {
+    return `${formatFixed(bytes / BYTES_PER_MEBIBYTE, 2)} MiB`
+}
+
+export function formatMs(value: number): string {
+    if (value >= 1_000) return `${formatFixed(value / 1_000, 2)} s`
+    return `${formatFixed(value, 2)} ms`
+}
+
+export function formatBytesPerSec(bytes: number, ms: number): string {
+    if (ms <= 0) return '∞'
+    const bps = (bytes / ms) * 1000
+    if (bps >= BYTES_PER_MEBIBYTE) return `${formatFixed(bps / BYTES_PER_MEBIBYTE, 2)} MiB/s`
+    if (bps >= 1024) return `${formatFixed(bps / 1024, 2)} KiB/s`
+    return `${formatFixed(bps, 0)} B/s`
+}
+
+export function readPositiveIntEnv(name: string, fallback: number): number {
+    const raw = process.env[name]
+    if (!raw) return fallback
+    const parsed = Number.parseInt(raw, 10)
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error(`env ${name}=${raw} must be a positive integer`)
+    }
+    return parsed
+}
+
+export function readCsvEnv(name: string, fallback: readonly string[]): readonly string[] {
+    const raw = process.env[name]
+    if (!raw) return fallback
+    return raw
+        .split(',')
+        .map((v) => v.trim())
+        .filter((v) => v.length > 0)
+}
+
+export function hasExposedGc(): boolean {
+    return typeof (globalThis as { gc?: () => void }).gc === 'function'
+}
+
+export function forceGcIfAvailable(): void {
+    const gc = (globalThis as { gc?: () => void }).gc
+    if (gc) gc()
+}
+
+export const NOOP_LOGGER: Logger = {
+    level: 'error',
+    trace: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: (...args: unknown[]) => {
+        if (process.env.ZAPO_BENCH_VERBOSE) console.warn('[lib warn]', ...args)
+    },
+    error: (...args: unknown[]) => {
+        if (process.env.ZAPO_BENCH_VERBOSE) console.error('[lib error]', ...args)
+    }
+}
+
+// ─── Profiler ─────────────────────────────────────────────────────────
+
+export interface ProfilerOptions {
+    readonly cpu: boolean
+    readonly heap: boolean
+    readonly snapshot: boolean
+    readonly perScenario: boolean
+    readonly snapshotPerScenario: boolean
+    readonly outDir: string
+}
+
+export function readProfilerOptions(args: ReadonlySet<string>): ProfilerOptions {
+    const outDirArg = process.argv.find((a) => a.startsWith('--out-dir='))
+    return {
+        cpu: args.has('--cpu'),
+        heap: args.has('--heap'),
+        snapshot: args.has('--snapshot'),
+        perScenario: args.has('--per-scenario'),
+        snapshotPerScenario: args.has('--snapshot-per-scenario'),
+        outDir: outDirArg ? outDirArg.split('=')[1] : process.cwd()
+    }
+}
+
+function slug(name: string): string {
+    return name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '')
+}
+
+export class BenchProfiler {
+    public readonly options: ProfilerOptions
+    private session: inspector.Session | null = null
+    private active = false
+
+    public constructor(options: ProfilerOptions) {
+        this.options = options
+    }
+
+    public get enabled(): boolean {
+        return (
+            this.options.cpu ||
+            this.options.heap ||
+            this.options.snapshot ||
+            this.options.snapshotPerScenario
+        )
+    }
+
+    public async start(): Promise<void> {
+        if (!this.enabled) return
+        await mkdir(this.options.outDir, { recursive: true })
+        this.session = new inspector.Session()
+        this.session.connect()
+        if (this.options.heap) {
+            await this.session.post('HeapProfiler.startTrackingHeapObjects', {
+                trackAllocations: true
+            })
+            console.log('[heap] allocation tracking started')
+        }
+        if (this.options.cpu) {
+            await this.session.post('Profiler.enable')
+            await this.session.post('Profiler.start')
+            console.log('[cpu] profiling started')
+        }
+        this.active = true
+    }
+
+    public async beforeScenario(name: string): Promise<void> {
+        if (!this.active || !this.session) return
+        if (this.options.cpu && this.options.perScenario) {
+            try {
+                await this.session.post('Profiler.start')
+            } catch {
+                // already running – fine
+            }
+        }
+        if (this.options.snapshotPerScenario) {
+            await this.takeHeapSnapshot(`pre-${slug(name)}`).catch((err) =>
+                console.error(`[snapshot:pre-${name}]`, err)
+            )
+        }
+    }
+
+    public async afterScenario(name: string): Promise<void> {
+        if (!this.active || !this.session) return
+        if (this.options.cpu && this.options.perScenario) {
+            try {
+                const result = (await this.session.post('Profiler.stop')) as {
+                    profile: unknown
+                }
+                const out = this.fileName(`cpu-${slug(name)}`, 'cpuprofile')
+                await writeFile(out, JSON.stringify(result.profile))
+                console.log(`[cpu] saved ${out}`)
+                await this.session.post('Profiler.start')
+            } catch (err) {
+                console.error(`[cpu:per-scenario:${name}]`, err)
+            }
+        }
+        if (this.options.snapshotPerScenario) {
+            await this.takeHeapSnapshot(`post-${slug(name)}`).catch((err) =>
+                console.error(`[snapshot:post-${name}]`, err)
+            )
+        }
+    }
+
+    public async stop(): Promise<void> {
+        if (!this.active || !this.session) return
+        if (this.options.cpu) {
+            try {
+                const result = (await this.session.post('Profiler.stop')) as {
+                    profile: unknown
+                }
+                const out = this.fileName('cpu', 'cpuprofile')
+                await writeFile(out, JSON.stringify(result.profile))
+                console.log(`[cpu] saved ${out}`)
+            } catch (err) {
+                console.error('[cpu:stop]', err)
+            }
+        }
+        if (this.options.heap) {
+            await this.saveHeapTimeline().catch((err) => console.error('[heap]', err))
+        }
+        try {
+            this.session.disconnect()
+        } catch {
+            // best-effort
+        }
+        this.session = null
+        this.active = false
+    }
+
+    public async takeHeapSnapshot(label: string): Promise<void> {
+        if (!this.session) return
+        const chunks: string[] = []
+        const onChunk = (msg: { params: { chunk: string } }): void => {
+            chunks.push(msg.params.chunk)
+        }
+        this.session.on(
+            'HeapProfiler.addHeapSnapshotChunk',
+            onChunk as unknown as (m: object) => void
+        )
+        try {
+            await this.session.post('HeapProfiler.takeHeapSnapshot', { reportProgress: false })
+        } finally {
+            this.session.removeListener(
+                'HeapProfiler.addHeapSnapshotChunk',
+                onChunk as unknown as (m: object) => void
+            )
+        }
+        const out = this.fileName(`snapshot-${label}`, 'heapsnapshot')
+        const content = chunks.join('')
+        await writeFile(out, content)
+        console.log(
+            `[snapshot:${label}] saved ${out} (${(content.length / 1024 / 1024).toFixed(1)} MB)`
+        )
+    }
+
+    private async saveHeapTimeline(): Promise<void> {
+        if (!this.session) return
+        const chunks: string[] = []
+        const onChunk = (msg: { params: { chunk: string } }): void => {
+            chunks.push(msg.params.chunk)
+        }
+        this.session.on(
+            'HeapProfiler.addHeapSnapshotChunk',
+            onChunk as unknown as (m: object) => void
+        )
+        try {
+            await this.session.post('HeapProfiler.takeHeapSnapshot', {
+                reportProgress: false,
+                treatGlobalObjectsAsRoots: true
+            })
+            await this.session.post('HeapProfiler.stopTrackingHeapObjects')
+        } finally {
+            this.session.removeListener(
+                'HeapProfiler.addHeapSnapshotChunk',
+                onChunk as unknown as (m: object) => void
+            )
+        }
+        const out = this.fileName('heap', 'heaptimeline')
+        const content = chunks.join('')
+        await writeFile(out, content)
+        console.log(`[heap] saved ${out} (${(content.length / 1024 / 1024).toFixed(1)} MB)`)
+    }
+
+    private fileName(prefix: string, ext: string): string {
+        return resolvePath(this.options.outDir, `${prefix}-${Date.now()}.${ext}`)
+    }
+}
+
+// ─── Scenario runner ──────────────────────────────────────────────────
+
+export interface ScenarioResult {
+    readonly name: string
+    readonly opsCount: number
+    readonly elapsedMs: number
+    readonly throughputOpsPerSec: number
+    readonly avgMsPerOp: number
+    readonly cpuTimeMs: number
+    readonly cpuPercent: number
+    readonly rssBeforeBytes: number
+    readonly rssAfterBytes: number
+    readonly rssDeltaBytes: number
+    readonly heapDeltaBytes: number
+    readonly opsLabel: string
+}
+
+export function snapshotMemory(): { rss: number; heap: number } {
+    const m = process.memoryUsage()
+    return { rss: m.rss, heap: m.heapUsed }
+}
+
+export async function runScenario(
+    name: string,
+    opsCount: number,
+    operation: () => Promise<void>,
+    opsLabel = 'ops'
+): Promise<ScenarioResult> {
+    forceGcIfAvailable()
+    const before = snapshotMemory()
+    const startedCpu = process.cpuUsage()
+    const startedAt = performance.now()
+    await operation()
+    const elapsedMs = performance.now() - startedAt
+    const cpu = process.cpuUsage(startedCpu)
+    const cpuTimeMs = (cpu.user + cpu.system) / 1_000
+    const after = snapshotMemory()
+    return {
+        name,
+        opsCount,
+        elapsedMs,
+        throughputOpsPerSec: opsCount > 0 ? (opsCount / elapsedMs) * 1_000 : 0,
+        avgMsPerOp: opsCount > 0 ? elapsedMs / opsCount : 0,
+        cpuTimeMs,
+        cpuPercent: elapsedMs > 0 ? (cpuTimeMs / elapsedMs) * 100 : 0,
+        rssBeforeBytes: before.rss,
+        rssAfterBytes: after.rss,
+        rssDeltaBytes: Math.max(0, after.rss - before.rss),
+        heapDeltaBytes: Math.max(0, after.heap - before.heap),
+        opsLabel
+    }
+}
+
+export function printResult(result: ScenarioResult): void {
+    console.log(`──[ ${result.name} ]──────────────────────────────`)
+    console.log(`  ${result.opsLabel.padEnd(18)}: ${result.opsCount}`)
+    console.log(`  elapsed           : ${formatMs(result.elapsedMs)}`)
+    console.log(
+        `  throughput        : ${formatFixed(result.throughputOpsPerSec, 1)} ${result.opsLabel}/s`
+    )
+    console.log(`  avg / ${result.opsLabel.padEnd(11)} : ${formatMs(result.avgMsPerOp)}`)
+    console.log(`  CPU time          : ${formatMs(result.cpuTimeMs)}`)
+    console.log(`  CPU %             : ${formatFixed(result.cpuPercent, 1)}`)
+    console.log(`  RSS before        : ${formatMiB(result.rssBeforeBytes)}`)
+    console.log(`  RSS after         : ${formatMiB(result.rssAfterBytes)}`)
+    console.log(`  RSS delta         : ${formatMiB(result.rssDeltaBytes)}`)
+    console.log(`  heap delta        : ${formatMiB(result.heapDeltaBytes)}`)
+    console.log('')
+}
+
+export function maybePrintJson(results: readonly ScenarioResult[]): void {
+    if (process.env.ZAPO_BENCH_JSON !== '1') return
+    console.log(
+        JSON.stringify(
+            results.map((r) => ({
+                name: r.name,
+                opsCount: r.opsCount,
+                opsLabel: r.opsLabel,
+                elapsedMs: r.elapsedMs,
+                throughputOpsPerSec: r.throughputOpsPerSec,
+                avgMsPerOp: r.avgMsPerOp,
+                cpuTimeMs: r.cpuTimeMs,
+                cpuPercent: r.cpuPercent,
+                rssDeltaBytes: r.rssDeltaBytes,
+                heapDeltaBytes: r.heapDeltaBytes
+            })),
+            null,
+            2
+        )
+    )
+}
+
+// ─── Helpers for the --separate-process pattern ───────────────────────
+
+export interface RpcLike {
+    startProfiling(options: { cpu?: boolean; heap?: boolean; outDir?: string }): Promise<void>
+    stopProfiling(options: {
+        cpu?: boolean
+        heap?: boolean
+        outDir?: string
+    }): Promise<{ cpuPath?: string; heapPath?: string }>
+    takeSnapshot(label: string, outDir?: string): Promise<string>
+}
+
+export async function startServerProfilingIfRequested(
+    rpc: RpcLike,
+    profilerOptions: ProfilerOptions,
+    argSet: ReadonlySet<string>
+): Promise<void> {
+    if (argSet.has('--no-server-prof')) {
+        console.log('[server] profiling skipped (--no-server-prof)')
+        return
+    }
+    if (!profilerOptions.cpu && !profilerOptions.heap) return
+    await rpc.startProfiling({
+        cpu: profilerOptions.cpu,
+        heap: profilerOptions.heap,
+        outDir: profilerOptions.outDir
+    })
+    console.log('[server] profiling started')
+}
+
+export async function stopServerProfilingIfRequested(
+    rpc: RpcLike,
+    profilerOptions: ProfilerOptions,
+    argSet: ReadonlySet<string>
+): Promise<void> {
+    if (argSet.has('--no-server-prof')) return
+    if (!profilerOptions.cpu && !profilerOptions.heap) return
+    const paths = await rpc
+        .stopProfiling({
+            cpu: profilerOptions.cpu,
+            heap: profilerOptions.heap,
+            outDir: profilerOptions.outDir
+        })
+        .catch((): { cpuPath?: string; heapPath?: string } => ({}))
+    if (paths.cpuPath) console.log(`[server:cpu] saved ${paths.cpuPath}`)
+    if (paths.heapPath) console.log(`[server:heap] saved ${paths.heapPath}`)
+}
+
+export async function takeServerSnapshotIfRequested(
+    rpc: RpcLike,
+    label: string,
+    profilerOptions: ProfilerOptions,
+    argSet: ReadonlySet<string>
+): Promise<void> {
+    if (!argSet.has('--snapshot')) return
+    await rpc.takeSnapshot(label, profilerOptions.outDir).then(
+        (p) => console.log(`[server:snapshot] saved ${p}`),
+        (err) => console.error('[server:snapshot]', err)
+    )
+}
+
+// ─── Emergency-stop wiring ────────────────────────────────────────────
+
+let _emergencyStopRan = false
+export function installEmergencyStop(): void {
+    const handler = (label: string, err: unknown): void => {
+        if (_emergencyStopRan) return
+        _emergencyStopRan = true
+        console.error(`[${label}]`, err)
+        process.exit(1)
+    }
+    process.on('uncaughtException', (err) => handler('uncaughtException', err))
+    process.on('unhandledRejection', (err) => handler('unhandledRejection', err))
+}

--- a/packages/fake-server/bench/_fixtures.ts
+++ b/packages/fake-server/bench/_fixtures.ts
@@ -1,0 +1,266 @@
+/**
+ * Reusable fixture builders for fake-server benches: pair a single
+ * `WaClient` against a fresh `FakeWaServer`, then provision contacts /
+ * groups on demand. Used by every messaging-flavored bench.
+ */
+
+import { WaClient, type WaClientEventMap } from 'zapo-js'
+
+import { type FakePeer } from '../src/api/FakePeer'
+import { FakeWaServer, type WaFakeConnectionPipeline } from '../src/api/FakeWaServer'
+import { parsePairingQrString } from '../src/protocol/auth/pair-device'
+
+import { NOOP_LOGGER } from './_common'
+import type { BenchStoreFixture } from './_store-factory'
+import { ServerRpc } from './server-rpc'
+
+export interface PairedFixture {
+    readonly server: FakeWaServer
+    readonly client: WaClient
+    readonly pipeline: WaFakeConnectionPipeline
+    readonly meJid: string
+    readonly meDeviceJid: string
+    readonly storeFixture: BenchStoreFixture
+}
+
+export interface BringUpOptions {
+    readonly sessionId?: string
+    readonly historyEnabled?: boolean
+    readonly emitSnapshotMutations?: boolean
+    readonly chatSync?: boolean
+}
+
+export async function bringUpPairedClient(
+    storeFixture: BenchStoreFixture,
+    options: BringUpOptions = {}
+): Promise<PairedFixture> {
+    const server = await FakeWaServer.start()
+
+    const client = new WaClient(
+        {
+            store: storeFixture.store,
+            sessionId: options.sessionId ?? 'zapo-bench',
+            chatSocketUrls: [server.url],
+            connectTimeoutMs: 60_000,
+            history: options.historyEnabled ? { enabled: true } : undefined,
+            chatEvents: options.emitSnapshotMutations ? { emitSnapshotMutations: true } : undefined,
+            proxy: {
+                mediaUpload: server.mediaProxyAgent,
+                mediaDownload: server.mediaProxyAgent
+            },
+            testHooks: {
+                noiseRootCa: server.noiseRootCa
+            }
+        },
+        NOOP_LOGGER
+    )
+
+    const meJid = '5511999999999@s.whatsapp.net'
+    const meDeviceJid = '5511999999999:1@s.whatsapp.net'
+
+    const materialPromise = new Promise<{
+        readonly advSecretKey: Uint8Array
+        readonly identityPublicKey: Uint8Array
+    }>((resolve) => {
+        client.once('auth_qr', (event: Parameters<WaClientEventMap['auth_qr']>[0]) => {
+            const parsed = parsePairingQrString(event.qr)
+            resolve({
+                advSecretKey: parsed.advSecretKey,
+                identityPublicKey: parsed.identityPublicKey
+            })
+        })
+    })
+
+    const pairedPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('auth_paired timeout')), 60_000)
+        client.once('auth_paired', () => {
+            clearTimeout(timer)
+            resolve()
+        })
+    })
+
+    await client.connect()
+    const pipeline = await server.waitForAuthenticatedPipeline()
+    await server.runPairing(pipeline, { deviceJid: meDeviceJid }, () => materialPromise)
+    const pipelineAfterPairPromise = server.waitForNextAuthenticatedPipeline()
+    await pairedPromise
+    const pipelineAfterPair = await pipelineAfterPairPromise
+    await server.triggerPreKeyUpload(pipelineAfterPair)
+
+    return {
+        server,
+        client,
+        pipeline: pipelineAfterPair,
+        meJid,
+        meDeviceJid,
+        storeFixture
+    }
+}
+
+export async function teardownFixture(fixture: PairedFixture): Promise<void> {
+    await fixture.client.disconnect().catch(() => undefined)
+    await fixture.server.stop()
+    await fixture.storeFixture.destroy().catch(() => undefined)
+}
+
+// ─── Separate-process variant (server runs in a child) ────────────────
+
+export interface RpcPairedFixture {
+    readonly rpc: ServerRpc
+    readonly client: WaClient
+    readonly meJid: string
+    readonly meDeviceJid: string
+    readonly storeFixture: BenchStoreFixture
+}
+
+/**
+ * Like {@link bringUpPairedClient} but the `FakeWaServer` lives in a
+ * forked child process via {@link ServerRpc}. Use this for benches
+ * launched with `--separate-process` so the CPU profile of the lib
+ * does NOT include fake-server time.
+ *
+ * The caller is responsible for: starting the profiler in the child
+ * if desired (`rpc.startProfiling(...)`), and tearing the child + the
+ * store down via {@link teardownRpcFixture}.
+ */
+export async function bringUpPairedClientViaRpc(
+    storeFixture: BenchStoreFixture,
+    options: BringUpOptions = {}
+): Promise<RpcPairedFixture> {
+    const rpc = new ServerRpc()
+    await rpc.spawn()
+    await rpc.start()
+
+    const client = new WaClient(
+        {
+            store: storeFixture.store,
+            sessionId: options.sessionId ?? 'zapo-bench-separate',
+            chatSocketUrls: [rpc.serverUrl],
+            connectTimeoutMs: 60_000,
+            history: options.historyEnabled ? { enabled: true } : undefined,
+            chatEvents: options.emitSnapshotMutations ? { emitSnapshotMutations: true } : undefined,
+            proxy: {
+                mediaUpload: rpc.mediaProxyAgent!,
+                mediaDownload: rpc.mediaProxyAgent!
+            },
+            testHooks: {
+                noiseRootCa: rpc.noiseRootCa
+            }
+        },
+        NOOP_LOGGER
+    )
+
+    const meJid = '5511999999999@s.whatsapp.net'
+    const meDeviceJid = '5511999999999:1@s.whatsapp.net'
+
+    client.once('auth_qr', (event: Parameters<WaClientEventMap['auth_qr']>[0]) => {
+        const parsed = parsePairingQrString(event.qr)
+        rpc.sendPairingMaterial({
+            advSecretKey: parsed.advSecretKey,
+            identityPublicKey: parsed.identityPublicKey
+        })
+    })
+
+    const pairedPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('auth_paired timeout')), 60_000)
+        client.once('auth_paired', () => {
+            clearTimeout(timer)
+            resolve()
+        })
+    })
+
+    await client.connect()
+    await rpc.waitForAuthenticatedPipeline()
+    const pairPromise = rpc.runPairing(meDeviceJid)
+    const waitNextPromise = rpc.waitForNextAuthenticatedPipeline()
+    await pairedPromise
+    await pairPromise
+    await waitNextPromise
+    await rpc.triggerPreKeyUpload()
+
+    return { rpc, client, meJid, meDeviceJid, storeFixture }
+}
+
+export async function teardownRpcFixture(fixture: RpcPairedFixture): Promise<void> {
+    await fixture.client.disconnect().catch(() => undefined)
+    await fixture.rpc.stop()
+    await fixture.storeFixture.destroy().catch(() => undefined)
+}
+
+// ─── Contacts / groups ────────────────────────────────────────────────
+
+export interface ContactFixture {
+    readonly userJid: string
+    readonly devices: readonly FakePeer[]
+}
+
+export interface GroupFixture {
+    readonly groupJid: string
+    readonly members: readonly FakePeer[]
+    readonly designatedSender: FakePeer
+}
+
+export async function ensurePreKeyPool(
+    server: FakeWaServer,
+    pipeline: WaFakeConnectionPipeline,
+    requiredHeadroom: number
+): Promise<void> {
+    if (server.preKeysAvailable() >= requiredHeadroom) return
+    await server.triggerPreKeyUpload(pipeline, { force: true })
+}
+
+export async function buildContacts(
+    server: FakeWaServer,
+    pipeline: WaFakeConnectionPipeline,
+    count: number,
+    devicesPerContact: number
+): Promise<readonly ContactFixture[]> {
+    const out: ContactFixture[] = []
+    const deviceIds = Array.from({ length: devicesPerContact }, (_, idx) => idx + 1)
+    for (let i = 0; i < count; i += 1) {
+        await ensurePreKeyPool(server, pipeline, devicesPerContact)
+        const userJid = `5511${String(7_000_000_000 + i).padStart(10, '0')}@s.whatsapp.net`
+        const devices = await server.createFakePeerWithDevices({ userJid, deviceIds }, pipeline)
+        out.push({ userJid, devices })
+    }
+    return out
+}
+
+export async function buildGroups(
+    server: FakeWaServer,
+    pipeline: WaFakeConnectionPipeline,
+    groupCount: number,
+    memberCount: number
+): Promise<readonly GroupFixture[]> {
+    const out: GroupFixture[] = []
+    let memberCursor = 0
+    for (let g = 0; g < groupCount; g += 1) {
+        const groupJid = `120363${String(900_000_000_000 + g).padStart(15, '0')}@g.us`
+        const members: FakePeer[] = []
+        for (let m = 0; m < memberCount; m += 1) {
+            const memberJid = `5511${String(8_000_000_000 + memberCursor).padStart(10, '0')}@s.whatsapp.net`
+            memberCursor += 1
+            await ensurePreKeyPool(server, pipeline, 1)
+            const peer = await server.createFakePeer({ jid: memberJid }, pipeline)
+            members.push(peer)
+        }
+        server.createFakeGroup({
+            groupJid,
+            subject: `Bench Group ${g + 1}`,
+            participants: members
+        })
+        out.push({ groupJid, members, designatedSender: members[0] })
+    }
+    return out
+}
+
+export function bucketize(total: number, slots: number): readonly number[] {
+    if (slots <= 0) throw new Error('bucketize requires slots > 0')
+    const base = Math.floor(total / slots)
+    const remainder = total - base * slots
+    const out = new Array<number>(slots)
+    for (let i = 0; i < slots; i += 1) {
+        out[i] = base + (i < remainder ? 1 : 0)
+    }
+    return out
+}

--- a/packages/fake-server/bench/_store-factory.ts
+++ b/packages/fake-server/bench/_store-factory.ts
@@ -1,0 +1,253 @@
+/**
+ * Pluggable store factory for the fake-server bench suite. Selects a
+ * backend via `ZAPO_BENCH_STORE` (memory | sqlite | postgres | mysql |
+ * redis | mongo) and wires the matching `@zapo-js/store-*` package into
+ * `createStore()` from `zapo-js`.
+ *
+ * - `memory` (default): in-process bounded maps. No external dep.
+ * - `sqlite`: file or `:memory:`. Driver via `ZAPO_BENCH_SQLITE_PATH`
+ *   (default `:memory:`). Persistent domains (`auth`, `signal`, etc.)
+ *   resolve to the sqlite backend; mailbox / cache domains stay in
+ *   memory unless explicitly switched.
+ * - `postgres` / `mysql`: needs a live server. Reads the same
+ *   `ZAPO_TEST_PG_*` / `ZAPO_TEST_MYSQL_*` env vars used by
+ *   `scripts/test-stores.cjs` and the per-package integration tests.
+ * - `redis`: needs a live redis. Reads `ZAPO_TEST_REDIS_HOST/PORT`.
+ * - `mongo`: needs a live mongo (replica set). Reads
+ *   `ZAPO_TEST_MONGO_HOST/PORT`.
+ *
+ * The factory returns a teardown that:
+ * - calls `await store.destroy()` (the WaStore handles per-domain
+ *   `destroy()` of stores it created), and
+ * - for backends that own a pool/client built from env vars, closes that
+ *   too. When a `Pool` / `Redis` / `Db` is passed in, we don't own it.
+ */
+
+import { createStore, type WaCreateStoreOptions, type WaStore } from 'zapo-js'
+
+type ProvidersFor<B extends string> = Required<NonNullable<WaCreateStoreOptions<B>['providers']>>
+
+export type StoreBackendName = 'memory' | 'sqlite' | 'postgres' | 'mysql' | 'redis' | 'mongo'
+
+const ALL_BACKENDS: ReadonlySet<StoreBackendName> = new Set([
+    'memory',
+    'sqlite',
+    'postgres',
+    'mysql',
+    'redis',
+    'mongo'
+])
+
+export function resolveStoreBackend(): StoreBackendName {
+    const raw = process.env.ZAPO_BENCH_STORE ?? 'memory'
+    if (!ALL_BACKENDS.has(raw as StoreBackendName)) {
+        throw new Error(`unknown ZAPO_BENCH_STORE=${raw}; valid: ${[...ALL_BACKENDS].join(', ')}`)
+    }
+    return raw as StoreBackendName
+}
+
+const PERSISTENT_DOMAINS = [
+    'auth',
+    'signal',
+    'preKey',
+    'session',
+    'identity',
+    'senderKey',
+    'appState',
+    'privacyToken'
+] as const
+
+const MAILBOX_DOMAINS = ['messages', 'threads', 'contacts'] as const
+
+const CACHE_DOMAINS = ['retry', 'groupMetadata', 'deviceList', 'messageSecret'] as const
+
+export interface BenchStoreFixture {
+    readonly backend: StoreBackendName
+    readonly store: WaStore
+    readonly description: string
+    destroy: () => Promise<void>
+}
+
+export async function buildBenchStore(): Promise<BenchStoreFixture> {
+    const backend = resolveStoreBackend()
+    switch (backend) {
+        case 'memory':
+            return buildMemoryStore()
+        case 'sqlite':
+            return await buildSqliteStore()
+        case 'postgres':
+            return await buildPostgresStore()
+        case 'mysql':
+            return await buildMysqlStore()
+        case 'redis':
+            return await buildRedisStore()
+        case 'mongo':
+            return await buildMongoStore()
+        default: {
+            const _exhaustive: never = backend
+            throw new Error(`unreachable: ${_exhaustive as string}`)
+        }
+    }
+}
+
+function buildProviders<B extends string>(name: B): ProvidersFor<B> {
+    const out: Record<string, B> = {}
+    for (const d of PERSISTENT_DOMAINS) out[d] = name
+    for (const d of MAILBOX_DOMAINS) out[d] = name
+    for (const d of CACHE_DOMAINS) out[d] = name
+    return out as ProvidersFor<B>
+}
+
+function buildMemoryStore(): BenchStoreFixture {
+    const store = createStore({
+        memory: { limits: { signalPreKeys: 16_384 } }
+    })
+    return {
+        backend: 'memory',
+        store,
+        description: 'in-process memory (signalPreKeys cap 16384)',
+        destroy: async () => {
+            await store.destroy()
+        }
+    }
+}
+
+async function buildSqliteStore(): Promise<BenchStoreFixture> {
+    const { createSqliteStore } = await import('@zapo-js/store-sqlite')
+    const path = process.env.ZAPO_BENCH_SQLITE_PATH ?? ':memory:'
+    const backend = createSqliteStore({ path })
+    const store = createStore({
+        backends: { sqlite: backend },
+        providers: buildProviders('sqlite')
+    })
+    return {
+        backend: 'sqlite',
+        store,
+        description: `sqlite (path=${path})`,
+        destroy: async () => {
+            await store.destroy()
+        }
+    }
+}
+
+async function buildPostgresStore(): Promise<BenchStoreFixture> {
+    const { createPostgresStore } = await import('@zapo-js/store-postgres')
+    const host = requireEnv('ZAPO_TEST_PG_HOST')
+    const port = parsePort('ZAPO_TEST_PG_PORT')
+    const user = process.env.ZAPO_TEST_PG_USER ?? 'postgres'
+    const password = process.env.ZAPO_TEST_PG_PASSWORD ?? 'test'
+    const database = process.env.ZAPO_TEST_PG_DATABASE ?? 'zapo_test'
+    const tablePrefix = uniquePrefix('pg')
+    const backend = createPostgresStore({
+        pool: { host, port, user, password, database, max: 16 },
+        tablePrefix
+    })
+    const store = createStore({
+        backends: { postgres: backend },
+        providers: buildProviders('postgres')
+    })
+    return {
+        backend: 'postgres',
+        store,
+        description: `postgres (${host}:${port}/${database} prefix=${tablePrefix})`,
+        destroy: async () => {
+            await store.destroy()
+        }
+    }
+}
+
+async function buildMysqlStore(): Promise<BenchStoreFixture> {
+    const { createMysqlStore } = await import('@zapo-js/store-mysql')
+    const host = requireEnv('ZAPO_TEST_MYSQL_HOST')
+    const port = parsePort('ZAPO_TEST_MYSQL_PORT')
+    const user = process.env.ZAPO_TEST_MYSQL_USER ?? 'root'
+    const password = process.env.ZAPO_TEST_MYSQL_PASSWORD ?? 'test'
+    const database = process.env.ZAPO_TEST_MYSQL_DATABASE ?? 'zapo_test'
+    const tablePrefix = uniquePrefix('mysql')
+    const backend = createMysqlStore({
+        pool: { host, port, user, password, database, connectionLimit: 16 },
+        tablePrefix
+    })
+    const store = createStore({
+        backends: { mysql: backend },
+        providers: buildProviders('mysql')
+    })
+    return {
+        backend: 'mysql',
+        store,
+        description: `mysql (${host}:${port}/${database} prefix=${tablePrefix})`,
+        destroy: async () => {
+            await store.destroy()
+        }
+    }
+}
+
+async function buildRedisStore(): Promise<BenchStoreFixture> {
+    const { createRedisStore } = await import('@zapo-js/store-redis')
+    const host = requireEnv('ZAPO_TEST_REDIS_HOST')
+    const port = parsePort('ZAPO_TEST_REDIS_PORT')
+    const keyPrefix = uniquePrefix('redis')
+    const backend = createRedisStore({
+        redis: { host, port, lazyConnect: false },
+        keyPrefix
+    })
+    const store = createStore({
+        backends: { redis: backend },
+        providers: buildProviders('redis')
+    })
+    return {
+        backend: 'redis',
+        store,
+        description: `redis (${host}:${port} prefix=${keyPrefix})`,
+        destroy: async () => {
+            await store.destroy()
+        }
+    }
+}
+
+async function buildMongoStore(): Promise<BenchStoreFixture> {
+    const { createMongoStore } = await import('@zapo-js/store-mongo')
+    const host = requireEnv('ZAPO_TEST_MONGO_HOST')
+    const port = parsePort('ZAPO_TEST_MONGO_PORT')
+    const uri = `mongodb://${host}:${port}/?directConnection=true`
+    const database = `zapo_bench_${Date.now().toString(36)}`
+    const backend = createMongoStore({
+        db: { uri, database }
+    })
+    const store = createStore({
+        backends: { mongo: backend },
+        providers: buildProviders('mongo')
+    })
+    return {
+        backend: 'mongo',
+        store,
+        description: `mongo (${host}:${port}/${database})`,
+        destroy: async () => {
+            await store.destroy()
+        }
+    }
+}
+
+function requireEnv(name: string): string {
+    const v = process.env[name]
+    if (!v) {
+        throw new Error(
+            `env ${name} is required for ZAPO_BENCH_STORE=${process.env.ZAPO_BENCH_STORE}; ` +
+                `start the docker-compose stack or use ZAPO_BENCH_STORE=memory`
+        )
+    }
+    return v
+}
+
+function parsePort(name: string): number {
+    const raw = requireEnv(name)
+    const parsed = Number.parseInt(raw, 10)
+    if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65535) {
+        throw new Error(`env ${name}=${raw} must be a valid TCP port`)
+    }
+    return parsed
+}
+
+function uniquePrefix(suffix: string): string {
+    return `bench_${process.pid.toString(36)}_${Date.now().toString(36)}_${suffix}_`
+}

--- a/packages/fake-server/bench/appstate.bench.ts
+++ b/packages/fake-server/bench/appstate.bench.ts
@@ -1,0 +1,451 @@
+/**
+ * App-state bench: measures both directions of app-state sync.
+ *
+ *   appstate_outgoing – N successive `client.chat.setChatMute(...)` calls,
+ *                       each shipped as an encrypted patch (HMAC + AES
+ *                       + protobuf encode + upload). Throughput =
+ *                       patches/sec.
+ *   appstate_incoming – server pushes ONE external `md-app-state`
+ *                       snapshot containing N mutations; we measure how
+ *                       fast the lib decrypts, verifies the HMAC chain,
+ *                       and emits `mutation` events.
+ *
+ * Tunables:
+ *   ZAPO_BENCH_APPSTATE_OUTGOING  (default 200)
+ *   ZAPO_BENCH_APPSTATE_INCOMING  (default 500)
+ *
+ * Profiling flags: same as messaging.bench. With --separate-process
+ * the fake server runs in a forked child and gets its own profiles.
+ * In that mode the FakeAppStateCollection (HMAC chain + encrypted
+ * snapshot build) ALSO runs in the child, which is the whole point –
+ * we want to isolate the lib's decrypt/verify cost from the
+ * server-side encrypt cost.
+ */
+
+import { randomBytes } from 'node:crypto'
+
+import type { WaClient, WaClientEventMap } from 'zapo-js'
+
+import { buildExternalBlobReference } from '../src/protocol/iq/appstate-sync'
+import { FakeAppStateCollection } from '../src/state/fake-app-state-collection'
+
+import {
+    BenchProfiler,
+    forceGcIfAvailable,
+    installEmergencyStop,
+    maybePrintJson,
+    printResult,
+    readPositiveIntEnv,
+    readProfilerOptions,
+    runScenario,
+    startServerProfilingIfRequested,
+    stopServerProfilingIfRequested,
+    takeServerSnapshotIfRequested,
+    type ScenarioResult
+} from './_common'
+import {
+    bringUpPairedClient,
+    bringUpPairedClientViaRpc,
+    teardownFixture,
+    teardownRpcFixture
+} from './_fixtures'
+import { buildBenchStore } from './_store-factory'
+
+type WaMutationEvent = Parameters<WaClientEventMap['mutation']>[0]
+
+function waitForMutationCount(
+    client: WaClient,
+    needed: number,
+    predicate: (event: WaMutationEvent) => boolean,
+    timeoutMs: number
+): Promise<number> {
+    return new Promise((resolve, reject) => {
+        let count = 0
+        const timer = setTimeout(
+            () => reject(new Error(`only saw ${count}/${needed} matching mutations`)),
+            timeoutMs
+        )
+        const listener: WaClientEventMap['mutation'] = (event) => {
+            if (!predicate(event)) return
+            count += 1
+            if (count >= needed) {
+                clearTimeout(timer)
+                client.off('mutation', listener)
+                resolve(count)
+            }
+        }
+        client.on('mutation', listener)
+    })
+}
+
+function buildSeedMutation(version: number) {
+    return {
+        operation: 'set' as const,
+        index: JSON.stringify(['mute', '5511555555555@s.whatsapp.net']),
+        value: { timestamp: Date.now(), muteAction: { muted: false } },
+        version
+    }
+}
+
+function buildIncomingMutations(count: number) {
+    const muteEnd = Date.now() + 60 * 60 * 1_000
+    const out = []
+    for (let i = 0; i < count; i += 1) {
+        const jid = `5511${String(7_200_000_000 + i).padStart(10, '0')}@s.whatsapp.net`
+        out.push({
+            operation: 'set' as const,
+            index: JSON.stringify(['mute', jid]),
+            value: {
+                timestamp: Date.now() - count + i,
+                muteAction: { muted: true, muteEndTimestamp: muteEnd }
+            },
+            version: 2 + i
+        })
+    }
+    return out
+}
+
+// ─── in-process scenarios ────────────────────────────────────────────
+
+async function runOutgoingScenarioInProcess(
+    ops: number,
+    profiler: BenchProfiler
+): Promise<ScenarioResult> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClient(storeFixture, {
+        sessionId: 'bench-appstate-out'
+    })
+    const { server, client, pipeline } = fixture
+
+    const syncKeyId = new Uint8Array(randomBytes(16))
+    const syncKeyData = new Uint8Array(randomBytes(32))
+    server.registerAppStateSyncKey(syncKeyId, syncKeyData)
+
+    const seedCollection = new FakeAppStateCollection({
+        name: 'regular_high',
+        keyId: syncKeyId,
+        keyData: syncKeyData
+    })
+    await seedCollection.applyMutation(buildSeedMutation(2) as never)
+    const bootstrapPatch = await seedCollection.encodePendingPatch()
+    const bootstrapVersion = seedCollection.version
+
+    let bootstrapShipped = false
+    server.provideAppStateCollection('regular_high', () => {
+        if (bootstrapShipped) {
+            return { name: 'regular_high', version: bootstrapVersion }
+        }
+        bootstrapShipped = true
+        return {
+            name: 'regular_high',
+            version: bootstrapVersion,
+            patches: [bootstrapPatch]
+        }
+    })
+
+    const peer = await server.createFakePeer(
+        { jid: '5511888888888@s.whatsapp.net', displayName: 'Primary Device' },
+        pipeline
+    )
+
+    const bootstrapApplied = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(
+            () => reject(new Error('bootstrap mutation never applied')),
+            10_000
+        )
+        const handler: WaClientEventMap['mutation'] = (event) => {
+            if (event.schema === 'Mute' && event.operation === 'set') {
+                clearTimeout(timer)
+                client.off('mutation', handler)
+                resolve()
+            }
+        }
+        client.on('mutation', handler)
+    })
+
+    await peer.sendAppStateSyncKeyShare({
+        keys: [{ keyId: syncKeyId, keyData: syncKeyData, timestamp: Date.now() }]
+    })
+    await bootstrapApplied
+
+    const scenarioName = 'appstate_outgoing'
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            ops,
+            async () => {
+                const muteEnd = Date.now() + 60 * 60 * 1_000
+                for (let i = 0; i < ops; i += 1) {
+                    const chatJid = `5511${String(7_400_000_000 + i).padStart(10, '0')}@s.whatsapp.net`
+                    await client.chat.setChatMute(chatJid, true, muteEnd)
+                }
+            },
+            'patches'
+        )
+        await profiler.afterScenario(scenarioName)
+        return result
+    } finally {
+        await teardownFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+async function runIncomingScenarioInProcess(
+    mutations: number,
+    profiler: BenchProfiler
+): Promise<ScenarioResult> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClient(storeFixture, {
+        sessionId: 'bench-appstate-in',
+        emitSnapshotMutations: true
+    })
+    const { server, client, pipeline } = fixture
+
+    const syncKeyId = new Uint8Array(randomBytes(16))
+    const syncKeyData = new Uint8Array(randomBytes(32))
+
+    const collection = new FakeAppStateCollection({
+        name: 'regular_high',
+        keyId: syncKeyId,
+        keyData: syncKeyData
+    })
+    for (const m of buildIncomingMutations(mutations)) {
+        await collection.applyMutation(m as never)
+    }
+    const snapshotBytes = await collection.encodeSnapshot()
+    const snapshotVersion = collection.version
+
+    const mediaBlob = await server.publishMediaBlob({
+        mediaType: 'md-app-state',
+        plaintext: snapshotBytes
+    })
+
+    let snapshotShipped = false
+    server.provideAppStateCollection('regular_high', () => {
+        if (snapshotShipped) return { name: 'regular_high', version: snapshotVersion }
+        snapshotShipped = true
+        return {
+            name: 'regular_high',
+            version: snapshotVersion,
+            snapshot: buildExternalBlobReference({
+                mediaKey: mediaBlob.mediaKey,
+                directPath: server.mediaUrl(mediaBlob.path),
+                fileSha256: mediaBlob.fileSha256,
+                fileEncSha256: mediaBlob.fileEncSha256,
+                fileSizeBytes: mediaBlob.fileLength
+            })
+        }
+    })
+
+    const peer = await server.createFakePeer(
+        { jid: '5511888888888@s.whatsapp.net', displayName: 'Primary Device' },
+        pipeline
+    )
+
+    const scenarioName = 'appstate_incoming'
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            mutations,
+            async () => {
+                const allMutationsSeen = waitForMutationCount(
+                    client,
+                    mutations,
+                    (event) => event.schema === 'Mute' && event.operation === 'set',
+                    180_000
+                )
+                await peer.sendAppStateSyncKeyShare({
+                    keys: [{ keyId: syncKeyId, keyData: syncKeyData, timestamp: Date.now() }]
+                })
+                await allMutationsSeen
+            },
+            'mutations'
+        )
+        await profiler.afterScenario(scenarioName)
+        return result
+    } finally {
+        await teardownFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+// ─── separate-process scenarios ───────────────────────────────────────
+
+async function runOutgoingScenarioRpc(
+    ops: number,
+    profiler: BenchProfiler,
+    argSet: ReadonlySet<string>
+): Promise<ScenarioResult> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClientViaRpc(storeFixture, {
+        sessionId: 'bench-appstate-out'
+    })
+    const { rpc, client } = fixture
+    await startServerProfilingIfRequested(rpc, profiler.options, argSet)
+    await takeServerSnapshotIfRequested(rpc, 'server-pre-outgoing', profiler.options, argSet)
+
+    const syncKeyId = new Uint8Array(randomBytes(16))
+    const syncKeyData = new Uint8Array(randomBytes(32))
+
+    // Set up bootstrap entirely on the server side – the
+    // FakeAppStateCollection encrypt cost stays out of the lib profile.
+    await rpc.setupAppStateBootstrap({
+        name: 'regular_high',
+        syncKeyId,
+        syncKeyData,
+        mutation: buildSeedMutation(2)
+    })
+    const peer = await rpc.createFakePeer({ jid: '5511888888888@s.whatsapp.net' })
+
+    const bootstrapApplied = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(
+            () => reject(new Error('bootstrap mutation never applied')),
+            10_000
+        )
+        const handler: WaClientEventMap['mutation'] = (event) => {
+            if (event.schema === 'Mute' && event.operation === 'set') {
+                clearTimeout(timer)
+                client.off('mutation', handler)
+                resolve()
+            }
+        }
+        client.on('mutation', handler)
+    })
+
+    await rpc.peerSendAppStateSyncKeyShare({
+        peerId: peer.peerId,
+        keys: [{ keyId: syncKeyId, keyData: syncKeyData, timestamp: Date.now() }]
+    })
+    await bootstrapApplied
+
+    const scenarioName = 'appstate_outgoing'
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            ops,
+            async () => {
+                const muteEnd = Date.now() + 60 * 60 * 1_000
+                for (let i = 0; i < ops; i += 1) {
+                    const chatJid = `5511${String(7_400_000_000 + i).padStart(10, '0')}@s.whatsapp.net`
+                    await client.chat.setChatMute(chatJid, true, muteEnd)
+                }
+            },
+            'patches'
+        )
+        await profiler.afterScenario(scenarioName)
+        await takeServerSnapshotIfRequested(rpc, 'server-post-outgoing', profiler.options, argSet)
+        await stopServerProfilingIfRequested(rpc, profiler.options, argSet)
+        return result
+    } finally {
+        await teardownRpcFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+async function runIncomingScenarioRpc(
+    mutations: number,
+    profiler: BenchProfiler,
+    argSet: ReadonlySet<string>
+): Promise<ScenarioResult> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClientViaRpc(storeFixture, {
+        sessionId: 'bench-appstate-in',
+        emitSnapshotMutations: true
+    })
+    const { rpc, client } = fixture
+    await startServerProfilingIfRequested(rpc, profiler.options, argSet)
+    await takeServerSnapshotIfRequested(rpc, 'server-pre-incoming', profiler.options, argSet)
+
+    const syncKeyId = new Uint8Array(randomBytes(16))
+    const syncKeyData = new Uint8Array(randomBytes(32))
+
+    await rpc.setupAppStateExternalSnapshot({
+        name: 'regular_high',
+        syncKeyId,
+        syncKeyData,
+        mutations: buildIncomingMutations(mutations)
+    })
+    const peer = await rpc.createFakePeer({ jid: '5511888888888@s.whatsapp.net' })
+
+    const scenarioName = 'appstate_incoming'
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            mutations,
+            async () => {
+                const allMutationsSeen = waitForMutationCount(
+                    client,
+                    mutations,
+                    (event) => event.schema === 'Mute' && event.operation === 'set',
+                    180_000
+                )
+                await rpc.peerSendAppStateSyncKeyShare({
+                    peerId: peer.peerId,
+                    keys: [{ keyId: syncKeyId, keyData: syncKeyData, timestamp: Date.now() }]
+                })
+                await allMutationsSeen
+            },
+            'mutations'
+        )
+        await profiler.afterScenario(scenarioName)
+        await takeServerSnapshotIfRequested(rpc, 'server-post-incoming', profiler.options, argSet)
+        await stopServerProfilingIfRequested(rpc, profiler.options, argSet)
+        return result
+    } finally {
+        await teardownRpcFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+async function main(): Promise<void> {
+    installEmergencyStop()
+    const argSet = new Set(process.argv.slice(2))
+    const profiler = new BenchProfiler(readProfilerOptions(argSet))
+    await profiler.start()
+
+    const outgoingOps = readPositiveIntEnv('ZAPO_BENCH_APPSTATE_OUTGOING', 200)
+    const incomingOps = readPositiveIntEnv('ZAPO_BENCH_APPSTATE_INCOMING', 500)
+    const backendName = process.env.ZAPO_BENCH_STORE ?? 'memory'
+    const separate = argSet.has('--separate-process')
+
+    console.log('zapo-js appstate bench')
+    console.log('──────────────────────')
+    console.log(`  outgoing patches  : ${outgoingOps}`)
+    console.log(`  incoming mutations: ${incomingOps}`)
+    console.log(`  store             : ${backendName}`)
+    console.log(`  mode              : ${separate ? 'separate-process' : 'in-process'}`)
+    console.log('')
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('start').catch((err) => console.error('[snapshot]', err))
+    }
+
+    const results: ScenarioResult[] = []
+    const out = separate
+        ? await runOutgoingScenarioRpc(outgoingOps, profiler, argSet)
+        : await runOutgoingScenarioInProcess(outgoingOps, profiler)
+    results.push(out)
+    printResult(out)
+
+    const inc = separate
+        ? await runIncomingScenarioRpc(incomingOps, profiler, argSet)
+        : await runIncomingScenarioInProcess(incomingOps, profiler)
+    results.push(inc)
+    printResult(inc)
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('end').catch((err) => console.error('[snapshot]', err))
+    }
+    await profiler.stop()
+
+    maybePrintJson(results)
+}
+
+void main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/fake-server/bench/bulk-usync.bench.ts
+++ b/packages/fake-server/bench/bulk-usync.bench.ts
@@ -1,0 +1,205 @@
+/**
+ * Bulk USync bench: exercises the lib's device-list refresh + first-send
+ * fanout path. Each scenario builds a fresh group with N members (each
+ * with K devices), then times the FIRST message send – which forces the
+ * lib to:
+ *   1. USync the entire member list (1 IQ, ~N JIDs)
+ *   2. Fetch missing prekey bundles (1 IQ per missing device)
+ *   3. Run X3DH for every device (parallel)
+ *   4. Build + ship sender-key distribution + the encrypted message
+ *
+ * Compared to the steady-state SEND-group bench, this isolates the
+ * cold path (no cached device list, no existing Signal session) which
+ * exercises USync parse + device-list store + Signal session init
+ * heavily.
+ *
+ * Tunables:
+ *   ZAPO_BENCH_USYNC_SIZES   csv (default "50,200,500")
+ *   ZAPO_BENCH_USYNC_DEVICES (default 1) devices per member
+ *
+ * Profiling flags: same as messaging.bench. With --separate-process
+ * the fake server runs in a forked child and gets its own
+ * cpu-server-* / snapshot-server-* outputs.
+ */
+
+import { performance } from 'node:perf_hooks'
+
+import {
+    BenchProfiler,
+    forceGcIfAvailable,
+    formatMs,
+    installEmergencyStop,
+    maybePrintJson,
+    printResult,
+    readCsvEnv,
+    readPositiveIntEnv,
+    readProfilerOptions,
+    runScenario,
+    startServerProfilingIfRequested,
+    stopServerProfilingIfRequested,
+    takeServerSnapshotIfRequested,
+    type ScenarioResult
+} from './_common'
+import {
+    bringUpPairedClient,
+    bringUpPairedClientViaRpc,
+    ensurePreKeyPool,
+    teardownFixture,
+    teardownRpcFixture
+} from './_fixtures'
+import { buildBenchStore } from './_store-factory'
+
+async function runUsyncScenarioInProcess(
+    memberCount: number,
+    devicesPerMember: number,
+    profiler: BenchProfiler,
+    iteration: number
+): Promise<ScenarioResult> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClient(storeFixture, {
+        sessionId: `bench-usync-${memberCount}-${iteration}`
+    })
+    const { server, client, pipeline } = fixture
+
+    const groupJid = `120363${String(900_000_500_000 + iteration).padStart(15, '0')}@g.us`
+    const members = []
+    const deviceIds = Array.from({ length: devicesPerMember }, (_, idx) => idx + 1)
+    for (let m = 0; m < memberCount; m += 1) {
+        await ensurePreKeyPool(server, pipeline, devicesPerMember)
+        const jid = `5511${String(8_500_000_000 + iteration * 100_000 + m).padStart(10, '0')}@s.whatsapp.net`
+        const peers = await server.createFakePeerWithDevices({ userJid: jid, deviceIds }, pipeline)
+        members.push(peers[0])
+    }
+    server.createFakeGroup({
+        groupJid,
+        subject: `Bench USync Group ${iteration}`,
+        participants: members
+    })
+
+    const scenarioName = `usync_${memberCount}members_${devicesPerMember}dev`
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            memberCount * devicesPerMember,
+            async () => {
+                await client.message.send(groupJid, { conversation: 'bulk-usync first send' })
+            },
+            'devices'
+        )
+        await profiler.afterScenario(scenarioName)
+        return result
+    } finally {
+        await teardownFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+async function runUsyncScenarioRpc(
+    memberCount: number,
+    devicesPerMember: number,
+    profiler: BenchProfiler,
+    iteration: number,
+    argSet: ReadonlySet<string>
+): Promise<ScenarioResult> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClientViaRpc(storeFixture, {
+        sessionId: `bench-usync-${memberCount}-${iteration}`
+    })
+    const { rpc, client } = fixture
+    await startServerProfilingIfRequested(rpc, profiler.options, argSet)
+    await takeServerSnapshotIfRequested(rpc, `server-pre-${memberCount}m`, profiler.options, argSet)
+
+    const groupJid = `120363${String(900_000_500_000 + iteration).padStart(15, '0')}@g.us`
+    const deviceIds = Array.from({ length: devicesPerMember }, (_, idx) => idx + 1)
+    const memberPeerIds: string[] = []
+    for (let m = 0; m < memberCount; m += 1) {
+        await rpc.ensurePreKeyPool(devicesPerMember)
+        const jid = `5511${String(8_500_000_000 + iteration * 100_000 + m).padStart(10, '0')}@s.whatsapp.net`
+        const result = await rpc.createFakePeerWithDevices({ userJid: jid, deviceIds })
+        memberPeerIds.push(result.devicePeerIds[0])
+    }
+    await rpc.createFakeGroup({
+        groupJid,
+        subject: `Bench USync Group ${iteration}`,
+        participantPeerIds: memberPeerIds
+    })
+
+    const scenarioName = `usync_${memberCount}members_${devicesPerMember}dev`
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            memberCount * devicesPerMember,
+            async () => {
+                await client.message.send(groupJid, { conversation: 'bulk-usync first send' })
+            },
+            'devices'
+        )
+        await profiler.afterScenario(scenarioName)
+        await takeServerSnapshotIfRequested(
+            rpc,
+            `server-post-${memberCount}m`,
+            profiler.options,
+            argSet
+        )
+        await stopServerProfilingIfRequested(rpc, profiler.options, argSet)
+        return result
+    } finally {
+        await teardownRpcFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+async function main(): Promise<void> {
+    installEmergencyStop()
+    const argSet = new Set(process.argv.slice(2))
+    const profiler = new BenchProfiler(readProfilerOptions(argSet))
+    await profiler.start()
+
+    const sizes = readCsvEnv('ZAPO_BENCH_USYNC_SIZES', ['50', '200', '500']).map((s) => {
+        const n = Number.parseInt(s, 10)
+        if (!Number.isFinite(n) || n <= 0) throw new Error(`invalid size "${s}"`)
+        return n
+    })
+    const devicesPerMember = readPositiveIntEnv('ZAPO_BENCH_USYNC_DEVICES', 1)
+    const backendName = process.env.ZAPO_BENCH_STORE ?? 'memory'
+    const separate = argSet.has('--separate-process')
+
+    console.log('zapo-js bulk-usync bench')
+    console.log('────────────────────────')
+    console.log(`  member counts  : ${sizes.join(', ')}`)
+    console.log(`  devices/member : ${devicesPerMember}`)
+    console.log(`  store          : ${backendName}`)
+    console.log(`  mode           : ${separate ? 'separate-process' : 'in-process'}`)
+    console.log('')
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('start').catch((err) => console.error('[snapshot]', err))
+    }
+
+    const results: ScenarioResult[] = []
+    for (let i = 0; i < sizes.length; i += 1) {
+        const memberCount = sizes[i]
+        const setupStart = performance.now()
+        console.log(`▶ running ${memberCount} members × ${devicesPerMember} devices...`)
+        const result = separate
+            ? await runUsyncScenarioRpc(memberCount, devicesPerMember, profiler, i, argSet)
+            : await runUsyncScenarioInProcess(memberCount, devicesPerMember, profiler, i)
+        console.log(`  (full run incl. fixture build: ${formatMs(performance.now() - setupStart)})`)
+        results.push(result)
+        printResult(result)
+    }
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('end').catch((err) => console.error('[snapshot]', err))
+    }
+    await profiler.stop()
+
+    maybePrintJson(results)
+}
+
+void main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/fake-server/bench/connect-lifecycle.bench.ts
+++ b/packages/fake-server/bench/connect-lifecycle.bench.ts
@@ -1,0 +1,442 @@
+/**
+ * Cold-start lifecycle bench: measure `new WaClient()` → `auth_paired`
+ * → `connection_open` over N iterations against a FRESH server + store
+ * each time. Surfaces the bootstrap cost that the steady-state
+ * messaging bench amortizes away by pairing only once.
+ *
+ * Per-stage timing:
+ *   T0  client.connect() begins
+ *   T1  server sees authenticated pipeline (post handshake)
+ *   T2  client emits `auth_qr` (QR string ready)
+ *   T3  client emits `auth_paired` (pairing flow done)
+ *   T4  client emits `connection_open` (initial sync done, ready)
+ *
+ * Tunables:
+ *   ZAPO_BENCH_CONNECT_ITERATIONS  (default 10)
+ *
+ * Profiling flags: same as the messaging bench
+ *   --cpu --heap --snapshot --per-scenario --snapshot-per-scenario
+ *   --out-dir=<path>
+ */
+
+import { performance } from 'node:perf_hooks'
+
+import { WaClient, type WaClientEventMap } from 'zapo-js'
+
+import { FakeWaServer } from '../src/api/FakeWaServer'
+import { parsePairingQrString } from '../src/protocol/auth/pair-device'
+
+import {
+    BenchProfiler,
+    forceGcIfAvailable,
+    formatFixed,
+    formatMs,
+    installEmergencyStop,
+    maybePrintJson,
+    NOOP_LOGGER,
+    printResult,
+    readPositiveIntEnv,
+    readProfilerOptions,
+    runScenario,
+    type ScenarioResult,
+    snapshotMemory
+} from './_common'
+import { buildBenchStore } from './_store-factory'
+import { ServerRpc } from './server-rpc'
+
+interface StageTimings {
+    readonly connectStartedAt: number
+    readonly authenticatedPipelineAt: number
+    readonly authQrAt: number
+    readonly authPairedAt: number
+    readonly connectionOpenAt: number
+}
+
+interface IterationResult {
+    readonly timings: StageTimings
+    readonly handshakeMs: number
+    readonly qrMs: number
+    readonly pairedMs: number
+    readonly readyMs: number
+    readonly totalMs: number
+}
+
+async function runOneIterationRpc(
+    iteration: number,
+    captureServerProfile: { cpu: boolean; heap: boolean; outDir: string } | null,
+    serverSnapshotLabel: string | null
+): Promise<IterationResult> {
+    const storeFixture = await buildBenchStore()
+    const rpc = new ServerRpc()
+    await rpc.spawn()
+    await rpc.start()
+    if (captureServerProfile && (captureServerProfile.cpu || captureServerProfile.heap)) {
+        await rpc.startProfiling(captureServerProfile)
+    }
+    if (serverSnapshotLabel && captureServerProfile) {
+        await rpc
+            .takeSnapshot(`server-${serverSnapshotLabel}-pre`, captureServerProfile.outDir)
+            .then(
+                (p) => console.log(`[server:snapshot] ${p}`),
+                (err) => console.error('[server:snapshot]', err)
+            )
+    }
+
+    const client = new WaClient(
+        {
+            store: storeFixture.store,
+            sessionId: `zapo-connect-bench-rpc-${iteration}`,
+            chatSocketUrls: [rpc.serverUrl],
+            connectTimeoutMs: 60_000,
+            proxy: {
+                mediaUpload: rpc.mediaProxyAgent!,
+                mediaDownload: rpc.mediaProxyAgent!
+            },
+            testHooks: {
+                noiseRootCa: rpc.noiseRootCa
+            }
+        },
+        NOOP_LOGGER
+    )
+
+    const meDeviceJid = '5511999999999:1@s.whatsapp.net'
+
+    let authQrAt = 0
+    client.once('auth_qr', (event: Parameters<WaClientEventMap['auth_qr']>[0]) => {
+        authQrAt = performance.now()
+        const parsed = parsePairingQrString(event.qr)
+        rpc.sendPairingMaterial({
+            advSecretKey: parsed.advSecretKey,
+            identityPublicKey: parsed.identityPublicKey
+        })
+    })
+
+    let authPairedAt = 0
+    const pairedPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('auth_paired timeout')), 60_000)
+        client.once('auth_paired', () => {
+            authPairedAt = performance.now()
+            clearTimeout(timer)
+            resolve()
+        })
+    })
+
+    let connectionOpenAt = 0
+    const openPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('connection open timeout')), 60_000)
+        const listener: WaClientEventMap['connection'] = (event) => {
+            if (event.status !== 'open') return
+            connectionOpenAt = performance.now()
+            clearTimeout(timer)
+            client.off('connection', listener)
+            resolve()
+        }
+        client.on('connection', listener)
+    })
+
+    const connectStartedAt = performance.now()
+    try {
+        const connectPromise = client.connect()
+        await rpc.waitForAuthenticatedPipeline()
+        const authenticatedPipelineAt = performance.now()
+        const pairPromise = rpc.runPairing(meDeviceJid)
+        const waitNext = rpc.waitForNextAuthenticatedPipeline()
+        await connectPromise
+        await pairedPromise
+        await pairPromise
+        await waitNext
+        await rpc.triggerPreKeyUpload()
+        await openPromise
+
+        return {
+            timings: {
+                connectStartedAt,
+                authenticatedPipelineAt,
+                authQrAt,
+                authPairedAt,
+                connectionOpenAt
+            },
+            handshakeMs: authenticatedPipelineAt - connectStartedAt,
+            qrMs: authQrAt - connectStartedAt,
+            pairedMs: authPairedAt - connectStartedAt,
+            readyMs: connectionOpenAt - connectStartedAt,
+            totalMs: connectionOpenAt - connectStartedAt
+        }
+    } finally {
+        if (serverSnapshotLabel && captureServerProfile) {
+            await rpc
+                .takeSnapshot(`server-${serverSnapshotLabel}-post`, captureServerProfile.outDir)
+                .then(
+                    (p) => console.log(`[server:snapshot] ${p}`),
+                    (err) => console.error('[server:snapshot]', err)
+                )
+        }
+        if (captureServerProfile && (captureServerProfile.cpu || captureServerProfile.heap)) {
+            const paths = await rpc
+                .stopProfiling(captureServerProfile)
+                .catch((): { cpuPath?: string; heapPath?: string } => ({}))
+            if (paths.cpuPath) console.log(`[server:cpu iter ${iteration}] ${paths.cpuPath}`)
+            if (paths.heapPath) console.log(`[server:heap iter ${iteration}] ${paths.heapPath}`)
+        }
+        await client.disconnect().catch(() => undefined)
+        await rpc.stop().catch(() => undefined)
+        await storeFixture.destroy().catch(() => undefined)
+        forceGcIfAvailable()
+    }
+}
+
+async function runOneIteration(iteration: number): Promise<IterationResult> {
+    const storeFixture = await buildBenchStore()
+    const server = await FakeWaServer.start()
+    const client = new WaClient(
+        {
+            store: storeFixture.store,
+            sessionId: `zapo-connect-bench-${iteration}`,
+            chatSocketUrls: [server.url],
+            connectTimeoutMs: 60_000,
+            proxy: {
+                mediaUpload: server.mediaProxyAgent,
+                mediaDownload: server.mediaProxyAgent
+            },
+            testHooks: {
+                noiseRootCa: server.noiseRootCa
+            }
+        },
+        NOOP_LOGGER
+    )
+
+    const meDeviceJid = '5511999999999:1@s.whatsapp.net'
+
+    let authQrAt = 0
+    const materialPromise = new Promise<{
+        readonly advSecretKey: Uint8Array
+        readonly identityPublicKey: Uint8Array
+    }>((resolve) => {
+        client.once('auth_qr', (event: Parameters<WaClientEventMap['auth_qr']>[0]) => {
+            authQrAt = performance.now()
+            const parsed = parsePairingQrString(event.qr)
+            resolve({
+                advSecretKey: parsed.advSecretKey,
+                identityPublicKey: parsed.identityPublicKey
+            })
+        })
+    })
+
+    let authPairedAt = 0
+    const pairedPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('auth_paired timeout')), 60_000)
+        client.once('auth_paired', () => {
+            authPairedAt = performance.now()
+            clearTimeout(timer)
+            resolve()
+        })
+    })
+
+    let connectionOpenAt = 0
+    const openPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('connection open timeout')), 60_000)
+        const listener: WaClientEventMap['connection'] = (event) => {
+            if (event.status !== 'open') return
+            connectionOpenAt = performance.now()
+            clearTimeout(timer)
+            client.off('connection', listener)
+            resolve()
+        }
+        client.on('connection', listener)
+    })
+
+    const connectStartedAt = performance.now()
+    try {
+        const connectPromise = client.connect()
+        const pipeline = await server.waitForAuthenticatedPipeline()
+        const authenticatedPipelineAt = performance.now()
+
+        await server.runPairing(pipeline, { deviceJid: meDeviceJid }, () => materialPromise)
+        await connectPromise
+        await pairedPromise
+        const pipelineAfterPair = await server.waitForNextAuthenticatedPipeline()
+        await server.triggerPreKeyUpload(pipelineAfterPair)
+        await openPromise
+
+        return {
+            timings: {
+                connectStartedAt,
+                authenticatedPipelineAt,
+                authQrAt,
+                authPairedAt,
+                connectionOpenAt
+            },
+            handshakeMs: authenticatedPipelineAt - connectStartedAt,
+            qrMs: authQrAt - connectStartedAt,
+            pairedMs: authPairedAt - connectStartedAt,
+            readyMs: connectionOpenAt - connectStartedAt,
+            totalMs: connectionOpenAt - connectStartedAt
+        }
+    } finally {
+        await client.disconnect().catch(() => undefined)
+        await server.stop().catch(() => undefined)
+        await storeFixture.destroy().catch(() => undefined)
+        forceGcIfAvailable()
+    }
+}
+
+function quantile(samples: readonly number[], q: number): number {
+    if (samples.length === 0) return 0
+    const sorted = [...samples].sort((a, b) => a - b)
+    const idx = Math.min(sorted.length - 1, Math.floor(q * sorted.length))
+    return sorted[idx]
+}
+
+function median(samples: readonly number[]): number {
+    return quantile(samples, 0.5)
+}
+
+async function runConnectScenario(
+    iterations: number,
+    mode: 'in-process' | 'separate-process',
+    serverProfileOpts: { cpu: boolean; heap: boolean; outDir: string } | null,
+    serverSnapshot: boolean
+): Promise<{
+    result: ScenarioResult
+    perStage: { name: string; median: number; p95: number; min: number; max: number }[]
+}> {
+    const results: IterationResult[] = []
+    // Server snapshots only on first and last iteration – capturing one
+    // per iteration would be wasteful (10+ snapshots of identical state).
+    const runOne = (i: number): Promise<IterationResult> => {
+        if (mode !== 'separate-process') return runOneIteration(i)
+        const snapshotLabel = serverSnapshot
+            ? i === 0
+                ? 'first'
+                : i === iterations - 1
+                  ? 'last'
+                  : null
+            : null
+        return runOneIterationRpc(i, serverProfileOpts, snapshotLabel)
+    }
+
+    // warm-up: 1 iteration (excluded from stats) to avoid JIT / module-init bias
+    if (iterations > 1) {
+        await runOne(-1)
+        forceGcIfAvailable()
+    }
+
+    const scenario = await runScenario(
+        'connect_lifecycle',
+        iterations,
+        async () => {
+            for (let i = 0; i < iterations; i += 1) {
+                results.push(await runOne(i))
+            }
+        },
+        'iterations'
+    )
+
+    const handshake = results.map((r) => r.handshakeMs)
+    const qr = results.map((r) => r.qrMs)
+    const paired = results.map((r) => r.pairedMs)
+    const ready = results.map((r) => r.readyMs)
+
+    return {
+        result: scenario,
+        perStage: [
+            {
+                name: 'connect → handshake done',
+                median: median(handshake),
+                p95: quantile(handshake, 0.95),
+                min: Math.min(...handshake),
+                max: Math.max(...handshake)
+            },
+            {
+                name: 'connect → QR emitted',
+                median: median(qr),
+                p95: quantile(qr, 0.95),
+                min: Math.min(...qr),
+                max: Math.max(...qr)
+            },
+            {
+                name: 'connect → auth_paired',
+                median: median(paired),
+                p95: quantile(paired, 0.95),
+                min: Math.min(...paired),
+                max: Math.max(...paired)
+            },
+            {
+                name: 'connect → ready',
+                median: median(ready),
+                p95: quantile(ready, 0.95),
+                min: Math.min(...ready),
+                max: Math.max(...ready)
+            }
+        ]
+    }
+}
+
+async function main(): Promise<void> {
+    installEmergencyStop()
+    const argSet = new Set(process.argv.slice(2))
+    const profiler = new BenchProfiler(readProfilerOptions(argSet))
+    await profiler.start()
+
+    const iterations = readPositiveIntEnv('ZAPO_BENCH_CONNECT_ITERATIONS', 10)
+    const backendName = process.env.ZAPO_BENCH_STORE ?? 'memory'
+    const separate = argSet.has('--separate-process')
+
+    console.log('zapo-js connect-lifecycle bench')
+    console.log('───────────────────────────────')
+    console.log(`  iterations  : ${iterations}`)
+    console.log(`  store       : ${backendName}`)
+    console.log(`  mode        : ${separate ? 'separate-process (server per iter)' : 'in-process'}`)
+    console.log('')
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('start').catch((err) => console.error('[snapshot]', err))
+    }
+
+    // Server profile (only meaningful in separate-process mode) -
+    // captured per-iteration since each iter spawns a new child.
+    const serverProfileOpts =
+        separate &&
+        !argSet.has('--no-server-prof') &&
+        (profiler.options.cpu || profiler.options.heap)
+            ? {
+                  cpu: profiler.options.cpu,
+                  heap: profiler.options.heap,
+                  outDir: profiler.options.outDir
+              }
+            : null
+
+    const { result, perStage } = await runConnectScenario(
+        iterations,
+        separate ? 'separate-process' : 'in-process',
+        serverProfileOpts,
+        separate && argSet.has('--snapshot')
+    )
+
+    // Memory before / after the whole bench
+    const memNow = snapshotMemory()
+    printResult(result)
+
+    console.log('Per-stage timing (median / p95 / min / max):')
+    for (const s of perStage) {
+        console.log(
+            `  ${s.name.padEnd(28)}: ${formatMs(s.median).padStart(10)}  /  ${formatMs(s.p95).padStart(10)}  /  ${formatMs(s.min).padStart(10)}  /  ${formatMs(s.max).padStart(10)}`
+        )
+    }
+    console.log(
+        `  final RSS / heap: ${formatFixed(memNow.rss / 1_048_576, 1)} MiB / ${formatFixed(memNow.heap / 1_048_576, 1)} MiB`
+    )
+    console.log('')
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('end').catch((err) => console.error('[snapshot]', err))
+    }
+    await profiler.stop()
+
+    maybePrintJson([result])
+}
+
+void main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/fake-server/bench/group-provision.bench.ts
+++ b/packages/fake-server/bench/group-provision.bench.ts
@@ -1,0 +1,346 @@
+/**
+ * Group provisioning bench: measures the IQ round-trip cost of creating
+ * groups + adding participants. Exercises the retry-tracker, IQ
+ * orchestration, group-metadata store, and (indirectly) the sender-key
+ * fanout that follows.
+ *
+ * Two scenarios per run:
+ *   create_group   – N successive `createGroup(name, jids[K])` calls
+ *   add_participants – 1 group, N successive `addParticipants(group, [jid])`
+ *                      calls (per-jid, sequential)
+ *
+ * Tunables:
+ *   ZAPO_BENCH_GROUP_OPS         (default 100)  ops per scenario
+ *   ZAPO_BENCH_GROUP_MEMBERS_PER_CREATE (default 5) jids per group on create
+ *
+ * Profiling flags: same as messaging.bench. With --separate-process
+ * the fake server runs in a forked child and gets its own profiles.
+ */
+
+import type { FakeWaServer } from '../src/api/FakeWaServer'
+import { buildIqResult } from '../src/protocol/iq/router'
+import type { BinaryNode } from '../src/transport/codec'
+
+import {
+    BenchProfiler,
+    forceGcIfAvailable,
+    installEmergencyStop,
+    maybePrintJson,
+    printResult,
+    readPositiveIntEnv,
+    readProfilerOptions,
+    runScenario,
+    startServerProfilingIfRequested,
+    stopServerProfilingIfRequested,
+    takeServerSnapshotIfRequested,
+    type ScenarioResult
+} from './_common'
+import {
+    bringUpPairedClient,
+    bringUpPairedClientViaRpc,
+    teardownFixture,
+    teardownRpcFixture
+} from './_fixtures'
+import { buildBenchStore } from './_store-factory'
+
+function findChild(node: BinaryNode, tag: string): BinaryNode | undefined {
+    if (!Array.isArray(node.content)) return undefined
+    return node.content.find((child) => child.tag === tag)
+}
+
+function attachGroupHandlersInProcess(server: FakeWaServer): void {
+    server.registerIqHandler(
+        { xmlns: 'w:g2', type: 'set', childTag: 'create' },
+        (iq) => {
+            const create = findChild(iq, 'create')
+            const participantJids: string[] = []
+            if (create && Array.isArray(create.content)) {
+                for (const child of create.content) {
+                    if (child.tag === 'participant' && child.attrs.jid) {
+                        participantJids.push(child.attrs.jid)
+                    }
+                }
+            }
+            const result = buildIqResult(iq)
+            const fakeGroupJid = `120363${String(900_000_700_000 + Math.floor(Math.random() * 1_000_000)).padStart(15, '0')}@g.us`
+            return {
+                ...result,
+                attrs: { ...result.attrs, from: '@g.us' },
+                content: [
+                    {
+                        tag: 'group',
+                        attrs: {
+                            id: fakeGroupJid,
+                            subject: create?.attrs.subject ?? 'New Group',
+                            creation: String(Math.floor(Date.now() / 1_000)),
+                            creator: participantJids[0] ?? ''
+                        },
+                        content: participantJids.map((jid) => ({
+                            tag: 'participant',
+                            attrs: { jid, add_request: 'success' }
+                        }))
+                    }
+                ]
+            }
+        },
+        'bench-group-create'
+    )
+    for (const action of ['add', 'remove', 'promote', 'demote'] as const) {
+        server.registerIqHandler(
+            { xmlns: 'w:g2', type: 'set', childTag: action },
+            (iq) => {
+                const actionNode = findChild(iq, action)
+                const participants =
+                    actionNode && Array.isArray(actionNode.content)
+                        ? actionNode.content.filter((c) => c.tag === 'participant')
+                        : []
+                const result = buildIqResult(iq)
+                return {
+                    ...result,
+                    content: [
+                        {
+                            tag: action,
+                            attrs: actionNode?.attrs ?? {},
+                            content: participants.map((p) => ({
+                                tag: 'participant',
+                                attrs: { ...p.attrs, add_request: 'success' }
+                            }))
+                        }
+                    ]
+                }
+            },
+            `bench-group-${action}`
+        )
+    }
+}
+
+interface GroupBenchConfig {
+    readonly ops: number
+    readonly membersPerCreate: number
+}
+
+type GroupCreateResult = { id?: string; jid?: string }
+
+function extractGroupJid(result: unknown): string {
+    const r = result as GroupCreateResult
+    return r.id ?? r.jid ?? ''
+}
+
+// ─── in-process scenarios ────────────────────────────────────────────
+
+async function runCreateGroupScenarioInProcess(
+    config: GroupBenchConfig,
+    profiler: BenchProfiler
+): Promise<ScenarioResult> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClient(storeFixture, { sessionId: 'bench-group-create' })
+    const { server, client } = fixture
+    attachGroupHandlersInProcess(server)
+
+    const scenarioName = 'create_group'
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            config.ops,
+            async () => {
+                for (let i = 0; i < config.ops; i += 1) {
+                    const jids = Array.from(
+                        { length: config.membersPerCreate },
+                        (_, k) =>
+                            `5511${String(7_700_000_000 + i * 10_000 + k).padStart(10, '0')}@s.whatsapp.net`
+                    )
+                    await client.group.createGroup(`Bench Group ${i}`, jids)
+                }
+            },
+            'groups'
+        )
+        await profiler.afterScenario(scenarioName)
+        return result
+    } finally {
+        await teardownFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+async function runAddParticipantsScenarioInProcess(
+    config: GroupBenchConfig,
+    profiler: BenchProfiler
+): Promise<ScenarioResult> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClient(storeFixture, {
+        sessionId: 'bench-group-addparts'
+    })
+    const { server, client } = fixture
+    attachGroupHandlersInProcess(server)
+
+    const seedJids = Array.from(
+        { length: config.membersPerCreate },
+        (_, k) => `5511${String(7_800_000_000 + k).padStart(10, '0')}@s.whatsapp.net`
+    )
+    const groupResult = await client.group.createGroup('Bench Add-Parts Group', seedJids)
+    const groupJid = extractGroupJid(groupResult)
+    if (!groupJid) throw new Error('group create returned no jid')
+
+    const scenarioName = 'add_participants'
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            config.ops,
+            async () => {
+                for (let i = 0; i < config.ops; i += 1) {
+                    const jid = `5511${String(7_900_000_000 + i).padStart(10, '0')}@s.whatsapp.net`
+                    await client.group.addParticipants(groupJid, [jid])
+                }
+            },
+            'adds'
+        )
+        await profiler.afterScenario(scenarioName)
+        return result
+    } finally {
+        await teardownFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+// ─── separate-process scenarios ───────────────────────────────────────
+
+async function runCreateGroupScenarioRpc(
+    config: GroupBenchConfig,
+    profiler: BenchProfiler,
+    argSet: ReadonlySet<string>
+): Promise<ScenarioResult> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClientViaRpc(storeFixture, {
+        sessionId: 'bench-group-create'
+    })
+    const { rpc, client } = fixture
+    await startServerProfilingIfRequested(rpc, profiler.options, argSet)
+    await takeServerSnapshotIfRequested(rpc, 'server-pre-create', profiler.options, argSet)
+    await rpc.setupGroupBenchHandlers()
+
+    const scenarioName = 'create_group'
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            config.ops,
+            async () => {
+                for (let i = 0; i < config.ops; i += 1) {
+                    const jids = Array.from(
+                        { length: config.membersPerCreate },
+                        (_, k) =>
+                            `5511${String(7_700_000_000 + i * 10_000 + k).padStart(10, '0')}@s.whatsapp.net`
+                    )
+                    await client.group.createGroup(`Bench Group ${i}`, jids)
+                }
+            },
+            'groups'
+        )
+        await profiler.afterScenario(scenarioName)
+        await takeServerSnapshotIfRequested(rpc, 'server-post-create', profiler.options, argSet)
+        await stopServerProfilingIfRequested(rpc, profiler.options, argSet)
+        return result
+    } finally {
+        await teardownRpcFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+async function runAddParticipantsScenarioRpc(
+    config: GroupBenchConfig,
+    profiler: BenchProfiler,
+    argSet: ReadonlySet<string>
+): Promise<ScenarioResult> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClientViaRpc(storeFixture, {
+        sessionId: 'bench-group-addparts'
+    })
+    const { rpc, client } = fixture
+    await startServerProfilingIfRequested(rpc, profiler.options, argSet)
+    await takeServerSnapshotIfRequested(rpc, 'server-pre-addparts', profiler.options, argSet)
+    await rpc.setupGroupBenchHandlers()
+
+    const seedJids = Array.from(
+        { length: config.membersPerCreate },
+        (_, k) => `5511${String(7_800_000_000 + k).padStart(10, '0')}@s.whatsapp.net`
+    )
+    const groupResult = await client.group.createGroup('Bench Add-Parts Group', seedJids)
+    const groupJid = extractGroupJid(groupResult)
+    if (!groupJid) throw new Error('group create returned no jid')
+
+    const scenarioName = 'add_participants'
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            config.ops,
+            async () => {
+                for (let i = 0; i < config.ops; i += 1) {
+                    const jid = `5511${String(7_900_000_000 + i).padStart(10, '0')}@s.whatsapp.net`
+                    await client.group.addParticipants(groupJid, [jid])
+                }
+            },
+            'adds'
+        )
+        await profiler.afterScenario(scenarioName)
+        await takeServerSnapshotIfRequested(rpc, 'server-post-addparts', profiler.options, argSet)
+        await stopServerProfilingIfRequested(rpc, profiler.options, argSet)
+        return result
+    } finally {
+        await teardownRpcFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+async function main(): Promise<void> {
+    installEmergencyStop()
+    const argSet = new Set(process.argv.slice(2))
+    const profiler = new BenchProfiler(readProfilerOptions(argSet))
+    await profiler.start()
+
+    const config: GroupBenchConfig = {
+        ops: readPositiveIntEnv('ZAPO_BENCH_GROUP_OPS', 100),
+        membersPerCreate: readPositiveIntEnv('ZAPO_BENCH_GROUP_MEMBERS_PER_CREATE', 5)
+    }
+    const backendName = process.env.ZAPO_BENCH_STORE ?? 'memory'
+    const separate = argSet.has('--separate-process')
+
+    console.log('zapo-js group-provision bench')
+    console.log('─────────────────────────────')
+    console.log(`  ops / scenario     : ${config.ops}`)
+    console.log(`  members per create : ${config.membersPerCreate}`)
+    console.log(`  store              : ${backendName}`)
+    console.log(`  mode               : ${separate ? 'separate-process' : 'in-process'}`)
+    console.log('')
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('start').catch((err) => console.error('[snapshot]', err))
+    }
+
+    const results: ScenarioResult[] = []
+    const createResult = separate
+        ? await runCreateGroupScenarioRpc(config, profiler, argSet)
+        : await runCreateGroupScenarioInProcess(config, profiler)
+    results.push(createResult)
+    printResult(createResult)
+
+    const addResult = separate
+        ? await runAddParticipantsScenarioRpc(config, profiler, argSet)
+        : await runAddParticipantsScenarioInProcess(config, profiler)
+    results.push(addResult)
+    printResult(addResult)
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('end').catch((err) => console.error('[snapshot]', err))
+    }
+    await profiler.stop()
+
+    maybePrintJson(results)
+}
+
+void main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/fake-server/bench/history-sync.bench.ts
+++ b/packages/fake-server/bench/history-sync.bench.ts
@@ -125,46 +125,49 @@ async function runHistoryScenarioInProcess(
             totalMessages,
             async () => {
                 let receivedChunks = 0
-                const allChunksDone = new Promise<void>((resolve, reject) => {
-                    const timer = setTimeout(
-                        () =>
-                            reject(
-                                new Error(
-                                    `history-sync stalled at chunk ${receivedChunks}/${chunks}`
-                                )
-                            ),
-                        180_000
-                    )
-                    const listener: WaClientEventMap['history_sync_chunk'] = () => {
-                        receivedChunks += 1
-                        if (receivedChunks >= chunks) {
-                            clearTimeout(timer)
-                            client.off('history_sync_chunk', listener)
-                            resolve()
+                let timer: NodeJS.Timeout | null = null
+                let listener: WaClientEventMap['history_sync_chunk'] | null = null
+                try {
+                    const allChunksDone = new Promise<void>((resolve, reject) => {
+                        timer = setTimeout(
+                            () =>
+                                reject(
+                                    new Error(
+                                        `history-sync stalled at chunk ${receivedChunks}/${chunks}`
+                                    )
+                                ),
+                            180_000
+                        )
+                        listener = () => {
+                            receivedChunks += 1
+                            if (receivedChunks >= chunks) resolve()
                         }
-                    }
-                    client.on('history_sync_chunk', listener)
-                })
-
-                for (let i = 0; i < chunks; i += 1) {
-                    const convs = buildChunkConversationsFlat(preset, i).map((c) => ({
-                        id: c.id,
-                        name: c.name,
-                        unreadCount: c.unreadCount,
-                        messages: c.messages.map((m) => ({
-                            id: m.id,
-                            fromMe: m.fromMe,
-                            timestamp: m.timestamp,
-                            message: { conversation: m.conversation }
-                        }))
-                    }))
-                    await peer.sendHistorySync({
-                        chunkOrder: i,
-                        progress: Math.min(100, Math.round(((i + 1) / chunks) * 100)),
-                        conversations: convs
+                        client.on('history_sync_chunk', listener)
                     })
+
+                    for (let i = 0; i < chunks; i += 1) {
+                        const convs = buildChunkConversationsFlat(preset, i).map((c) => ({
+                            id: c.id,
+                            name: c.name,
+                            unreadCount: c.unreadCount,
+                            messages: c.messages.map((m) => ({
+                                id: m.id,
+                                fromMe: m.fromMe,
+                                timestamp: m.timestamp,
+                                message: { conversation: m.conversation }
+                            }))
+                        }))
+                        await peer.sendHistorySync({
+                            chunkOrder: i,
+                            progress: Math.min(100, Math.round(((i + 1) / chunks) * 100)),
+                            conversations: convs
+                        })
+                    }
+                    await allChunksDone
+                } finally {
+                    if (timer) clearTimeout(timer)
+                    if (listener) client.off('history_sync_chunk', listener)
                 }
-                await allChunksDone
             },
             'msgs'
         )
@@ -195,48 +198,50 @@ async function runHistoryScenarioRpc(
     await startServerProfilingIfRequested(rpc, profiler.options, argSet)
     await takeServerSnapshotIfRequested(rpc, `server-pre-${presetName}`, profiler.options, argSet)
 
-    const peer = await rpc.createFakePeer({ jid: '5511888888888@s.whatsapp.net' })
-
     const totalMessages = chunks * preset.conversations * preset.messagesPerConversation
     const scenarioName = `history_${presetName}`
 
     try {
+        const peer = await rpc.createFakePeer({ jid: '5511888888888@s.whatsapp.net' })
         await profiler.beforeScenario(scenarioName)
         const result = await runScenario(
             scenarioName,
             totalMessages,
             async () => {
                 let receivedChunks = 0
-                const allChunksDone = new Promise<void>((resolve, reject) => {
-                    const timer = setTimeout(
-                        () =>
-                            reject(
-                                new Error(
-                                    `history-sync stalled at chunk ${receivedChunks}/${chunks}`
-                                )
-                            ),
-                        180_000
-                    )
-                    const listener: WaClientEventMap['history_sync_chunk'] = () => {
-                        receivedChunks += 1
-                        if (receivedChunks >= chunks) {
-                            clearTimeout(timer)
-                            client.off('history_sync_chunk', listener)
-                            resolve()
+                let timer: NodeJS.Timeout | null = null
+                let listener: WaClientEventMap['history_sync_chunk'] | null = null
+                try {
+                    const allChunksDone = new Promise<void>((resolve, reject) => {
+                        timer = setTimeout(
+                            () =>
+                                reject(
+                                    new Error(
+                                        `history-sync stalled at chunk ${receivedChunks}/${chunks}`
+                                    )
+                                ),
+                            180_000
+                        )
+                        listener = () => {
+                            receivedChunks += 1
+                            if (receivedChunks >= chunks) resolve()
                         }
-                    }
-                    client.on('history_sync_chunk', listener)
-                })
-
-                for (let i = 0; i < chunks; i += 1) {
-                    await rpc.peerSendHistorySync({
-                        peerId: peer.peerId,
-                        chunkOrder: i,
-                        progress: Math.min(100, Math.round(((i + 1) / chunks) * 100)),
-                        conversations: buildChunkConversationsFlat(preset, i)
+                        client.on('history_sync_chunk', listener)
                     })
+
+                    for (let i = 0; i < chunks; i += 1) {
+                        await rpc.peerSendHistorySync({
+                            peerId: peer.peerId,
+                            chunkOrder: i,
+                            progress: Math.min(100, Math.round(((i + 1) / chunks) * 100)),
+                            conversations: buildChunkConversationsFlat(preset, i)
+                        })
+                    }
+                    await allChunksDone
+                } finally {
+                    if (timer) clearTimeout(timer)
+                    if (listener) client.off('history_sync_chunk', listener)
                 }
-                await allChunksDone
             },
             'msgs'
         )
@@ -247,9 +252,9 @@ async function runHistoryScenarioRpc(
             profiler.options,
             argSet
         )
-        await stopServerProfilingIfRequested(rpc, profiler.options, argSet)
         return result
     } finally {
+        await stopServerProfilingIfRequested(rpc, profiler.options, argSet).catch(() => undefined)
         await teardownRpcFixture(fixture)
         forceGcIfAvailable()
     }

--- a/packages/fake-server/bench/history-sync.bench.ts
+++ b/packages/fake-server/bench/history-sync.bench.ts
@@ -1,0 +1,308 @@
+/**
+ * History-sync ingestion bench: measure how fast the lib processes a
+ * history-sync push from a paired peer. Each scenario varies chunk
+ * size (conversations × messages per conversation) and measures
+ * push-to-`history_sync_chunk`-event latency + per-message ingest
+ * throughput.
+ *
+ * Tunables:
+ *   ZAPO_BENCH_HISTORY_CHUNKS    (default 5)   chunks per scenario
+ *   ZAPO_BENCH_HISTORY_SCENARIOS (default "small,medium,large")
+ *
+ * Scenario presets (conversations × msgs/conversation):
+ *   small  = 5 × 20      (100 msgs / chunk)
+ *   medium = 20 × 50     (1000 msgs / chunk)
+ *   large  = 50 × 100    (5000 msgs / chunk)
+ *   xlarge = 100 × 200   (20000 msgs / chunk)
+ *
+ * Profiling flags: same as messaging.bench. With --separate-process
+ * the fake server runs in a forked child and gets its own profiles.
+ */
+
+import type { WaClientEventMap } from 'zapo-js'
+
+import {
+    BenchProfiler,
+    forceGcIfAvailable,
+    installEmergencyStop,
+    maybePrintJson,
+    printResult,
+    readCsvEnv,
+    readPositiveIntEnv,
+    readProfilerOptions,
+    runScenario,
+    startServerProfilingIfRequested,
+    stopServerProfilingIfRequested,
+    takeServerSnapshotIfRequested,
+    type ScenarioResult
+} from './_common'
+import {
+    bringUpPairedClient,
+    bringUpPairedClientViaRpc,
+    teardownFixture,
+    teardownRpcFixture
+} from './_fixtures'
+import { buildBenchStore } from './_store-factory'
+
+interface ChunkPreset {
+    readonly name: string
+    readonly conversations: number
+    readonly messagesPerConversation: number
+}
+
+const PRESETS: Readonly<Record<string, ChunkPreset>> = Object.freeze({
+    small: { name: 'small', conversations: 5, messagesPerConversation: 20 },
+    medium: { name: 'medium', conversations: 20, messagesPerConversation: 50 },
+    large: { name: 'large', conversations: 50, messagesPerConversation: 100 },
+    xlarge: { name: 'xlarge', conversations: 100, messagesPerConversation: 200 }
+})
+
+interface SerializedConversation {
+    id: string
+    name: string
+    unreadCount: number
+    messages: {
+        id: string
+        fromMe: boolean
+        timestamp: number
+        conversation: string
+    }[]
+}
+
+function buildChunkConversationsFlat(
+    preset: ChunkPreset,
+    chunkIndex: number
+): SerializedConversation[] {
+    const conversations: SerializedConversation[] = []
+    for (let c = 0; c < preset.conversations; c += 1) {
+        const messages = []
+        for (let m = 0; m < preset.messagesPerConversation; m += 1) {
+            messages.push({
+                id: `chunk-${chunkIndex}-conv-${c}-msg-${m}`,
+                fromMe: m % 3 === 0,
+                timestamp: 1_700_000_000 + chunkIndex * 1000 + c * 100 + m,
+                conversation: `history msg c${c}-m${m} chunk${chunkIndex}`
+            })
+        }
+        conversations.push({
+            id: `5511${String(7_000_000_000 + chunkIndex * 1000 + c).padStart(10, '0')}@s.whatsapp.net`,
+            name: `Chunk${chunkIndex} Conv${c}`,
+            unreadCount: c % 10,
+            messages
+        })
+    }
+    return conversations
+}
+
+async function runHistoryScenarioInProcess(
+    presetName: string,
+    chunks: number,
+    profiler: BenchProfiler
+): Promise<ScenarioResult> {
+    const preset = PRESETS[presetName]
+    if (!preset) {
+        throw new Error(`unknown preset "${presetName}"; valid: ${Object.keys(PRESETS).join(',')}`)
+    }
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClient(storeFixture, {
+        sessionId: `bench-history-${presetName}`,
+        historyEnabled: true
+    })
+    const { server, client, pipeline } = fixture
+
+    const peer = await server.createFakePeer(
+        { jid: '5511888888888@s.whatsapp.net', displayName: 'Primary Device' },
+        pipeline
+    )
+
+    const totalMessages = chunks * preset.conversations * preset.messagesPerConversation
+    const scenarioName = `history_${presetName}`
+
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            totalMessages,
+            async () => {
+                let receivedChunks = 0
+                const allChunksDone = new Promise<void>((resolve, reject) => {
+                    const timer = setTimeout(
+                        () =>
+                            reject(
+                                new Error(
+                                    `history-sync stalled at chunk ${receivedChunks}/${chunks}`
+                                )
+                            ),
+                        180_000
+                    )
+                    const listener: WaClientEventMap['history_sync_chunk'] = () => {
+                        receivedChunks += 1
+                        if (receivedChunks >= chunks) {
+                            clearTimeout(timer)
+                            client.off('history_sync_chunk', listener)
+                            resolve()
+                        }
+                    }
+                    client.on('history_sync_chunk', listener)
+                })
+
+                for (let i = 0; i < chunks; i += 1) {
+                    const convs = buildChunkConversationsFlat(preset, i).map((c) => ({
+                        id: c.id,
+                        name: c.name,
+                        unreadCount: c.unreadCount,
+                        messages: c.messages.map((m) => ({
+                            id: m.id,
+                            fromMe: m.fromMe,
+                            timestamp: m.timestamp,
+                            message: { conversation: m.conversation }
+                        }))
+                    }))
+                    await peer.sendHistorySync({
+                        chunkOrder: i,
+                        progress: Math.min(100, Math.round(((i + 1) / chunks) * 100)),
+                        conversations: convs
+                    })
+                }
+                await allChunksDone
+            },
+            'msgs'
+        )
+        await profiler.afterScenario(scenarioName)
+        return result
+    } finally {
+        await teardownFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+async function runHistoryScenarioRpc(
+    presetName: string,
+    chunks: number,
+    profiler: BenchProfiler,
+    argSet: ReadonlySet<string>
+): Promise<ScenarioResult> {
+    const preset = PRESETS[presetName]
+    if (!preset) {
+        throw new Error(`unknown preset "${presetName}"; valid: ${Object.keys(PRESETS).join(',')}`)
+    }
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClientViaRpc(storeFixture, {
+        sessionId: `bench-history-${presetName}`,
+        historyEnabled: true
+    })
+    const { rpc, client } = fixture
+    await startServerProfilingIfRequested(rpc, profiler.options, argSet)
+    await takeServerSnapshotIfRequested(rpc, `server-pre-${presetName}`, profiler.options, argSet)
+
+    const peer = await rpc.createFakePeer({ jid: '5511888888888@s.whatsapp.net' })
+
+    const totalMessages = chunks * preset.conversations * preset.messagesPerConversation
+    const scenarioName = `history_${presetName}`
+
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            totalMessages,
+            async () => {
+                let receivedChunks = 0
+                const allChunksDone = new Promise<void>((resolve, reject) => {
+                    const timer = setTimeout(
+                        () =>
+                            reject(
+                                new Error(
+                                    `history-sync stalled at chunk ${receivedChunks}/${chunks}`
+                                )
+                            ),
+                        180_000
+                    )
+                    const listener: WaClientEventMap['history_sync_chunk'] = () => {
+                        receivedChunks += 1
+                        if (receivedChunks >= chunks) {
+                            clearTimeout(timer)
+                            client.off('history_sync_chunk', listener)
+                            resolve()
+                        }
+                    }
+                    client.on('history_sync_chunk', listener)
+                })
+
+                for (let i = 0; i < chunks; i += 1) {
+                    await rpc.peerSendHistorySync({
+                        peerId: peer.peerId,
+                        chunkOrder: i,
+                        progress: Math.min(100, Math.round(((i + 1) / chunks) * 100)),
+                        conversations: buildChunkConversationsFlat(preset, i)
+                    })
+                }
+                await allChunksDone
+            },
+            'msgs'
+        )
+        await profiler.afterScenario(scenarioName)
+        await takeServerSnapshotIfRequested(
+            rpc,
+            `server-post-${presetName}`,
+            profiler.options,
+            argSet
+        )
+        await stopServerProfilingIfRequested(rpc, profiler.options, argSet)
+        return result
+    } finally {
+        await teardownRpcFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+async function main(): Promise<void> {
+    installEmergencyStop()
+    const argSet = new Set(process.argv.slice(2))
+    const profiler = new BenchProfiler(readProfilerOptions(argSet))
+    await profiler.start()
+
+    const chunks = readPositiveIntEnv('ZAPO_BENCH_HISTORY_CHUNKS', 5)
+    const requested = readCsvEnv('ZAPO_BENCH_HISTORY_SCENARIOS', ['small', 'medium', 'large'])
+    const backendName = process.env.ZAPO_BENCH_STORE ?? 'memory'
+    const separate = argSet.has('--separate-process')
+
+    console.log('zapo-js history-sync bench')
+    console.log('──────────────────────────')
+    console.log(`  chunks per scenario : ${chunks}`)
+    console.log(`  scenarios           : ${requested.join(', ')}`)
+    console.log(`  store               : ${backendName}`)
+    console.log(`  mode                : ${separate ? 'separate-process' : 'in-process'}`)
+    for (const name of requested) {
+        const p = PRESETS[name]
+        if (!p) continue
+        console.log(
+            `    ${name.padEnd(8)} ${p.conversations} conversations × ${p.messagesPerConversation} msgs = ${p.conversations * p.messagesPerConversation} msgs/chunk`
+        )
+    }
+    console.log('')
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('start').catch((err) => console.error('[snapshot]', err))
+    }
+
+    const results: ScenarioResult[] = []
+    for (const presetName of requested) {
+        const result = separate
+            ? await runHistoryScenarioRpc(presetName, chunks, profiler, argSet)
+            : await runHistoryScenarioInProcess(presetName, chunks, profiler)
+        results.push(result)
+        printResult(result)
+    }
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('end').catch((err) => console.error('[snapshot]', err))
+    }
+    await profiler.stop()
+
+    maybePrintJson(results)
+}
+
+void main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/fake-server/bench/media-upload.bench.ts
+++ b/packages/fake-server/bench/media-upload.bench.ts
@@ -1,0 +1,220 @@
+/**
+ * Media-upload throughput bench: measures encrypted upload + send for
+ * binary payloads of varying sizes. Exercises:
+ *   - AES-CTR streaming encrypt
+ *   - SHA-256 hashing (plain + encrypted bodies)
+ *   - HMAC-SHA-256 (sidecar key derivation)
+ *   - HTTPS upload to fake server
+ *   - the message-encrypt-and-send pipeline
+ *
+ * Tunables:
+ *   ZAPO_BENCH_MEDIA_UPLOADS  (default 20)
+ *   ZAPO_BENCH_MEDIA_SIZES    (default "10240,102400,1048576,4194304")
+ *                              bytes per upload, comma-separated
+ *
+ * Profiling flags: same as messaging.bench. With --separate-process
+ * the fake server runs in a forked child and gets its own profiles.
+ */
+
+import { randomBytes } from 'node:crypto'
+
+import {
+    BenchProfiler,
+    forceGcIfAvailable,
+    formatBytesPerSec,
+    formatFixed,
+    formatMiB,
+    installEmergencyStop,
+    maybePrintJson,
+    printResult,
+    readCsvEnv,
+    readPositiveIntEnv,
+    readProfilerOptions,
+    runScenario,
+    startServerProfilingIfRequested,
+    stopServerProfilingIfRequested,
+    takeServerSnapshotIfRequested,
+    type ScenarioResult
+} from './_common'
+import {
+    bringUpPairedClient,
+    bringUpPairedClientViaRpc,
+    ensurePreKeyPool,
+    teardownFixture,
+    teardownRpcFixture
+} from './_fixtures'
+import { buildBenchStore } from './_store-factory'
+
+function fillRandom(size: number): Uint8Array {
+    return new Uint8Array(randomBytes(size).buffer)
+}
+
+interface MediaScenarioOutput {
+    readonly result: ScenarioResult
+    readonly totalBytes: number
+    readonly throughputBytesPerSec: number
+}
+
+async function runMediaScenarioInProcess(
+    sizeBytes: number,
+    uploads: number,
+    profiler: BenchProfiler
+): Promise<MediaScenarioOutput> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClient(storeFixture, {
+        sessionId: `bench-media-${sizeBytes}`
+    })
+    const { server, client, pipeline } = fixture
+    await ensurePreKeyPool(server, pipeline, 2)
+
+    const peerJid = '5511777777777@s.whatsapp.net'
+    await server.createFakePeer({ jid: peerJid }, pipeline)
+
+    const scenarioName = `media_${sizeBytes}B`
+    const totalBytes = sizeBytes * uploads
+    const buffer = fillRandom(sizeBytes)
+
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            uploads,
+            async () => {
+                for (let i = 0; i < uploads; i += 1) {
+                    await client.message.send(peerJid, {
+                        type: 'image',
+                        media: buffer,
+                        mimetype: 'image/jpeg',
+                        caption: `media bench #${i}`
+                    })
+                }
+            },
+            'uploads'
+        )
+        await profiler.afterScenario(scenarioName)
+        const throughputBps = result.elapsedMs > 0 ? (totalBytes / result.elapsedMs) * 1_000 : 0
+        return { result, totalBytes, throughputBytesPerSec: throughputBps }
+    } finally {
+        await teardownFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+async function runMediaScenarioRpc(
+    sizeBytes: number,
+    uploads: number,
+    profiler: BenchProfiler,
+    argSet: ReadonlySet<string>
+): Promise<MediaScenarioOutput> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClientViaRpc(storeFixture, {
+        sessionId: `bench-media-${sizeBytes}`
+    })
+    const { rpc, client } = fixture
+    await startServerProfilingIfRequested(rpc, profiler.options, argSet)
+    await takeServerSnapshotIfRequested(rpc, `server-pre-${sizeBytes}B`, profiler.options, argSet)
+    await rpc.ensurePreKeyPool(2)
+
+    const peerJid = '5511777777777@s.whatsapp.net'
+    await rpc.createFakePeer({ jid: peerJid })
+
+    const scenarioName = `media_${sizeBytes}B`
+    const totalBytes = sizeBytes * uploads
+    const buffer = fillRandom(sizeBytes)
+
+    try {
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            uploads,
+            async () => {
+                for (let i = 0; i < uploads; i += 1) {
+                    await client.message.send(peerJid, {
+                        type: 'image',
+                        media: buffer,
+                        mimetype: 'image/jpeg',
+                        caption: `media bench #${i}`
+                    })
+                }
+            },
+            'uploads'
+        )
+        await profiler.afterScenario(scenarioName)
+        await takeServerSnapshotIfRequested(
+            rpc,
+            `server-post-${sizeBytes}B`,
+            profiler.options,
+            argSet
+        )
+        await stopServerProfilingIfRequested(rpc, profiler.options, argSet)
+        const throughputBps = result.elapsedMs > 0 ? (totalBytes / result.elapsedMs) * 1_000 : 0
+        return { result, totalBytes, throughputBytesPerSec: throughputBps }
+    } finally {
+        await teardownRpcFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+function parseSizes(): readonly number[] {
+    const raw = readCsvEnv('ZAPO_BENCH_MEDIA_SIZES', [
+        String(10 * 1024),
+        String(100 * 1024),
+        String(1024 * 1024),
+        String(4 * 1024 * 1024)
+    ])
+    return raw.map((s) => {
+        const n = Number.parseInt(s, 10)
+        if (!Number.isFinite(n) || n <= 0) throw new Error(`invalid size "${s}"`)
+        return n
+    })
+}
+
+async function main(): Promise<void> {
+    installEmergencyStop()
+    const argSet = new Set(process.argv.slice(2))
+    const profiler = new BenchProfiler(readProfilerOptions(argSet))
+    await profiler.start()
+
+    const sizes = parseSizes()
+    const uploads = readPositiveIntEnv('ZAPO_BENCH_MEDIA_UPLOADS', 20)
+    const backendName = process.env.ZAPO_BENCH_STORE ?? 'memory'
+    const separate = argSet.has('--separate-process')
+
+    console.log('zapo-js media-upload bench')
+    console.log('──────────────────────────')
+    console.log(`  uploads per size  : ${uploads}`)
+    console.log(`  sizes (bytes)     : ${sizes.map((s) => formatMiB(s)).join(', ')}`)
+    console.log(`  store             : ${backendName}`)
+    console.log(`  mode              : ${separate ? 'separate-process' : 'in-process'}`)
+    console.log('')
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('start').catch((err) => console.error('[snapshot]', err))
+    }
+
+    const aggregated: ScenarioResult[] = []
+    for (const size of sizes) {
+        const { result, totalBytes, throughputBytesPerSec } = separate
+            ? await runMediaScenarioRpc(size, uploads, profiler, argSet)
+            : await runMediaScenarioInProcess(size, uploads, profiler)
+        aggregated.push(result)
+        printResult(result)
+        console.log(
+            `  total transferred : ${formatMiB(totalBytes)}  →  ${formatBytesPerSec(totalBytes, result.elapsedMs)}` +
+                `   (${formatFixed(throughputBytesPerSec / (1024 * 1024), 2)} MiB/s)`
+        )
+        console.log('')
+    }
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('end').catch((err) => console.error('[snapshot]', err))
+    }
+    await profiler.stop()
+
+    maybePrintJson(aggregated)
+}
+
+void main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/fake-server/bench/media-upload.bench.ts
+++ b/packages/fake-server/bench/media-upload.bench.ts
@@ -65,16 +65,14 @@ async function runMediaScenarioInProcess(
         sessionId: `bench-media-${sizeBytes}`
     })
     const { server, client, pipeline } = fixture
-    await ensurePreKeyPool(server, pipeline, 2)
-
-    const peerJid = '5511777777777@s.whatsapp.net'
-    await server.createFakePeer({ jid: peerJid }, pipeline)
-
     const scenarioName = `media_${sizeBytes}B`
     const totalBytes = sizeBytes * uploads
     const buffer = fillRandom(sizeBytes)
 
     try {
+        await ensurePreKeyPool(server, pipeline, 2)
+        const peerJid = '5511777777777@s.whatsapp.net'
+        await server.createFakePeer({ jid: peerJid }, pipeline)
         await profiler.beforeScenario(scenarioName)
         const result = await runScenario(
             scenarioName,
@@ -111,18 +109,23 @@ async function runMediaScenarioRpc(
         sessionId: `bench-media-${sizeBytes}`
     })
     const { rpc, client } = fixture
-    await startServerProfilingIfRequested(rpc, profiler.options, argSet)
-    await takeServerSnapshotIfRequested(rpc, `server-pre-${sizeBytes}B`, profiler.options, argSet)
-    await rpc.ensurePreKeyPool(2)
-
-    const peerJid = '5511777777777@s.whatsapp.net'
-    await rpc.createFakePeer({ jid: peerJid })
-
     const scenarioName = `media_${sizeBytes}B`
     const totalBytes = sizeBytes * uploads
     const buffer = fillRandom(sizeBytes)
 
     try {
+        await startServerProfilingIfRequested(rpc, profiler.options, argSet)
+        await takeServerSnapshotIfRequested(
+            rpc,
+            `server-pre-${sizeBytes}B`,
+            profiler.options,
+            argSet
+        )
+        await rpc.ensurePreKeyPool(2)
+
+        const peerJid = '5511777777777@s.whatsapp.net'
+        await rpc.createFakePeer({ jid: peerJid })
+
         await profiler.beforeScenario(scenarioName)
         const result = await runScenario(
             scenarioName,
@@ -146,10 +149,10 @@ async function runMediaScenarioRpc(
             profiler.options,
             argSet
         )
-        await stopServerProfilingIfRequested(rpc, profiler.options, argSet)
         const throughputBps = result.elapsedMs > 0 ? (totalBytes / result.elapsedMs) * 1_000 : 0
         return { result, totalBytes, throughputBytesPerSec: throughputBps }
     } finally {
+        await stopServerProfilingIfRequested(rpc, profiler.options, argSet).catch(() => undefined)
         await teardownRpcFixture(fixture)
         forceGcIfAvailable()
     }

--- a/packages/fake-server/bench/receipts-flood.bench.ts
+++ b/packages/fake-server/bench/receipts-flood.bench.ts
@@ -1,0 +1,220 @@
+/**
+ * Receipts-flood bench: server pushes N `<receipt/>` stanzas in a
+ * tight burst; we measure how fast the lib parses, dedups via the
+ * retry tracker, emits `receipt`, and acks. Exercises the IQ ack path
+ * + event dispatch + retry-tracker map under sustained inbound load.
+ *
+ * Tunables:
+ *   ZAPO_BENCH_RECEIPTS      (default 5000)
+ *   ZAPO_BENCH_RECEIPT_TYPES (default "delivery,read") types to cycle
+ *
+ * Profiling flags: same as messaging.bench. With --separate-process
+ * the fake server runs in a forked child and gets its own profiles.
+ */
+
+import type { WaClientEventMap } from 'zapo-js'
+
+import { buildReceipt, type FakeReceiptType } from '../src/protocol/push/receipt'
+
+import {
+    BenchProfiler,
+    forceGcIfAvailable,
+    installEmergencyStop,
+    maybePrintJson,
+    printResult,
+    readCsvEnv,
+    readPositiveIntEnv,
+    readProfilerOptions,
+    runScenario,
+    startServerProfilingIfRequested,
+    stopServerProfilingIfRequested,
+    takeServerSnapshotIfRequested,
+    type ScenarioResult
+} from './_common'
+import {
+    bringUpPairedClient,
+    bringUpPairedClientViaRpc,
+    teardownFixture,
+    teardownRpcFixture
+} from './_fixtures'
+import { buildBenchStore } from './_store-factory'
+
+const ALLOWED_TYPES = new Set<FakeReceiptType>(['delivery', 'read', 'played', 'retry'])
+
+interface ReceiptInput {
+    id: string
+    from: string
+    type?: FakeReceiptType
+    t?: number
+}
+
+function buildReceiptInputs(
+    count: number,
+    peerJid: string,
+    types: readonly FakeReceiptType[]
+): ReceiptInput[] {
+    const out: ReceiptInput[] = new Array(count)
+    const nowSec = Math.floor(Date.now() / 1_000)
+    for (let i = 0; i < count; i += 1) {
+        out[i] = {
+            id: `bench-receipt-${i}`,
+            from: peerJid,
+            type: types[i % types.length],
+            t: nowSec
+        }
+    }
+    return out
+}
+
+async function runReceiptsScenarioInProcess(
+    totalReceipts: number,
+    types: readonly FakeReceiptType[],
+    profiler: BenchProfiler
+): Promise<ScenarioResult> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClient(storeFixture, { sessionId: 'bench-receipts' })
+    const { client, pipeline } = fixture
+    const peerJid = '5511777777777@s.whatsapp.net'
+
+    try {
+        let received = 0
+        const allDone = new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(
+                () => reject(new Error(`receipts stalled at ${received}/${totalReceipts}`)),
+                120_000
+            )
+            const listener: WaClientEventMap['receipt'] = () => {
+                received += 1
+                if (received >= totalReceipts) {
+                    clearTimeout(timer)
+                    client.off('receipt', listener)
+                    resolve()
+                }
+            }
+            client.on('receipt', listener)
+        })
+
+        const inputs = buildReceiptInputs(totalReceipts, peerJid, types)
+        const scenarioName = 'receipts_flood'
+        await profiler.beforeScenario(scenarioName)
+        const result = await runScenario(
+            scenarioName,
+            totalReceipts,
+            async () => {
+                for (let i = 0; i < inputs.length; i += 1) {
+                    await pipeline.sendStanza(buildReceipt(inputs[i]))
+                }
+                await allDone
+            },
+            'receipts'
+        )
+        await profiler.afterScenario(scenarioName)
+        return result
+    } finally {
+        await teardownFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+async function runReceiptsScenarioRpc(
+    totalReceipts: number,
+    types: readonly FakeReceiptType[],
+    profiler: BenchProfiler,
+    argSet: ReadonlySet<string>
+): Promise<ScenarioResult> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClientViaRpc(storeFixture, { sessionId: 'bench-receipts' })
+    const { rpc, client } = fixture
+    await startServerProfilingIfRequested(rpc, profiler.options, argSet)
+    await takeServerSnapshotIfRequested(rpc, 'server-pre', profiler.options, argSet)
+    const peerJid = '5511777777777@s.whatsapp.net'
+
+    try {
+        let received = 0
+        const allDone = new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(
+                () => reject(new Error(`receipts stalled at ${received}/${totalReceipts}`)),
+                120_000
+            )
+            const listener: WaClientEventMap['receipt'] = () => {
+                received += 1
+                if (received >= totalReceipts) {
+                    clearTimeout(timer)
+                    client.off('receipt', listener)
+                    resolve()
+                }
+            }
+            client.on('receipt', listener)
+        })
+
+        const inputs = buildReceiptInputs(totalReceipts, peerJid, types)
+        const scenarioName = 'receipts_flood'
+        await profiler.beforeScenario(scenarioName)
+        // Batch IPC: ship all receipts in 1 RPC call (avoid one-IPC-per-receipt
+        // overhead that would dominate at high N).
+        const result = await runScenario(
+            scenarioName,
+            totalReceipts,
+            async () => {
+                await rpc.pipelineSendReceiptBatch(inputs)
+                await allDone
+            },
+            'receipts'
+        )
+        await profiler.afterScenario(scenarioName)
+        await takeServerSnapshotIfRequested(rpc, 'server-post', profiler.options, argSet)
+        await stopServerProfilingIfRequested(rpc, profiler.options, argSet)
+        return result
+    } finally {
+        await teardownRpcFixture(fixture)
+        forceGcIfAvailable()
+    }
+}
+
+async function main(): Promise<void> {
+    installEmergencyStop()
+    const argSet = new Set(process.argv.slice(2))
+    const profiler = new BenchProfiler(readProfilerOptions(argSet))
+    await profiler.start()
+
+    const totalReceipts = readPositiveIntEnv('ZAPO_BENCH_RECEIPTS', 5_000)
+    const typesRaw = readCsvEnv('ZAPO_BENCH_RECEIPT_TYPES', ['delivery', 'read'])
+    const types: FakeReceiptType[] = []
+    for (const t of typesRaw) {
+        if (!ALLOWED_TYPES.has(t as FakeReceiptType)) {
+            throw new Error(`unknown receipt type "${t}"; valid: ${[...ALLOWED_TYPES].join(',')}`)
+        }
+        types.push(t as FakeReceiptType)
+    }
+    const backendName = process.env.ZAPO_BENCH_STORE ?? 'memory'
+    const separate = argSet.has('--separate-process')
+
+    console.log('zapo-js receipts-flood bench')
+    console.log('────────────────────────────')
+    console.log(`  receipts : ${totalReceipts}`)
+    console.log(`  types    : ${types.join(', ')}`)
+    console.log(`  store    : ${backendName}`)
+    console.log(`  mode     : ${separate ? 'separate-process' : 'in-process'}`)
+    console.log('')
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('start').catch((err) => console.error('[snapshot]', err))
+    }
+
+    const result = separate
+        ? await runReceiptsScenarioRpc(totalReceipts, types, profiler, argSet)
+        : await runReceiptsScenarioInProcess(totalReceipts, types, profiler)
+    printResult(result)
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('end').catch((err) => console.error('[snapshot]', err))
+    }
+    await profiler.stop()
+
+    maybePrintJson([result])
+}
+
+void main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/fake-server/bench/receipts-flood.bench.ts
+++ b/packages/fake-server/bench/receipts-flood.bench.ts
@@ -78,18 +78,16 @@ async function runReceiptsScenarioInProcess(
 
     try {
         let received = 0
+        let timer: NodeJS.Timeout | null = null
+        let listener: WaClientEventMap['receipt'] | null = null
         const allDone = new Promise<void>((resolve, reject) => {
-            const timer = setTimeout(
+            timer = setTimeout(
                 () => reject(new Error(`receipts stalled at ${received}/${totalReceipts}`)),
                 120_000
             )
-            const listener: WaClientEventMap['receipt'] = () => {
+            listener = () => {
                 received += 1
-                if (received >= totalReceipts) {
-                    clearTimeout(timer)
-                    client.off('receipt', listener)
-                    resolve()
-                }
+                if (received >= totalReceipts) resolve()
             }
             client.on('receipt', listener)
         })
@@ -97,19 +95,24 @@ async function runReceiptsScenarioInProcess(
         const inputs = buildReceiptInputs(totalReceipts, peerJid, types)
         const scenarioName = 'receipts_flood'
         await profiler.beforeScenario(scenarioName)
-        const result = await runScenario(
-            scenarioName,
-            totalReceipts,
-            async () => {
-                for (let i = 0; i < inputs.length; i += 1) {
-                    await pipeline.sendStanza(buildReceipt(inputs[i]))
-                }
-                await allDone
-            },
-            'receipts'
-        )
-        await profiler.afterScenario(scenarioName)
-        return result
+        try {
+            const result = await runScenario(
+                scenarioName,
+                totalReceipts,
+                async () => {
+                    for (let i = 0; i < inputs.length; i += 1) {
+                        await pipeline.sendStanza(buildReceipt(inputs[i]))
+                    }
+                    await allDone
+                },
+                'receipts'
+            )
+            await profiler.afterScenario(scenarioName)
+            return result
+        } finally {
+            if (timer) clearTimeout(timer)
+            if (listener) client.off('receipt', listener)
+        }
     } finally {
         await teardownFixture(fixture)
         forceGcIfAvailable()
@@ -125,24 +128,23 @@ async function runReceiptsScenarioRpc(
     const storeFixture = await buildBenchStore()
     const fixture = await bringUpPairedClientViaRpc(storeFixture, { sessionId: 'bench-receipts' })
     const { rpc, client } = fixture
-    await startServerProfilingIfRequested(rpc, profiler.options, argSet)
-    await takeServerSnapshotIfRequested(rpc, 'server-pre', profiler.options, argSet)
     const peerJid = '5511777777777@s.whatsapp.net'
 
     try {
+        await startServerProfilingIfRequested(rpc, profiler.options, argSet)
+        await takeServerSnapshotIfRequested(rpc, 'server-pre', profiler.options, argSet)
+
         let received = 0
+        let timer: NodeJS.Timeout | null = null
+        let listener: WaClientEventMap['receipt'] | null = null
         const allDone = new Promise<void>((resolve, reject) => {
-            const timer = setTimeout(
+            timer = setTimeout(
                 () => reject(new Error(`receipts stalled at ${received}/${totalReceipts}`)),
                 120_000
             )
-            const listener: WaClientEventMap['receipt'] = () => {
+            listener = () => {
                 received += 1
-                if (received >= totalReceipts) {
-                    clearTimeout(timer)
-                    client.off('receipt', listener)
-                    resolve()
-                }
+                if (received >= totalReceipts) resolve()
             }
             client.on('receipt', listener)
         })
@@ -150,22 +152,27 @@ async function runReceiptsScenarioRpc(
         const inputs = buildReceiptInputs(totalReceipts, peerJid, types)
         const scenarioName = 'receipts_flood'
         await profiler.beforeScenario(scenarioName)
-        // Batch IPC: ship all receipts in 1 RPC call (avoid one-IPC-per-receipt
-        // overhead that would dominate at high N).
-        const result = await runScenario(
-            scenarioName,
-            totalReceipts,
-            async () => {
-                await rpc.pipelineSendReceiptBatch(inputs)
-                await allDone
-            },
-            'receipts'
-        )
-        await profiler.afterScenario(scenarioName)
-        await takeServerSnapshotIfRequested(rpc, 'server-post', profiler.options, argSet)
-        await stopServerProfilingIfRequested(rpc, profiler.options, argSet)
-        return result
+        try {
+            // Batch IPC: ship all receipts in 1 RPC call (avoid one-IPC-per-receipt
+            // overhead that would dominate at high N).
+            const result = await runScenario(
+                scenarioName,
+                totalReceipts,
+                async () => {
+                    await rpc.pipelineSendReceiptBatch(inputs)
+                    await allDone
+                },
+                'receipts'
+            )
+            await profiler.afterScenario(scenarioName)
+            await takeServerSnapshotIfRequested(rpc, 'server-post', profiler.options, argSet)
+            return result
+        } finally {
+            if (timer) clearTimeout(timer)
+            if (listener) client.off('receipt', listener)
+        }
     } finally {
+        await stopServerProfilingIfRequested(rpc, profiler.options, argSet).catch(() => undefined)
         await teardownRpcFixture(fixture)
         forceGcIfAvailable()
     }

--- a/packages/fake-server/bench/reconnect-resume.bench.ts
+++ b/packages/fake-server/bench/reconnect-resume.bench.ts
@@ -1,0 +1,234 @@
+/**
+ * Reconnect / resume bench: pair once, then loop N reconnect cycles
+ * against the SAME server + persistent store. Each cycle measures the
+ * time from `client.connect()` to `connection_open` using the IK
+ * (resume) handshake – the path real users hit after a transient
+ * network blip or after the lib restarts.
+ *
+ * Each iteration creates a NEW `WaClient` instance bound to the same
+ * `WaStore` (so credentials persist). For the bench we measure:
+ *   - handshake completion (debug_connection_success)
+ *   - full ready signal (connection_open)
+ *
+ * Tunables:
+ *   ZAPO_BENCH_RECONNECT_ITERATIONS  (default 20)
+ *
+ * Profiling flags: same as messaging.bench.
+ */
+
+import type { Agent } from 'node:https'
+import { performance } from 'node:perf_hooks'
+
+import { WaClient, type WaClientEventMap, type WaStore } from 'zapo-js'
+
+import type { FakeWaServer } from '../src/api/FakeWaServer'
+
+import {
+    BenchProfiler,
+    forceGcIfAvailable,
+    formatMs,
+    installEmergencyStop,
+    maybePrintJson,
+    NOOP_LOGGER,
+    printResult,
+    readPositiveIntEnv,
+    readProfilerOptions,
+    runScenario,
+    startServerProfilingIfRequested,
+    stopServerProfilingIfRequested,
+    takeServerSnapshotIfRequested,
+    type ScenarioResult
+} from './_common'
+import { bringUpPairedClient, bringUpPairedClientViaRpc } from './_fixtures'
+import { buildBenchStore } from './_store-factory'
+import type { ServerRpc } from './server-rpc'
+
+interface ResumeTimings {
+    readonly handshakeMs: number
+    readonly readyMs: number
+}
+
+function quantile(samples: readonly number[], q: number): number {
+    if (samples.length === 0) return 0
+    const sorted = [...samples].sort((a, b) => a - b)
+    const idx = Math.min(sorted.length - 1, Math.floor(q * sorted.length))
+    return sorted[idx]
+}
+
+interface ResumeServerHandle {
+    readonly url: string
+    readonly noiseRootCa: { publicKey: Uint8Array; serial: number }
+    readonly mediaProxyAgent?: Agent | null
+}
+
+async function singleResume(
+    handle: ResumeServerHandle,
+    storeFixture: { store: WaStore },
+    sessionId: string
+): Promise<ResumeTimings> {
+    // Same sessionId as the original pairing so the memory auth store
+    // is shared and the lib resolves credentials → IK resume handshake
+    // (not XX). With a persistent backend the sessionId scopes to the
+    // same row/keyspace, achieving the same effect.
+    const client = new WaClient(
+        {
+            store: storeFixture.store,
+            sessionId,
+            chatSocketUrls: [handle.url],
+            connectTimeoutMs: 30_000,
+            testHooks: {
+                noiseRootCa: handle.noiseRootCa
+            }
+        },
+        NOOP_LOGGER
+    )
+
+    let handshakeAt = 0
+    const handshakePromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('handshake timeout')), 30_000)
+        client.once('debug_connection_success', () => {
+            handshakeAt = performance.now()
+            clearTimeout(timer)
+            resolve()
+        })
+    })
+
+    let readyAt = 0
+    const readyPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('ready timeout')), 30_000)
+        const listener: WaClientEventMap['connection'] = (event) => {
+            if (event.status !== 'open') return
+            readyAt = performance.now()
+            clearTimeout(timer)
+            client.off('connection', listener)
+            resolve()
+        }
+        client.on('connection', listener)
+    })
+
+    const startedAt = performance.now()
+    try {
+        await client.connect()
+        await handshakePromise
+        await readyPromise
+        return {
+            handshakeMs: handshakeAt - startedAt,
+            readyMs: readyAt - startedAt
+        }
+    } finally {
+        await client.disconnect().catch(() => undefined)
+    }
+}
+
+async function main(): Promise<void> {
+    installEmergencyStop()
+    const argSet = new Set(process.argv.slice(2))
+    const profiler = new BenchProfiler(readProfilerOptions(argSet))
+    await profiler.start()
+
+    const iterations = readPositiveIntEnv('ZAPO_BENCH_RECONNECT_ITERATIONS', 20)
+    const backendName = process.env.ZAPO_BENCH_STORE ?? 'memory'
+    const separate = argSet.has('--separate-process')
+
+    console.log('zapo-js reconnect-resume bench')
+    console.log('──────────────────────────────')
+    console.log(`  iterations : ${iterations}`)
+    console.log(`  store      : ${backendName}`)
+    console.log(`  mode       : ${separate ? 'separate-process' : 'in-process'}`)
+    console.log('')
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('start').catch((err) => console.error('[snapshot]', err))
+    }
+
+    // Initial pairing once (full XX). Subsequent iterations reuse the
+    // store + sessionId and use IK (resume).
+    const sharedSessionId = 'bench-resume-shared'
+    const storeFixture = await buildBenchStore()
+
+    let serverHandle: ResumeServerHandle
+    let inProcServer: FakeWaServer | null = null
+    let rpc: ServerRpc | null = null
+
+    if (separate) {
+        const fixture = await bringUpPairedClientViaRpc(storeFixture, {
+            sessionId: sharedSessionId
+        })
+        rpc = fixture.rpc
+        serverHandle = {
+            url: rpc.serverUrl,
+            noiseRootCa: rpc.noiseRootCa
+        }
+        await fixture.client.disconnect().catch(() => undefined)
+        await startServerProfilingIfRequested(rpc, profiler.options, argSet)
+        await takeServerSnapshotIfRequested(rpc, 'server-pre', profiler.options, argSet)
+    } else {
+        const fixture = await bringUpPairedClient(storeFixture, { sessionId: sharedSessionId })
+        inProcServer = fixture.server
+        serverHandle = {
+            url: fixture.server.url,
+            noiseRootCa: fixture.server.noiseRootCa
+        }
+        await fixture.client.disconnect().catch(() => undefined)
+    }
+
+    const handshakes: number[] = []
+    const readys: number[] = []
+    let results: ScenarioResult | null = null
+
+    try {
+        // Warm-up (excluded from medians).
+        if (iterations > 1) {
+            await singleResume(serverHandle, storeFixture, sharedSessionId)
+            forceGcIfAvailable()
+        }
+
+        const scenarioName = 'reconnect_resume'
+        await profiler.beforeScenario(scenarioName)
+        results = await runScenario(
+            scenarioName,
+            iterations,
+            async () => {
+                for (let i = 0; i < iterations; i += 1) {
+                    const t = await singleResume(serverHandle, storeFixture, sharedSessionId)
+                    handshakes.push(t.handshakeMs)
+                    readys.push(t.readyMs)
+                }
+            },
+            'reconnects'
+        )
+        await profiler.afterScenario(scenarioName)
+        if (rpc) {
+            await takeServerSnapshotIfRequested(rpc, 'server-post', profiler.options, argSet)
+            await stopServerProfilingIfRequested(rpc, profiler.options, argSet)
+        }
+    } finally {
+        if (rpc) await rpc.stop().catch(() => undefined)
+        if (inProcServer) await inProcServer.stop().catch(() => undefined)
+        await storeFixture.destroy().catch(() => undefined)
+    }
+
+    if (!results) throw new Error('no results captured')
+    printResult(results)
+
+    const print = (label: string, samples: readonly number[]): void => {
+        console.log(
+            `  ${label.padEnd(24)}: median ${formatMs(quantile(samples, 0.5)).padStart(8)}  |  p95 ${formatMs(quantile(samples, 0.95)).padStart(8)}  |  min ${formatMs(Math.min(...samples)).padStart(8)}  |  max ${formatMs(Math.max(...samples)).padStart(8)}`
+        )
+    }
+    console.log('Per-iteration resume timing:')
+    print('connect → handshake', handshakes)
+    print('connect → ready', readys)
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('end').catch((err) => console.error('[snapshot]', err))
+    }
+    await profiler.stop()
+
+    maybePrintJson([results])
+}
+
+void main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/fake-server/bench/run-all-stores.cjs
+++ b/packages/fake-server/bench/run-all-stores.cjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/**
+ * Run every bench against every requested store backend, capturing
+ * CPU profiles + heap snapshots into per-(bench, store) directories.
+ *
+ * Usage:
+ *   node packages/fake-server/bench/run-all-stores.cjs [--stores=memory,sqlite,...]
+ *       [--benches=connect-lifecycle,history-sync,...]
+ *       [--out=<dir>] [--no-cpu] [--no-snapshot] [--start-docker]
+ *
+ * Defaults:
+ *   stores  = memory,sqlite
+ *   benches = all 8 benches (connect-lifecycle, history-sync,
+ *             bulk-usync, group-provision, media-upload,
+ *             receipts-flood, reconnect-resume, appstate)
+ *   out     = <repo>/bench-profiles/all-stores-<ts>
+ *
+ * When `--start-docker` is passed, the script also spins up the
+ * `packages/docker-compose.test.yml` services for stores that need
+ * them, captures the ephemeral ports, and tears them down at the end.
+ * Without the flag, the stores are expected to be reachable via the
+ * `ZAPO_TEST_*` env vars (set the same way `scripts/test-stores.cjs`
+ * does).
+ *
+ * The bench files themselves are run with:
+ *   node --expose-gc --import tsx <bench> --cpu --snapshot --out-dir=<dir>
+ * (toggle flags via `--no-cpu` / `--no-snapshot`).
+ */
+
+const { execSync, spawnSync } = require('node:child_process')
+const { mkdirSync, writeFileSync } = require('node:fs')
+const { join, resolve } = require('node:path')
+
+const REPO_ROOT = resolve(__dirname, '../../..')
+const COMPOSE_FILE = join(REPO_ROOT, 'packages', 'docker-compose.test.yml')
+
+const ALL_BENCHES = [
+    'connect-lifecycle',
+    'history-sync',
+    'bulk-usync',
+    'group-provision',
+    'media-upload',
+    'receipts-flood',
+    'reconnect-resume',
+    'appstate'
+]
+
+const ALL_STORES = ['memory', 'sqlite', 'postgres', 'mysql', 'redis', 'mongo']
+const DOCKER_STORES = new Set(['postgres', 'mysql', 'redis', 'mongo'])
+
+function parseArgs(argv) {
+    const out = {
+        stores: ['memory', 'sqlite'],
+        benches: ALL_BENCHES.slice(),
+        outDir: null,
+        cpu: true,
+        snapshot: true,
+        startDocker: false
+    }
+    for (const arg of argv) {
+        if (arg.startsWith('--stores=')) {
+            out.stores = arg.split('=')[1].split(',').filter(Boolean)
+        } else if (arg.startsWith('--benches=')) {
+            out.benches = arg.split('=')[1].split(',').filter(Boolean)
+        } else if (arg.startsWith('--out=')) {
+            out.outDir = arg.split('=')[1]
+        } else if (arg === '--no-cpu') {
+            out.cpu = false
+        } else if (arg === '--no-snapshot') {
+            out.snapshot = false
+        } else if (arg === '--start-docker') {
+            out.startDocker = true
+        } else if (arg === '--all-stores') {
+            out.stores = ALL_STORES.slice()
+        } else if (arg === '--help' || arg === '-h') {
+            console.log(`Usage: node run-all-stores.cjs [options]
+  --stores=<csv>      memory,sqlite,postgres,mysql,redis,mongo (default: memory,sqlite)
+  --all-stores        shortcut for all 6 backends
+  --benches=<csv>     ${ALL_BENCHES.join(',')} (default: all)
+  --out=<dir>         output directory (default: <repo>/bench-profiles/all-stores-<ts>)
+  --no-cpu            skip CPU profile capture
+  --no-snapshot       skip heap snapshot capture
+  --start-docker      spin up docker-compose services for pg/mysql/redis/mongo`)
+            process.exit(0)
+        } else {
+            console.error(`unknown arg: ${arg}`)
+            process.exit(1)
+        }
+    }
+    for (const b of out.benches) {
+        if (!ALL_BENCHES.includes(b)) {
+            console.error(`unknown bench: ${b}; valid: ${ALL_BENCHES.join(',')}`)
+            process.exit(1)
+        }
+    }
+    for (const s of out.stores) {
+        if (!ALL_STORES.includes(s)) {
+            console.error(`unknown store: ${s}; valid: ${ALL_STORES.join(',')}`)
+            process.exit(1)
+        }
+    }
+    return out
+}
+
+function getComposePort(service, containerPort) {
+    const output = execSync(
+        `docker compose -f "${COMPOSE_FILE}" port ${service} ${containerPort}`,
+        { encoding: 'utf8', cwd: REPO_ROOT }
+    ).trim()
+    const match = output.match(/:(\d+)$/)
+    if (!match) throw new Error(`failed to read port for ${service}: ${output}`)
+    return match[1]
+}
+
+function ensureDocker(stores) {
+    const needed = stores.filter((s) => DOCKER_STORES.has(s))
+    if (needed.length === 0) return {}
+    console.log(`▶ starting docker-compose services for ${needed.join(', ')}...`)
+    execSync(`docker compose -f "${COMPOSE_FILE}" up -d --wait`, {
+        stdio: 'inherit',
+        cwd: REPO_ROOT,
+        timeout: 300_000
+    })
+    const env = {}
+    if (stores.includes('mysql')) {
+        env.ZAPO_TEST_MYSQL_HOST = 'localhost'
+        env.ZAPO_TEST_MYSQL_PORT = getComposePort('mysql', 3306)
+        env.ZAPO_TEST_MYSQL_USER = 'root'
+        env.ZAPO_TEST_MYSQL_PASSWORD = 'test'
+        env.ZAPO_TEST_MYSQL_DATABASE = 'zapo_test'
+    }
+    if (stores.includes('postgres')) {
+        env.ZAPO_TEST_PG_HOST = 'localhost'
+        env.ZAPO_TEST_PG_PORT = getComposePort('postgres', 5432)
+        env.ZAPO_TEST_PG_USER = 'postgres'
+        env.ZAPO_TEST_PG_PASSWORD = 'test'
+        env.ZAPO_TEST_PG_DATABASE = 'zapo_test'
+    }
+    if (stores.includes('redis')) {
+        env.ZAPO_TEST_REDIS_HOST = 'localhost'
+        env.ZAPO_TEST_REDIS_PORT = getComposePort('redis', 6379)
+    }
+    if (stores.includes('mongo')) {
+        env.ZAPO_TEST_MONGO_HOST = 'localhost'
+        env.ZAPO_TEST_MONGO_PORT = getComposePort('mongo', 27017)
+    }
+    return env
+}
+
+function stopDocker() {
+    console.log('▶ stopping docker-compose services...')
+    try {
+        execSync(`docker compose -f "${COMPOSE_FILE}" down`, {
+            stdio: 'inherit',
+            cwd: REPO_ROOT
+        })
+    } catch (err) {
+        console.error('failed to stop containers:', err.message)
+    }
+}
+
+function ensureOutDir(opts) {
+    const root = opts.outDir
+        ? resolve(opts.outDir)
+        : join(REPO_ROOT, 'bench-profiles', `all-stores-${Date.now()}`)
+    mkdirSync(root, { recursive: true })
+    return root
+}
+
+function runBench(bench, store, outRoot, opts, extraEnv) {
+    const subDir = join(outRoot, `${bench}_${store}`)
+    mkdirSync(subDir, { recursive: true })
+    const benchFile = join(__dirname, `${bench}.bench.ts`)
+    const flags = ['--separate-process']
+    if (opts.cpu) flags.push('--cpu')
+    if (opts.snapshot) flags.push('--snapshot')
+    flags.push(`--out-dir=${subDir}`)
+
+    const env = {
+        ...process.env,
+        ZAPO_BENCH_STORE: store,
+        ...extraEnv
+    }
+
+    console.log(`\n┌──[ ${bench} × ${store} ]──`)
+    const started = Date.now()
+    const res = spawnSync(
+        process.execPath,
+        ['--expose-gc', '--import', 'tsx', benchFile, ...flags],
+        {
+            stdio: 'inherit',
+            cwd: REPO_ROOT,
+            env,
+            timeout: 1_800_000
+        }
+    )
+    const elapsedMs = Date.now() - started
+    const outcome = {
+        bench,
+        store,
+        outDir: subDir,
+        elapsedMs,
+        exitCode: res.status,
+        signal: res.signal,
+        error: res.error ? res.error.message : null
+    }
+    if (res.status !== 0) {
+        console.log(`└──  ✗ FAILED (exit ${res.status}, ${elapsedMs}ms)`)
+    } else {
+        console.log(`└──  ✓ ok (${elapsedMs}ms)`)
+    }
+    return outcome
+}
+
+function writeSummary(outRoot, results) {
+    const summaryPath = join(outRoot, 'summary.json')
+    writeFileSync(
+        summaryPath,
+        JSON.stringify({ generatedAt: new Date().toISOString(), results }, null, 2)
+    )
+    console.log(`\nSummary written to ${summaryPath}`)
+    const ok = results.filter((r) => r.exitCode === 0).length
+    const fail = results.length - ok
+    console.log(`Result: ${ok} ok / ${fail} failed (of ${results.length})`)
+    if (fail > 0) {
+        console.log('\nFailures:')
+        for (const r of results) {
+            if (r.exitCode === 0) continue
+            console.log(
+                `  - ${r.bench} × ${r.store}  (exit ${r.exitCode}${r.error ? ': ' + r.error : ''})`
+            )
+        }
+    }
+}
+
+async function main() {
+    const opts = parseArgs(process.argv.slice(2))
+    const outRoot = ensureOutDir(opts)
+    console.log(`Output directory: ${outRoot}`)
+    console.log(`Stores : ${opts.stores.join(', ')}`)
+    console.log(`Benches: ${opts.benches.join(', ')}`)
+    console.log(
+        `Flags  : ${opts.cpu ? '+cpu' : '-cpu'} ${opts.snapshot ? '+snapshot' : '-snapshot'}`
+    )
+
+    let dockerEnv = {}
+    let dockerStarted = false
+    try {
+        if (opts.startDocker) {
+            dockerEnv = ensureDocker(opts.stores)
+            dockerStarted = true
+        }
+
+        const results = []
+        for (const store of opts.stores) {
+            for (const bench of opts.benches) {
+                results.push(runBench(bench, store, outRoot, opts, dockerEnv))
+            }
+        }
+        writeSummary(outRoot, results)
+        const fail = results.filter((r) => r.exitCode !== 0).length
+        process.exitCode = fail > 0 ? 1 : 0
+    } finally {
+        if (dockerStarted) {
+            stopDocker()
+        }
+    }
+}
+
+main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/fake-server/bench/server-process.ts
+++ b/packages/fake-server/bench/server-process.ts
@@ -15,6 +15,11 @@ import { resolve as resolvePath } from 'node:path'
 
 import type { FakePeer } from '../src/api/FakePeer'
 import { FakeWaServer, type WaFakeConnectionPipeline } from '../src/api/FakeWaServer'
+import { buildExternalBlobReference } from '../src/protocol/iq/appstate-sync'
+import { buildIqResult } from '../src/protocol/iq/router'
+import { buildReceipt, type FakeReceiptType } from '../src/protocol/push/receipt'
+import { FakeAppStateCollection } from '../src/state/fake-app-state-collection'
+import type { BinaryNode } from '../src/transport/codec'
 
 // ─── State ────────────────────────────────────────────────────────────
 
@@ -300,6 +305,232 @@ async function handleTakeSnapshot(params: {
     return { path: out }
 }
 
+// ─── Bench-specific handlers ──────────────────────────────────────────
+
+interface SerializedConversationMsg {
+    readonly id: string
+    readonly fromMe: boolean
+    readonly timestamp: number
+    readonly conversation: string
+}
+
+interface SerializedConversation {
+    readonly id: string
+    readonly name?: string
+    readonly unreadCount?: number
+    readonly messages?: readonly SerializedConversationMsg[]
+}
+
+async function handlePeerSendHistorySync(params: {
+    peerId: string
+    chunkOrder?: number
+    progress?: number
+    conversations?: readonly SerializedConversation[]
+    pushnames?: readonly { id: string; pushname: string }[]
+}): Promise<void> {
+    const peer = peersById.get(params.peerId)
+    if (!peer) throw new Error(`peer ${params.peerId} not found`)
+    await peer.sendHistorySync({
+        chunkOrder: params.chunkOrder,
+        progress: params.progress,
+        conversations: params.conversations?.map((c) => ({
+            id: c.id,
+            name: c.name,
+            unreadCount: c.unreadCount,
+            messages: c.messages?.map((m) => ({
+                id: m.id,
+                fromMe: m.fromMe,
+                timestamp: m.timestamp,
+                message: { conversation: m.conversation }
+            }))
+        })),
+        pushnames: params.pushnames
+    })
+}
+
+async function handlePeerSendAppStateSyncKeyShare(params: {
+    peerId: string
+    keys: { keyIdBytes: number[]; keyDataBytes: number[]; timestamp: number }[]
+}): Promise<void> {
+    const peer = peersById.get(params.peerId)
+    if (!peer) throw new Error(`peer ${params.peerId} not found`)
+    await peer.sendAppStateSyncKeyShare({
+        keys: params.keys.map((k) => ({
+            keyId: new Uint8Array(k.keyIdBytes),
+            keyData: new Uint8Array(k.keyDataBytes),
+            timestamp: k.timestamp
+        }))
+    })
+}
+
+async function handlePipelineSendReceiptBatch(params: {
+    receipts: { id: string; from: string; type?: FakeReceiptType; t?: number }[]
+}): Promise<void> {
+    if (!pipeline) throw new Error('no pipeline')
+    for (const r of params.receipts) {
+        await pipeline.sendStanza(buildReceipt(r))
+    }
+}
+
+function findChildNode(node: BinaryNode, tag: string): BinaryNode | undefined {
+    if (!Array.isArray(node.content)) return undefined
+    return node.content.find((child) => child.tag === tag)
+}
+
+function handleSetupGroupBenchHandlers(): void {
+    if (!server) throw new Error('server not started')
+    server.registerIqHandler(
+        { xmlns: 'w:g2', type: 'set', childTag: 'create' },
+        (iq) => {
+            const create = findChildNode(iq, 'create')
+            const participantJids: string[] = []
+            if (create && Array.isArray(create.content)) {
+                for (const child of create.content) {
+                    if (child.tag === 'participant' && child.attrs.jid) {
+                        participantJids.push(child.attrs.jid)
+                    }
+                }
+            }
+            const result = buildIqResult(iq)
+            const fakeGroupJid = `120363${String(900_000_700_000 + Math.floor(Math.random() * 1_000_000)).padStart(15, '0')}@g.us`
+            return {
+                ...result,
+                attrs: { ...result.attrs, from: '@g.us' },
+                content: [
+                    {
+                        tag: 'group',
+                        attrs: {
+                            id: fakeGroupJid,
+                            subject: create?.attrs.subject ?? 'New Group',
+                            creation: String(Math.floor(Date.now() / 1_000)),
+                            creator: participantJids[0] ?? ''
+                        },
+                        content: participantJids.map((jid) => ({
+                            tag: 'participant',
+                            attrs: { jid, add_request: 'success' }
+                        }))
+                    }
+                ]
+            }
+        },
+        'bench-group-create'
+    )
+    for (const action of ['add', 'remove', 'promote', 'demote'] as const) {
+        server.registerIqHandler(
+            { xmlns: 'w:g2', type: 'set', childTag: action },
+            (iq) => {
+                const actionNode = findChildNode(iq, action)
+                const participants =
+                    actionNode && Array.isArray(actionNode.content)
+                        ? actionNode.content.filter((c) => c.tag === 'participant')
+                        : []
+                const result = buildIqResult(iq)
+                return {
+                    ...result,
+                    content: [
+                        {
+                            tag: action,
+                            attrs: actionNode?.attrs ?? {},
+                            content: participants.map((p) => ({
+                                tag: 'participant',
+                                attrs: { ...p.attrs, add_request: 'success' }
+                            }))
+                        }
+                    ]
+                }
+            },
+            `bench-group-${action}`
+        )
+    }
+}
+
+function handleRegisterAppStateSyncKey(params: {
+    keyIdBytes: number[]
+    keyDataBytes: number[]
+}): void {
+    if (!server) throw new Error('server not started')
+    server.registerAppStateSyncKey(
+        new Uint8Array(params.keyIdBytes),
+        new Uint8Array(params.keyDataBytes)
+    )
+}
+
+interface SerializedMutation {
+    readonly operation: 'set' | 'remove'
+    readonly index: string
+    readonly value?: Record<string, unknown> | null
+    readonly version: number
+}
+
+async function handleSetupAppStateBootstrap(params: {
+    name: string
+    syncKeyIdBytes: number[]
+    syncKeyDataBytes: number[]
+    mutation: SerializedMutation
+}): Promise<void> {
+    if (!server) throw new Error('server not started')
+    const keyId = new Uint8Array(params.syncKeyIdBytes)
+    const keyData = new Uint8Array(params.syncKeyDataBytes)
+    server.registerAppStateSyncKey(keyId, keyData)
+    const coll = new FakeAppStateCollection({ name: params.name, keyId, keyData })
+    await coll.applyMutation({
+        operation: params.mutation.operation,
+        index: params.mutation.index,
+        value: (params.mutation.value ?? null) as never,
+        version: params.mutation.version
+    })
+    const patch = await coll.encodePendingPatch()
+    const version = coll.version
+    let shipped = false
+    server.provideAppStateCollection(params.name, () => {
+        if (shipped) return { name: params.name, version }
+        shipped = true
+        return { name: params.name, version, patches: [patch] }
+    })
+}
+
+async function handleSetupAppStateExternalSnapshot(params: {
+    name: string
+    syncKeyIdBytes: number[]
+    syncKeyDataBytes: number[]
+    mutations: readonly SerializedMutation[]
+}): Promise<void> {
+    if (!server) throw new Error('server not started')
+    const keyId = new Uint8Array(params.syncKeyIdBytes)
+    const keyData = new Uint8Array(params.syncKeyDataBytes)
+    const coll = new FakeAppStateCollection({ name: params.name, keyId, keyData })
+    for (const m of params.mutations)
+        await coll.applyMutation({
+            operation: m.operation,
+            index: m.index,
+            value: (m.value ?? null) as never,
+            version: m.version
+        })
+    const snapshotBytes = await coll.encodeSnapshot()
+    const snapshotVersion = coll.version
+    const mediaBlob = await server.publishMediaBlob({
+        mediaType: 'md-app-state',
+        plaintext: snapshotBytes
+    })
+    const srv = server
+    let shipped = false
+    server.provideAppStateCollection(params.name, () => {
+        if (shipped) return { name: params.name, version: snapshotVersion }
+        shipped = true
+        return {
+            name: params.name,
+            version: snapshotVersion,
+            snapshot: buildExternalBlobReference({
+                mediaKey: mediaBlob.mediaKey,
+                directPath: srv.mediaUrl(mediaBlob.path),
+                fileSha256: mediaBlob.fileSha256,
+                fileEncSha256: mediaBlob.fileEncSha256,
+                fileSizeBytes: mediaBlob.fileLength
+            })
+        }
+    })
+}
+
 // ─── Dispatch ─────────────────────────────────────────────────────────
 
 const handlers: Record<
@@ -329,7 +560,22 @@ const handlers: Record<
     mediaProxyAgent: handleMediaProxyAgent,
     startProfiling: handleStartProfiling as (p: Record<string, unknown>) => Promise<void>,
     stopProfiling: handleStopProfiling as (p: Record<string, unknown>) => Promise<unknown>,
-    takeSnapshot: handleTakeSnapshot as (p: Record<string, unknown>) => Promise<unknown>
+    takeSnapshot: handleTakeSnapshot as (p: Record<string, unknown>) => Promise<unknown>,
+    peerSendHistorySync: handlePeerSendHistorySync as (p: Record<string, unknown>) => Promise<void>,
+    peerSendAppStateSyncKeyShare: handlePeerSendAppStateSyncKeyShare as (
+        p: Record<string, unknown>
+    ) => Promise<void>,
+    pipelineSendReceiptBatch: handlePipelineSendReceiptBatch as (
+        p: Record<string, unknown>
+    ) => Promise<void>,
+    setupGroupBenchHandlers: handleSetupGroupBenchHandlers as (p: Record<string, unknown>) => void,
+    registerAppStateSyncKey: handleRegisterAppStateSyncKey as (p: Record<string, unknown>) => void,
+    setupAppStateBootstrap: handleSetupAppStateBootstrap as (
+        p: Record<string, unknown>
+    ) => Promise<void>,
+    setupAppStateExternalSnapshot: handleSetupAppStateExternalSnapshot as (
+        p: Record<string, unknown>
+    ) => Promise<void>
 }
 
 process.on('message', async (msg: RpcRequest) => {

--- a/packages/fake-server/bench/server-rpc.ts
+++ b/packages/fake-server/bench/server-rpc.ts
@@ -221,6 +221,102 @@ export class ServerRpc {
         return result.path
     }
 
+    // ─── Bench-specific RPC wrappers (push from server side) ──────
+
+    public async peerSendHistorySync(input: {
+        peerId: string
+        chunkOrder?: number
+        progress?: number
+        conversations?: readonly {
+            id: string
+            name?: string
+            unreadCount?: number
+            messages?: readonly {
+                id: string
+                fromMe: boolean
+                timestamp: number
+                conversation: string
+            }[]
+        }[]
+        pushnames?: readonly { id: string; pushname: string }[]
+    }): Promise<void> {
+        await this.call('peerSendHistorySync', input)
+    }
+
+    public async peerSendAppStateSyncKeyShare(input: {
+        peerId: string
+        keys: { keyId: Uint8Array; keyData: Uint8Array; timestamp: number }[]
+    }): Promise<void> {
+        await this.call('peerSendAppStateSyncKeyShare', {
+            peerId: input.peerId,
+            keys: input.keys.map((k) => ({
+                keyIdBytes: Array.from(k.keyId),
+                keyDataBytes: Array.from(k.keyData),
+                timestamp: k.timestamp
+            }))
+        })
+    }
+
+    public async pipelineSendReceiptBatch(
+        receipts: readonly {
+            id: string
+            from: string
+            type?: string
+            t?: number
+        }[]
+    ): Promise<void> {
+        await this.call('pipelineSendReceiptBatch', { receipts })
+    }
+
+    public async setupGroupBenchHandlers(): Promise<void> {
+        await this.call('setupGroupBenchHandlers')
+    }
+
+    public async registerAppStateSyncKey(keyId: Uint8Array, keyData: Uint8Array): Promise<void> {
+        await this.call('registerAppStateSyncKey', {
+            keyIdBytes: Array.from(keyId),
+            keyDataBytes: Array.from(keyData)
+        })
+    }
+
+    public async setupAppStateBootstrap(input: {
+        name: string
+        syncKeyId: Uint8Array
+        syncKeyData: Uint8Array
+        mutation: {
+            operation: 'set' | 'remove'
+            index: string
+            value?: Record<string, unknown> | null
+            version: number
+        }
+    }): Promise<void> {
+        await this.call('setupAppStateBootstrap', {
+            name: input.name,
+            syncKeyIdBytes: Array.from(input.syncKeyId),
+            syncKeyDataBytes: Array.from(input.syncKeyData),
+            mutation: input.mutation
+        })
+    }
+
+    public async setupAppStateExternalSnapshot(input: {
+        name: string
+        syncKeyId: Uint8Array
+        syncKeyData: Uint8Array
+        mutations: readonly {
+            operation: 'set' | 'remove'
+            index: string
+            value?: Record<string, unknown> | null
+            version: number
+        }[]
+    }): Promise<void> {
+        await this.call('setupAppStateExternalSnapshot', {
+            name: input.name,
+            syncKeyIdBytes: Array.from(input.syncKeyId),
+            syncKeyDataBytes: Array.from(input.syncKeyData),
+            mutations: input.mutations
+        })
+    }
+
     public async stop(): Promise<void> {
         try {
             await this.call('stop')

--- a/packages/fake-server/package.json
+++ b/packages/fake-server/package.json
@@ -29,7 +29,16 @@
         "typecheck": "tsc --noEmit",
         "test": "node --import tsx --test --test-concurrency=1 \"src/**/__tests__/**/*.test.ts\"",
         "cli": "node --import tsx src/bin.ts",
-        "bench:messaging": "node --expose-gc --import tsx bench/messaging.bench.ts"
+        "bench:messaging": "node --expose-gc --import tsx bench/messaging.bench.ts",
+        "bench:connect": "node --expose-gc --import tsx bench/connect-lifecycle.bench.ts",
+        "bench:history": "node --expose-gc --import tsx bench/history-sync.bench.ts",
+        "bench:usync": "node --expose-gc --import tsx bench/bulk-usync.bench.ts",
+        "bench:group": "node --expose-gc --import tsx bench/group-provision.bench.ts",
+        "bench:media": "node --expose-gc --import tsx bench/media-upload.bench.ts",
+        "bench:receipts": "node --expose-gc --import tsx bench/receipts-flood.bench.ts",
+        "bench:reconnect": "node --expose-gc --import tsx bench/reconnect-resume.bench.ts",
+        "bench:appstate": "node --expose-gc --import tsx bench/appstate.bench.ts",
+        "bench:all-stores": "node bench/run-all-stores.cjs"
     },
     "peerDependencies": {
         "zapo-js": ">=0.1.0"


### PR DESCRIPTION
New benches under packages/fake-server/bench/:
- connect-lifecycle: cold connect→ready per-stage timing
- history-sync: lib ingest throughput vs chunk size
- bulk-usync: single USync + first-send fanout cost
- group-provision: createGroup + addParticipants throughput
- media-upload: encrypt+upload bytes/sec at varying sizes
- receipts-flood: inbound receipt ingest throughput
- reconnect-resume: IK resume handshake latency
- appstate: outgoing patches/sec + incoming snapshot ingest

Shared infra:
- _common.ts: BenchProfiler (CPU+heap+snapshot), runScenario, format/env helpers, server-side profile/snapshot wrappers
- _fixtures.ts: bringUpPairedClient (in-process) + bringUpPairedClientViaRpc (separate-process via existing server-rpc/server-process bridge)
- _store-factory.ts: ZAPO_BENCH_STORE selector for memory/sqlite/postgres/mysql/redis/mongo (same ZAPO_TEST_* env contract as scripts/test-stores.cjs)

server-process.ts + server-rpc.ts gain 7 bench-specific RPC handlers (peerSendHistorySync, peerSendAppStateSyncKeyShare, pipelineSendReceiptBatch, setupGroupBenchHandlers, registerAppStateSyncKey, setupAppStateBootstrap, setupAppStateExternalSnapshot) so every bench supports --separate-process and emits a separate cpu-server-*.cpuprofile / snapshot-server-*.heapsnapshot alongside the lib-side profile.

run-all-stores.cjs orchestrates the cartesian product of benches × stores with optional --start-docker that brings up packages/docker-compose.test.yml on ephemeral ports (no conflict with host services on 3306/5432/6379/27017).

.gitignore now excludes bench-profiles/ and bench-profiles-*/ output dirs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive benchmarking suite with multiple performance scenarios: app-state synchronization, history sync, bulk USync, connection lifecycle, group provisioning, media upload, and receipts handling.
  * Added support for multiple storage backends: memory, SQLite, PostgreSQL, MySQL, Redis, and MongoDB.
  * Added CPU profiling and heap snapshot capabilities for performance analysis.
  * Added performance metrics collection and reporting (throughput, latency, memory usage).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->