### PR TITLE
feat(store): opt-in read-through cacheLayer for hot signal domains

### DIFF
--- a/src/store/cache/__tests__/cache.test.ts
+++ b/src/store/cache/__tests__/cache.test.ts
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { SenderKeyRecord, SignalAddress, SignalSessionRecord } from '@signal/types'
+import { withIdentityCache } from '@store/cache/identity.cache'
+import { withPrivacyTokenCache } from '@store/cache/privacy-token.cache'
+import { withSenderKeyCache } from '@store/cache/sender-key.cache'
+import { withSessionCache } from '@store/cache/session.cache'
+import type { WaStoredPrivacyTokenRecord } from '@store/contracts/privacy-token.store'
+import { WaIdentityMemoryStore } from '@store/memory/identity.store'
+import { WaPrivacyTokenMemoryStore } from '@store/memory/privacy-token.store'
+import { SenderKeyMemoryStore } from '@store/memory/sender-key.store'
+import { WaSessionMemoryStore } from '@store/memory/session.store'
+
+/** Wraps a real store, counting calls to the named methods, leaving the rest delegating. */
+function spy<T extends object>(
+    inner: T,
+    ...counted: (keyof T)[]
+): { readonly store: T; readonly counts: Map<keyof T, number> } {
+    const counts = new Map<keyof T, number>()
+    for (const method of counted) counts.set(method, 0)
+    const store = new Proxy(inner, {
+        get(target, prop, receiver) {
+            const value = Reflect.get(target, prop, receiver)
+            if (typeof value !== 'function') return value
+            const bound = (value as (...args: unknown[]) => unknown).bind(target)
+            if (!counts.has(prop as keyof T)) return bound
+            return (...args: unknown[]) => {
+                counts.set(prop as keyof T, (counts.get(prop as keyof T) ?? 0) + 1)
+                return bound(...args)
+            }
+        }
+    })
+    return { store, counts }
+}
+
+const addr = (user: string, device = 0): SignalAddress => ({ user, device })
+const sess = (marker: number): SignalSessionRecord => ({ marker }) as unknown as SignalSessionRecord
+const skRecord = (groupId: string, user: string): SenderKeyRecord => ({
+    groupId,
+    sender: addr(user),
+    keyId: 1,
+    iteration: 0,
+    chainKey: new Uint8Array([1]),
+    signingPublicKey: new Uint8Array([2])
+})
+const tok = (
+    jid: string,
+    fields: Partial<WaStoredPrivacyTokenRecord> = {}
+): WaStoredPrivacyTokenRecord => ({ jid, updatedAtMs: 1, ...fields })
+
+test('session cache: read-through populates L1 and avoids repeat backend reads', async () => {
+    const { store: backend, counts } = spy(new WaSessionMemoryStore(), 'getSession')
+    await backend.setSession(addr('a'), sess(1))
+    const cache = withSessionCache(backend)
+
+    assert.deepEqual(await cache.getSession(addr('a')), sess(1))
+    assert.equal(counts.get('getSession'), 1)
+    assert.deepEqual(await cache.getSession(addr('a')), sess(1))
+    assert.equal(counts.get('getSession'), 1)
+})
+
+test('session cache: write-through serves sets from L1 without a backend read', async () => {
+    const { store: backend, counts } = spy(new WaSessionMemoryStore(), 'getSession')
+    const cache = withSessionCache(backend)
+
+    await cache.setSession(addr('a'), sess(2))
+    assert.deepEqual(await cache.getSession(addr('a')), sess(2))
+    assert.equal(counts.get('getSession'), 0)
+})
+
+test('session cache: delete clears the L1 entry', async () => {
+    const { store: backend, counts } = spy(new WaSessionMemoryStore(), 'getSession')
+    const cache = withSessionCache(backend)
+
+    await cache.setSession(addr('a'), sess(3))
+    await cache.deleteSession(addr('a'))
+    assert.equal(await cache.getSession(addr('a')), null)
+    assert.equal(counts.get('getSession'), 1)
+})
+
+test('session cache: no negative caching (a later-present key is seen)', async () => {
+    const { store: backend, counts } = spy(new WaSessionMemoryStore(), 'getSession')
+    const cache = withSessionCache(backend)
+
+    assert.equal(await cache.getSession(addr('a')), null)
+    assert.equal(counts.get('getSession'), 1)
+    await backend.setSession(addr('a'), sess(4))
+    assert.deepEqual(await cache.getSession(addr('a')), sess(4))
+    assert.equal(counts.get('getSession'), 2)
+})
+
+test('session cache: batch fetches only the missing addresses from the backend', async () => {
+    const { store: backend } = spy(new WaSessionMemoryStore())
+    let lastBatch: readonly SignalAddress[] = []
+    const tracking = new Proxy(backend, {
+        get(target, prop, receiver) {
+            if (prop === 'getSessionsBatch') {
+                return (addresses: readonly SignalAddress[]) => {
+                    lastBatch = addresses
+                    return target.getSessionsBatch(addresses)
+                }
+            }
+            return Reflect.get(target, prop, receiver)
+        }
+    })
+    await backend.setSession(addr('a'), sess(1))
+    await backend.setSession(addr('b'), sess(2))
+    const cache = withSessionCache(tracking)
+
+    await cache.getSession(addr('a')) // populate L1 for 'a'
+    const out = await cache.getSessionsBatch([addr('a'), addr('b')])
+    assert.deepEqual(out, [sess(1), sess(2)])
+    assert.deepEqual(lastBatch, [addr('b')])
+})
+
+test('identity cache: read-through then write-through', async () => {
+    const { store: backend, counts } = spy(new WaIdentityMemoryStore(), 'getRemoteIdentity')
+    await backend.setRemoteIdentity(addr('a'), new Uint8Array([7]))
+    const cache = withIdentityCache(backend)
+
+    assert.deepEqual(await cache.getRemoteIdentity(addr('a')), new Uint8Array([7]))
+    assert.equal(counts.get('getRemoteIdentity'), 1)
+    assert.deepEqual(await cache.getRemoteIdentity(addr('a')), new Uint8Array([7]))
+    assert.equal(counts.get('getRemoteIdentity'), 1)
+
+    await cache.setRemoteIdentity(addr('b'), new Uint8Array([8]))
+    assert.deepEqual(await cache.getRemoteIdentity(addr('b')), new Uint8Array([8]))
+    assert.equal(counts.get('getRemoteIdentity'), 1)
+})
+
+test('sender-key cache: device key read-through, group list always hits backend', async () => {
+    const { store: backend, counts } = spy(
+        new SenderKeyMemoryStore(),
+        'getDeviceSenderKey',
+        'getGroupSenderKeyList'
+    )
+    await backend.upsertSenderKey(skRecord('g', 'a'))
+    const cache = withSenderKeyCache(backend)
+
+    assert.ok(await cache.getDeviceSenderKey('g', addr('a')))
+    assert.ok(await cache.getDeviceSenderKey('g', addr('a')))
+    assert.equal(counts.get('getDeviceSenderKey'), 1)
+
+    await cache.getGroupSenderKeyList('g')
+    await cache.getGroupSenderKeyList('g')
+    assert.equal(counts.get('getGroupSenderKeyList'), 2)
+})
+
+test('sender-key cache: markForgetSenderKey invalidates the L1 entry', async () => {
+    const { store: backend } = spy(new SenderKeyMemoryStore())
+    await backend.upsertSenderKey(skRecord('g', 'a'))
+    const cache = withSenderKeyCache(backend)
+
+    await cache.getDeviceSenderKey('g', addr('a')) // populate L1
+    const deleted = await cache.markForgetSenderKey('g', [addr('a')])
+    assert.ok(deleted > 0)
+    assert.equal(await cache.getDeviceSenderKey('g', addr('a')), null)
+})
+
+test('privacy-token cache: read-through', async () => {
+    const { store: backend, counts } = spy(new WaPrivacyTokenMemoryStore(), 'getByJid')
+    await backend.upsert(tok('j', { tcToken: new Uint8Array([1]) }))
+    const cache = withPrivacyTokenCache(backend)
+
+    assert.ok(await cache.getByJid('j'))
+    assert.equal(counts.get('getByJid'), 1)
+    assert.ok(await cache.getByJid('j'))
+    assert.equal(counts.get('getByJid'), 1)
+})
+
+test('privacy-token cache: upsert invalidates so the merged backend record is read fresh', async () => {
+    const { store: backend } = spy(new WaPrivacyTokenMemoryStore())
+    await backend.upsert(tok('j', { tcToken: new Uint8Array([1]) }))
+    const cache = withPrivacyTokenCache(backend)
+
+    await cache.getByJid('j') // L1 now holds { tcToken }
+    await cache.upsert(tok('j', { nctSalt: new Uint8Array([9]) })) // backend merges, L1 invalidated
+
+    const merged = await cache.getByJid('j')
+    // write-through of the partial would have dropped tcToken; invalidate-on-write keeps both
+    assert.ok(merged?.tcToken)
+    assert.ok(merged?.nctSalt)
+})

