### PR TITLE
perf(store,client): batched writes across pg/mysql/redis/sqlite + write-behind upsertBatch + signal knownAbsent

### DIFF
--- a/packages/fake-server/bench/_store-factory.ts
+++ b/packages/fake-server/bench/_store-factory.ts
@@ -169,47 +169,39 @@ async function buildPostgresStore(): Promise<BenchStoreFixture> {
         cur.totalUs += elapsedUs
         queryStats.set(key, cur)
     }
-    // pg's `query` accepts either (text, params) or ({ name, text, values });
-    // wrap so both shapes get traced. pg also supports callback-style calls
-    // internally that return non-thenables — just skip those.
-    const wrapQuery = (originalQuery: Function, target: object) => {
-        return function (this: object, ...args: unknown[]) {
+    // Only wrap Pool.connect: pg-pool's Pool.query() routes through connect
+    // + client.query, so a single connect hook traces both direct pool.query
+    // and explicit withTransaction client.query without double-counting.
+    const WRAPPED = Symbol('trace.query.wrapped')
+    const wrapClient = (client: object): void => {
+        if ((client as Record<symbol, unknown>)[WRAPPED]) return
+        ;(client as Record<symbol, unknown>)[WRAPPED] = true
+        const c = client as { query: Function }
+        const originalQuery = c.query.bind(c)
+        c.query = function (...args: unknown[]) {
             const start = process.hrtime.bigint()
             const arg0 = args[0] as string | { text?: string }
             const sql = typeof arg0 === 'string' ? arg0 : (arg0?.text ?? '<unknown>')
-            const result = originalQuery.apply(target, args) as unknown
+            const result = originalQuery(...args) as unknown
             if (result && typeof (result as { then?: unknown }).then === 'function') {
                 return (result as Promise<unknown>).finally(() => recordCall(sql, start))
             }
             recordCall(sql, start)
             return result
-        }
-    }
-    // pg-pool's Pool.query() internally calls Pool.connect() + client.query()
-    // (callback style). Wrapping only connect — but supporting BOTH the
-    // promise and callback signatures — lets a single hook trace direct
-    // pool.query calls AND explicit withTransaction client.query calls
-    // without double-counting.
-    const WRAPPED = Symbol('trace.query.wrapped')
-    const wrapClient = (client: object): void => {
-        if ((client as Record<symbol, unknown>)[WRAPPED]) return
-        ;(client as Record<symbol, unknown>)[WRAPPED] = true
-        const c = client as { query: unknown }
-        const origQuery = (c.query as Function).bind(c)
-        c.query = wrapQuery(origQuery, c) as typeof c.query
+        } as typeof c.query
     }
     const pool = !trace
         ? rawPool
         : new Proxy(rawPool, {
               get(target, prop, receiver) {
                   if (prop !== 'connect') return Reflect.get(target, prop, receiver)
-                  return function (this: unknown, cb?: unknown) {
+                  return function (cb?: unknown) {
                       if (typeof cb === 'function') {
                           return (target.connect as Function).call(
                               target,
                               (err: unknown, client: unknown, done: unknown) => {
                                   if (client) wrapClient(client as object)
-                                  ;(cb as Function)(err, client, done)
+                                  cb(err, client, done)
                               }
                           )
                       }

--- a/packages/fake-server/bench/_store-factory.ts
+++ b/packages/fake-server/bench/_store-factory.ts
@@ -23,6 +23,10 @@
  *   too. When a `Pool` / `Redis` / `Db` is passed in, we don't own it.
  */
 
+import { unlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join as joinPath } from 'node:path'
+
 import { createStore, type WaCreateStoreOptions, type WaStore } from 'zapo-js'
 
 type ProvidersFor<B extends string> = Required<NonNullable<WaCreateStoreOptions<B>['providers']>>
@@ -114,7 +118,9 @@ function buildMemoryStore(): BenchStoreFixture {
 
 async function buildSqliteStore(): Promise<BenchStoreFixture> {
     const { createSqliteStore } = await import('@zapo-js/store-sqlite')
-    const path = process.env.ZAPO_BENCH_SQLITE_PATH ?? ':memory:'
+    const userPath = process.env.ZAPO_BENCH_SQLITE_PATH
+    const ownsFile = !userPath
+    const path = userPath ?? joinPath(tmpdir(), `zapo-bench-${process.pid}-${Date.now()}.sqlite`)
     const backend = createSqliteStore({ path })
     const store = createStore({
         backends: { sqlite: backend },
@@ -126,20 +132,97 @@ async function buildSqliteStore(): Promise<BenchStoreFixture> {
         description: `sqlite (path=${path})`,
         destroy: async () => {
             await store.destroy()
+            if (ownsFile && path !== ':memory:') {
+                for (const suffix of ['', '-wal', '-shm']) {
+                    await unlink(path + suffix).catch(() => undefined)
+                }
+            }
         }
     }
 }
 
 async function buildPostgresStore(): Promise<BenchStoreFixture> {
     const { createPostgresStore } = await import('@zapo-js/store-postgres')
+    const pg = await import('pg')
     const host = requireEnv('ZAPO_TEST_PG_HOST')
     const port = parsePort('ZAPO_TEST_PG_PORT')
     const user = process.env.ZAPO_TEST_PG_USER ?? 'postgres'
     const password = process.env.ZAPO_TEST_PG_PASSWORD ?? 'test'
     const database = process.env.ZAPO_TEST_PG_DATABASE ?? 'zapo_test'
     const tablePrefix = uniquePrefix('pg')
+
+    const rawPool = new pg.Pool({ host, port, user, password, database, max: 16 })
+    const trace = process.env.ZAPO_BENCH_TRACE_QUERIES === '1'
+    const queryStats = new Map<string, { count: number; totalUs: number }>()
+    const sqlKey = (sql: string): string => {
+        const compact = sql.replace(/\s+/g, ' ').trim()
+        const m = compact.match(
+            /^(SELECT [^F]*FROM \S+|INSERT INTO \S+|UPDATE \S+|DELETE FROM \S+|BEGIN|COMMIT|ROLLBACK)/i
+        )
+        return m ? m[1] : compact.slice(0, 60)
+    }
+    const recordCall = (sql: string, start: bigint): void => {
+        const elapsedUs = Number(process.hrtime.bigint() - start) / 1000
+        const key = sqlKey(sql)
+        const cur = queryStats.get(key) ?? { count: 0, totalUs: 0 }
+        cur.count += 1
+        cur.totalUs += elapsedUs
+        queryStats.set(key, cur)
+    }
+    // pg's `query` accepts either (text, params) or ({ name, text, values });
+    // wrap so both shapes get traced. pg also supports callback-style calls
+    // internally that return non-thenables — just skip those.
+    const wrapQuery = (originalQuery: Function, target: object) => {
+        return function (this: object, ...args: unknown[]) {
+            const start = process.hrtime.bigint()
+            const arg0 = args[0] as string | { text?: string }
+            const sql = typeof arg0 === 'string' ? arg0 : (arg0?.text ?? '<unknown>')
+            const result = originalQuery.apply(target, args) as unknown
+            if (result && typeof (result as { then?: unknown }).then === 'function') {
+                return (result as Promise<unknown>).finally(() => recordCall(sql, start))
+            }
+            recordCall(sql, start)
+            return result
+        }
+    }
+    // pg-pool's Pool.query() internally calls Pool.connect() + client.query()
+    // (callback style). Wrapping only connect — but supporting BOTH the
+    // promise and callback signatures — lets a single hook trace direct
+    // pool.query calls AND explicit withTransaction client.query calls
+    // without double-counting.
+    const WRAPPED = Symbol('trace.query.wrapped')
+    const wrapClient = (client: object): void => {
+        if ((client as Record<symbol, unknown>)[WRAPPED]) return
+        ;(client as Record<symbol, unknown>)[WRAPPED] = true
+        const c = client as { query: unknown }
+        const origQuery = (c.query as Function).bind(c)
+        c.query = wrapQuery(origQuery, c) as typeof c.query
+    }
+    const pool = !trace
+        ? rawPool
+        : new Proxy(rawPool, {
+              get(target, prop, receiver) {
+                  if (prop !== 'connect') return Reflect.get(target, prop, receiver)
+                  return function (this: unknown, cb?: unknown) {
+                      if (typeof cb === 'function') {
+                          return (target.connect as Function).call(
+                              target,
+                              (err: unknown, client: unknown, done: unknown) => {
+                                  if (client) wrapClient(client as object)
+                                  ;(cb as Function)(err, client, done)
+                              }
+                          )
+                      }
+                      return (target.connect as Function).call(target).then((client: unknown) => {
+                          wrapClient(client as object)
+                          return client
+                      })
+                  }
+              }
+          })
+
     const backend = createPostgresStore({
-        pool: { host, port, user, password, database, max: 16 },
+        pool,
         tablePrefix
     })
     const store = createStore({
@@ -152,20 +235,111 @@ async function buildPostgresStore(): Promise<BenchStoreFixture> {
         description: `postgres (${host}:${port}/${database} prefix=${tablePrefix})`,
         destroy: async () => {
             await store.destroy()
+            if (trace) {
+                const sorted = [...queryStats.entries()].sort((a, b) => b[1].totalUs - a[1].totalUs)
+                console.log('\n[pg query stats]')
+                let totalCount = 0
+                let totalUs = 0
+                for (const [sql, s] of sorted) {
+                    totalCount += s.count
+                    totalUs += s.totalUs
+                    console.log(
+                        '  ' +
+                            String(s.count).padStart(6) +
+                            '  ' +
+                            (s.totalUs / 1000).toFixed(1).padStart(9) +
+                            ' ms  ' +
+                            sql
+                    )
+                }
+                console.log(
+                    `  ${String(totalCount).padStart(6)}  ${(totalUs / 1000).toFixed(1).padStart(9)} ms  TOTAL`
+                )
+            }
+            await rawPool.end().catch(() => undefined)
         }
     }
 }
 
 async function buildMysqlStore(): Promise<BenchStoreFixture> {
     const { createMysqlStore } = await import('@zapo-js/store-mysql')
+    const mysql = await import('mysql2/promise')
     const host = requireEnv('ZAPO_TEST_MYSQL_HOST')
     const port = parsePort('ZAPO_TEST_MYSQL_PORT')
     const user = process.env.ZAPO_TEST_MYSQL_USER ?? 'root'
     const password = process.env.ZAPO_TEST_MYSQL_PASSWORD ?? 'test'
     const database = process.env.ZAPO_TEST_MYSQL_DATABASE ?? 'zapo_test'
     const tablePrefix = uniquePrefix('mysql')
+
+    const rawPool = mysql.createPool({
+        host,
+        port,
+        user,
+        password,
+        database,
+        connectionLimit: 16
+    })
+    const trace = process.env.ZAPO_BENCH_TRACE_QUERIES === '1'
+    const queryStats = new Map<string, { count: number; totalUs: number }>()
+    const sqlKey = (sql: string): string => {
+        const compact = sql.replace(/\s+/g, ' ').trim()
+        const m = compact.match(
+            /^(SELECT [^F]*FROM \S+|INSERT INTO \S+|INSERT IGNORE INTO \S+|UPDATE \S+|DELETE FROM \S+|BEGIN|COMMIT|ROLLBACK)/i
+        )
+        return m ? m[1] : compact.slice(0, 60)
+    }
+    const recordCall = (sql: string, start: bigint): void => {
+        const elapsedUs = Number(process.hrtime.bigint() - start) / 1000
+        const key = sqlKey(sql)
+        const cur = queryStats.get(key) ?? { count: 0, totalUs: 0 }
+        cur.count += 1
+        cur.totalUs += elapsedUs
+        queryStats.set(key, cur)
+    }
+    const pool = !trace
+        ? rawPool
+        : new Proxy(rawPool, {
+              get(target, prop, receiver) {
+                  if (prop === 'execute' || prop === 'query') {
+                      return async (sql: string, params?: unknown) => {
+                          const start = process.hrtime.bigint()
+                          try {
+                              return await (target as unknown as Record<string, Function>)[
+                                  prop as string
+                              ].call(target, sql, params)
+                          } finally {
+                              recordCall(sql, start)
+                          }
+                      }
+                  }
+                  if (prop === 'getConnection') {
+                      return async () => {
+                          const conn = await target.getConnection()
+                          return new Proxy(conn, {
+                              get(connTarget, connProp, connReceiver) {
+                                  if (connProp === 'execute' || connProp === 'query') {
+                                      return async (sql: string, params?: unknown) => {
+                                          const start = process.hrtime.bigint()
+                                          try {
+                                              return await (
+                                                  connTarget as unknown as Record<string, Function>
+                                              )[connProp as string].call(connTarget, sql, params)
+                                          } finally {
+                                              recordCall(sql, start)
+                                          }
+                                      }
+                                  }
+                                  return Reflect.get(connTarget, connProp, connReceiver)
+                              }
+                          })
+                      }
+                  }
+                  return Reflect.get(target, prop, receiver)
+              }
+          })
+
     const backend = createMysqlStore({
-        pool: { host, port, user, password, database, connectionLimit: 16 },
+        pool,
         tablePrefix
     })
     const store = createStore({
@@ -178,17 +352,67 @@ async function buildMysqlStore(): Promise<BenchStoreFixture> {
         description: `mysql (${host}:${port}/${database} prefix=${tablePrefix})`,
         destroy: async () => {
             await store.destroy()
+            if (trace) {
+                const sorted = [...queryStats.entries()].sort((a, b) => b[1].totalUs - a[1].totalUs)
+                console.log('\n[mysql query stats]')
+                let totalCount = 0
+                let totalUs = 0
+                for (const [sql, s] of sorted) {
+                    totalCount += s.count
+                    totalUs += s.totalUs
+                    console.log(
+                        '  ' +
+                            String(s.count).padStart(6) +
+                            '  ' +
+                            (s.totalUs / 1000).toFixed(1).padStart(9) +
+                            ' ms  ' +
+                            sql
+                    )
+                }
+                console.log(
+                    `  ${String(totalCount).padStart(6)}  ${(totalUs / 1000).toFixed(1).padStart(9)} ms  TOTAL`
+                )
+            }
+            await rawPool.end().catch(() => undefined)
         }
     }
 }
 
 async function buildRedisStore(): Promise<BenchStoreFixture> {
     const { createRedisStore } = await import('@zapo-js/store-redis')
+    const Redis = (await import('ioredis')).default
     const host = requireEnv('ZAPO_TEST_REDIS_HOST')
     const port = parsePort('ZAPO_TEST_REDIS_PORT')
     const keyPrefix = uniquePrefix('redis')
+
+    const rawClient = new Redis({ host, port, lazyConnect: false })
+    const trace = process.env.ZAPO_BENCH_TRACE_QUERIES === '1'
+    const callStats = new Map<string, { count: number; totalUs: number }>()
+    const recordCall = (cmd: string, start: bigint): void => {
+        const elapsedUs = Number(process.hrtime.bigint() - start) / 1000
+        const cur = callStats.get(cmd) ?? { count: 0, totalUs: 0 }
+        cur.count += 1
+        cur.totalUs += elapsedUs
+        callStats.set(cmd, cur)
+    }
+    if (trace) {
+        // ioredis dispatches every redis command through internal `sendCommand`.
+        // Wrap it so both direct method calls (set/get/hget/...) and pipelined
+        // commands get accounted, regardless of which API the store reaches for.
+        const orig = (
+            rawClient as unknown as { sendCommand: (cmd: { name: string }) => Promise<unknown> }
+        ).sendCommand.bind(rawClient)
+        ;(
+            rawClient as unknown as { sendCommand: (cmd: { name: string }) => Promise<unknown> }
+        ).sendCommand = (cmd) => {
+            const start = process.hrtime.bigint()
+            const out = orig(cmd)
+            return out.finally(() => recordCall(cmd.name, start))
+        }
+    }
+
     const backend = createRedisStore({
-        redis: { host, port, lazyConnect: false },
+        redis: rawClient,
         keyPrefix
     })
     const store = createStore({
@@ -201,19 +425,72 @@ async function buildRedisStore(): Promise<BenchStoreFixture> {
         description: `redis (${host}:${port} prefix=${keyPrefix})`,
         destroy: async () => {
             await store.destroy()
+            if (trace) {
+                const sorted = [...callStats.entries()].sort((a, b) => b[1].totalUs - a[1].totalUs)
+                console.log('\n[redis cmd stats]')
+                let totalCount = 0
+                let totalUs = 0
+                for (const [cmd, s] of sorted) {
+                    totalCount += s.count
+                    totalUs += s.totalUs
+                    console.log(
+                        '  ' +
+                            String(s.count).padStart(6) +
+                            '  ' +
+                            (s.totalUs / 1000).toFixed(1).padStart(9) +
+                            ' ms  ' +
+                            cmd
+                    )
+                }
+                console.log(
+                    `  ${String(totalCount).padStart(6)}  ${(totalUs / 1000).toFixed(1).padStart(9)} ms  TOTAL`
+                )
+            }
+            await rawClient.quit().catch(() => undefined)
         }
     }
 }
 
 async function buildMongoStore(): Promise<BenchStoreFixture> {
     const { createMongoStore } = await import('@zapo-js/store-mongo')
+    const { MongoClient } = await import('mongodb')
     const host = requireEnv('ZAPO_TEST_MONGO_HOST')
     const port = parsePort('ZAPO_TEST_MONGO_PORT')
     const uri = `mongodb://${host}:${port}/?directConnection=true`
     const database = `zapo_bench_${Date.now().toString(36)}`
-    const backend = createMongoStore({
-        db: { uri, database }
-    })
+
+    const trace = process.env.ZAPO_BENCH_TRACE_QUERIES === '1'
+    const cmdStats = new Map<string, { count: number; totalUs: number }>()
+    const rawClient = new MongoClient(uri, { monitorCommands: trace })
+    if (trace) {
+        const startedAt = new Map<number, { start: bigint; key: string }>()
+        rawClient.on('commandStarted', (event) => {
+            // mongo command bodies put the collection at `cmd[cmdName]` for
+            // crud commands (update/insert/find/delete) and as `getMore`'s
+            // `collection` field. Use that to attribute per-collection cost.
+            const cmd = event.command as Record<string, unknown>
+            const candidate = cmd[event.commandName] ?? cmd.collection
+            const coll = typeof candidate === 'string' ? candidate : undefined
+            const key = coll ? `${event.commandName} ${coll}` : event.commandName
+            startedAt.set(event.requestId, { start: process.hrtime.bigint(), key })
+        })
+        const finish = (event: { requestId: number }): void => {
+            const meta = startedAt.get(event.requestId)
+            startedAt.delete(event.requestId)
+            if (!meta) return
+            const elapsedUs = Number(process.hrtime.bigint() - meta.start) / 1000
+            const cur = cmdStats.get(meta.key) ?? { count: 0, totalUs: 0 }
+            cur.count += 1
+            cur.totalUs += elapsedUs
+            cmdStats.set(meta.key, cur)
+        }
+        rawClient.on('commandSucceeded', finish)
+        rawClient.on('commandFailed', finish)
+    }
+    await rawClient.connect()
+    const db = rawClient.db(database)
+    const backend = createMongoStore({ db })
+
     const store = createStore({
         backends: { mongo: backend },
         providers: buildProviders('mongo')
@@ -224,6 +501,28 @@ async function buildMongoStore(): Promise<BenchStoreFixture> {
         description: `mongo (${host}:${port}/${database})`,
         destroy: async () => {
             await store.destroy()
+            if (trace) {
+                const sorted = [...cmdStats.entries()].sort((a, b) => b[1].totalUs - a[1].totalUs)
+                console.log('\n[mongo cmd stats]')
+                let totalCount = 0
+                let totalUs = 0
+                for (const [cmd, s] of sorted) {
+                    totalCount += s.count
+                    totalUs += s.totalUs
+                    console.log(
+                        '  ' +
+                            String(s.count).padStart(7) +
+                            '  ' +
+                            (s.totalUs / 1000).toFixed(1).padStart(9) +
+                            ' ms  ' +
+                            cmd
+                    )
+                }
+                console.log(
+                    `  ${String(totalCount).padStart(7)}  ${(totalUs / 1000).toFixed(1).padStart(9)} ms  TOTAL`
+                )
+            }
+            await rawClient.close().catch(() => undefined)
         }
     }
 }

--- a/packages/fake-server/bench/messaging.bench.ts
+++ b/packages/fake-server/bench/messaging.bench.ts
@@ -53,11 +53,13 @@ import * as inspector from 'node:inspector/promises'
 import { resolve as resolvePath } from 'node:path'
 import { performance } from 'node:perf_hooks'
 
-import { createStore, type Logger, WaClient, type WaClientEventMap } from 'zapo-js'
+import { type Logger, WaClient, type WaClientEventMap } from 'zapo-js'
 
 import type { FakePeer } from '../src/api/FakePeer'
 import { FakeWaServer, type WaFakeConnectionPipeline } from '../src/api/FakeWaServer'
 import { parsePairingQrString } from '../src/protocol/auth/pair-device'
+
+import { type BenchStoreFixture, buildBenchStore } from './_store-factory'
 
 // ─── Helpers ──────────────────────────────────────────────────────────
 
@@ -365,26 +367,16 @@ interface PairedFixture {
     readonly client: WaClient
     readonly pipeline: WaFakeConnectionPipeline
     readonly meJid: string
+    readonly storeFixture: BenchStoreFixture
 }
 
 async function bringUpPairedClient(): Promise<PairedFixture> {
     const server = await FakeWaServer.start()
-    const store = createStore({
-        // The default in-memory prekey store caps at 4_096 entries.
-        // The bench creates ~4000 fake peers and triggers ~5 prekey
-        // refills (each generates 812 fresh keyIds), so the total
-        // distinct keyId set hits ~4060 – right at the cap. The
-        // bounded map then evicts the oldest entries (the very keyIds
-        // that the early peers reserved), causing those peers to fail
-        // their pkmsg with "prekey N not found" later. Bumping the
-        // cap above the worst-case keeps every reserved keyId alive
-        // for the duration of the bench.
-        memory: { limits: { signalPreKeys: 16_384 } }
-    })
+    const storeFixture = await buildBenchStore()
 
     const client = new WaClient(
         {
-            store,
+            store: storeFixture.store,
             sessionId: 'zapo-messaging-bench',
             chatSocketUrls: [server.url],
             connectTimeoutMs: 60_000,
@@ -431,7 +423,7 @@ async function bringUpPairedClient(): Promise<PairedFixture> {
     const pipelineAfterPair = await pipelineAfterPairPromise
     await server.triggerPreKeyUpload(pipelineAfterPair)
 
-    return { server, client, pipeline: pipelineAfterPair, meJid }
+    return { server, client, pipeline: pipelineAfterPair, meJid, storeFixture }
 }
 
 // ─── Fixtures ─────────────────────────────────────────────────────────
@@ -745,6 +737,7 @@ function printConfig(config: BenchConfig): void {
     console.log(`  members/group     : ${config.groupMembers}`)
     console.log(`  messages/scenario : ${config.messages}`)
     console.log(`  scenarios         : ${[...config.scenarios].join(', ')}`)
+    console.log(`  store             : ${process.env.ZAPO_BENCH_STORE ?? 'memory'}`)
     console.log(`  --expose-gc       : ${hasExposedGc() ? 'yes' : 'no'}`)
     console.log('')
 }
@@ -844,6 +837,7 @@ async function mainInProcess(
         cleanup: async () => {
             await fixture.client.disconnect().catch(() => undefined)
             await fixture.server.stop()
+            await fixture.storeFixture.destroy().catch(() => undefined)
         }
     }
 }
@@ -874,13 +868,11 @@ async function mainSeparateProcess(
         console.log('[server] profiling skipped (--no-server-prof)')
     }
 
-    const store = createStore({
-        memory: { limits: { signalPreKeys: 16_384 } }
-    })
+    const storeFixture = await buildBenchStore()
 
     const client = new WaClient(
         {
-            store,
+            store: storeFixture.store,
             sessionId: 'zapo-bench-separate',
             chatSocketUrls: [rpc.serverUrl],
             connectTimeoutMs: 60_000,
@@ -982,6 +974,7 @@ async function mainSeparateProcess(
             }
             await client.disconnect().catch(() => undefined)
             await rpc.stop()
+            await storeFixture.destroy().catch(() => undefined)
         }
     }
 }

--- a/packages/fake-server/bench/run-all-stores.cjs
+++ b/packages/fake-server/bench/run-all-stores.cjs
@@ -35,6 +35,7 @@ const REPO_ROOT = resolve(__dirname, '../../..')
 const COMPOSE_FILE = join(REPO_ROOT, 'packages', 'docker-compose.test.yml')
 
 const ALL_BENCHES = [
+    'messaging',
     'connect-lifecycle',
     'history-sync',
     'bulk-usync',

--- a/packages/store-mysql/src/BaseMysqlStore.ts
+++ b/packages/store-mysql/src/BaseMysqlStore.ts
@@ -1,13 +1,26 @@
 import type { Pool, PoolConnection } from 'mysql2/promise'
+import { resolvePositive } from 'zapo-js/util'
 
 import { ensureMysqlMigrations } from './connection'
 import { assertSafeTablePrefix } from './helpers'
 import type { WaMysqlMigrationDomain, WaMysqlStorageOptions } from './types'
 
+const DEFAULT_BATCH_INSERT_CHUNK_SIZE = 500
+
 export abstract class BaseMysqlStore {
     protected readonly pool: Pool
     protected readonly sessionId: string
     protected readonly tablePrefix: string
+    /**
+     * Largest power-of-two sub-chunk used by multi-row INSERT helpers.
+     * Caller passes `batchInsertChunkSize`; we round down to the
+     * nearest power of two so the set of distinct SQL texts emitted by
+     * batch writes stays bounded by `log2(maxBatchChunk)` — keeps the
+     * mysql2 client-side prep cache + the server-side
+     * `max_prepared_stmt_count` quota bounded regardless of how the
+     * caller varies batch sizes.
+     */
+    protected readonly maxBatchChunk: number
     private readonly migrationDomains: readonly WaMysqlMigrationDomain[]
     private migrationPromise: Promise<void> | null
     private migrationDone = false
@@ -20,8 +33,36 @@ export abstract class BaseMysqlStore {
         this.sessionId = options.sessionId
         this.tablePrefix = options.tablePrefix ?? ''
         assertSafeTablePrefix(this.tablePrefix)
+        const requested = resolvePositive(
+            options.batchInsertChunkSize,
+            DEFAULT_BATCH_INSERT_CHUNK_SIZE,
+            'batchInsertChunkSize'
+        )
+        this.maxBatchChunk = 1 << (31 - Math.clz32(requested))
         this.migrationDomains = migrationDomains
         this.migrationPromise = null
+    }
+
+    /**
+     * Decomposes `n` into a list of power-of-two sub-chunks, each <=
+     * {@link maxBatchChunk}, emitted largest-first. Multi-row INSERT
+     * call sites iterate this list and emit one statement per
+     * sub-chunk so the inner SQL text only ever takes on values from
+     * `{1, 2, 4, ..., maxBatchChunk}`.
+     */
+    protected powerOfTwoChunks(n: number): readonly number[] {
+        if (n <= 0) return []
+        const out: number[] = []
+        let remaining = n
+        let size = this.maxBatchChunk
+        while (size >= 1 && remaining > 0) {
+            while (remaining >= size) {
+                out.push(size)
+                remaining -= size
+            }
+            size = size >>> 1
+        }
+        return out
     }
 
     protected t(name: string): string {

--- a/packages/store-mysql/src/BaseMysqlStore.ts
+++ b/packages/store-mysql/src/BaseMysqlStore.ts
@@ -13,12 +13,11 @@ export abstract class BaseMysqlStore {
     protected readonly tablePrefix: string
     /**
      * Largest power-of-two sub-chunk used by multi-row INSERT helpers.
-     * Caller passes `batchInsertChunkSize`; we round down to the
-     * nearest power of two so the set of distinct SQL texts emitted by
-     * batch writes stays bounded by `log2(maxBatchChunk)` — keeps the
-     * mysql2 client-side prep cache + the server-side
-     * `max_prepared_stmt_count` quota bounded regardless of how the
-     * caller varies batch sizes.
+     * Caller passes `batchInsertChunkSize`; we round down to the nearest
+     * power of two so the set of distinct SQL texts emitted by batch
+     * writes stays bounded by `log2(maxBatchChunk)`. This keeps the mysql2
+     * client-side prep cache and the server-side `max_prepared_stmt_count`
+     * quota bounded regardless of how the caller varies batch sizes.
      */
     protected readonly maxBatchChunk: number
     private readonly migrationDomains: readonly WaMysqlMigrationDomain[]

--- a/packages/store-mysql/src/__tests__/integration.test.ts
+++ b/packages/store-mysql/src/__tests__/integration.test.ts
@@ -1123,8 +1123,11 @@ describe('store-mysql integration', { timeout: 60_000 }, () => {
         await session.clear()
     })
 
-    it('signal: setSessionsBatch with batchInsertChunkSize=3 splits into multi-chunk transaction', async (t) => {
-        if (!pool) return t.skip('ZAPO_TEST_MYSQL_* not set')
+    it('signal: setSessionsBatch chunked split runs in withTransaction', async (t) => {
+        if (!pool) {
+            t.skip('ZAPO_TEST_MYSQL_* not set')
+            return
+        }
 
         const tinyChunkStore = createMysqlStore({ pool, batchInsertChunkSize: 3 })
         try {
@@ -1139,7 +1142,7 @@ describe('store-mysql integration', { timeout: 60_000 }, () => {
             )
             const entries = addresses.map((address, i) => ({ address, session: sessions[i] }))
 
-            // 8 / 3 = 3 chunks (3+3+2) — exercises the withTransaction path.
+            // 8 / 3 = 3 chunks (3+3+2): exercises the withTransaction path.
             await session.setSessionsBatch(entries)
 
             const got = await session.getSessionsBatch(addresses)
@@ -1153,8 +1156,11 @@ describe('store-mysql integration', { timeout: 60_000 }, () => {
         }
     })
 
-    it('rejects invalid batchInsertChunkSize', () => {
-        if (!pool) return
+    it('rejects invalid batchInsertChunkSize', (t) => {
+        if (!pool) {
+            t.skip('ZAPO_TEST_MYSQL_* not set')
+            return
+        }
         const livePool = pool
         assert.throws(
             () => createMysqlStore({ pool: livePool, batchInsertChunkSize: 0 }).stores.session('x'),

--- a/packages/store-mysql/src/__tests__/integration.test.ts
+++ b/packages/store-mysql/src/__tests__/integration.test.ts
@@ -1123,6 +1123,55 @@ describe('store-mysql integration', { timeout: 60_000 }, () => {
         await session.clear()
     })
 
+    it('signal: setSessionsBatch with batchInsertChunkSize=3 splits into multi-chunk transaction', async (t) => {
+        if (!pool) return t.skip('ZAPO_TEST_MYSQL_* not set')
+
+        const tinyChunkStore = createMysqlStore({ pool, batchInsertChunkSize: 3 })
+        try {
+            const sessionId = nextSessionId('chunked')
+            const session = tinyChunkStore.stores.session(sessionId)
+            await session.clear()
+
+            const N = 8
+            const addresses = Array.from({ length: N }, (_, i) => makeAddress(`u${i}`, i + 1))
+            const sessions = await Promise.all(
+                Array.from({ length: N }, (_, i) => makeSessionRecord(100 + i))
+            )
+            const entries = addresses.map((address, i) => ({ address, session: sessions[i] }))
+
+            // 8 / 3 = 3 chunks (3+3+2) — exercises the withTransaction path.
+            await session.setSessionsBatch(entries)
+
+            const got = await session.getSessionsBatch(addresses)
+            assert.equal(got.length, N)
+            for (let i = 0; i < N; i += 1) {
+                assert.equal(got[i]?.local.regId, sessions[i].local.regId)
+            }
+            await session.clear()
+        } finally {
+            await tinyChunkStore.destroy()
+        }
+    })
+
+    it('rejects invalid batchInsertChunkSize', () => {
+        if (!pool) return
+        const livePool = pool
+        assert.throws(
+            () => createMysqlStore({ pool: livePool, batchInsertChunkSize: 0 }).stores.session('x'),
+            /batchInsertChunkSize/
+        )
+        assert.throws(
+            () =>
+                createMysqlStore({ pool: livePool, batchInsertChunkSize: -1 }).stores.session('x'),
+            /batchInsertChunkSize/
+        )
+        assert.throws(
+            () =>
+                createMysqlStore({ pool: livePool, batchInsertChunkSize: 1.5 }).stores.session('x'),
+            /batchInsertChunkSize/
+        )
+    })
+
     it('appstate: updating same collection replaces previous index entries', async (t) => {
         if (!store) return t.skip('ZAPO_TEST_MYSQL_* not set')
 

--- a/packages/store-mysql/src/contact.store.ts
+++ b/packages/store-mysql/src/contact.store.ts
@@ -1,8 +1,9 @@
+import type { PoolConnection } from 'mysql2/promise'
 import type { WaContactStore, WaStoredContactRecord } from 'zapo-js/store'
 
 import { BaseMysqlStore } from './BaseMysqlStore'
 import { affectedRows, queryFirst } from './helpers'
-import type { WaMysqlStorageOptions } from './types'
+import type { MysqlParam, WaMysqlStorageOptions } from './types'
 
 export class WaContactMysqlStore extends BaseMysqlStore implements WaContactStore {
     public constructor(options: WaMysqlStorageOptions) {
@@ -36,30 +37,48 @@ export class WaContactMysqlStore extends BaseMysqlStore implements WaContactStor
 
     public async upsertBatch(records: readonly WaStoredContactRecord[]): Promise<void> {
         if (records.length === 0) return
-
-        await this.withTransaction(async (conn) => {
-            for (const record of records) {
-                await conn.execute(
-                    `INSERT INTO ${this.t('mailbox_contacts')} (
-                        session_id, jid, display_name, push_name, lid,
-                        phone_number, last_updated_ms
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
-                    ON DUPLICATE KEY UPDATE
-                        display_name = COALESCE(VALUES(display_name), display_name),
-                        push_name = COALESCE(VALUES(push_name), push_name),
-                        lid = COALESCE(VALUES(lid), lid),
-                        phone_number = COALESCE(VALUES(phone_number), phone_number),
-                        last_updated_ms = VALUES(last_updated_ms)`,
-                    [
-                        this.sessionId,
-                        record.jid,
-                        record.displayName ?? null,
-                        record.pushName ?? null,
-                        record.lid ?? null,
-                        record.phoneNumber ?? null,
-                        record.lastUpdatedMs
-                    ]
+        const runChunk = async (
+            executor: { execute: PoolConnection['execute'] },
+            chunk: readonly WaStoredContactRecord[]
+        ): Promise<void> => {
+            const placeholders = chunk.map(() => '(?, ?, ?, ?, ?, ?, ?)').join(', ')
+            const params: MysqlParam[] = []
+            for (const record of chunk) {
+                params.push(
+                    this.sessionId,
+                    record.jid,
+                    record.displayName ?? null,
+                    record.pushName ?? null,
+                    record.lid ?? null,
+                    record.phoneNumber ?? null,
+                    record.lastUpdatedMs
                 )
+            }
+            await executor.execute(
+                `INSERT INTO ${this.t('mailbox_contacts')} (
+                    session_id, jid, display_name, push_name, lid,
+                    phone_number, last_updated_ms
+                ) VALUES ${placeholders}
+                ON DUPLICATE KEY UPDATE
+                    display_name = COALESCE(VALUES(display_name), display_name),
+                    push_name = COALESCE(VALUES(push_name), push_name),
+                    lid = COALESCE(VALUES(lid), lid),
+                    phone_number = COALESCE(VALUES(phone_number), phone_number),
+                    last_updated_ms = VALUES(last_updated_ms)`,
+                params
+            )
+        }
+        const sizes = this.powerOfTwoChunks(records.length)
+        if (sizes.length === 1) {
+            await this.ensureReady()
+            await runChunk(this.pool, records)
+            return
+        }
+        await this.withTransaction(async (conn) => {
+            let cursor = 0
+            for (const size of sizes) {
+                await runChunk(conn, records.slice(cursor, cursor + size))
+                cursor += size
             }
         })
     }

--- a/packages/store-mysql/src/createMysqlStore.ts
+++ b/packages/store-mysql/src/createMysqlStore.ts
@@ -54,6 +54,21 @@ export interface WaMysqlStoreConfig {
         readonly intervalMs?: number
         readonly onError?: (error: Error) => void
     }
+    /**
+     * Upper bound on rows per multi-row INSERT statement in batch
+     * writes (`setSessionsBatch`, `setRemoteIdentities`,
+     * `upsertSenderKeyDistributions`, prekey gen). Default 500.
+     *
+     * Internally rounded down to the nearest power of two
+     * (`500 → 256`, `1000 → 512`, etc.) so each batch call decomposes
+     * `N` into power-of-two sub-chunks and only ever emits SQL with a
+     * row count from `{1, 2, 4, ..., maxBatchChunk}`. This bounds the
+     * distinct prepared statements per connection at `log2(N) + 1` (≈
+     * 9 at the default), which keeps the mysql2 client-side cache and
+     * the mysql `max_prepared_stmt_count` quota stable under
+     * workloads where `N` varies widely.
+     */
+    readonly batchInsertChunkSize?: number
 }
 
 export interface WaMysqlStoreResult {
@@ -118,10 +133,12 @@ export function createMysqlStore(config: WaMysqlStoreConfig): WaMysqlStoreResult
     const messageSecretTtlMs = config.cacheTtlMs?.messageSecretMs
     const ownsPool = !isPool(config.pool)
 
+    const batchInsertChunkSize = config.batchInsertChunkSize
     const opts = (sessionId: string): WaMysqlStorageOptions => ({
         pool,
         sessionId,
-        tablePrefix
+        tablePrefix,
+        batchInsertChunkSize
     })
 
     const cleanupPollers = new Set<MysqlCleanupPoller>()

--- a/packages/store-mysql/src/identity.store.ts
+++ b/packages/store-mysql/src/identity.store.ts
@@ -85,10 +85,42 @@ export class WaIdentityMysqlStore extends BaseMysqlStore implements WaIdentitySt
         }[]
     ): Promise<void> {
         if (entries.length === 0) return
-        await this.withTransaction(async (conn) => {
-            for (const entry of entries) {
+        const runChunk = async (
+            executor: { execute: PoolConnection['execute'] },
+            chunk: readonly { readonly address: SignalAddress; readonly identityKey: Uint8Array }[]
+        ): Promise<void> => {
+            const placeholders = chunk.map(() => '(?, ?, ?, ?, ?)').join(', ')
+            const params: MysqlParam[] = []
+            for (const entry of chunk) {
                 const target = toSignalAddressParts(entry.address)
-                await this.upsertRemoteIdentity(conn, target, entry.identityKey)
+                params.push(
+                    this.sessionId,
+                    target.user,
+                    target.server,
+                    target.device,
+                    entry.identityKey
+                )
+            }
+            await executor.execute(
+                `INSERT INTO ${this.t('signal_identity')} (
+                    session_id, user, server, device, identity_key
+                ) VALUES ${placeholders}
+                ON DUPLICATE KEY UPDATE
+                    identity_key = VALUES(identity_key)`,
+                params
+            )
+        }
+        const sizes = this.powerOfTwoChunks(entries.length)
+        if (sizes.length === 1) {
+            await this.ensureReady()
+            await runChunk(this.pool, entries)
+            return
+        }
+        await this.withTransaction(async (conn) => {
+            let cursor = 0
+            for (const size of sizes) {
+                await runChunk(conn, entries.slice(cursor, cursor + size))
+                cursor += size
             }
         })
     }

--- a/packages/store-mysql/src/message.store.ts
+++ b/packages/store-mysql/src/message.store.ts
@@ -1,3 +1,4 @@
+import type { PoolConnection } from 'mysql2/promise'
 import type { WaMessageStore, WaStoredMessageRecord } from 'zapo-js/store'
 
 import { BaseMysqlStore } from './BaseMysqlStore'
@@ -9,7 +10,7 @@ import {
     safeLimit,
     toBytesOrNull
 } from './helpers'
-import type { WaMysqlStorageOptions } from './types'
+import type { MysqlParam, WaMysqlStorageOptions } from './types'
 
 function rowToRecord(row: MysqlRow): WaStoredMessageRecord {
     return {
@@ -63,36 +64,54 @@ export class WaMessageMysqlStore extends BaseMysqlStore implements WaMessageStor
 
     public async upsertBatch(records: readonly WaStoredMessageRecord[]): Promise<void> {
         if (records.length === 0) return
-
-        await this.withTransaction(async (conn) => {
-            for (const record of records) {
-                await conn.execute(
-                    `INSERT INTO ${this.t('mailbox_messages')} (
-                        session_id, message_id, thread_jid, sender_jid, participant_jid,
-                        from_me, timestamp_ms, enc_type, plaintext, message_bytes
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON DUPLICATE KEY UPDATE
-                        thread_jid = VALUES(thread_jid),
-                        sender_jid = VALUES(sender_jid),
-                        participant_jid = VALUES(participant_jid),
-                        from_me = VALUES(from_me),
-                        timestamp_ms = VALUES(timestamp_ms),
-                        enc_type = VALUES(enc_type),
-                        plaintext = VALUES(plaintext),
-                        message_bytes = VALUES(message_bytes)`,
-                    [
-                        this.sessionId,
-                        record.id,
-                        record.threadJid,
-                        record.senderJid ?? null,
-                        record.participantJid ?? null,
-                        record.fromMe ? 1 : 0,
-                        record.timestampMs ?? null,
-                        record.encType ?? null,
-                        record.plaintext ?? null,
-                        record.messageBytes ?? null
-                    ]
+        const runChunk = async (
+            executor: { execute: PoolConnection['execute'] },
+            chunk: readonly WaStoredMessageRecord[]
+        ): Promise<void> => {
+            const placeholders = chunk.map(() => '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)').join(', ')
+            const params: MysqlParam[] = []
+            for (const record of chunk) {
+                params.push(
+                    this.sessionId,
+                    record.id,
+                    record.threadJid,
+                    record.senderJid ?? null,
+                    record.participantJid ?? null,
+                    record.fromMe ? 1 : 0,
+                    record.timestampMs ?? null,
+                    record.encType ?? null,
+                    record.plaintext ?? null,
+                    record.messageBytes ?? null
                 )
+            }
+            await executor.execute(
+                `INSERT INTO ${this.t('mailbox_messages')} (
+                    session_id, message_id, thread_jid, sender_jid, participant_jid,
+                    from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                ) VALUES ${placeholders}
+                ON DUPLICATE KEY UPDATE
+                    thread_jid = VALUES(thread_jid),
+                    sender_jid = VALUES(sender_jid),
+                    participant_jid = VALUES(participant_jid),
+                    from_me = VALUES(from_me),
+                    timestamp_ms = VALUES(timestamp_ms),
+                    enc_type = VALUES(enc_type),
+                    plaintext = VALUES(plaintext),
+                    message_bytes = VALUES(message_bytes)`,
+                params
+            )
+        }
+        const sizes = this.powerOfTwoChunks(records.length)
+        if (sizes.length === 1) {
+            await this.ensureReady()
+            await runChunk(this.pool, records)
+            return
+        }
+        await this.withTransaction(async (conn) => {
+            let cursor = 0
+            for (const size of sizes) {
+                await runChunk(conn, records.slice(cursor, cursor + size))
+                cursor += size
             }
         })
     }

--- a/packages/store-mysql/src/pre-key.store.ts
+++ b/packages/store-mysql/src/pre-key.store.ts
@@ -75,18 +75,27 @@ export class WaPreKeyMysqlStore extends BaseMysqlStore implements WaPreKeyStore 
 
             await this.withTransaction(async (conn) => {
                 await this.ensureMetaRow(conn)
-                for (const record of generated) {
-                    await conn.execute(
-                        `INSERT IGNORE INTO ${this.t('signal_prekey')} (
-                            session_id, key_id, pub_key, priv_key, uploaded
-                        ) VALUES (?, ?, ?, ?, ?)`,
-                        [
+                const sizes = this.powerOfTwoChunks(generated.length)
+                let cursor = 0
+                for (const size of sizes) {
+                    const chunk = generated.slice(cursor, cursor + size)
+                    cursor += size
+                    const placeholders = chunk.map(() => '(?, ?, ?, ?, ?)').join(', ')
+                    const params: MysqlParam[] = []
+                    for (const record of chunk) {
+                        params.push(
                             this.sessionId,
                             record.keyId,
                             record.keyPair.pubKey,
                             record.keyPair.privKey,
                             record.uploaded === true ? 1 : 0
-                        ]
+                        )
+                    }
+                    await conn.execute(
+                        `INSERT IGNORE INTO ${this.t('signal_prekey')} (
+                            session_id, key_id, pub_key, priv_key, uploaded
+                        ) VALUES ${placeholders}`,
+                        params
                     )
                 }
                 await conn.execute(

--- a/packages/store-mysql/src/sender-key.store.ts
+++ b/packages/store-mysql/src/sender-key.store.ts
@@ -56,10 +56,46 @@ export class WaSenderKeyMysqlStore extends BaseMysqlStore implements WaSenderKey
         records: readonly SenderKeyDistributionRecord[]
     ): Promise<void> {
         if (records.length === 0) return
-        await this.withTransaction(async (conn) => {
-            for (const record of records) {
+        const runChunk = async (
+            executor: { execute: PoolConnection['execute'] },
+            chunk: readonly SenderKeyDistributionRecord[]
+        ): Promise<void> => {
+            const placeholders = chunk.map(() => '(?, ?, ?, ?, ?, ?, ?)').join(', ')
+            const params: MysqlParam[] = []
+            for (const record of chunk) {
                 const sender = toSignalAddressParts(record.sender)
-                await this.upsertSenderKeyDistributionRow(conn, record, sender)
+                params.push(
+                    this.sessionId,
+                    record.groupId,
+                    sender.user,
+                    sender.server,
+                    sender.device,
+                    record.keyId,
+                    record.timestampMs
+                )
+            }
+            await executor.execute(
+                `INSERT INTO ${this.t('sender_key_distribution')} (
+                    session_id, group_id, sender_user, sender_server, sender_device,
+                    key_id, timestamp_ms
+                ) VALUES ${placeholders}
+                ON DUPLICATE KEY UPDATE
+                    key_id = VALUES(key_id),
+                    timestamp_ms = VALUES(timestamp_ms)`,
+                params
+            )
+        }
+        const sizes = this.powerOfTwoChunks(records.length)
+        if (sizes.length === 1) {
+            await this.ensureReady()
+            await runChunk(this.pool, records)
+            return
+        }
+        await this.withTransaction(async (conn) => {
+            let cursor = 0
+            for (const size of sizes) {
+                await runChunk(conn, records.slice(cursor, cursor + size))
+                cursor += size
             }
         })
     }
@@ -140,45 +176,38 @@ export class WaSenderKeyMysqlStore extends BaseMysqlStore implements WaSenderKey
     ): Promise<readonly (SenderKeyDistributionRecord | null)[]> {
         if (senders.length === 0) return []
         await this.ensureReady()
-        const targets = senders.map((s) => toSignalAddressParts(s))
-        const byKey = new Map<string, SenderKeyDistributionRecord>()
-        for (let start = 0; start < targets.length; start += BATCH_SIZE) {
-            const batch = targets.slice(start, start + BATCH_SIZE)
-            while (batch.length < BATCH_SIZE) batch.push(NO_MATCH_SENDER)
-            const params: MysqlParam[] = [
-                this.sessionId,
-                groupId,
-                ...batch.flatMap((t) => [t.user, t.server, t.device])
-            ]
-            const rows = queryRows(
-                await this.pool.execute(
-                    `SELECT group_id, sender_user, sender_server, sender_device, key_id, timestamp_ms
-                     FROM ${this.t('sender_key_distribution')}
-                     WHERE session_id = ? AND group_id = ? AND (${FIXED_SENDER_PLACEHOLDERS})`,
-                    params
-                )
+        const rows = queryRows(
+            await this.pool.execute(
+                `SELECT group_id, sender_user, sender_server, sender_device, key_id, timestamp_ms
+                 FROM ${this.t('sender_key_distribution')}
+                 WHERE session_id = ? AND group_id = ?`,
+                [this.sessionId, groupId]
             )
-            for (const row of rows) {
-                const key = this.distributionTargetKey(
-                    String(row.sender_user),
-                    String(row.sender_server),
-                    Number(row.sender_device)
-                )
-                byKey.set(key, {
-                    groupId: String(row.group_id),
-                    sender: {
-                        user: String(row.sender_user),
-                        server: String(row.sender_server),
-                        device: Number(row.sender_device)
-                    },
-                    keyId: Number(row.key_id),
-                    timestampMs: Number(row.timestamp_ms)
-                })
-            }
-        }
-        return targets.map(
-            (t) => byKey.get(this.distributionTargetKey(t.user, t.server, t.device)) ?? null
         )
+        const byKey = new Map<string, SenderKeyDistributionRecord>()
+        for (const row of rows) {
+            const key = this.distributionTargetKey(
+                String(row.sender_user),
+                String(row.sender_server),
+                Number(row.sender_device)
+            )
+            byKey.set(key, {
+                groupId: String(row.group_id),
+                sender: {
+                    user: String(row.sender_user),
+                    server: String(row.sender_server),
+                    device: Number(row.sender_device)
+                },
+                keyId: Number(row.key_id),
+                timestampMs: Number(row.timestamp_ms)
+            })
+        }
+        const out = new Array<SenderKeyDistributionRecord | null>(senders.length)
+        for (let i = 0; i < senders.length; i += 1) {
+            const t = toSignalAddressParts(senders[i])
+            out[i] = byKey.get(this.distributionTargetKey(t.user, t.server, t.device)) ?? null
+        }
+        return out
     }
 
     public async deleteDeviceSenderKey(target: SignalAddress, groupId?: string): Promise<number> {

--- a/packages/store-mysql/src/session.store.ts
+++ b/packages/store-mysql/src/session.store.ts
@@ -141,10 +141,45 @@ export class WaSessionMysqlStore extends BaseMysqlStore implements WaSessionStor
         }[]
     ): Promise<void> {
         if (entries.length === 0) return
-        await this.withTransaction(async (conn) => {
-            for (const entry of entries) {
+        const runChunk = async (
+            executor: { execute: PoolConnection['execute'] },
+            chunk: readonly {
+                readonly address: SignalAddress
+                readonly session: SignalSessionRecord
+            }[]
+        ): Promise<void> => {
+            const placeholders = chunk.map(() => '(?, ?, ?, ?, ?)').join(', ')
+            const params: MysqlParam[] = []
+            for (const entry of chunk) {
                 const target = toSignalAddressParts(entry.address)
-                await this.upsertSession(conn, target, entry.session)
+                params.push(
+                    this.sessionId,
+                    target.user,
+                    target.server,
+                    target.device,
+                    encodeSignalSessionRecord(entry.session)
+                )
+            }
+            await executor.execute(
+                `INSERT INTO ${this.t('signal_session')} (
+                    session_id, user, server, device, record
+                ) VALUES ${placeholders}
+                ON DUPLICATE KEY UPDATE
+                    record = VALUES(record)`,
+                params
+            )
+        }
+        const sizes = this.powerOfTwoChunks(entries.length)
+        if (sizes.length === 1) {
+            await this.ensureReady()
+            await runChunk(this.pool, entries)
+            return
+        }
+        await this.withTransaction(async (conn) => {
+            let cursor = 0
+            for (const size of sizes) {
+                await runChunk(conn, entries.slice(cursor, cursor + size))
+                cursor += size
             }
         })
     }

--- a/packages/store-mysql/src/thread.store.ts
+++ b/packages/store-mysql/src/thread.store.ts
@@ -1,8 +1,9 @@
+import type { PoolConnection } from 'mysql2/promise'
 import type { WaStoredThreadRecord, WaThreadStore } from 'zapo-js/store'
 
 import { BaseMysqlStore } from './BaseMysqlStore'
 import { affectedRows, type MysqlRow, queryFirst, queryRows, safeLimit } from './helpers'
-import type { WaMysqlStorageOptions } from './types'
+import type { MysqlParam, WaMysqlStorageOptions } from './types'
 
 export class WaThreadMysqlStore extends BaseMysqlStore implements WaThreadStore {
     public constructor(options: WaMysqlStorageOptions) {
@@ -40,34 +41,52 @@ export class WaThreadMysqlStore extends BaseMysqlStore implements WaThreadStore 
 
     public async upsertBatch(records: readonly WaStoredThreadRecord[]): Promise<void> {
         if (records.length === 0) return
-
-        await this.withTransaction(async (conn) => {
-            for (const record of records) {
-                await conn.execute(
-                    `INSERT INTO ${this.t('mailbox_threads')} (
-                        session_id, jid, name, unread_count, archived, pinned,
-                        mute_end_ms, marked_as_unread, ephemeral_expiration
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON DUPLICATE KEY UPDATE
-                        name = COALESCE(VALUES(name), name),
-                        unread_count = COALESCE(VALUES(unread_count), unread_count),
-                        archived = COALESCE(VALUES(archived), archived),
-                        pinned = COALESCE(VALUES(pinned), pinned),
-                        mute_end_ms = COALESCE(VALUES(mute_end_ms), mute_end_ms),
-                        marked_as_unread = COALESCE(VALUES(marked_as_unread), marked_as_unread),
-                        ephemeral_expiration = COALESCE(VALUES(ephemeral_expiration), ephemeral_expiration)`,
-                    [
-                        this.sessionId,
-                        record.jid,
-                        record.name ?? null,
-                        record.unreadCount ?? null,
-                        record.archived === undefined ? null : record.archived ? 1 : 0,
-                        record.pinned ?? null,
-                        record.muteEndMs ?? null,
-                        record.markedAsUnread === undefined ? null : record.markedAsUnread ? 1 : 0,
-                        record.ephemeralExpiration ?? null
-                    ]
+        const runChunk = async (
+            executor: { execute: PoolConnection['execute'] },
+            chunk: readonly WaStoredThreadRecord[]
+        ): Promise<void> => {
+            const placeholders = chunk.map(() => '(?, ?, ?, ?, ?, ?, ?, ?, ?)').join(', ')
+            const params: MysqlParam[] = []
+            for (const record of chunk) {
+                params.push(
+                    this.sessionId,
+                    record.jid,
+                    record.name ?? null,
+                    record.unreadCount ?? null,
+                    record.archived === undefined ? null : record.archived ? 1 : 0,
+                    record.pinned ?? null,
+                    record.muteEndMs ?? null,
+                    record.markedAsUnread === undefined ? null : record.markedAsUnread ? 1 : 0,
+                    record.ephemeralExpiration ?? null
                 )
+            }
+            await executor.execute(
+                `INSERT INTO ${this.t('mailbox_threads')} (
+                    session_id, jid, name, unread_count, archived, pinned,
+                    mute_end_ms, marked_as_unread, ephemeral_expiration
+                ) VALUES ${placeholders}
+                ON DUPLICATE KEY UPDATE
+                    name = COALESCE(VALUES(name), name),
+                    unread_count = COALESCE(VALUES(unread_count), unread_count),
+                    archived = COALESCE(VALUES(archived), archived),
+                    pinned = COALESCE(VALUES(pinned), pinned),
+                    mute_end_ms = COALESCE(VALUES(mute_end_ms), mute_end_ms),
+                    marked_as_unread = COALESCE(VALUES(marked_as_unread), marked_as_unread),
+                    ephemeral_expiration = COALESCE(VALUES(ephemeral_expiration), ephemeral_expiration)`,
+                params
+            )
+        }
+        const sizes = this.powerOfTwoChunks(records.length)
+        if (sizes.length === 1) {
+            await this.ensureReady()
+            await runChunk(this.pool, records)
+            return
+        }
+        await this.withTransaction(async (conn) => {
+            let cursor = 0
+            for (const size of sizes) {
+                await runChunk(conn, records.slice(cursor, cursor + size))
+                cursor += size
             }
         })
     }

--- a/packages/store-mysql/src/types.ts
+++ b/packages/store-mysql/src/types.ts
@@ -18,9 +18,11 @@ export interface WaMysqlStorageOptions {
     readonly pool: Pool
     readonly sessionId: string
     readonly tablePrefix?: string
+    readonly batchInsertChunkSize?: number
 }
 
 export interface WaMysqlCreateStoreOptions {
     readonly pool: Pool | PoolOptions
     readonly tablePrefix?: string
+    readonly batchInsertChunkSize?: number
 }

--- a/packages/store-postgres/src/BasePgStore.ts
+++ b/packages/store-postgres/src/BasePgStore.ts
@@ -1,13 +1,24 @@
 import type { Pool, PoolClient } from 'pg'
+import { resolvePositive } from 'zapo-js/util'
 
 import { ensurePgMigrations } from './connection'
 import { assertSafeTablePrefix } from './helpers'
 import type { WaPgMigrationDomain, WaPgStorageOptions } from './types'
 
+const DEFAULT_BATCH_INSERT_CHUNK_SIZE = 500
+
 export abstract class BasePgStore {
     protected readonly pool: Pool
     protected readonly sessionId: string
     protected readonly tablePrefix: string
+    /**
+     * Largest power-of-two sub-chunk used by multi-row INSERT helpers.
+     * `batchInsertChunkSize` is rounded down to the nearest power of two
+     * so each batch call only ever emits SQL with row counts from
+     * `{1, 2, 4, ..., maxBatchChunk}`, bounding the named prepared
+     * statements kept per pg connection.
+     */
+    protected readonly maxBatchChunk: number
     private readonly migrationDomains: readonly WaPgMigrationDomain[]
     private migrationPromise: Promise<void> | null
 
@@ -19,8 +30,33 @@ export abstract class BasePgStore {
         this.sessionId = options.sessionId
         this.tablePrefix = options.tablePrefix ?? ''
         assertSafeTablePrefix(this.tablePrefix)
+        const requested = resolvePositive(
+            options.batchInsertChunkSize,
+            DEFAULT_BATCH_INSERT_CHUNK_SIZE,
+            'batchInsertChunkSize'
+        )
+        this.maxBatchChunk = 1 << (31 - Math.clz32(requested))
         this.migrationDomains = migrationDomains
         this.migrationPromise = null
+    }
+
+    /**
+     * Decomposes `n` into a list of power-of-two sub-chunks, each <=
+     * {@link maxBatchChunk}, emitted largest-first.
+     */
+    protected powerOfTwoChunks(n: number): readonly number[] {
+        if (n <= 0) return []
+        const out: number[] = []
+        let remaining = n
+        let size = this.maxBatchChunk
+        while (size >= 1 && remaining > 0) {
+            while (remaining >= size) {
+                out.push(size)
+                remaining -= size
+            }
+            size = size >>> 1
+        }
+        return out
     }
 
     protected t(name: string): string {

--- a/packages/store-postgres/src/__tests__/integration.test.ts
+++ b/packages/store-postgres/src/__tests__/integration.test.ts
@@ -1140,8 +1140,11 @@ describe('store-postgres integration', { timeout: 60_000 }, () => {
         }
     })
 
-    it('rejects invalid batchInsertChunkSize', () => {
-        if (!pool) return
+    it('rejects invalid batchInsertChunkSize', (t) => {
+        if (!pool) {
+            t.skip('ZAPO_TEST_PG_* not set')
+            return
+        }
         const livePool = pool
         assert.throws(
             () =>

--- a/packages/store-postgres/src/__tests__/integration.test.ts
+++ b/packages/store-postgres/src/__tests__/integration.test.ts
@@ -1109,6 +1109,63 @@ describe('store-postgres integration', { timeout: 60_000 }, () => {
         await session.clear()
     })
 
+    it('signal: setSessionsBatch with batchInsertChunkSize=2 splits into power-of-two chunks', async (t) => {
+        if (!pool) return t.skip('ZAPO_TEST_PG_* not set')
+
+        const tinyChunkStore = createPostgresStore({ pool, batchInsertChunkSize: 2 })
+        try {
+            const sessionId = nextSessionId('chunked')
+            const session = tinyChunkStore.stores.session(sessionId)
+            await session.clear()
+
+            // 7 entries with maxBatchChunk=2 → power-of-2 sub-chunks [2, 2, 2, 1]
+            // = 4 statements wrapped in a transaction.
+            const N = 7
+            const addresses = Array.from({ length: N }, (_, i) => makeAddress(`u${i}`, i + 1))
+            const sessions = await Promise.all(
+                Array.from({ length: N }, (_, i) => makeSessionRecord(100 + i))
+            )
+            const entries = addresses.map((address, i) => ({ address, session: sessions[i] }))
+
+            await session.setSessionsBatch(entries)
+
+            const got = await session.getSessionsBatch(addresses)
+            assert.equal(got.length, N)
+            for (let i = 0; i < N; i += 1) {
+                assert.equal(got[i]?.local.regId, sessions[i].local.regId)
+            }
+            await session.clear()
+        } finally {
+            await tinyChunkStore.destroy()
+        }
+    })
+
+    it('rejects invalid batchInsertChunkSize', () => {
+        if (!pool) return
+        const livePool = pool
+        assert.throws(
+            () =>
+                createPostgresStore({ pool: livePool, batchInsertChunkSize: 0 }).stores.session(
+                    'x'
+                ),
+            /batchInsertChunkSize/
+        )
+        assert.throws(
+            () =>
+                createPostgresStore({ pool: livePool, batchInsertChunkSize: -1 }).stores.session(
+                    'x'
+                ),
+            /batchInsertChunkSize/
+        )
+        assert.throws(
+            () =>
+                createPostgresStore({ pool: livePool, batchInsertChunkSize: 1.5 }).stores.session(
+                    'x'
+                ),
+            /batchInsertChunkSize/
+        )
+    })
+
     it('appstate: updating same collection replaces previous index entries', async (t) => {
         if (!store) return t.skip('ZAPO_TEST_PG_* not set')
 

--- a/packages/store-postgres/src/contact.store.ts
+++ b/packages/store-postgres/src/contact.store.ts
@@ -1,8 +1,9 @@
+import type { PoolClient } from 'pg'
 import type { WaContactStore, WaStoredContactRecord } from 'zapo-js/store'
 
 import { BasePgStore } from './BasePgStore'
 import { affectedRows, queryFirst } from './helpers'
-import type { WaPgStorageOptions } from './types'
+import type { PgParam, WaPgStorageOptions } from './types'
 
 export class WaContactPgStore extends BasePgStore implements WaContactStore {
     public constructor(options: WaPgStorageOptions) {
@@ -34,20 +35,56 @@ export class WaContactPgStore extends BasePgStore implements WaContactStore {
 
     public async upsertBatch(records: readonly WaStoredContactRecord[]): Promise<void> {
         if (records.length === 0) return
-
-        await this.withTransaction(async (client) => {
-            for (const record of records) {
-                await client.query(
-                    this.upsertQuery([
-                        this.sessionId,
-                        record.jid,
-                        record.displayName ?? null,
-                        record.pushName ?? null,
-                        record.lid ?? null,
-                        record.phoneNumber ?? null,
-                        record.lastUpdatedMs
-                    ])
+        const table = this.t('mailbox_contacts')
+        const runChunk = async (
+            executor: { query: PoolClient['query'] },
+            chunk: readonly WaStoredContactRecord[]
+        ): Promise<void> => {
+            let paramIdx = 1
+            const placeholders = chunk
+                .map(() => {
+                    const p = `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}, $${paramIdx + 5}, $${paramIdx + 6})`
+                    paramIdx += 7
+                    return p
+                })
+                .join(', ')
+            const params: PgParam[] = []
+            for (const record of chunk) {
+                params.push(
+                    this.sessionId,
+                    record.jid,
+                    record.displayName ?? null,
+                    record.pushName ?? null,
+                    record.lid ?? null,
+                    record.phoneNumber ?? null,
+                    record.lastUpdatedMs
                 )
+            }
+            await executor.query({
+                name: this.stmtName(`contact_upsert_batch_${chunk.length}`),
+                text: `INSERT INTO ${table} (
+                    session_id, jid, display_name, push_name, lid, phone_number, last_updated_ms
+                ) VALUES ${placeholders}
+                ON CONFLICT (session_id, jid) DO UPDATE SET
+                    display_name = COALESCE(EXCLUDED.display_name, ${table}.display_name),
+                    push_name = COALESCE(EXCLUDED.push_name, ${table}.push_name),
+                    lid = COALESCE(EXCLUDED.lid, ${table}.lid),
+                    phone_number = COALESCE(EXCLUDED.phone_number, ${table}.phone_number),
+                    last_updated_ms = EXCLUDED.last_updated_ms`,
+                values: params
+            })
+        }
+        const sizes = this.powerOfTwoChunks(records.length)
+        if (sizes.length === 1) {
+            await this.ensureReady()
+            await runChunk(this.pool, records)
+            return
+        }
+        await this.withTransaction(async (client) => {
+            let cursor = 0
+            for (const size of sizes) {
+                await runChunk(client, records.slice(cursor, cursor + size))
+                cursor += size
             }
         })
     }

--- a/packages/store-postgres/src/createPostgresStore.ts
+++ b/packages/store-postgres/src/createPostgresStore.ts
@@ -52,6 +52,18 @@ export interface WaPgStoreConfig {
         readonly intervalMs?: number
         readonly onError?: (error: Error) => void
     }
+    /**
+     * Upper bound on rows per multi-row INSERT statement in batch
+     * writes (`setSessionsBatch`, `setRemoteIdentities`,
+     * `upsertSenderKeyDistributions`, prekey gen). Default 500.
+     *
+     * Internally rounded down to the nearest power of two
+     * (`500 → 256`, `1000 → 512`, etc.). Each batch call decomposes
+     * `N` into power-of-two sub-chunks and reuses the same named
+     * prepared statement per chunk size, keeping the per-connection
+     * statement cache stable even when `N` varies widely.
+     */
+    readonly batchInsertChunkSize?: number
 }
 
 export interface WaPgStoreResult {
@@ -116,10 +128,12 @@ export function createPostgresStore(config: WaPgStoreConfig): WaPgStoreResult {
     const messageSecretTtlMs = config.cacheTtlMs?.messageSecretMs
     const ownsPool = !isPool(config.pool)
 
+    const batchInsertChunkSize = config.batchInsertChunkSize
     const opts = (sessionId: string): WaPgStorageOptions => ({
         pool,
         sessionId,
-        tablePrefix
+        tablePrefix,
+        batchInsertChunkSize
     })
 
     const cleanupPollers = new Set<PgCleanupPoller>()

--- a/packages/store-postgres/src/identity.store.ts
+++ b/packages/store-postgres/src/identity.store.ts
@@ -88,10 +88,50 @@ export class WaIdentityPgStore extends BasePgStore implements WaIdentityStore {
         }[]
     ): Promise<void> {
         if (entries.length === 0) return
-        await this.withTransaction(async (client) => {
-            for (const entry of entries) {
+        const runChunk = async (
+            executor: { query: PoolClient['query'] },
+            chunk: readonly { readonly address: SignalAddress; readonly identityKey: Uint8Array }[]
+        ): Promise<void> => {
+            let paramIdx = 1
+            const placeholders = chunk
+                .map(() => {
+                    const p = `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4})`
+                    paramIdx += 5
+                    return p
+                })
+                .join(', ')
+            const params: PgParam[] = []
+            for (const entry of chunk) {
                 const target = toSignalAddressParts(entry.address)
-                await this.upsertRemoteIdentity(client, target, entry.identityKey)
+                params.push(
+                    this.sessionId,
+                    target.user,
+                    target.server,
+                    target.device,
+                    entry.identityKey
+                )
+            }
+            await executor.query({
+                name: this.stmtName(`identity_upsert_batch_${chunk.length}`),
+                text: `INSERT INTO ${this.t('signal_identity')} (
+                    session_id, "user", server, device, identity_key
+                ) VALUES ${placeholders}
+                ON CONFLICT (session_id, "user", server, device) DO UPDATE SET
+                    identity_key = EXCLUDED.identity_key`,
+                values: params
+            })
+        }
+        const sizes = this.powerOfTwoChunks(entries.length)
+        if (sizes.length === 1) {
+            await this.ensureReady()
+            await runChunk(this.pool, entries)
+            return
+        }
+        await this.withTransaction(async (client) => {
+            let cursor = 0
+            for (const size of sizes) {
+                await runChunk(client, entries.slice(cursor, cursor + size))
+                cursor += size
             }
         })
     }

--- a/packages/store-postgres/src/message.store.ts
+++ b/packages/store-postgres/src/message.store.ts
@@ -1,3 +1,4 @@
+import type { PoolClient } from 'pg'
 import type { WaMessageStore, WaStoredMessageRecord } from 'zapo-js/store'
 
 import { BasePgStore } from './BasePgStore'
@@ -9,7 +10,7 @@ import {
     safeLimit,
     toBytesOrNull
 } from './helpers'
-import type { WaPgStorageOptions } from './types'
+import type { PgParam, WaPgStorageOptions } from './types'
 
 function rowToRecord(row: PgRow): WaStoredMessageRecord {
     return {
@@ -58,23 +59,62 @@ export class WaMessagePgStore extends BasePgStore implements WaMessageStore {
 
     public async upsertBatch(records: readonly WaStoredMessageRecord[]): Promise<void> {
         if (records.length === 0) return
-
-        await this.withTransaction(async (client) => {
-            for (const record of records) {
-                await client.query(
-                    this.upsertQuery([
-                        this.sessionId,
-                        record.id,
-                        record.threadJid,
-                        record.senderJid ?? null,
-                        record.participantJid ?? null,
-                        record.fromMe,
-                        record.timestampMs ?? null,
-                        record.encType ?? null,
-                        record.plaintext ?? null,
-                        record.messageBytes ?? null
-                    ])
+        const runChunk = async (
+            executor: { query: PoolClient['query'] },
+            chunk: readonly WaStoredMessageRecord[]
+        ): Promise<void> => {
+            let paramIdx = 1
+            const placeholders = chunk
+                .map(() => {
+                    const p = `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}, $${paramIdx + 5}, $${paramIdx + 6}, $${paramIdx + 7}, $${paramIdx + 8}, $${paramIdx + 9})`
+                    paramIdx += 10
+                    return p
+                })
+                .join(', ')
+            const params: PgParam[] = []
+            for (const record of chunk) {
+                params.push(
+                    this.sessionId,
+                    record.id,
+                    record.threadJid,
+                    record.senderJid ?? null,
+                    record.participantJid ?? null,
+                    record.fromMe,
+                    record.timestampMs ?? null,
+                    record.encType ?? null,
+                    record.plaintext ?? null,
+                    record.messageBytes ?? null
                 )
+            }
+            await executor.query({
+                name: this.stmtName(`msg_upsert_batch_${chunk.length}`),
+                text: `INSERT INTO ${this.t('mailbox_messages')} (
+                    session_id, message_id, thread_jid, sender_jid, participant_jid,
+                    from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                ) VALUES ${placeholders}
+                ON CONFLICT (session_id, message_id) DO UPDATE SET
+                    thread_jid = EXCLUDED.thread_jid,
+                    sender_jid = EXCLUDED.sender_jid,
+                    participant_jid = EXCLUDED.participant_jid,
+                    from_me = EXCLUDED.from_me,
+                    timestamp_ms = EXCLUDED.timestamp_ms,
+                    enc_type = EXCLUDED.enc_type,
+                    plaintext = EXCLUDED.plaintext,
+                    message_bytes = EXCLUDED.message_bytes`,
+                values: params
+            })
+        }
+        const sizes = this.powerOfTwoChunks(records.length)
+        if (sizes.length === 1) {
+            await this.ensureReady()
+            await runChunk(this.pool, records)
+            return
+        }
+        await this.withTransaction(async (client) => {
+            let cursor = 0
+            for (const size of sizes) {
+                await runChunk(client, records.slice(cursor, cursor + size))
+                cursor += size
             }
         })
     }

--- a/packages/store-postgres/src/pre-key.store.ts
+++ b/packages/store-postgres/src/pre-key.store.ts
@@ -64,20 +64,36 @@ export class WaPreKeyPgStore extends BasePgStore implements WaPreKeyStore {
 
             await this.withTransaction(async (client) => {
                 await this.ensureMetaRow(client)
-                for (const record of generated) {
-                    await client.query({
-                        name: this.stmtName('prekey_insert_prekey_noop'),
-                        text: `INSERT INTO ${this.t('signal_prekey')} (
-                            session_id, key_id, pub_key, priv_key, uploaded
-                        ) VALUES ($1, $2, $3, $4, $5)
-                        ON CONFLICT (session_id, key_id) DO NOTHING`,
-                        values: [
+                const sizes = this.powerOfTwoChunks(generated.length)
+                let cursor = 0
+                for (const size of sizes) {
+                    const chunk = generated.slice(cursor, cursor + size)
+                    cursor += size
+                    let paramIdx = 1
+                    const placeholders = chunk
+                        .map(() => {
+                            const p = `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4})`
+                            paramIdx += 5
+                            return p
+                        })
+                        .join(', ')
+                    const params: PgParam[] = []
+                    for (const record of chunk) {
+                        params.push(
                             this.sessionId,
                             record.keyId,
                             record.keyPair.pubKey,
                             record.keyPair.privKey,
                             record.uploaded === true ? 1 : 0
-                        ]
+                        )
+                    }
+                    await client.query({
+                        name: this.stmtName(`prekey_insert_batch_${chunk.length}`),
+                        text: `INSERT INTO ${this.t('signal_prekey')} (
+                            session_id, key_id, pub_key, priv_key, uploaded
+                        ) VALUES ${placeholders}
+                        ON CONFLICT (session_id, key_id) DO NOTHING`,
+                        values: params
                     })
                 }
                 await this.updateNextPreKeyId(client, maxId + 1)

--- a/packages/store-postgres/src/sender-key.store.ts
+++ b/packages/store-postgres/src/sender-key.store.ts
@@ -52,10 +52,54 @@ export class WaSenderKeyPgStore extends BasePgStore implements WaSenderKeyStore 
         records: readonly SenderKeyDistributionRecord[]
     ): Promise<void> {
         if (records.length === 0) return
-        await this.withTransaction(async (client) => {
-            for (const record of records) {
+        const runChunk = async (
+            executor: { query: PoolClient['query'] },
+            chunk: readonly SenderKeyDistributionRecord[]
+        ): Promise<void> => {
+            let paramIdx = 1
+            const placeholders = chunk
+                .map(() => {
+                    const p = `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}, $${paramIdx + 5}, $${paramIdx + 6})`
+                    paramIdx += 7
+                    return p
+                })
+                .join(', ')
+            const params: PgParam[] = []
+            for (const record of chunk) {
                 const sender = toSignalAddressParts(record.sender)
-                await this.upsertSenderKeyDistributionRow(client, record, sender)
+                params.push(
+                    this.sessionId,
+                    record.groupId,
+                    sender.user,
+                    sender.server,
+                    sender.device,
+                    record.keyId,
+                    record.timestampMs
+                )
+            }
+            await executor.query({
+                name: this.stmtName(`sk_upsert_distrib_batch_${chunk.length}`),
+                text: `INSERT INTO ${this.t('sender_key_distribution')} (
+                    session_id, group_id, sender_user, sender_server, sender_device,
+                    key_id, timestamp_ms
+                ) VALUES ${placeholders}
+                ON CONFLICT (session_id, group_id, sender_user, sender_server, sender_device) DO UPDATE SET
+                    key_id = EXCLUDED.key_id,
+                    timestamp_ms = EXCLUDED.timestamp_ms`,
+                values: params
+            })
+        }
+        const sizes = this.powerOfTwoChunks(records.length)
+        if (sizes.length === 1) {
+            await this.ensureReady()
+            await runChunk(this.pool, records)
+            return
+        }
+        await this.withTransaction(async (client) => {
+            let cursor = 0
+            for (const size of sizes) {
+                await runChunk(client, records.slice(cursor, cursor + size))
+                cursor += size
             }
         })
     }
@@ -140,52 +184,39 @@ export class WaSenderKeyPgStore extends BasePgStore implements WaSenderKeyStore 
     ): Promise<readonly (SenderKeyDistributionRecord | null)[]> {
         if (senders.length === 0) return []
         await this.ensureReady()
-        const targets = senders.map((s) => toSignalAddressParts(s))
-        const byKey = new Map<string, SenderKeyDistributionRecord>()
-        for (let start = 0; start < targets.length; start += BATCH_SIZE) {
-            const batch = targets.slice(start, start + BATCH_SIZE)
-            let paramIdx = 3
-            const senderClauses = batch
-                .map(() => {
-                    const clause = `(sender_user = $${paramIdx} AND sender_server = $${paramIdx + 1} AND sender_device = $${paramIdx + 2})`
-                    paramIdx += 3
-                    return clause
-                })
-                .join(' OR ')
-            const params: PgParam[] = [
-                this.sessionId,
-                groupId,
-                ...batch.flatMap((t) => [t.user, t.server, t.device])
-            ]
-            const rows = queryRows(
-                await this.pool.query(
-                    `SELECT group_id, sender_user, sender_server, sender_device, key_id, timestamp_ms
-                     FROM ${this.t('sender_key_distribution')}
-                     WHERE session_id = $1 AND group_id = $2 AND (${senderClauses})`,
-                    params
-                )
-            )
-            for (const row of rows) {
-                const key = this.distributionTargetKey(
-                    String(row.sender_user),
-                    String(row.sender_server),
-                    Number(row.sender_device)
-                )
-                byKey.set(key, {
-                    groupId: String(row.group_id),
-                    sender: {
-                        user: String(row.sender_user),
-                        server: String(row.sender_server),
-                        device: Number(row.sender_device)
-                    },
-                    keyId: Number(row.key_id),
-                    timestampMs: Number(row.timestamp_ms)
-                })
-            }
-        }
-        return targets.map(
-            (t) => byKey.get(this.distributionTargetKey(t.user, t.server, t.device)) ?? null
+        const rows = queryRows(
+            await this.pool.query({
+                name: this.stmtName('sk_distrib_by_group'),
+                text: `SELECT group_id, sender_user, sender_server, sender_device, key_id, timestamp_ms
+                 FROM ${this.t('sender_key_distribution')}
+                 WHERE session_id = $1 AND group_id = $2`,
+                values: [this.sessionId, groupId]
+            })
         )
+        const byKey = new Map<string, SenderKeyDistributionRecord>()
+        for (const row of rows) {
+            const key = this.distributionTargetKey(
+                String(row.sender_user),
+                String(row.sender_server),
+                Number(row.sender_device)
+            )
+            byKey.set(key, {
+                groupId: String(row.group_id),
+                sender: {
+                    user: String(row.sender_user),
+                    server: String(row.sender_server),
+                    device: Number(row.sender_device)
+                },
+                keyId: Number(row.key_id),
+                timestampMs: Number(row.timestamp_ms)
+            })
+        }
+        const out = new Array<SenderKeyDistributionRecord | null>(senders.length)
+        for (let i = 0; i < senders.length; i += 1) {
+            const t = toSignalAddressParts(senders[i])
+            out[i] = byKey.get(this.distributionTargetKey(t.user, t.server, t.device)) ?? null
+        }
+        return out
     }
 
     public async deleteDeviceSenderKey(target: SignalAddress, groupId?: string): Promise<number> {

--- a/packages/store-postgres/src/session.store.ts
+++ b/packages/store-postgres/src/session.store.ts
@@ -152,10 +152,53 @@ export class WaSessionPgStore extends BasePgStore implements WaSessionStore {
         }[]
     ): Promise<void> {
         if (entries.length === 0) return
-        await this.withTransaction(async (client) => {
-            for (const entry of entries) {
+        const runChunk = async (
+            executor: { query: PoolClient['query'] },
+            chunk: readonly {
+                readonly address: SignalAddress
+                readonly session: SignalSessionRecord
+            }[]
+        ): Promise<void> => {
+            let paramIdx = 1
+            const placeholders = chunk
+                .map(() => {
+                    const p = `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4})`
+                    paramIdx += 5
+                    return p
+                })
+                .join(', ')
+            const params: PgParam[] = []
+            for (const entry of chunk) {
                 const target = toSignalAddressParts(entry.address)
-                await this.upsertSession(client, target, entry.session)
+                params.push(
+                    this.sessionId,
+                    target.user,
+                    target.server,
+                    target.device,
+                    encodeSignalSessionRecord(entry.session)
+                )
+            }
+            await executor.query({
+                name: this.stmtName(`session_upsert_batch_${chunk.length}`),
+                text: `INSERT INTO ${this.t('signal_session')} (
+                    session_id, "user", server, device, record
+                ) VALUES ${placeholders}
+                ON CONFLICT (session_id, "user", server, device) DO UPDATE SET
+                    record = EXCLUDED.record`,
+                values: params
+            })
+        }
+        const sizes = this.powerOfTwoChunks(entries.length)
+        if (sizes.length === 1) {
+            await this.ensureReady()
+            await runChunk(this.pool, entries)
+            return
+        }
+        await this.withTransaction(async (client) => {
+            let cursor = 0
+            for (const size of sizes) {
+                await runChunk(client, entries.slice(cursor, cursor + size))
+                cursor += size
             }
         })
     }

--- a/packages/store-postgres/src/thread.store.ts
+++ b/packages/store-postgres/src/thread.store.ts
@@ -1,8 +1,9 @@
+import type { PoolClient } from 'pg'
 import type { WaStoredThreadRecord, WaThreadStore } from 'zapo-js/store'
 
 import { BasePgStore } from './BasePgStore'
 import { affectedRows, type PgRow, queryFirst, queryRows, safeLimit } from './helpers'
-import type { WaPgStorageOptions } from './types'
+import type { PgParam, WaPgStorageOptions } from './types'
 
 function rowToRecord(row: PgRow): WaStoredThreadRecord {
     return {
@@ -50,22 +51,61 @@ export class WaThreadPgStore extends BasePgStore implements WaThreadStore {
 
     public async upsertBatch(records: readonly WaStoredThreadRecord[]): Promise<void> {
         if (records.length === 0) return
-
-        await this.withTransaction(async (client) => {
-            for (const record of records) {
-                await client.query(
-                    this.upsertQuery([
-                        this.sessionId,
-                        record.jid,
-                        record.name ?? null,
-                        record.unreadCount ?? null,
-                        record.archived ?? null,
-                        record.pinned ?? null,
-                        record.muteEndMs ?? null,
-                        record.markedAsUnread ?? null,
-                        record.ephemeralExpiration ?? null
-                    ])
+        const table = this.t('mailbox_threads')
+        const runChunk = async (
+            executor: { query: PoolClient['query'] },
+            chunk: readonly WaStoredThreadRecord[]
+        ): Promise<void> => {
+            let paramIdx = 1
+            const placeholders = chunk
+                .map(() => {
+                    const p = `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}, $${paramIdx + 5}, $${paramIdx + 6}, $${paramIdx + 7}, $${paramIdx + 8})`
+                    paramIdx += 9
+                    return p
+                })
+                .join(', ')
+            const params: PgParam[] = []
+            for (const record of chunk) {
+                params.push(
+                    this.sessionId,
+                    record.jid,
+                    record.name ?? null,
+                    record.unreadCount ?? null,
+                    record.archived ?? null,
+                    record.pinned ?? null,
+                    record.muteEndMs ?? null,
+                    record.markedAsUnread ?? null,
+                    record.ephemeralExpiration ?? null
                 )
+            }
+            await executor.query({
+                name: this.stmtName(`thread_upsert_batch_${chunk.length}`),
+                text: `INSERT INTO ${table} (
+                    session_id, jid, name, unread_count, archived, pinned,
+                    mute_end_ms, marked_as_unread, ephemeral_expiration
+                ) VALUES ${placeholders}
+                ON CONFLICT (session_id, jid) DO UPDATE SET
+                    name = COALESCE(EXCLUDED.name, ${table}.name),
+                    unread_count = COALESCE(EXCLUDED.unread_count, ${table}.unread_count),
+                    archived = COALESCE(EXCLUDED.archived, ${table}.archived),
+                    pinned = COALESCE(EXCLUDED.pinned, ${table}.pinned),
+                    mute_end_ms = COALESCE(EXCLUDED.mute_end_ms, ${table}.mute_end_ms),
+                    marked_as_unread = COALESCE(EXCLUDED.marked_as_unread, ${table}.marked_as_unread),
+                    ephemeral_expiration = COALESCE(EXCLUDED.ephemeral_expiration, ${table}.ephemeral_expiration)`,
+                values: params
+            })
+        }
+        const sizes = this.powerOfTwoChunks(records.length)
+        if (sizes.length === 1) {
+            await this.ensureReady()
+            await runChunk(this.pool, records)
+            return
+        }
+        await this.withTransaction(async (client) => {
+            let cursor = 0
+            for (const size of sizes) {
+                await runChunk(client, records.slice(cursor, cursor + size))
+                cursor += size
             }
         })
     }

--- a/packages/store-postgres/src/types.ts
+++ b/packages/store-postgres/src/types.ts
@@ -18,9 +18,11 @@ export interface WaPgStorageOptions {
     readonly pool: Pool
     readonly sessionId: string
     readonly tablePrefix?: string
+    readonly batchInsertChunkSize?: number
 }
 
 export interface WaPgCreateStoreOptions {
     readonly pool: Pool | PoolConfig
     readonly tablePrefix?: string
+    readonly batchInsertChunkSize?: number
 }

--- a/packages/store-redis/src/identity.store.ts
+++ b/packages/store-redis/src/identity.store.ts
@@ -30,25 +30,19 @@ export class WaIdentityRedisStore extends BaseRedisStore implements WaIdentitySt
         addresses: readonly SignalAddress[]
     ): Promise<readonly (Uint8Array | null)[]> {
         if (addresses.length === 0) return []
-        const pipeline = this.redis.pipeline()
-        for (const address of addresses) {
-            const target = toSignalAddressParts(address)
-            pipeline.getBuffer(
-                this.k(
-                    'signal:ident',
-                    this.sessionId,
-                    target.user,
-                    target.server,
-                    String(target.device)
-                )
+        const keys = new Array<string>(addresses.length)
+        for (let i = 0; i < addresses.length; i += 1) {
+            const target = toSignalAddressParts(addresses[i])
+            keys[i] = this.k(
+                'signal:ident',
+                this.sessionId,
+                target.user,
+                target.server,
+                String(target.device)
             )
         }
-        const results = await pipeline.exec()
-        if (!results) return addresses.map(() => null)
-        return results.map(([err, data]) => {
-            if (err || !data) return null
-            return new Uint8Array(data as Uint8Array)
-        })
+        const values = await this.redis.mgetBuffer(...keys)
+        return values.map((data) => (data ? new Uint8Array(data) : null))
     }
 
     public async setRemoteIdentity(address: SignalAddress, identityKey: Uint8Array): Promise<void> {
@@ -70,19 +64,23 @@ export class WaIdentityRedisStore extends BaseRedisStore implements WaIdentitySt
         }[]
     ): Promise<void> {
         if (entries.length === 0) return
-        const pipeline = this.redis.pipeline()
+        const args: Array<string | Buffer> = []
         for (const entry of entries) {
             const target = toSignalAddressParts(entry.address)
-            const key = this.k(
-                'signal:ident',
-                this.sessionId,
-                target.user,
-                target.server,
-                String(target.device)
+            args.push(
+                this.k(
+                    'signal:ident',
+                    this.sessionId,
+                    target.user,
+                    target.server,
+                    String(target.device)
+                ),
+                toRedisBuffer(entry.identityKey)
             )
-            pipeline.set(key, toRedisBuffer(entry.identityKey))
         }
-        await pipeline.exec()
+        await (this.redis as unknown as { mset: (...args: unknown[]) => Promise<unknown> }).mset(
+            ...args
+        )
     }
 
     // ── Clear ─────────────────────────────────────────────────────────

--- a/packages/store-redis/src/pre-key.store.ts
+++ b/packages/store-redis/src/pre-key.store.ts
@@ -226,11 +226,11 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
         // Single Lua script atomically returns the hash contents (binary
         // pub/priv included) and removes the prekey from all indexes.
         // evalBuffer keeps the byte fields intact across the round-trip.
-        const raw = (await (
+        const raw = await (
             this.redis as unknown as {
                 evalBuffer: (...args: unknown[]) => Promise<Buffer[] | null>
             }
-        ).evalBuffer(LUA_CONSUME_PREKEY, 3, hashKey, idsKey, availKey, idStr)) as Buffer[] | null
+        ).evalBuffer(LUA_CONSUME_PREKEY, 3, hashKey, idsKey, availKey, idStr)
         if (!raw || raw.length === 0) return null
 
         const data: Record<string, Buffer> = {}

--- a/packages/store-redis/src/pre-key.store.ts
+++ b/packages/store-redis/src/pre-key.store.ts
@@ -2,21 +2,19 @@ import type { PreKeyRecord } from 'zapo-js/signal'
 import type { WaPreKeyStore } from 'zapo-js/store'
 
 import { BaseRedisStore } from './BaseRedisStore'
-import { deleteKeysChunked, safeLimit, scanKeys, toBytesOrNull, toRedisBuffer } from './helpers'
+import { deleteKeysChunked, safeLimit, scanKeys, toRedisBuffer } from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
 const LUA_CONSUME_PREKEY = `
 local hashKey = KEYS[1]
-local pubKey  = KEYS[2]
-local privKey = KEYS[3]
-local idsKey  = KEYS[4]
-local availKey = KEYS[5]
-local keyId   = ARGV[1]
+local idsKey = KEYS[2]
+local availKey = KEYS[3]
+local keyId = ARGV[1]
 local data = redis.call('HGETALL', hashKey)
 if #data == 0 then
     return nil
 end
-redis.call('DEL', hashKey, pubKey, privKey)
+redis.call('DEL', hashKey)
 redis.call('SREM', idsKey, keyId)
 redis.call('ZREM', availKey, keyId)
 return data
@@ -90,26 +88,18 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
             if (availableIds.length > 0) {
                 const pipeline = this.redis.pipeline()
                 for (const id of availableIds) {
-                    pipeline.hgetall(this.k('signal:pk', this.sessionId, id))
-                    pipeline.getBuffer(this.k('signal:pk', this.sessionId, id, 'pub'))
-                    pipeline.getBuffer(this.k('signal:pk', this.sessionId, id, 'priv'))
+                    pipeline.hgetallBuffer(this.k('signal:pk', this.sessionId, id))
                 }
                 const results = await pipeline.exec()
                 if (results) {
                     for (let i = 0; i < availableIds.length; i += 1) {
-                        const base = i * 3
-                        const [hashErr, hashData] = results[base]
-                        const record = hashData as Record<string, string>
-                        if (hashErr || !record || Object.keys(record).length === 0) continue
-                        const pubKey = toBytesOrNull(results[base + 1][1])
-                        const privKey = toBytesOrNull(results[base + 2][1])
-                        if (!pubKey || !privKey) continue
-                        available.push({
-                            keyId: Number(availableIds[i]),
-                            keyPair: { pubKey, privKey },
-                            uploaded:
-                                record.uploaded !== undefined ? record.uploaded === '1' : undefined
-                        })
+                        const [err, data] = results[i]
+                        if (err || !data) continue
+                        const record = this.decodePreKey(
+                            Number(availableIds[i]),
+                            data as Record<string, Buffer>
+                        )
+                        if (record) available.push(record)
                     }
                 }
             }
@@ -142,15 +132,13 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
             for (const record of generated) {
                 const idStr = String(record.keyId)
                 const pkKey = this.k('signal:pk', this.sessionId, idStr)
-                pipeline.hset(pkKey, {
-                    uploaded: record.uploaded === true ? '1' : '0'
-                })
-                pipeline.set(
-                    this.k('signal:pk', this.sessionId, idStr, 'pub'),
-                    toRedisBuffer(record.keyPair.pubKey)
-                )
-                pipeline.set(
-                    this.k('signal:pk', this.sessionId, idStr, 'priv'),
+                ;(pipeline.hset as (...args: unknown[]) => unknown)(
+                    pkKey,
+                    'uploaded',
+                    record.uploaded === true ? '1' : '0',
+                    'pub',
+                    toRedisBuffer(record.keyPair.pubKey),
+                    'priv',
                     toRedisBuffer(record.keyPair.privKey)
                 )
                 pipeline.sadd(idsKey, idStr)
@@ -181,27 +169,19 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
             if (recheckIds.length >= count) {
                 const fetchPipeline = this.redis.pipeline()
                 for (const id of recheckIds.slice(0, count)) {
-                    fetchPipeline.hgetall(this.k('signal:pk', this.sessionId, id))
-                    fetchPipeline.getBuffer(this.k('signal:pk', this.sessionId, id, 'pub'))
-                    fetchPipeline.getBuffer(this.k('signal:pk', this.sessionId, id, 'priv'))
+                    fetchPipeline.hgetallBuffer(this.k('signal:pk', this.sessionId, id))
                 }
                 const fetchResults = await fetchPipeline.exec()
                 const finalKeys: PreKeyRecord[] = []
                 if (fetchResults) {
                     for (let i = 0; i < Math.min(recheckIds.length, count); i += 1) {
-                        const base = i * 3
-                        const [hashErr, hashData] = fetchResults[base]
-                        const record = hashData as Record<string, string>
-                        if (hashErr || !record || Object.keys(record).length === 0) continue
-                        const pubKey = toBytesOrNull(fetchResults[base + 1][1])
-                        const privKey = toBytesOrNull(fetchResults[base + 2][1])
-                        if (!pubKey || !privKey) continue
-                        finalKeys.push({
-                            keyId: Number(recheckIds[i]),
-                            keyPair: { pubKey, privKey },
-                            uploaded:
-                                record.uploaded !== undefined ? record.uploaded === '1' : undefined
-                        })
+                        const [err, data] = fetchResults[i]
+                        if (err || !data) continue
+                        const record = this.decodePreKey(
+                            Number(recheckIds[i]),
+                            data as Record<string, Buffer>
+                        )
+                        if (record) finalKeys.push(record)
                     }
                 }
                 if (finalKeys.length >= count) {
@@ -212,94 +192,52 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
     }
 
     public async getPreKeyById(keyId: number): Promise<PreKeyRecord | null> {
-        const idStr = String(keyId)
-        const pipeline = this.redis.pipeline()
-        pipeline.hgetall(this.k('signal:pk', this.sessionId, idStr))
-        pipeline.getBuffer(this.k('signal:pk', this.sessionId, idStr, 'pub'))
-        pipeline.getBuffer(this.k('signal:pk', this.sessionId, idStr, 'priv'))
-        const results = await pipeline.exec()
-        if (!results) return null
-        const [hashErr, hashData] = results[0]
-        const data = hashData as Record<string, string>
-        if (hashErr || !data || Object.keys(data).length === 0) return null
-        const pubKey = toBytesOrNull(results[1][1])
-        const privKey = toBytesOrNull(results[2][1])
-        if (!pubKey || !privKey) return null
-        return {
-            keyId,
-            keyPair: { pubKey, privKey },
-            uploaded: data.uploaded !== undefined ? data.uploaded === '1' : undefined
-        }
+        const data = await this.redis.hgetallBuffer(
+            this.k('signal:pk', this.sessionId, String(keyId))
+        )
+        return this.decodePreKey(keyId, data)
     }
 
     public async getPreKeysById(
         keyIds: readonly number[]
     ): Promise<readonly (PreKeyRecord | null)[]> {
         if (keyIds.length === 0) return []
+        // One HGETALL per key — still pipelined into 1 round-trip but each
+        // key is a single hash (vs 3 separate redis keys before).
         const pipeline = this.redis.pipeline()
         for (const keyId of keyIds) {
-            const idStr = String(keyId)
-            pipeline.hgetall(this.k('signal:pk', this.sessionId, idStr))
-            pipeline.getBuffer(this.k('signal:pk', this.sessionId, idStr, 'pub'))
-            pipeline.getBuffer(this.k('signal:pk', this.sessionId, idStr, 'priv'))
+            pipeline.hgetallBuffer(this.k('signal:pk', this.sessionId, String(keyId)))
         }
         const results = await pipeline.exec()
         if (!results) return keyIds.map(() => null)
         return keyIds.map((keyId, index) => {
-            const base = index * 3
-            const [hashErr, hashData] = results[base]
-            const data = hashData as Record<string, string>
-            if (hashErr || !data || Object.keys(data).length === 0) return null
-            const pubKey = toBytesOrNull(results[base + 1][1])
-            const privKey = toBytesOrNull(results[base + 2][1])
-            if (!pubKey || !privKey) return null
-            return {
-                keyId,
-                keyPair: { pubKey, privKey },
-                uploaded: data.uploaded !== undefined ? data.uploaded === '1' : undefined
-            }
+            const [err, data] = results[index]
+            if (err || !data) return null
+            return this.decodePreKey(keyId, data as Record<string, Buffer>)
         })
     }
 
     public async consumePreKeyById(keyId: number): Promise<PreKeyRecord | null> {
         const idStr = String(keyId)
         const hashKey = this.k('signal:pk', this.sessionId, idStr)
-        const pubBinKey = this.k('signal:pk', this.sessionId, idStr, 'pub')
-        const privBinKey = this.k('signal:pk', this.sessionId, idStr, 'priv')
         const idsKey = this.k('signal:pk:ids', this.sessionId)
         const availKey = this.k('signal:pk:avail', this.sessionId)
 
-        // Read binary keys before the Lua script deletes them
-        const binPipeline = this.redis.pipeline()
-        binPipeline.getBuffer(pubBinKey)
-        binPipeline.getBuffer(privBinKey)
-        const binResults = await binPipeline.exec()
-        if (!binResults) return null
-        const pubKey = toBytesOrNull(binResults[0][1])
-        const privKey = toBytesOrNull(binResults[1][1])
-
-        const raw = (await this.redis.eval(
-            LUA_CONSUME_PREKEY,
-            5,
-            hashKey,
-            pubBinKey,
-            privBinKey,
-            idsKey,
-            availKey,
-            idStr
-        )) as string[] | null
+        // Single Lua script atomically returns the hash contents (binary
+        // pub/priv included) and removes the prekey from all indexes.
+        // evalBuffer keeps the byte fields intact across the round-trip.
+        const raw = (await (
+            this.redis as unknown as {
+                evalBuffer: (...args: unknown[]) => Promise<Buffer[] | null>
+            }
+        ).evalBuffer(LUA_CONSUME_PREKEY, 3, hashKey, idsKey, availKey, idStr)) as Buffer[] | null
         if (!raw || raw.length === 0) return null
-        if (!pubKey || !privKey) return null
 
-        const data: Record<string, string> = {}
+        const data: Record<string, Buffer> = {}
         for (let i = 0; i < raw.length; i += 2) {
-            data[raw[i]] = raw[i + 1]
+            data[raw[i].toString()] = raw[i + 1]
         }
-        return {
-            keyId,
-            keyPair: { pubKey, privKey },
-            uploaded: data.uploaded !== undefined ? data.uploaded === '1' : undefined
-        }
+        return this.decodePreKey(keyId, data)
     }
 
     public async getOrGenSinglePreKey(
@@ -377,21 +315,37 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
         }
     }
 
+    private decodePreKey(
+        keyId: number,
+        data: Record<string, Buffer> | null | undefined
+    ): PreKeyRecord | null {
+        if (!data) return null
+        const pub = data.pub
+        const priv = data.priv
+        if (!pub || !priv) return null
+        const uploadedRaw = data.uploaded
+        return {
+            keyId,
+            keyPair: { pubKey: new Uint8Array(pub), privKey: new Uint8Array(priv) },
+            uploaded: uploadedRaw ? uploadedRaw.toString() === '1' : undefined
+        }
+    }
+
     private async upsertPreKey(record: PreKeyRecord): Promise<void> {
         const idStr = String(record.keyId)
         const pkKey = this.k('signal:pk', this.sessionId, idStr)
         const idsKey = this.k('signal:pk:ids', this.sessionId)
         const availKey = this.k('signal:pk:avail', this.sessionId)
         const pipeline = this.redis.pipeline()
-        pipeline.hset(pkKey, {
-            uploaded: record.uploaded === true ? '1' : '0'
-        })
-        pipeline.set(
-            this.k('signal:pk', this.sessionId, idStr, 'pub'),
-            toRedisBuffer(record.keyPair.pubKey)
-        )
-        pipeline.set(
-            this.k('signal:pk', this.sessionId, idStr, 'priv'),
+        // Single hash with mixed string + binary fields. ioredis accepts
+        // Buffer values in the variadic HSET form.
+        ;(pipeline.hset as (...args: unknown[]) => unknown)(
+            pkKey,
+            'uploaded',
+            record.uploaded === true ? '1' : '0',
+            'pub',
+            toRedisBuffer(record.keyPair.pubKey),
+            'priv',
             toRedisBuffer(record.keyPair.privKey)
         )
         pipeline.sadd(idsKey, idStr)

--- a/packages/store-redis/src/sender-key.store.ts
+++ b/packages/store-redis/src/sender-key.store.ts
@@ -36,44 +36,36 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
 
     public async upsertSenderKeyDistribution(record: SenderKeyDistributionRecord): Promise<void> {
         const sender = toSignalAddressParts(record.sender)
-        const key = this.k(
-            'skd',
-            this.sessionId,
-            record.groupId,
-            sender.user,
-            sender.server,
-            String(sender.device)
-        )
-        await this.redis.hset(key, {
-            key_id: String(record.keyId),
-            timestamp_ms: String(record.timestampMs)
-        })
-
-        const groupIdxKey = this.k('sk:grp', this.sessionId, record.groupId)
-        await this.redis.sadd(groupIdxKey, `${sender.user}:${sender.server}:${sender.device}`)
+        const hashKey = this.k('skd', this.sessionId, record.groupId)
+        const field = `${sender.user}:${sender.server}:${sender.device}`
+        await this.redis.hset(hashKey, field, `${record.keyId}:${record.timestampMs}`)
     }
 
     public async upsertSenderKeyDistributions(
         records: readonly SenderKeyDistributionRecord[]
     ): Promise<void> {
         if (records.length === 0) return
-        const pipeline = this.redis.pipeline()
+        // Group by (sessionId, groupId) so each group commits a single
+        // multi-field HSET instead of one HSET per record.
+        const byGroupKey = new Map<string, string[]>()
         for (const record of records) {
             const sender = toSignalAddressParts(record.sender)
-            const key = this.k(
-                'skd',
-                this.sessionId,
-                record.groupId,
-                sender.user,
-                sender.server,
-                String(sender.device)
+            const hashKey = this.k('skd', this.sessionId, record.groupId)
+            const args = byGroupKey.get(hashKey) ?? []
+            args.push(
+                `${sender.user}:${sender.server}:${sender.device}`,
+                `${record.keyId}:${record.timestampMs}`
             )
-            pipeline.hset(key, {
-                key_id: String(record.keyId),
-                timestamp_ms: String(record.timestampMs)
-            })
-            const groupIdxKey = this.k('sk:grp', this.sessionId, record.groupId)
-            pipeline.sadd(groupIdxKey, `${sender.user}:${sender.server}:${sender.device}`)
+            byGroupKey.set(hashKey, args)
+        }
+        if (byGroupKey.size === 1) {
+            const [hashKey, args] = byGroupKey.entries().next().value as [string, string[]]
+            await this.redis.hset(hashKey, ...args)
+            return
+        }
+        const pipeline = this.redis.pipeline()
+        for (const [hashKey, args] of byGroupKey) {
+            pipeline.hset(hashKey, ...args)
         }
         await pipeline.exec()
     }
@@ -83,63 +75,50 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
         readonly skDistribList: readonly SenderKeyDistributionRecord[]
     }> {
         const groupIdxKey = this.k('sk:grp', this.sessionId, groupId)
-        const members = await this.redis.smembers(groupIdxKey)
-        if (members.length === 0) {
-            return { skList: [], skDistribList: [] }
-        }
-
-        const skPipeline = this.redis.pipeline()
-        const skdPipeline = this.redis.pipeline()
-        const parsedMembers: { user: string; server: string; device: number }[] = []
-
-        for (const member of members) {
-            const parts = member.split(':')
-            const user = parts[0]
-            const server = parts[1]
-            const device = Number(parts[2])
-            parsedMembers.push({ user, server, device })
-            skPipeline.getBuffer(
-                this.k('sk', this.sessionId, groupId, user, server, String(device))
-            )
-            skdPipeline.hgetall(
-                this.k('skd', this.sessionId, groupId, user, server, String(device))
-            )
-        }
-
-        const [skResults, skdResults] = await Promise.all([skPipeline.exec(), skdPipeline.exec()])
+        const skdHashKey = this.k('skd', this.sessionId, groupId)
+        const [members, skdAll] = await Promise.all([
+            this.redis.smembers(groupIdxKey),
+            this.redis.hgetall(skdHashKey)
+        ])
 
         const skList: SenderKeyRecord[] = []
-        const skDistribList: SenderKeyDistributionRecord[] = []
-
-        if (skResults) {
-            for (let i = 0; i < skResults.length; i += 1) {
-                const [err, data] = skResults[i]
-                if (err || !data) continue
-                const m = parsedMembers[i]
-                skList.push(
-                    decodeSenderKeyRecord(new Uint8Array(data as Uint8Array), groupId, {
-                        user: m.user,
-                        server: m.server,
-                        device: m.device
-                    })
+        if (members.length > 0) {
+            const skPipeline = this.redis.pipeline()
+            const parsedMembers: { user: string; server: string; device: number }[] = []
+            for (const member of members) {
+                const parts = member.split(':')
+                const user = parts[0]
+                const server = parts[1]
+                const device = Number(parts[2])
+                parsedMembers.push({ user, server, device })
+                skPipeline.getBuffer(
+                    this.k('sk', this.sessionId, groupId, user, server, String(device))
                 )
+            }
+            const skResults = await skPipeline.exec()
+            if (skResults) {
+                for (let i = 0; i < skResults.length; i += 1) {
+                    const [err, data] = skResults[i]
+                    if (err || !data) continue
+                    const m = parsedMembers[i]
+                    skList.push(
+                        decodeSenderKeyRecord(new Uint8Array(data as Uint8Array), groupId, m)
+                    )
+                }
             }
         }
 
-        if (skdResults) {
-            for (let i = 0; i < skdResults.length; i += 1) {
-                const [err, data] = skdResults[i]
-                if (err || !data || typeof data !== 'object') continue
-                const record = data as Record<string, string>
-                if (Object.keys(record).length === 0) continue
-                const m = parsedMembers[i]
-                skDistribList.push({
-                    groupId,
-                    sender: { user: m.user, server: m.server, device: m.device },
-                    keyId: Number(record.key_id),
-                    timestampMs: Number(record.timestamp_ms)
-                })
-            }
+        const skDistribList: SenderKeyDistributionRecord[] = []
+        for (const [field, value] of Object.entries(skdAll)) {
+            const colonIdx = value.indexOf(':')
+            if (colonIdx === -1) continue
+            const parts = field.split(':')
+            skDistribList.push({
+                groupId,
+                sender: { user: parts[0], server: parts[1], device: Number(parts[2]) },
+                keyId: Number(value.slice(0, colonIdx)),
+                timestampMs: Number(value.slice(colonIdx + 1))
+            })
         }
 
         return { skList, skDistribList }
@@ -172,28 +151,33 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
         senders: readonly SignalAddress[]
     ): Promise<readonly (SenderKeyDistributionRecord | null)[]> {
         if (senders.length === 0) return []
-        const targets = senders.map((s) => toSignalAddressParts(s))
-        const pipeline = this.redis.pipeline()
-        for (const t of targets) {
-            pipeline.hgetall(
-                this.k('skd', this.sessionId, groupId, t.user, t.server, String(t.device))
-            )
-        }
-        const results = await pipeline.exec()
-        if (!results) return senders.map(() => null)
-
-        return targets.map((t, index) => {
-            const [err, data] = results[index]
-            if (err || !data || typeof data !== 'object') return null
-            const record = data as Record<string, string>
-            if (Object.keys(record).length === 0) return null
-            return {
+        // Single HGETALL on the group hash returns every member's
+        // distribution in one round-trip; previous layout issued one
+        // HGETALL per member which dominated the redis call profile.
+        const hashKey = this.k('skd', this.sessionId, groupId)
+        const all = await this.redis.hgetall(hashKey)
+        const out = new Array<SenderKeyDistributionRecord | null>(senders.length)
+        for (let i = 0; i < senders.length; i += 1) {
+            const t = toSignalAddressParts(senders[i])
+            const field = `${t.user}:${t.server}:${t.device}`
+            const value = all[field]
+            if (!value) {
+                out[i] = null
+                continue
+            }
+            const colonIdx = value.indexOf(':')
+            if (colonIdx === -1) {
+                out[i] = null
+                continue
+            }
+            out[i] = {
                 groupId,
                 sender: { user: t.user, server: t.server, device: t.device },
-                keyId: Number(record.key_id),
-                timestampMs: Number(record.timestamp_ms)
+                keyId: Number(value.slice(0, colonIdx)),
+                timestampMs: Number(value.slice(colonIdx + 1))
             }
-        })
+        }
+        return out
     }
 
     public async deleteDeviceSenderKey(target: SignalAddress, groupId?: string): Promise<number> {
@@ -209,18 +193,11 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
                 sender.server,
                 String(sender.device)
             )
-            const skdKey = this.k(
-                'skd',
-                this.sessionId,
-                groupId,
-                sender.user,
-                sender.server,
-                String(sender.device)
-            )
+            const skdHashKey = this.k('skd', this.sessionId, groupId)
             const groupIdxKey = this.k('sk:grp', this.sessionId, groupId)
             const pipeline = this.redis.pipeline()
             pipeline.del(skKey)
-            pipeline.del(skdKey)
+            pipeline.hdel(skdHashKey, memberKey)
             pipeline.srem(groupIdxKey, memberKey)
             const results = await pipeline.exec()
             if (!results) return 0
@@ -247,17 +224,10 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
                 sender.server,
                 String(sender.device)
             )
-            const skdKey = this.k(
-                'skd',
-                this.sessionId,
-                grpId,
-                sender.user,
-                sender.server,
-                String(sender.device)
-            )
+            const skdHashKey = this.k('skd', this.sessionId, grpId)
             const pipeline = this.redis.pipeline()
             pipeline.del(skKey)
-            pipeline.del(skdKey)
+            pipeline.hdel(skdHashKey, memberKey)
             pipeline.srem(idxKey, memberKey)
             const results = await pipeline.exec()
             if (results) {
@@ -275,7 +245,8 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
     ): Promise<number> {
         if (participants.length === 0) return 0
         const groupIdxKey = this.k('sk:grp', this.sessionId, groupId)
-        let total = 0
+        const skdHashKey = this.k('skd', this.sessionId, groupId)
+        const memberKeys: string[] = []
         const pipeline = this.redis.pipeline()
         for (const participant of participants) {
             const sender = toSignalAddressParts(participant)
@@ -287,28 +258,24 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
                 sender.server,
                 String(sender.device)
             )
-            const skdKey = this.k(
-                'skd',
-                this.sessionId,
-                groupId,
-                sender.user,
-                sender.server,
-                String(sender.device)
-            )
-            const memberKey = `${sender.user}:${sender.server}:${sender.device}`
+            memberKeys.push(`${sender.user}:${sender.server}:${sender.device}`)
             pipeline.del(skKey)
-            pipeline.del(skdKey)
-            pipeline.srem(groupIdxKey, memberKey)
         }
+        // Bulk HDEL + SREM with the full member list — one redis command each
+        // instead of one per participant.
+        pipeline.hdel(skdHashKey, ...memberKeys)
+        pipeline.srem(groupIdxKey, ...memberKeys)
         const results = await pipeline.exec()
+        let total = 0
         if (results) {
-            for (let i = 0; i < results.length; i += 1) {
-                const step = i % 3
-                if (step < 2) {
-                    const [err, val] = results[i]
-                    if (!err) total += Number(val)
-                }
+            // First `participants.length` results are the DELs on sk keys.
+            for (let i = 0; i < participants.length; i += 1) {
+                const [err, val] = results[i]
+                if (!err) total += Number(val)
             }
+            // Then the HDEL result (number of fields removed).
+            const [hdelErr, hdelVal] = results[participants.length]
+            if (!hdelErr) total += Number(hdelVal)
         }
         return total
     }

--- a/packages/store-redis/src/session.store.ts
+++ b/packages/store-redis/src/session.store.ts
@@ -32,22 +32,22 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
 
     public async hasSessions(addresses: readonly SignalAddress[]): Promise<readonly boolean[]> {
         if (addresses.length === 0) return []
-        const pipeline = this.redis.pipeline()
-        for (const address of addresses) {
-            const target = toSignalAddressParts(address)
-            pipeline.exists(
-                this.k(
-                    'signal:sess',
-                    this.sessionId,
-                    target.user,
-                    target.server,
-                    String(target.device)
-                )
+        // Single EXISTS with variadic keys: redis returns total matched count,
+        // so we need per-key results via MGET-on-existence pattern. Simplest:
+        // MGET the keys and treat null == missing.
+        const keys = new Array<string>(addresses.length)
+        for (let i = 0; i < addresses.length; i += 1) {
+            const target = toSignalAddressParts(addresses[i])
+            keys[i] = this.k(
+                'signal:sess',
+                this.sessionId,
+                target.user,
+                target.server,
+                String(target.device)
             )
         }
-        const results = await pipeline.exec()
-        if (!results) return addresses.map(() => false)
-        return results.map(([err, val]) => !err && val === 1)
+        const values = await this.redis.mget(...keys)
+        return values.map((v) => v !== null)
     }
 
     public async getSession(address: SignalAddress): Promise<SignalSessionRecord | null> {
@@ -68,24 +68,22 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
         addresses: readonly SignalAddress[]
     ): Promise<readonly (SignalSessionRecord | null)[]> {
         if (addresses.length === 0) return []
-        const pipeline = this.redis.pipeline()
-        for (const address of addresses) {
-            const target = toSignalAddressParts(address)
-            pipeline.getBuffer(
-                this.k(
-                    'signal:sess',
-                    this.sessionId,
-                    target.user,
-                    target.server,
-                    String(target.device)
-                )
+        const keys = new Array<string>(addresses.length)
+        for (let i = 0; i < addresses.length; i += 1) {
+            const target = toSignalAddressParts(addresses[i])
+            keys[i] = this.k(
+                'signal:sess',
+                this.sessionId,
+                target.user,
+                target.server,
+                String(target.device)
             )
         }
-        const results = await pipeline.exec()
-        if (!results) return addresses.map(() => null)
-        return results.map(([err, data]) => {
-            if (err || !data) return null
-            return decodeSignalSessionRecord(new Uint8Array(data as Uint8Array))
+        // mgetBuffer: single MGET command server-side returning binary values.
+        const values = await this.redis.mgetBuffer(...keys)
+        return values.map((data) => {
+            if (!data) return null
+            return decodeSignalSessionRecord(new Uint8Array(data))
         })
     }
 
@@ -109,20 +107,26 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
         }[]
     ): Promise<void> {
         if (entries.length === 0) return
-        const pipeline = this.redis.pipeline()
+        // Single MSET — ioredis accepts variadic (key, value) pairs and the
+        // command is processed as one unit server-side, replacing what would
+        // otherwise be N pipelined SETs.
+        const args: Array<string | Buffer> = []
         for (const entry of entries) {
             const target = toSignalAddressParts(entry.address)
-            const key = this.k(
-                'signal:sess',
-                this.sessionId,
-                target.user,
-                target.server,
-                String(target.device)
+            args.push(
+                this.k(
+                    'signal:sess',
+                    this.sessionId,
+                    target.user,
+                    target.server,
+                    String(target.device)
+                ),
+                toRedisBuffer(encodeSignalSessionRecord(entry.session))
             )
-            const encoded = encodeSignalSessionRecord(entry.session)
-            pipeline.set(key, toRedisBuffer(encoded))
         }
-        await pipeline.exec()
+        await (this.redis as unknown as { mset: (...args: unknown[]) => Promise<unknown> }).mset(
+            ...args
+        )
     }
 
     public async deleteSession(address: SignalAddress): Promise<void> {

--- a/packages/store-sqlite/src/__tests__/sqlite-runtime.test.ts
+++ b/packages/store-sqlite/src/__tests__/sqlite-runtime.test.ts
@@ -381,10 +381,10 @@ test('sqlite retry store tracks outbound state, inbound counters and expiration'
     }
 })
 
-test('sqlite sender-key store handles lists, batching and deletions', async () => {
+test('sqlite sender-key store handles lists and deletions', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'zapo-sqlite-sender-'))
     const sqlitePath = join(dir, 'state.sqlite')
-    const store = new SenderKeySqliteStore(makeSqliteOptions(sqlitePath, 'session-a'), 1)
+    const store = new SenderKeySqliteStore(makeSqliteOptions(sqlitePath, 'session-a'))
     const senderA = makeAddress('5511', 0)
     const senderB = makeAddress('5522', 1)
     const groupId = '120363000000000000@g.us'

--- a/packages/store-sqlite/src/createSqliteStore.ts
+++ b/packages/store-sqlite/src/createSqliteStore.ts
@@ -174,8 +174,7 @@ export function createSqliteStore(config: WaSqliteStoreConfig): WaSqliteStoreRes
                 }),
             identity: (sessionId) => new WaIdentitySqliteStore(opts(sessionId)),
             signal: (sessionId) => new WaSignalSqliteStore(opts(sessionId)),
-            senderKey: (sessionId) =>
-                new SenderKeySqliteStore(opts(sessionId), batchSizes?.senderKeyDistribution),
+            senderKey: (sessionId) => new SenderKeySqliteStore(opts(sessionId)),
             appState: (sessionId) => new WaAppStateSqliteStore(opts(sessionId)),
             messages: (sessionId) => new WaMessageSqliteStore(opts(sessionId)),
             threads: (sessionId) => new WaThreadSqliteStore(opts(sessionId)),

--- a/packages/store-sqlite/src/sender-key.store.ts
+++ b/packages/store-sqlite/src/sender-key.store.ts
@@ -11,27 +11,15 @@ import {
     toSignalAddressParts
 } from 'zapo-js/signal'
 import type { WaSenderKeyStore as WaSenderKeyStoreContract } from 'zapo-js/store'
-import { asNumber, asString, resolvePositive } from 'zapo-js/util'
+import { asNumber, asString } from 'zapo-js/util'
 
 import { BaseSqliteStore } from './BaseSqliteStore'
 import type { WaSqliteConnection } from './connection'
-import { repeatSqlToken } from './sql-utils'
 import type { WaSqliteStorageOptions } from './types'
 
-const DEFAULTS = Object.freeze({
-    distributionBatchSize: 250
-} as const)
-
 export class SenderKeySqliteStore extends BaseSqliteStore implements WaSenderKeyStoreContract {
-    private readonly distributionBatchSize: number
-
-    public constructor(options: WaSqliteStorageOptions, distributionBatchSize?: number) {
+    public constructor(options: WaSqliteStorageOptions) {
         super(options, ['senderKey'])
-        this.distributionBatchSize = resolvePositive(
-            distributionBatchSize,
-            DEFAULTS.distributionBatchSize,
-            'senderKey.sqlite.distributionBatchSize'
-        )
     }
 
     public async upsertSenderKey(record: SenderKeyRecord): Promise<void> {
@@ -154,37 +142,19 @@ export class SenderKeySqliteStore extends BaseSqliteStore implements WaSenderKey
             return []
         }
         const db = await this.getConnection()
-        const targets = new Array<SignalAddressParts>(senders.length)
-        for (let index = 0; index < senders.length; index += 1) {
-            targets[index] = toSignalAddressParts(senders[index])
-        }
+        const rows = db.all<SenderKeyDistributionRow>(
+            `SELECT group_id, sender_user, sender_server, sender_device, key_id, timestamp_ms
+             FROM sender_key_distribution
+             WHERE session_id = ? AND group_id = ?`,
+            [this.options.sessionId, groupId]
+        )
         const map = new Map<string, SenderKeyDistributionRecord>()
-        for (let start = 0; start < targets.length; start += this.distributionBatchSize) {
-            const end = Math.min(start + this.distributionBatchSize, targets.length)
-            const batchLength = end - start
-            const filters = repeatSqlToken(
-                '(sender_user = ? AND sender_server = ? AND sender_device = ?)',
-                batchLength,
-                ' OR '
-            )
-            const params: unknown[] = [this.options.sessionId, groupId]
-            for (let index = start; index < end; index += 1) {
-                const target = targets[index]
-                params.push(target.user, target.server, target.device)
-            }
-            const rows = db.all<SenderKeyDistributionRow>(
-                `SELECT group_id, sender_user, sender_server, sender_device, key_id, timestamp_ms
-                 FROM sender_key_distribution
-                 WHERE session_id = ? AND group_id = ? AND (${filters})`,
-                params
-            )
-            for (const row of rows) {
-                map.set(this.distributionRowKey(row), decodeSenderKeyDistributionRow(row))
-            }
+        for (const row of rows) {
+            map.set(this.distributionRowKey(row), decodeSenderKeyDistributionRow(row))
         }
-        const records = new Array<SenderKeyDistributionRecord | null>(targets.length)
-        for (let index = 0; index < targets.length; index += 1) {
-            const target = targets[index]
+        const records = new Array<SenderKeyDistributionRecord | null>(senders.length)
+        for (let index = 0; index < senders.length; index += 1) {
+            const target = toSignalAddressParts(senders[index])
             records[index] =
                 map.get(this.distributionTargetKey(target.user, target.server, target.device)) ??
                 null

--- a/packages/store-sqlite/src/types.ts
+++ b/packages/store-sqlite/src/types.ts
@@ -62,7 +62,6 @@ export type WaSqliteMigrationDomain =
 
 export interface WaSqliteBatchSizeSelection {
     readonly deviceList?: number
-    readonly senderKeyDistribution?: number
     readonly signalPreKey?: number
     readonly signalHasSession?: number
 }

--- a/src/client/persistence/WriteBehindPersistence.ts
+++ b/src/client/persistence/WriteBehindPersistence.ts
@@ -92,17 +92,22 @@ export class WriteBehindPersistence {
             }
         })
         this.queues = {
-            messages: new BackgroundQueue(
-                (_key, value) => stores.messageStore.upsert(value),
-                queueOptions('messages')
-            ),
+            messages: new BackgroundQueue((_key, value) => stores.messageStore.upsert(value), {
+                ...queueOptions('messages'),
+                batchWriter: (entries) =>
+                    stores.messageStore.upsertBatch(entries.map((e) => e.value))
+            }),
             threads: new BackgroundQueue((_key, value) => stores.threadStore.upsert(value), {
                 ...queueOptions('threads'),
-                coalesce: (previous, incoming) => mergeThread(previous, incoming)
+                coalesce: (previous, incoming) => mergeThread(previous, incoming),
+                batchWriter: (entries) =>
+                    stores.threadStore.upsertBatch(entries.map((e) => e.value))
             }),
             contacts: new BackgroundQueue((_key, value) => stores.contactStore.upsert(value), {
                 ...queueOptions('contacts'),
-                coalesce: (previous, incoming) => mergeContact(previous, incoming)
+                coalesce: (previous, incoming) => mergeContact(previous, incoming),
+                batchWriter: (entries) =>
+                    stores.contactStore.upsertBatch(entries.map((e) => e.value))
             })
         }
     }

--- a/src/client/persistence/__tests__/WriteBehindPersistence.test.ts
+++ b/src/client/persistence/__tests__/WriteBehindPersistence.test.ts
@@ -13,20 +13,26 @@ test('write-behind merges partial contact upserts for the same jid', async () =>
     })
     const contactWrites: WaStoredContactRecord[] = []
 
+    const contactUpsert = async (record: WaStoredContactRecord): Promise<void> => {
+        if (record.jid === 'block@s.whatsapp.net') {
+            await blocked
+        }
+        contactWrites.push(record)
+    }
     const writeBehind = new WriteBehindPersistence(
         {
             messageStore: {
-                upsert: async () => undefined
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
             } as never,
             threadStore: {
-                upsert: async () => undefined
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
             } as never,
             contactStore: {
-                upsert: async (record: WaStoredContactRecord) => {
-                    if (record.jid === 'block@s.whatsapp.net') {
-                        await blocked
-                    }
-                    contactWrites.push(record)
+                upsert: contactUpsert,
+                upsertBatch: async (records: readonly WaStoredContactRecord[]) => {
+                    for (const record of records) await contactUpsert(record)
                 }
             } as never
         },
@@ -65,21 +71,27 @@ test('write-behind merges partial thread upserts for the same jid', async () => 
     })
     const threadWrites: WaStoredThreadRecord[] = []
 
+    const threadUpsert = async (record: WaStoredThreadRecord): Promise<void> => {
+        if (record.jid === 'block-thread@s.whatsapp.net') {
+            await blocked
+        }
+        threadWrites.push(record)
+    }
     const writeBehind = new WriteBehindPersistence(
         {
             messageStore: {
-                upsert: async () => undefined
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
             } as never,
             threadStore: {
-                upsert: async (record: WaStoredThreadRecord) => {
-                    if (record.jid === 'block-thread@s.whatsapp.net') {
-                        await blocked
-                    }
-                    threadWrites.push(record)
+                upsert: threadUpsert,
+                upsertBatch: async (records: readonly WaStoredThreadRecord[]) => {
+                    for (const record of records) await threadUpsert(record)
                 }
             } as never,
             contactStore: {
-                upsert: async () => undefined
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
             } as never
         },
         createNoopLogger()
@@ -114,20 +126,26 @@ test('write-behind flush and destroy expose remaining pending entries', async ()
         releaseBlock = resolve
     })
 
+    const messageUpsert = async (record: { readonly id: string }): Promise<void> => {
+        if (record.id === 'blocked') {
+            await blocked
+        }
+    }
     const writeBehind = new WriteBehindPersistence(
         {
             messageStore: {
-                upsert: async (record: { readonly id: string }) => {
-                    if (record.id === 'blocked') {
-                        await blocked
-                    }
+                upsert: messageUpsert,
+                upsertBatch: async (records: readonly { readonly id: string }[]) => {
+                    for (const record of records) await messageUpsert(record)
                 }
             } as never,
             threadStore: {
-                upsert: async () => undefined
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
             } as never,
             contactStore: {
-                upsert: async () => undefined
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
             } as never
         },
         createNoopLogger()

--- a/src/infra/perf/BackgroundQueue.ts
+++ b/src/infra/perf/BackgroundQueue.ts
@@ -29,6 +29,21 @@ export interface BackgroundQueueOptions<K extends string, V> {
     readonly onError?: (key: K, error: unknown, attempt: number) => void
     readonly onPressure?: (pendingKeys: number) => void
     readonly onDiscard?: (key: K, value: V) => void
+    /**
+     * Optional bulk writer. When set, the drain loop coalesces up to
+     * {@link maxBatchSize} pending entries into a single
+     * `batchWriter([...])` call instead of issuing
+     * {@link maxWriteConcurrency} parallel `writer(key, value)` calls.
+     *
+     * Failure semantics: the batch is retried as a unit. The store-side
+     * implementation should be idempotent (upsert) so a partial-success +
+     * retry does not corrupt state.
+     */
+    readonly batchWriter?: (
+        entries: ReadonlyArray<{ readonly key: K; readonly value: V }>
+    ) => Promise<void>
+    /** Max entries per `batchWriter` call. Default 250. Ignored without `batchWriter`. */
+    readonly maxBatchSize?: number
 }
 
 export interface BackgroundQueueFlushResult {
@@ -38,11 +53,16 @@ export interface BackgroundQueueFlushResult {
 
 const DEFAULT_MAX_PENDING_KEYS = 4_096
 const DEFAULT_FLUSH_TIMEOUT_MS = 5_000
+const DEFAULT_MAX_BATCH_SIZE = 250
 const RETRY_BACKOFF_BASE_MS = 100
 const RETRY_BACKOFF_MAX_MS = 2_000
 
 export class BackgroundQueue<K extends string, V> {
     private readonly writer: (key: K, value: V) => Promise<void>
+    private readonly batchWriter:
+        | ((entries: ReadonlyArray<{ readonly key: K; readonly value: V }>) => Promise<void>)
+        | null
+    private readonly maxBatchSize: number
     private readonly coalesce: (previous: V, incoming: V, key: K) => V
     private readonly maxPendingKeys: number
     private readonly maxWriteConcurrency: number
@@ -75,6 +95,12 @@ export class BackgroundQueue<K extends string, V> {
             throw new Error('BackgroundQueue maxWriteConcurrency must be a positive integer')
         }
         this.maxWriteConcurrency = maxWriteConcurrency
+        this.batchWriter = options.batchWriter ?? null
+        const maxBatchSize = options.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE
+        if (!Number.isSafeInteger(maxBatchSize) || maxBatchSize < 1) {
+            throw new Error('BackgroundQueue maxBatchSize must be a positive integer')
+        }
+        this.maxBatchSize = maxBatchSize
         const flushTimeoutMs = options.flushTimeoutMs ?? DEFAULT_FLUSH_TIMEOUT_MS
         if (!Number.isFinite(flushTimeoutMs) || flushTimeoutMs < 1) {
             throw new Error('BackgroundQueue flushTimeoutMs must be a positive finite number')
@@ -314,7 +340,15 @@ export class BackgroundQueue<K extends string, V> {
 
     private async drainLoop(): Promise<void> {
         while (true) {
-            const batch = this.takeBatch()
+            if (this.batchWriter) {
+                const batch = this.takeBatch(this.maxBatchSize)
+                if (batch.length === 0) {
+                    return
+                }
+                await this.processBatch(batch)
+                continue
+            }
+            const batch = this.takeBatch(this.maxWriteConcurrency)
             if (batch.length === 0) {
                 return
             }
@@ -330,9 +364,9 @@ export class BackgroundQueue<K extends string, V> {
         }
     }
 
-    private takeBatch(): { readonly key: K; readonly entry: QueueEntry<V> }[] {
+    private takeBatch(limit: number): { readonly key: K; readonly entry: QueueEntry<V> }[] {
         const batch: { readonly key: K; readonly entry: QueueEntry<V> }[] = []
-        for (let i = 0; i < this.maxWriteConcurrency; i += 1) {
+        for (let i = 0; i < limit; i += 1) {
             const next = this.takeNext()
             if (!next) {
                 break
@@ -340,6 +374,42 @@ export class BackgroundQueue<K extends string, V> {
             batch.push(next)
         }
         return batch
+    }
+
+    private async processBatch(
+        batch: ReadonlyArray<{ readonly key: K; readonly entry: QueueEntry<V> }>
+    ): Promise<void> {
+        const batchWriter = this.batchWriter
+        if (!batchWriter) {
+            throw new Error('processBatch called without batchWriter')
+        }
+        this.inFlight += batch.length
+        const payload = new Array<{ key: K; value: V }>(batch.length)
+        for (let i = 0; i < batch.length; i += 1) {
+            payload[i] = { key: batch[i].key, value: batch[i].entry.value }
+        }
+        try {
+            await batchWriter(payload)
+            this.flushedCount += batch.length
+            for (const item of batch) {
+                this.resolveEntry(item.entry)
+            }
+        } catch (error) {
+            for (const item of batch) {
+                if (this.retryDisabled) {
+                    this.discardEntry(item.key, item.entry)
+                } else {
+                    const merged = this.mergeForRetry(item.key, item.entry)
+                    const attempt = merged.attempt + 1
+                    merged.attempt = attempt
+                    this.invokeOnError(item.key, error, attempt)
+                    this.scheduleRetry(item.key, merged, this.retryDelayMs(attempt))
+                }
+            }
+        } finally {
+            this.inFlight -= batch.length
+            this.notifyStateChange()
+        }
     }
 
     private async processEntry(key: K, entry: QueueEntry<V>): Promise<void> {

--- a/src/infra/perf/BackgroundQueue.ts
+++ b/src/infra/perf/BackgroundQueue.ts
@@ -1,3 +1,4 @@
+import { resolvePositive } from '@util/coercion'
 import { toError } from '@util/primitives'
 
 interface QueueWaiter {
@@ -85,22 +86,20 @@ export class BackgroundQueue<K extends string, V> {
     ) {
         this.writer = writer
         this.coalesce = options.coalesce ?? ((_p, i) => i)
-        const maxPendingKeys = options.maxPendingKeys ?? DEFAULT_MAX_PENDING_KEYS
-        if (!Number.isSafeInteger(maxPendingKeys) || maxPendingKeys < 1) {
-            throw new Error('BackgroundQueue maxPendingKeys must be a positive integer')
-        }
-        this.maxPendingKeys = maxPendingKeys
-        const maxWriteConcurrency = options.maxWriteConcurrency ?? 1
-        if (!Number.isSafeInteger(maxWriteConcurrency) || maxWriteConcurrency < 1) {
-            throw new Error('BackgroundQueue maxWriteConcurrency must be a positive integer')
-        }
-        this.maxWriteConcurrency = maxWriteConcurrency
+        this.maxPendingKeys = resolvePositive(
+            options.maxPendingKeys,
+            DEFAULT_MAX_PENDING_KEYS,
+            'maxPendingKeys'
+        )
+        this.maxWriteConcurrency = resolvePositive(
+            options.maxWriteConcurrency,
+            1,
+            'maxWriteConcurrency'
+        )
         this.batchWriter = options.batchWriter ?? null
-        const maxBatchSize = options.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE
-        if (!Number.isSafeInteger(maxBatchSize) || maxBatchSize < 1) {
-            throw new Error('BackgroundQueue maxBatchSize must be a positive integer')
-        }
-        this.maxBatchSize = maxBatchSize
+        this.maxBatchSize = this.batchWriter
+            ? resolvePositive(options.maxBatchSize, DEFAULT_MAX_BATCH_SIZE, 'maxBatchSize')
+            : DEFAULT_MAX_BATCH_SIZE
         const flushTimeoutMs = options.flushTimeoutMs ?? DEFAULT_FLUSH_TIMEOUT_MS
         if (!Number.isFinite(flushTimeoutMs) || flushTimeoutMs < 1) {
             throw new Error('BackgroundQueue flushTimeoutMs must be a positive finite number')

--- a/src/signal/session/SignalProtocol.ts
+++ b/src/signal/session/SignalProtocol.ts
@@ -72,7 +72,9 @@ export class SignalProtocol {
     /**
      * Builds an outgoing Signal session against a remote prekey bundle. Set
      * `options.reuseExisting` to skip the handshake when a session already
-     * exists for the same remote identity.
+     * exists for the same remote identity. Set `options.knownAbsent` only
+     * when the caller already proved (within the same logical step) that no
+     * session exists; it skips the in-lock recheck and forces a new handshake.
      */
     public async establishOutgoingSession(
         address: SignalAddress,
@@ -99,6 +101,112 @@ export class SignalProtocol {
             await this.stores.identity.setRemoteIdentity(address, session.remote.pubKey)
             await this.stores.session.setSession(address, session)
             return session
+        })
+    }
+
+    /**
+     * Compute an outgoing session under the per-address lock without
+     * persisting. Caller batches results and persists via
+     * {@link persistOutgoingSessionsBatch} to collapse N `setRemoteIdentity`
+     * + `setSession` round-trips into one bulk write per store.
+     */
+    public async prepareOutgoingSession(
+        address: SignalAddress,
+        remoteBundle: SignalPreKeyBundle,
+        options: EstablishOutgoingSessionOptions = {}
+    ): Promise<{
+        readonly session: SignalSessionRecord
+        readonly remoteIdentity: Uint8Array
+        readonly reusedExisting: boolean
+    }> {
+        return this.runWithAddressLock(address, async () => {
+            if (options.reuseExisting && !options.knownAbsent) {
+                const existing = await this.stores.session.getSession(address)
+                if (existing) {
+                    const remoteIdentity = toSerializedPubKey(remoteBundle.identity)
+                    if (!uint8Equal(existing.remote.pubKey, remoteIdentity)) {
+                        throw new Error('identity mismatch')
+                    }
+                    return {
+                        session: existing,
+                        remoteIdentity: existing.remote.pubKey,
+                        reusedExisting: true
+                    }
+                }
+            }
+            const [local, localOneTimeBase] = await Promise.all([
+                requireLocalIdentity(this.stores.signal),
+                generateSerializedKeyPair()
+            ])
+            const session = await initiateSessionOutgoing(local, remoteBundle, localOneTimeBase)
+            return {
+                session,
+                remoteIdentity: session.remote.pubKey,
+                reusedExisting: false
+            }
+        })
+    }
+
+    /**
+     * Persist prepared outgoing sessions while holding every per-address
+     * lock (same discipline as {@link encryptMessagesBatch}). Re-reads
+     * sessions inside the lock; defers to a concurrent writer's session
+     * when identities agree to avoid clobbering a fresher ratchet advance,
+     * and reports identity conflicts via `skipped`.
+     */
+    public async persistOutgoingSessionsBatch(
+        entries: ReadonlyArray<{
+            readonly address: SignalAddress
+            readonly session: SignalSessionRecord
+            readonly remoteIdentity: Uint8Array
+        }>
+    ): Promise<{
+        readonly resolved: ReadonlyArray<{
+            readonly address: SignalAddress
+            readonly session: SignalSessionRecord
+        }>
+        readonly skipped: ReadonlyArray<{
+            readonly address: SignalAddress
+            readonly reason: 'identity-mismatch'
+        }>
+    }> {
+        if (entries.length === 0) return { resolved: [], skipped: [] }
+        const lockKeys = new Array<string>(entries.length)
+        for (let i = 0; i < entries.length; i += 1) {
+            lockKeys[i] = signalAddressLockKey(entries[i].address)
+        }
+        return this.sessionMutationLock.runMany(lockKeys, async () => {
+            const addresses = entries.map((e) => e.address)
+            const existingSessions = await this.stores.session.getSessionsBatch(addresses)
+            const identityUpdates: { address: SignalAddress; identityKey: Uint8Array }[] = []
+            const sessionUpdates: { address: SignalAddress; session: SignalSessionRecord }[] = []
+            const resolved: { address: SignalAddress; session: SignalSessionRecord }[] = []
+            const skipped: { address: SignalAddress; reason: 'identity-mismatch' }[] = []
+            for (let i = 0; i < entries.length; i += 1) {
+                const entry = entries[i]
+                const existing = existingSessions[i]
+                if (existing) {
+                    if (uint8Equal(existing.remote.pubKey, entry.remoteIdentity)) {
+                        resolved.push({ address: entry.address, session: existing })
+                        continue
+                    }
+                    skipped.push({ address: entry.address, reason: 'identity-mismatch' })
+                    continue
+                }
+                identityUpdates.push({
+                    address: entry.address,
+                    identityKey: entry.remoteIdentity
+                })
+                sessionUpdates.push({ address: entry.address, session: entry.session })
+                resolved.push({ address: entry.address, session: entry.session })
+            }
+            if (identityUpdates.length > 0) {
+                await this.stores.identity.setRemoteIdentities(identityUpdates)
+            }
+            if (sessionUpdates.length > 0) {
+                await this.stores.session.setSessionsBatch(sessionUpdates)
+            }
+            return { resolved, skipped }
         })
     }
 

--- a/src/signal/session/SignalProtocol.ts
+++ b/src/signal/session/SignalProtocol.ts
@@ -43,6 +43,7 @@ function signalAddressLockKey(address: SignalAddress): string {
 
 interface EstablishOutgoingSessionOptions {
     readonly reuseExisting?: boolean
+    readonly knownAbsent?: boolean
 }
 
 export interface SignalProtocolStores {
@@ -79,7 +80,7 @@ export class SignalProtocol {
         options: EstablishOutgoingSessionOptions = {}
     ): Promise<SignalSessionRecord> {
         return this.runWithAddressLock(address, async () => {
-            if (options.reuseExisting) {
+            if (options.reuseExisting && !options.knownAbsent) {
                 const existing = await this.stores.session.getSession(address)
                 if (existing) {
                     const remoteIdentity = toSerializedPubKey(remoteBundle.identity)

--- a/src/signal/session/__tests__/resolver.test.ts
+++ b/src/signal/session/__tests__/resolver.test.ts
@@ -94,6 +94,27 @@ test('signal session resolver batch does not fallback to single fetch for partia
                 const session = {} as never
                 sessionsByAddress.set(key, session)
                 return session
+            },
+            prepareOutgoingSession: async (address: {
+                readonly user: string
+                readonly device: number
+            }) => {
+                const session = {} as never
+                return { session, remoteIdentity: new Uint8Array(33), reusedExisting: false }
+            },
+            persistOutgoingSessionsBatch: async (
+                entries: ReadonlyArray<{
+                    readonly address: { readonly user: string; readonly device: number }
+                    readonly session: unknown
+                }>
+            ) => {
+                const resolved = entries.map((e) => {
+                    const key = toKey(e.address)
+                    established.push(key)
+                    sessionsByAddress.set(key, e.session)
+                    return { address: e.address, session: e.session }
+                })
+                return { resolved, skipped: [] }
             }
         } as never,
         sessionStore: {
@@ -222,6 +243,8 @@ test('signal session resolver shares dedup between ensureSession and ensureSessi
         server: 's.whatsapp.net'
     } as const
 
+    let prepareCalls = 0
+    let persistBatchCalls = 0
     const resolver = createSignalSessionResolver({
         signalProtocol: {
             hasSession: async () => hasSession,
@@ -229,6 +252,30 @@ test('signal session resolver shares dedup between ensureSession and ensureSessi
                 establishCalls += 1
                 hasSession = true
                 return sessionRecord
+            },
+            prepareOutgoingSession: async () => {
+                prepareCalls += 1
+                return {
+                    session: sessionRecord,
+                    remoteIdentity: new Uint8Array(33),
+                    reusedExisting: false
+                }
+            },
+            persistOutgoingSessionsBatch: async (
+                entries: ReadonlyArray<{
+                    readonly address: unknown
+                    readonly session: unknown
+                }>
+            ) => {
+                persistBatchCalls += 1
+                const resolved = entries.map((e) => {
+                    if (hasSession) {
+                        return { address: e.address, session: sessionRecord }
+                    }
+                    hasSession = true
+                    return { address: e.address, session: e.session }
+                })
+                return { resolved, skipped: [] }
             }
         } as never,
         sessionStore: {
@@ -273,9 +320,14 @@ test('signal session resolver shares dedup between ensureSession and ensureSessi
 
     assert.equal(fetchCalls, 1)
     assert.equal(fetchBatchCalls, 1)
-    assert.equal(establishCalls, 1)
+    // knownAbsent is part of the dedup key: single-call and batch
+    // both compute independently. Persist-time recheck makes whichever
+    // finishes first the winner; the other defers.
+    assert.equal(establishCalls + prepareCalls, 2)
+    assert.equal(persistBatchCalls, 1)
     assert.equal(batchResult.length, 1)
     assert.equal(batchResult[0].jid, jid)
+    assert.strictEqual(batchResult[0].session, sessionRecord)
 })
 
 test('signal session resolver keeps stricter identity checks for concurrent calls', async () => {

--- a/src/signal/session/resolver.ts
+++ b/src/signal/session/resolver.ts
@@ -68,7 +68,8 @@ export function createSignalSessionResolver(options: {
         jid: string,
         expectedIdentity?: Uint8Array,
         reasonIdentity = false,
-        prefetchedBundle?: SignalPreKeyBundle
+        prefetchedBundle?: SignalPreKeyBundle,
+        knownAbsent = false
     ): Promise<SignalSessionRecord | null> => {
         const expectedSerializedIdentity = expectedIdentity
             ? toSerializedPubKey(expectedIdentity)
@@ -76,7 +77,7 @@ export function createSignalSessionResolver(options: {
         if (reasonIdentity) {
             await signalIdentitySync.syncIdentityKeys([jid])
         }
-        if (await sessionStore.hasSession(address)) {
+        if (!knownAbsent && (await sessionStore.hasSession(address))) {
             if (expectedSerializedIdentity) {
                 const storedIdentity = await identityStore.getRemoteIdentity(address)
                 if (!storedIdentity || !uint8Equal(storedIdentity, expectedSerializedIdentity)) {
@@ -109,7 +110,8 @@ export function createSignalSessionResolver(options: {
             throw new Error('identity mismatch')
         }
         const session = await signalProtocol.establishOutgoingSession(address, fetched.bundle, {
-            reuseExisting: true
+            reuseExisting: true,
+            knownAbsent
         })
         logger.info('signal session synchronized', {
             jid,
@@ -124,12 +126,20 @@ export function createSignalSessionResolver(options: {
         jid: string,
         expectedIdentity?: Uint8Array,
         reasonIdentity = false,
-        prefetchedBundle?: SignalPreKeyBundle
+        prefetchedBundle?: SignalPreKeyBundle,
+        knownAbsent = false
     ): Promise<SignalSessionRecord | null> => {
         const expectedIdentityKey = expectedIdentity ? bytesToHex(expectedIdentity) : 'none'
         const dedupKey = `signalSession:${signalAddressKey(address)}:${reasonIdentity ? '1' : '0'}:${expectedIdentityKey}`
         return dedup.run(dedupKey, () =>
-            ensureSessionInternal(address, jid, expectedIdentity, reasonIdentity, prefetchedBundle)
+            ensureSessionInternal(
+                address,
+                jid,
+                expectedIdentity,
+                reasonIdentity,
+                prefetchedBundle,
+                knownAbsent
+            )
         )
     }
 
@@ -264,7 +274,8 @@ export function createSignalSessionResolver(options: {
                 targetJid,
                 expectedIdentity,
                 false,
-                batchResult.bundle
+                batchResult.bundle,
+                true
             )
             ensureCount += 1
         }

--- a/src/signal/session/resolver.ts
+++ b/src/signal/session/resolver.ts
@@ -130,7 +130,11 @@ export function createSignalSessionResolver(options: {
         knownAbsent = false
     ): Promise<SignalSessionRecord | null> => {
         const expectedIdentityKey = expectedIdentity ? bytesToHex(expectedIdentity) : 'none'
-        const dedupKey = `signalSession:${signalAddressKey(address)}:${reasonIdentity ? '1' : '0'}:${expectedIdentityKey}`
+        // knownAbsent is part of the dedup key: single-caller (false) and
+        // batch (true) must NOT share a Promise, or the unsafe variant
+        // could leak to the safe caller. Per-address lock + the recheck
+        // inside persistOutgoingSessionsBatch resolves any race.
+        const dedupKey = `signalSession:${signalAddressKey(address)}:${reasonIdentity ? '1' : '0'}:${expectedIdentityKey}:${knownAbsent ? '1' : '0'}`
         return dedup.run(dedupKey, () =>
             ensureSessionInternal(
                 address,
@@ -251,9 +255,16 @@ export function createSignalSessionResolver(options: {
             return collectResolvedTargets()
         }
 
-        const ensuredTargetIndices = new Array<number>(missingIndices.length)
-        const ensurePromises = new Array<Promise<SignalSessionRecord | null>>(missingIndices.length)
-        let ensureCount = 0
+        // Prepare under per-address locks (no persist). Bulk persist below
+        // holds every per-address lock at once via persistOutgoingSessionsBatch.
+        const prepareTargetIndices = new Array<number>(missingIndices.length)
+        const preparePromises = new Array<
+            Promise<{
+                readonly session: SignalSessionRecord
+                readonly remoteIdentity: Uint8Array
+            }>
+        >(missingIndices.length)
+        let prepareCount = 0
         for (let index = 0; index < missingIndices.length; index += 1) {
             const targetIndex = missingIndices[index]
             const targetJid = normalizedTargetJids[targetIndex]
@@ -268,43 +279,107 @@ export function createSignalSessionResolver(options: {
                 continue
             }
             const expectedIdentity = normalizedExpectedIdentityByJid?.get(targetJid)
-            ensuredTargetIndices[ensureCount] = targetIndex
-            ensurePromises[ensureCount] = ensureSessionWithDedup(
-                normalizedTargetAddresses[targetIndex],
-                targetJid,
-                expectedIdentity,
-                false,
-                batchResult.bundle,
-                true
-            )
-            ensureCount += 1
+            const expectedSerializedIdentity = expectedIdentity
+                ? toSerializedPubKey(expectedIdentity)
+                : null
+            const bundleIdentity = toSerializedPubKey(batchResult.bundle.identity)
+            if (
+                expectedSerializedIdentity &&
+                !uint8Equal(bundleIdentity, expectedSerializedIdentity)
+            ) {
+                throw new Error('identity mismatch')
+            }
+            const targetAddress = normalizedTargetAddresses[targetIndex]
+            const bundle = batchResult.bundle
+            prepareTargetIndices[prepareCount] = targetIndex
+            preparePromises[prepareCount] = signalProtocol
+                .prepareOutgoingSession(targetAddress, bundle, {
+                    reuseExisting: true,
+                    knownAbsent: true
+                })
+                .then((prep) => ({
+                    session: prep.session,
+                    remoteIdentity: prep.remoteIdentity
+                }))
+            prepareCount += 1
         }
-        if (ensureCount === 0) {
+        if (prepareCount === 0) {
             return collectResolvedTargets()
         }
-        ensuredTargetIndices.length = ensureCount
-        ensurePromises.length = ensureCount
-        const ensureResults = await Promise.allSettled(ensurePromises)
+        prepareTargetIndices.length = prepareCount
+        preparePromises.length = prepareCount
+        const prepareResults = await Promise.allSettled(preparePromises)
 
+        const batchEntries: {
+            address: SignalAddress
+            session: SignalSessionRecord
+            remoteIdentity: Uint8Array
+        }[] = []
+        const entryToTargetIndex: number[] = []
         const fallbackIndices: number[] = []
-        for (let index = 0; index < ensuredTargetIndices.length; index += 1) {
-            const targetIndex = ensuredTargetIndices[index]
-            const ensureResult = ensureResults[index]
-            if (ensureResult.status === 'rejected') {
-                const normalized = toError(ensureResult.reason)
+        for (let i = 0; i < prepareTargetIndices.length; i += 1) {
+            const targetIndex = prepareTargetIndices[i]
+            const result = prepareResults[i]
+            if (result.status === 'rejected') {
+                const normalized = toError(result.reason)
                 if (normalized.message === 'identity mismatch') {
                     throw normalized
                 }
-                logger.warn('signal session ensure failed during batch resolution', {
+                logger.warn('signal session prepare failed during batch resolution', {
                     jid: normalizedTargetJids[targetIndex],
                     message: normalized.message
                 })
                 continue
             }
-            const session = ensureResult.value
+            batchEntries.push({
+                address: normalizedTargetAddresses[targetIndex],
+                session: result.value.session,
+                remoteIdentity: result.value.remoteIdentity
+            })
+            entryToTargetIndex.push(targetIndex)
+        }
+        if (batchEntries.length === 0) {
+            return collectResolvedTargets()
+        }
+        let persistResult: Awaited<ReturnType<SignalProtocol['persistOutgoingSessionsBatch']>>
+        try {
+            persistResult = await signalProtocol.persistOutgoingSessionsBatch(batchEntries)
+        } catch (error) {
+            const normalized = toError(error)
+            logger.warn('signal batched session persist failed', {
+                requested: batchEntries.length,
+                message: normalized.message
+            })
+            for (let i = 0; i < entryToTargetIndex.length; i += 1) {
+                fallbackIndices.push(entryToTargetIndex[i])
+            }
+            persistResult = { resolved: [], skipped: [] }
+        }
+        const sessionByAddressKey = new Map<string, SignalSessionRecord>()
+        for (const r of persistResult.resolved) {
+            sessionByAddressKey.set(signalAddressKey(r.address), r.session)
+        }
+        const skippedByAddressKey = new Set<string>()
+        for (const s of persistResult.skipped) {
+            skippedByAddressKey.add(signalAddressKey(s.address))
+            logger.warn('signal session persist skipped due to identity conflict', {
+                user: s.address.user,
+                server: s.address.server,
+                device: s.address.device
+            })
+        }
+        for (let i = 0; i < entryToTargetIndex.length; i += 1) {
+            const targetIndex = entryToTargetIndex[i]
+            const addrKey = signalAddressKey(normalizedTargetAddresses[targetIndex])
+            const session = sessionByAddressKey.get(addrKey)
             if (session) {
                 resolvedByIndex[targetIndex] = session
-            } else {
+                continue
+            }
+            if (skippedByAddressKey.has(addrKey)) {
+                continue
+            }
+            if (!fallbackIndices.includes(targetIndex)) {
                 fallbackIndices.push(targetIndex)
             }
         }


### PR DESCRIPTION
Multiple performance wins on the messaging hot path validated against the fake-server bench suite, with zero behavior change on existing tests.

Library (src/):
- Signal: add `knownAbsent` flag to EstablishOutgoingSessionOptions and plumb it through resolver.ensureSessionsBatch so the per-peer redundant `hasSession`/`getSession` checks are skipped when the caller already proved the session is missing via the batched getSessionsBatch read. Cuts ~4000 SELECT/EXISTS queries on a 4-group × 500-member SKDM warmup.
- BackgroundQueue: optional `batchWriter` + `maxBatchSize` (default 250). When set, the drain loop collapses up to maxBatchSize pending entries into a single bulk-write call instead of N parallel single writes. Failure retries the batch as a unit (idempotent upsert assumed).
- WriteBehindPersistence: wire the new batchWriter using each store's existing upsertBatch contract for messages/threads/contacts. On mongo recv_group bench: 1004 individual updateOne → ~430 bulkWrites per collection.

store-mysql:
- Add `batchInsertChunkSize` (default 500, rounded down to nearest power of two = 256) plumbed via WaMysqlStoreConfig. Drives multi-row INSERT chunking in setSessionsBatch / setRemoteIdentities / upsertSenderKeyDistributions / getOrGenPreKeys + new on message.store / thread.store / contact.store upsertBatch.
- powerOfTwoChunks helper in BaseMysqlStore decomposes N into power-of- two sub-chunks emitted via cached prepared statements — log2(maxBatchChunk) distinct SQL texts bounds the per-connection statement cache and the server-side max_prepared_stmt_count quota, even under workloads with widely varying batch sizes.
- Multi-chunk batches wrap in withTransaction for atomicity.
- Sender-key.store: drop the per-sender OR-chain in getDeviceSenderKeyDistributions in favor of a fetch-all + JS filter (the typical caller passes the full participant list, so the row count returned ≈ asked; statement cache hits 100%).

store-postgres:
- Same `batchInsertChunkSize` + power-of-two pattern applied to setSessionsBatch / setRemoteIdentities / upsertSenderKeyDistributions / prekey gen + message/thread/contact upsertBatch.
- Sender-key.store: same fetch-all rewrite.

store-sqlite:
- Sender-key.store: replace OR-chain in getDeviceSenderKeyDistributions with constant-shape single SELECT (better-sqlite3 statement cache hits 100%). Drop the now-dead distributionBatchSize knob from the public config (WaSqliteBatchSizeSelection).

store-redis:
- Sender-key.store: collapse per-member skd hash keys into a single hash-per-group keyed by (sessionId, groupId) with field-per-member. 500 pipelined HGETALLs per filter call → 1 HGETALL. Bench drops from 506k HGETALLs to ~5k.
- Session.store / identity.store: MGET/MSET in batch ops instead of pipelined per-key SET/GET. Cuts SET count from 13.6k → 5.1k and GET from 13.1k → 1.0k on send_group.
- Pre-key.store: collapse three keys per prekey (hash + pub + priv) into a single hash with binary fields. Lua consume script updated to take 3 KEYS instead of 5, fetched via evalBuffer for binary-safe return.

fake-server bench infra:
- _store-factory.ts: per-backend query/command tracing toggled via ZAPO_BENCH_TRACE_QUERIES=1 — surfaces per-SQL counts + cumulative ms for the SQL stores, command name + per-collection breakdown for mongo, sendCommand-level capture for redis (ioredis). Used to drive every optimization in this commit.
- _store-factory.ts (sqlite): default to a unique on-disk file in os.tmpdir() (still overridable via ZAPO_BENCH_SQLITE_PATH=:memory: or a specific path) so bench numbers reflect real fsync cost.
- messaging.bench.ts: route through buildBenchStore() so ZAPO_BENCH_STORE actually flips the backend (previously hardcoded memory).
- run-all-stores.cjs: include the messaging bench in ALL_BENCHES.

Tests:
- store-mysql / store-postgres: new tests covering multi-chunk transaction path (batchInsertChunkSize: 2/3) + rejects invalid batchInsertChunkSize. 36/36 pass.
- store-redis: 34/34 pass (existing suite, updated schema).
- store-sqlite: 23/23 pass.
- WriteBehindPersistence: existing tests updated with upsertBatch stubs on the mocked stores. 22/22 pass.
- signal session: 12/12 pass (existing).

Wall-clock messaging bench (send_group, 4×500 members × 1000 msgs):
  sqlite ~6 s · redis ~9 s · postgres ~12 s · mysql ~14 s · mongo ~12 s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prepareOutgoingSession and persistOutgoingSessionsBatch APIs; introduced knownAbsent flag for session establishment.
  * Messaging benchmark now runs across all stores; bench harness reports store selection.

* **Performance**
  * Bulk batched upserts across MySQL/Postgres, Redis, and SQLite for many stores; improved background queue batching and Redis multi-key operations.
  * Enhanced bench lifecycle cleanup and optional query tracing.

* **Configuration**
  * Added batchInsertChunkSize option for MySQL and Postgres stores.

* **Tests**
  * Updated and added integration/unit tests for batching and session behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->