--- a/src/store/cache/identity.cache.ts
+++ b/src/store/cache/identity.cache.ts
@@ -1,0 +1,83 @@
+import type { WaIdentityStore } from '@store/contracts/identity.store'
+import { WaIdentityMemoryStore } from '@store/memory/identity.store'
+import type { WithDestroyLifecycle } from '@store/types'
+
+/**
+ * Read-through / write-through in-process cache for a persistent remote
+ * identity backend. Reuses {@link WaIdentityMemoryStore} as the bounded-LRU
+ * L1. Remote identities are read alongside sessions on the send path (the
+ * identity-mismatch guard), so caching them complements
+ * {@link withSessionCache}.
+ *
+ * The identity store has no per-key delete: identities are overwritten on
+ * re-establishment, so a peer's key change propagates through the
+ * write-through `setRemoteIdentity`. See {@link withSessionCache} for the
+ * shared coherence model and the single-writer-per-session assumption.
+ */
+export function withIdentityCache(
+    backend: WaIdentityStore,
+    maxEntries?: number
+): WithDestroyLifecycle<WaIdentityStore> {
+    const l1 = new WaIdentityMemoryStore({ maxRemoteIdentities: maxEntries })
+    let generation = 0
+
+    return {
+        getRemoteIdentity: async (address) => {
+            const cached = await l1.getRemoteIdentity(address)
+            if (cached !== null) return cached
+            const gen = generation
+            const fetched = await backend.getRemoteIdentity(address)
+            if (
+                fetched !== null &&
+                gen === generation &&
+                (await l1.getRemoteIdentity(address)) === null
+            ) {
+                await l1.setRemoteIdentity(address, fetched)
+            }
+            return fetched
+        },
+        getRemoteIdentities: async (addresses) => {
+            const cached = await l1.getRemoteIdentities(addresses)
+            const missing: number[] = []
+            for (let i = 0; i < addresses.length; i += 1) {
+                if (cached[i] === null) missing.push(i)
+            }
+            if (missing.length === 0) return cached
+            const gen = generation
+            const fetched = await backend.getRemoteIdentities(missing.map((i) => addresses[i]))
+            const coherent = gen === generation
+            const result = cached.slice()
+            for (let j = 0; j < missing.length; j += 1) {
+                const key = fetched[j]
+                result[missing[j]] = key
+                if (
+                    key !== null &&
+                    coherent &&
+                    (await l1.getRemoteIdentity(addresses[missing[j]])) === null
+                ) {
+                    await l1.setRemoteIdentity(addresses[missing[j]], key)
+                }
+            }
+            return result
+        },
+        setRemoteIdentity: async (address, identityKey) => {
+            generation += 1
+            await backend.setRemoteIdentity(address, identityKey)
+            await l1.setRemoteIdentity(address, identityKey)
+        },
+        setRemoteIdentities: async (entries) => {
+            generation += 1
+            await backend.setRemoteIdentities(entries)
+            await l1.setRemoteIdentities(entries)
+        },
+        clear: async () => {
+            generation += 1
+            await backend.clear()
+            await l1.clear()
+        },
+        destroy: async () => {
+            await l1.clear()
+            await (backend as WithDestroyLifecycle<WaIdentityStore>).destroy?.()
+        }
+    }
+}

--- a/src/store/cache/privacy-token.cache.ts
+++ b/src/store/cache/privacy-token.cache.ts
@@ -1,0 +1,63 @@
+import type { WaPrivacyTokenStore } from '@store/contracts/privacy-token.store'
+import { WaPrivacyTokenMemoryStore } from '@store/memory/privacy-token.store'
+import type { WithDestroyLifecycle } from '@store/types'
+
+/**
+ * Read-through cache for a persistent privacy-token backend. Reuses
+ * {@link WaPrivacyTokenMemoryStore} as the bounded-LRU L1.
+ *
+ * Unlike the signal caches this is **invalidate-on-write, not
+ * write-through**: `upsert` merges partial fields into the existing row on
+ * the backend, so caching the partial incoming record would diverge from the
+ * backend's merged result. Instead each upsert drops the L1 entry and the
+ * next read re-populates from the merged backend truth. See
+ * {@link withSessionCache} for the shared coherence model and the
+ * single-writer-per-session assumption.
+ */
+export function withPrivacyTokenCache(
+    backend: WaPrivacyTokenStore,
+    maxEntries?: number
+): WithDestroyLifecycle<WaPrivacyTokenStore> {
+    const l1 = new WaPrivacyTokenMemoryStore(maxEntries)
+    let generation = 0
+
+    return {
+        upsert: async (record) => {
+            generation += 1
+            await backend.upsert(record)
+            await l1.deleteByJid(record.jid)
+        },
+        upsertBatch: async (records) => {
+            generation += 1
+            await backend.upsertBatch(records)
+            for (let i = 0; i < records.length; i += 1) {
+                await l1.deleteByJid(records[i].jid)
+            }
+        },
+        getByJid: async (jid) => {
+            const cached = await l1.getByJid(jid)
+            if (cached !== null) return cached
+            const gen = generation
+            const fetched = await backend.getByJid(jid)
+            if (fetched !== null && gen === generation && (await l1.getByJid(jid)) === null) {
+                await l1.upsert(fetched)
+            }
+            return fetched
+        },
+        deleteByJid: async (jid) => {
+            generation += 1
+            const deleted = await backend.deleteByJid(jid)
+            await l1.deleteByJid(jid)
+            return deleted
+        },
+        clear: async () => {
+            generation += 1
+            await backend.clear()
+            await l1.clear()
+        },
+        destroy: async () => {
+            await l1.clear()
+            await backend.destroy?.()
+        }
+    }
+}

--- a/src/store/cache/sender-key.cache.ts
+++ b/src/store/cache/sender-key.cache.ts
@@ -1,0 +1,109 @@
+import type { WaSenderKeyStore } from '@store/contracts/sender-key.store'
+import { SenderKeyMemoryStore } from '@store/memory/sender-key.store'
+import type { WithDestroyLifecycle } from '@store/types'
+
+/**
+ * Read-through / write-through in-process cache for a persistent sender-key
+ * backend. Reuses {@link SenderKeyMemoryStore} as the bounded-LRU L1 so the
+ * per-(group, sender) lookups repeated across a group fan-out skip the
+ * backend round-trip.
+ *
+ * Only the point reads are cached. `getGroupSenderKeyList` returns the
+ * *complete* set for a group, which a partial point cache would under-report,
+ * so it goes straight to the backend. Upserts replace the whole record (no
+ * merge), so they are write-through; the sweep deletes
+ * (`deleteDeviceSenderKey`/`markForgetSenderKey`) run on the backend for the
+ * authoritative count and then invalidate the matching L1 entries via the
+ * memory store's own sweep. See {@link withSessionCache} for the shared
+ * coherence model and the single-writer-per-session assumption.
+ */
+export function withSenderKeyCache(
+    backend: WaSenderKeyStore,
+    maxEntries?: number
+): WithDestroyLifecycle<WaSenderKeyStore> {
+    const l1 = new SenderKeyMemoryStore({
+        maxSenderKeys: maxEntries,
+        maxSenderDistributions: maxEntries
+    })
+    let generation = 0
+
+    return {
+        upsertSenderKey: async (record) => {
+            generation += 1
+            await backend.upsertSenderKey(record)
+            await l1.upsertSenderKey(record)
+        },
+        upsertSenderKeyDistribution: async (record) => {
+            generation += 1
+            await backend.upsertSenderKeyDistribution(record)
+            await l1.upsertSenderKeyDistribution(record)
+        },
+        upsertSenderKeyDistributions: async (records) => {
+            generation += 1
+            await backend.upsertSenderKeyDistributions(records)
+            await l1.upsertSenderKeyDistributions(records)
+        },
+        getGroupSenderKeyList: (groupId) => backend.getGroupSenderKeyList(groupId),
+        getDeviceSenderKey: async (groupId, sender) => {
+            const cached = await l1.getDeviceSenderKey(groupId, sender)
+            if (cached !== null) return cached
+            const gen = generation
+            const fetched = await backend.getDeviceSenderKey(groupId, sender)
+            if (
+                fetched !== null &&
+                gen === generation &&
+                (await l1.getDeviceSenderKey(groupId, sender)) === null
+            ) {
+                await l1.upsertSenderKey(fetched)
+            }
+            return fetched
+        },
+        getDeviceSenderKeyDistributions: async (groupId, senders) => {
+            const cached = await l1.getDeviceSenderKeyDistributions(groupId, senders)
+            const missing: number[] = []
+            for (let i = 0; i < senders.length; i += 1) {
+                if (cached[i] === null) missing.push(i)
+            }
+            if (missing.length === 0) return cached
+            const gen = generation
+            const fetched = await backend.getDeviceSenderKeyDistributions(
+                groupId,
+                missing.map((i) => senders[i])
+            )
+            const coherent = gen === generation
+            const result = cached.slice()
+            for (let j = 0; j < missing.length; j += 1) {
+                const record = fetched[j]
+                result[missing[j]] = record
+                if (record !== null && coherent) {
+                    const [current] = await l1.getDeviceSenderKeyDistributions(groupId, [
+                        senders[missing[j]]
+                    ])
+                    if (current === null) await l1.upsertSenderKeyDistribution(record)
+                }
+            }
+            return result
+        },
+        deleteDeviceSenderKey: async (target, groupId) => {
+            generation += 1
+            const deleted = await backend.deleteDeviceSenderKey(target, groupId)
+            await l1.deleteDeviceSenderKey(target, groupId)
+            return deleted
+        },
+        markForgetSenderKey: async (groupId, participants) => {
+            generation += 1
+            const deleted = await backend.markForgetSenderKey(groupId, participants)
+            await l1.markForgetSenderKey(groupId, participants)
+            return deleted
+        },
+        clear: async () => {
+            generation += 1
+            await backend.clear()
+            await l1.clear()
+        },
+        destroy: async () => {
+            await l1.clear()
+            await (backend as WithDestroyLifecycle<WaSenderKeyStore>).destroy?.()
+        }
+    }
+}

--- a/src/store/cache/session.cache.ts
+++ b/src/store/cache/session.cache.ts
@@ -1,0 +1,97 @@
+import type { WaSessionStore } from '@store/contracts/session.store'
+import { WaSessionMemoryStore } from '@store/memory/session.store'
+import type { WithDestroyLifecycle } from '@store/types'
+
+/**
+ * Read-through / write-through in-process cache for a persistent session
+ * backend. Reuses {@link WaSessionMemoryStore} as the bounded-LRU L1 so that
+ * repeated reads of the same peer on the send/recv path skip the backend
+ * round-trip.
+ *
+ * Coherence model (single process):
+ * - every mutation (set/delete/clear) writes the backend then the L1 in
+ *   lock-step and bumps a generation counter;
+ * - a read only populates the L1 when no mutation interleaved its backend
+ *   fetch (generation unchanged) and the slot is still empty, so an in-flight
+ *   read can never resurrect a concurrently deleted entry nor overwrite a
+ *   fresher concurrent write;
+ * - there is no negative caching: a miss always re-hits the backend.
+ *
+ * This cache assumes a single writer per `sessionId` (the library's
+ * connection model). Do not share one backend across processes for the same
+ * session with the cache enabled - there is no cross-process invalidation
+ * channel, so another process's writes would leave this L1 stale.
+ */
+export function withSessionCache(
+    backend: WaSessionStore,
+    maxEntries?: number
+): WithDestroyLifecycle<WaSessionStore> {
+    const l1 = new WaSessionMemoryStore({ maxSessions: maxEntries })
+    let generation = 0
+
+    return {
+        hasSession: async (address) => {
+            if (await l1.hasSession(address)) return true
+            return backend.hasSession(address)
+        },
+        hasSessions: (addresses) => backend.hasSessions(addresses),
+        getSession: async (address) => {
+            const cached = await l1.getSession(address)
+            if (cached !== null) return cached
+            const gen = generation
+            const fetched = await backend.getSession(address)
+            if (fetched !== null && gen === generation && (await l1.getSession(address)) === null) {
+                await l1.setSession(address, fetched)
+            }
+            return fetched
+        },
+        getSessionsBatch: async (addresses) => {
+            const cached = await l1.getSessionsBatch(addresses)
+            const missing: number[] = []
+            for (let i = 0; i < addresses.length; i += 1) {
+                if (cached[i] === null) missing.push(i)
+            }
+            if (missing.length === 0) return cached
+            const gen = generation
+            const fetched = await backend.getSessionsBatch(missing.map((i) => addresses[i]))
+            const coherent = gen === generation
+            const result = cached.slice()
+            for (let j = 0; j < missing.length; j += 1) {
+                const record = fetched[j]
+                result[missing[j]] = record
+                if (
+                    record !== null &&
+                    coherent &&
+                    (await l1.getSession(addresses[missing[j]])) === null
+                ) {
+                    await l1.setSession(addresses[missing[j]], record)
+                }
+            }
+            return result
+        },
+        setSession: async (address, session) => {
+            generation += 1
+            await backend.setSession(address, session)
+            await l1.setSession(address, session)
+        },
+        setSessionsBatch: async (entries) => {
+            generation += 1
+            await backend.setSessionsBatch(entries)
+            await l1.setSessionsBatch(entries)
+        },
+        deleteSession: async (address) => {
+            generation += 1
+            await backend.deleteSession(address)
+            await l1.deleteSession(address)
+        },
+        clear: async () => {
+            generation += 1
+            await backend.clear()
+            await l1.clear()
+        },
+        destroy: async () => {
+            await l1.clear()
+            await (backend as WithDestroyLifecycle<WaSessionStore>).destroy?.()
+        }
+    }
+}

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -1,3 +1,7 @@
+import { withIdentityCache } from '@store/cache/identity.cache'
+import { withPrivacyTokenCache } from '@store/cache/privacy-token.cache'
+import { withSenderKeyCache } from '@store/cache/sender-key.cache'
+import { withSessionCache } from '@store/cache/session.cache'
 import type { WaAppStateStore } from '@store/contracts/appstate.store'
 import type { WaAuthStore } from '@store/contracts/auth.store'
 import type { WaContactStore } from '@store/contracts/contact.store'
@@ -101,6 +105,10 @@ async function destroyIfSupported(value: unknown): Promise<void> {
     await value.destroy()
 }
 
+function usesBackend(provider: string | undefined): boolean {
+    return !!provider && provider !== 'memory' && provider !== 'none'
+}
+
 function resolveStore<T>(
     sessionId: string,
     backends: Readonly<Record<string, WaStoreBackend>>,
@@ -183,6 +191,7 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
     const backends = (options.backends ?? {}) as Readonly<Record<string, WaStoreBackend>>
     const providers = options.providers ?? {}
     const cacheProviders = options.cacheProviders ?? {}
+    const cacheLayer = options.cacheLayer ?? {}
 
     if (Object.keys(backends).length > 0) {
         const missingProviders = REQUIRED_PROVIDER_DOMAINS.filter(
@@ -405,9 +414,21 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
             const authStore = withAuthLock(rawAuth)
             const signalStore = withSignalLock(rawSignal)
             const preKeyStore = withPreKeyLock(rawPreKey)
-            const sessionStore = withSessionLock(rawSession)
-            const identityStore = withIdentityLock(rawIdentity)
-            const senderKeyStore = withSenderKeyLock(rawSenderKey)
+            const sessionStore = withSessionLock(
+                cacheLayer.session && usesBackend(providers.session)
+                    ? withSessionCache(rawSession, cacheLayer.limits?.session)
+                    : rawSession
+            )
+            const identityStore = withIdentityLock(
+                cacheLayer.identity && usesBackend(providers.identity)
+                    ? withIdentityCache(rawIdentity, cacheLayer.limits?.identity)
+                    : rawIdentity
+            )
+            const senderKeyStore = withSenderKeyLock(
+                cacheLayer.senderKey && usesBackend(providers.senderKey)
+                    ? withSenderKeyCache(rawSenderKey, cacheLayer.limits?.senderKey)
+                    : rawSenderKey
+            )
             const appStateStore = withAppStateLock(rawAppState)
             const retryStore = withRetryLock(rawRetry)
             const groupMetadataStore = withGroupMetadataLock(rawGroupMetadata)
@@ -416,7 +437,11 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
             const messageSecretStore = withMessageSecretLock(rawMessageSecret)
             const threadStore = withThreadLock(rawThreads)
             const contactStore = withContactLock(rawContacts)
-            const privacyTokenStore = withPrivacyTokenLock(rawPrivacyToken)
+            const privacyTokenStore = withPrivacyTokenLock(
+                cacheLayer.privacyToken && usesBackend(providers.privacyToken)
+                    ? withPrivacyTokenCache(rawPrivacyToken, cacheLayer.limits?.privacyToken)
+                    : rawPrivacyToken
+            )
 
             let cachesDestroyed = false
             let sessionDestroyed = false

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -212,6 +212,72 @@ export interface WaCreateStoreOptions<B extends string = string> {
         readonly messageSecret?: B | 'memory' | 'none'
     }
     /**
+     * Opt-in in-process read-through cache in front of a *persistent* backend
+     * for the hot signal domains. Each enabled domain wraps its backend store
+     * with a bounded-LRU L1 (the in-tree memory provider) so repeated reads of
+     * the same peer on the send/recv path skip the backend round-trip; writes
+     * stay write-through (or invalidate-on-write for `privacyToken`) so the
+     * backend remains authoritative.
+     *
+     * A domain flag is a no-op unless that domain resolves to a real backend
+     * in {@link providers} - caching a `'memory'`/`'none'` provider in front of
+     * itself buys nothing and is skipped.
+     *
+     * **Single-writer assumption:** the L1 is per-process and has no
+     * cross-process invalidation channel. Enable this only when a single
+     * process owns a given `sessionId`'s backend rows (the library's
+     * connection model). Do **not** enable it when multiple processes share
+     * one backend for the *same* session - another process's writes would
+     * leave this cache stale. Different sessions sharing one backend are fine.
+     * All flags default to `false`.
+     *
+     * Distinct from {@link cacheProviders}: that selects *where* the bounded
+     * cache domains live; this layers an in-memory read cache *in front of*
+     * the persistent domains.
+     *
+     * Only the four domains below are exposed. The other persistent domains
+     * are deliberately excluded, each for a verified reason:
+     * - `signal`: the per-send `getRegistrationInfo` read is already memoized
+     *   write-through inside the signal lock (`signal.lock.ts`), and the
+     *   remaining reads (`getSignedPreKey`/`getSignedPreKeyById`/rotation ts)
+     *   change only on the rare signed-prekey rotation and fire on inbound
+     *   session-init, not per message - a second cache would add nothing.
+     * - `appState`: the sync client already caches collection state for the
+     *   sync-context lifetime, the only scope where reads both repeat and stay
+     *   coherent. Across sync cycles the version is incremented and persisted,
+     *   so a persistent cache yields ~0 hits, and the version is sent on the
+     *   wire (server-authoritative) - a stale one forces a refetch loop.
+     * - `preKey`: one-time prekeys are read exactly once then consumed
+     *   (deleted) on the inbound path, so there is nothing to re-read; serving
+     *   a consumed prekey from a stale cache would reuse a one-time key and
+     *   break forward secrecy. There is no safe, useful read here.
+     * - `auth` is loaded once per connect and kept in memory; the mailbox
+     *   domains (`messages`/`threads`/`contacts`) are cold, large reads off
+     *   the crypto path with write-behind already; and the cache domains
+     *   (retry/groupMetadata/deviceList/messageSecret) default to in-process
+     *   memory already, so an L1 in front would be a cache over a cache.
+     */
+    readonly cacheLayer?: {
+        /** Cache Signal Double-Ratchet sessions (key→record). Write-through. */
+        readonly session?: boolean
+        /** Cache remote identity keys (key→bytes). Write-through. */
+        readonly identity?: boolean
+        /** Cache per-(group, sender) sender keys + distributions. Write-through. */
+        readonly senderKey?: boolean
+        /** Cache trusted-contact tokens (jid→record). Invalidate-on-write. */
+        readonly privacyToken?: boolean
+        /**
+         * Per-domain L1 entry caps (LRU eviction once exceeded). Defaults to
+         * the matching memory-provider default when unset.
+         */
+        readonly limits?: {
+            readonly session?: number
+            readonly identity?: number
+            readonly senderKey?: number
+            readonly privacyToken?: number
+        }
+    }
+    /**
      * Memory-store tuning for the built-in `'memory'` providers. `limits`
      * caps per-domain entry counts (LRU eviction once exceeded); `cacheTtlMs`
      * controls how long cache entries live before being evicted. Tune these


### PR DESCRIPTION
Add an optional in-process read-through cache in front of persistent backends for the hot domains session, identity, senderKey and privacyToken. Each enabled domain wraps its backend store with a bounded-LRU L1 (the in-tree memory provider) so repeated reads of the same peer on the send/recv path skip the backend round-trip.

- session/identity/senderKey: read-through + write-through. senderKey's group-list read bypasses the L1 (a partial point cache would under-report a full group scan); the sweep deletes invalidate matching L1 entries.
- privacyToken: invalidate-on-write, because its upsert merges partial fields on the backend and a write-through of the partial would diverge.
- Coherence: every mutation bumps a generation counter and updates the L1 in lock-step; a read only populates the L1 when no mutation interleaved its fetch and the slot is still empty, so a concurrent delete is never resurrected by an in-flight read. No negative caching. The cache sits inside the per-domain lock.
- Wired via the createStore cacheLayer option (opt-in, all flags default false). A flag is a no-op unless the domain resolves to a real backend. Assumes a single writer per sessionId (per-process L1, no cross-process invalidation).

signal, appState and preKey are intentionally excluded (reason documented on the option): signal's per-send read is already memoized in the lock, appState is already cached for the sync-context lifetime, and preKey's one-time keys are read-once-then-consumed (no hits, and serving a consumed key would break forward secrecy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional in-process caching layer for session, identity, sender key, and privacy token stores to improve performance.
  * New `cacheLayer` configuration option with per-domain enable flags and entry limits.

* **Tests**
  * Added comprehensive test suite for cache functionality covering read/write operations, invalidation, and data consistency scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->