### PR TITLE
feat(mcp-server): multiplex multiple WaClient sessions over one shared store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -704,7 +704,9 @@ Re-exported curves (`@crypto/curves`):
 
 ## 13. MCP Dev Server (`@zapo-js/mcp-server`)
 
-Optional package that exposes the `WaClient` instance and the `zapo-js` module namespace as MCP tools, so an LLM agent can drive end-to-end flows (connect, pair, send, query groups/newsletters, inspect events, etc.) without writing throwaway scripts. Source: `packages/mcp-server/`.
+Optional package that exposes `WaClient` sessions and the `zapo-js` module namespace as MCP tools, so an LLM agent can drive end-to-end flows (connect, pair, send, query groups/newsletters, inspect events, etc.) without writing throwaway scripts. Source: `packages/mcp-server/`.
+
+The server multiplexes **multiple sessions over one shared store**: every tool takes an optional `session` id (default `MCP_SESSION_ID`), and a new id lazily spins up an additional `WaClient` on the same backend (the store scopes every row by session id). Event buffers are per-session; log lines are tagged with `context.session` so `logs` can filter by session.
 
 ### Registering with Claude Code
 
@@ -761,25 +763,26 @@ After editing source: rebuild → call `restart` with `mode: "process_exit"` →
 
 ### Environment variables
 
-| Var                                                                            | Default                       | Purpose                                           |
-| ------------------------------------------------------------------------------ | ----------------------------- | ------------------------------------------------- |
-| `MCP_AUTH_PATH`                                                                | `<cwd>/.auth/state.sqlite`    | sqlite credential store path                      |
-| `MCP_SESSION_ID`                                                               | `default_2`                   | session id passed to `WaClient`                   |
-| `MCP_LOG_LEVEL`                                                                | `info`                        | `trace` / `debug` / `info` / `warn` / `error`     |
-| `MCP_LOG_FILE`                                                                 | unset                         | append every log line as JSONL                    |
-| `MCP_LOG_BUFFER_SIZE`                                                          | `500`                         | in-memory log ring size                           |
-| `MCP_EVENT_BUFFER_SIZE`                                                        | `1000`                        | in-memory event ring size                         |
-| `MCP_CAPTURE_TRANSPORT`                                                        | `0`                           | also buffer noisy `transport_*` events            |
-| `MCP_HISTORY_DISABLED`                                                         | `0`                           | disable history sync on connect                   |
-| `MCP_TRANSPORT`                                                                | `stdio`                       | `stdio` or `http` (StreamableHTTPServerTransport) |
-| `MCP_HTTP_HOST` / `MCP_HTTP_PORT` / `MCP_HTTP_PATH`                            | `127.0.0.1` / `3737` / `/mcp` | HTTP listener config                              |
-| `MCP_FAKE_NOISE_PUBKEY_HEX` + `MCP_FAKE_NOISE_SERIAL` + `MCP_CHAT_SOCKET_URLS` | unset                         | point at `@zapo-js/fake-server` for tests         |
+| Var                                                                            | Default                       | Purpose                                               |
+| ------------------------------------------------------------------------------ | ----------------------------- | ----------------------------------------------------- |
+| `MCP_AUTH_PATH`                                                                | `<cwd>/.auth/state.sqlite`    | sqlite credential store path                          |
+| `MCP_SESSION_ID`                                                               | `default_2`                   | default session id (tools that omit `session` use it) |
+| `MCP_MAX_SESSIONS`                                                             | `16`                          | max concurrently-live sessions in the process         |
+| `MCP_LOG_LEVEL`                                                                | `info`                        | `trace` / `debug` / `info` / `warn` / `error`         |
+| `MCP_LOG_FILE`                                                                 | unset                         | append every log line as JSONL                        |
+| `MCP_LOG_BUFFER_SIZE`                                                          | `500`                         | in-memory log ring size                               |
+| `MCP_EVENT_BUFFER_SIZE`                                                        | `1000`                        | in-memory event ring size                             |
+| `MCP_CAPTURE_TRANSPORT`                                                        | `0`                           | also buffer noisy `transport_*` events                |
+| `MCP_HISTORY_DISABLED`                                                         | `0`                           | disable history sync on connect                       |
+| `MCP_TRANSPORT`                                                                | `stdio`                       | `stdio` or `http` (StreamableHTTPServerTransport)     |
+| `MCP_HTTP_HOST` / `MCP_HTTP_PORT` / `MCP_HTTP_PATH`                            | `127.0.0.1` / `3737` / `/mcp` | HTTP listener config                                  |
+| `MCP_FAKE_NOISE_PUBKEY_HEX` + `MCP_FAKE_NOISE_SERIAL` + `MCP_CHAT_SOCKET_URLS` | unset                         | point at `@zapo-js/fake-server` for tests             |
 
 ### Notes / limits
 
 - The cwd of the spawned MCP process determines the default `.auth/` location. When Claude Code spawns it, that's wherever Claude Code was started.
-- One `WaClient` per process. Multi-session needs multiple servers with distinct `MCP_AUTH_PATH` + `MCP_SESSION_ID`.
-- `WaClient` has no auto-reconnect. On `connection: close`, call `connect` again manually.
+- One process can run many sessions over one shared store: pass `session` to any tool (default `MCP_SESSION_ID`), bounded by `MCP_MAX_SESSIONS`. All sessions share the one `MCP_AUTH_PATH` backend. Running separate processes is only needed when you want isolated stores/auth files.
+- `WaClient` has no auto-reconnect. On `connection: close`, call `connect` again manually (per session).
 - `restart` (soft) does NOT pick up code changes; `process_exit` + reconnect does.
 - `node --watch` is not a full supervisor: it restarts on file changes only. `process_exit` from the `restart` tool kills the watcher too – under HTTP+watch, just edit a file to reload instead.
 

--- a/README.md
+++ b/README.md
@@ -105,16 +105,16 @@ The core lives at the repo root (`zapo-js`). Optional packages live in
 [`packages/`](packages/) and ship under the `@zapo-js/*` scope. Install
 only what you need.
 
-| Package                                              | Peer dependency             | Purpose                                                                                                                               |
-| ---------------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| [`@zapo-js/store-sqlite`](packages/store-sqlite)     | `better-sqlite3`            | SQLite persistent store (single-process bots, dev sessions, small-to-medium prod).                                                    |
-| [`@zapo-js/store-redis`](packages/store-redis)       | `ioredis`                   | Redis-backed store with native TTL eviction.                                                                                          |
-| [`@zapo-js/store-mongo`](packages/store-mongo)       | `mongodb`                   | MongoDB-backed store with TTL-index eviction.                                                                                         |
-| [`@zapo-js/store-mysql`](packages/store-mysql)       | `mysql2`                    | MySQL / MariaDB-backed store with background cleanup poller.                                                                          |
-| [`@zapo-js/store-postgres`](packages/store-postgres) | `pg`                        | PostgreSQL-backed store with background cleanup poller.                                                                               |
-| [`@zapo-js/media-utils`](packages/media-utils)       | `sharp` + `ffmpeg`          | `WaMediaProcessor`: thumbnails, waveforms, voice-note normalization.                                                                  |
-| [`@zapo-js/fake-server`](packages/fake-server)       | (none)                      | In-process fake WhatsApp Web server for end-to-end testing.                                                                           |
-| [`@zapo-js/mcp-server`](packages/mcp-server)         | `@modelcontextprotocol/sdk` | **Dev-only.** MCP server exposing the `WaClient` as dynamic tools for an LLM agent (Claude Code / Cursor / etc.). Not for production. |
+| Package                                              | Peer dependency             | Purpose                                                                                                                                          |
+| ---------------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`@zapo-js/store-sqlite`](packages/store-sqlite)     | `better-sqlite3`            | SQLite persistent store (single-process bots, dev sessions, small-to-medium prod).                                                               |
+| [`@zapo-js/store-redis`](packages/store-redis)       | `ioredis`                   | Redis-backed store with native TTL eviction.                                                                                                     |
+| [`@zapo-js/store-mongo`](packages/store-mongo)       | `mongodb`                   | MongoDB-backed store with TTL-index eviction.                                                                                                    |
+| [`@zapo-js/store-mysql`](packages/store-mysql)       | `mysql2`                    | MySQL / MariaDB-backed store with background cleanup poller.                                                                                     |
+| [`@zapo-js/store-postgres`](packages/store-postgres) | `pg`                        | PostgreSQL-backed store with background cleanup poller.                                                                                          |
+| [`@zapo-js/media-utils`](packages/media-utils)       | `sharp` + `ffmpeg`          | `WaMediaProcessor`: thumbnails, waveforms, voice-note normalization.                                                                             |
+| [`@zapo-js/fake-server`](packages/fake-server)       | (none)                      | In-process fake WhatsApp Web server for end-to-end testing.                                                                                      |
+| [`@zapo-js/mcp-server`](packages/mcp-server)         | `@modelcontextprotocol/sdk` | **Dev-only.** MCP server exposing multi-session `WaClient`s as dynamic tools for an LLM agent (Claude Code / Cursor / etc.). Not for production. |
 
 Each package's README has the install + config + integration notes.
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,16 +1,20 @@
 # @zapo-js/mcp-server
 
-Optional package that exposes the [`zapo-js`](https://www.npmjs.com/package/zapo-js) `WaClient` instance **and** the `zapo-js` module namespace as MCP tools, so an LLM agent (Claude Code, Cursor, etc.) can drive end-to-end WhatsApp flows - connect, pair, send, query groups/newsletters, inspect events, walk SQL state - without writing throwaway scripts. Source: [`packages/mcp-server/`](.).
+Optional package that exposes [`zapo-js`](https://www.npmjs.com/package/zapo-js) `WaClient` sessions **and** the `zapo-js` module namespace as MCP tools, so an LLM agent (Claude Code, Cursor, etc.) can drive end-to-end WhatsApp flows - connect, pair, send, query groups/newsletters, inspect events, walk SQL state - without writing throwaway scripts. Source: [`packages/mcp-server/`](.).
 
 > Built for **development and testing**, not as a production protocol server.
 
+One process can drive **multiple sessions over a single shared store**: every tool takes an optional `session` id (default `MCP_SESSION_ID`), and any new id lazily spins up an additional `WaClient` on the same backend (the store scopes every row by session id). See [Sessions](#sessions).
+
 ## Tool surface
 
-- **`call`** / **`inspect`** - walk dotted paths against `client` (the `WaClient` instance) or `lib` (the `zapo-js` module namespace, including `proto.*` and helpers like `parsePhoneJid`). `call` invokes functions; `inspect` lists members with origin class.
-- **`events`** / **`events_clear`** - bounded ring buffer of every `WaClientEventMap` event (filter by `types` / `since` / `limit` / `drain`).
-- **`logs`** / **`logs_clear`** - `BufferedTeeLogger` mirrors every runtime + lib log line into a queryable buffer (also stderr, and JSONL to `MCP_LOG_FILE` if set).
-- **`lifecycle`** - `status` / `start` / `destroy` for the `WaClient` instance.
-- **`restart`** - `soft` (drop the client + clear buffers) or `process_exit` (also exits the process so a supervisor / reconnect respawns it).
+Every tool takes an optional **`session`** id (default `MCP_SESSION_ID`); a new id lazily spins up another `WaClient` on the shared store. See [Sessions](#sessions).
+
+- **`call`** / **`inspect`** - walk dotted paths against `client` (the selected session's `WaClient`) or `lib` (the `zapo-js` module namespace, including `proto.*` and helpers like `parsePhoneJid`). `call` invokes functions; `inspect` lists members with origin class.
+- **`events`** / **`events_clear`** - per-session ring buffer of every `WaClientEventMap` event (filter by `types` / `since` / `limit` / `drain`; scoped to `session`).
+- **`logs`** / **`logs_clear`** - `BufferedTeeLogger` mirrors every runtime + lib log line into one queryable buffer (also stderr, and JSONL to `MCP_LOG_FILE` if set). Each session's lines are tagged with `context.session`; `logs` accepts a `session` filter.
+- **`lifecycle`** - `status` / `start` / `destroy` for a session's `WaClient`. `status` also returns a summary of every live session.
+- **`restart`** - `soft` resets one session (drop its client, clear its events + the shared log buffer); `process_exit` disconnects **every** session, destroys the shared store, then exits so a supervisor / reconnect respawns it.
 
 The full description, schema, and examples are inlined on each tool - agents should read them at runtime rather than memorize flags.
 
@@ -49,6 +53,32 @@ so the tool returns immediately. Then poll
 `events({ types: ['auth_qr', 'auth_pairing_code', 'auth_paired', 'connection'] })`,
 surface the QR string to the user, wait for `auth_paired`, and continue.
 
+## Sessions
+
+The server multiplexes any number of sessions over **one** store (the single
+`MCP_AUTH_PATH` backend, bounded by `MCP_MAX_SESSIONS`). Pass `session` to any
+tool; omitting it targets the default (`MCP_SESSION_ID`). A fresh id is created
+on first use - no extra server process needed.
+
+```text
+# bring up a second account alongside the default, on the same store
+lifecycle({ action: 'start', session: 'business' })
+call({ path: 'connect', session: 'business', noAwait: true })
+events({ session: 'business', types: ['auth_qr', 'auth_paired', 'connection'] })
+# ... scan the QR, wait for auth_paired ...
+call({ path: 'message.send', session: 'business', args: ['<jid>', { conversation: 'hi' }] })
+
+# list every live session
+lifecycle({ action: 'status' })
+# -> sessions: [{ sessionId, isDefault, clientCreated, bufferedEvents }, ...]
+```
+
+Each session has its own credentials row, event buffer, and connection
+lifecycle; they share one sqlite connection (writes serialize in-process, no
+cross-process `SQLITE_BUSY`). The in-process read-through cache (`cacheLayer`)
+is safe here because a single process owns each session's rows. Use separate
+processes only when you want isolated stores / auth files.
+
 ## Dev loop
 
 **Recommended (HTTP + `node --watch`, zero manual reconnect):**
@@ -84,29 +114,32 @@ After editing source: rebuild → call `restart` with `mode: "process_exit"` →
 
 ## Environment variables
 
-| Var                                                                            | Default                       | Purpose                                           |
-| ------------------------------------------------------------------------------ | ----------------------------- | ------------------------------------------------- |
-| `MCP_AUTH_PATH`                                                                | `<cwd>/.auth/state.sqlite`    | SQLite credential store path                      |
-| `MCP_SESSION_ID`                                                               | `default_2`                   | Session id passed to `WaClient`                   |
-| `MCP_LOG_LEVEL`                                                                | `info`                        | `trace` / `debug` / `info` / `warn` / `error`     |
-| `MCP_LOG_FILE`                                                                 | unset                         | Append every log line as JSONL                    |
-| `MCP_LOG_BUFFER_SIZE`                                                          | `500`                         | In-memory log ring size                           |
-| `MCP_EVENT_BUFFER_SIZE`                                                        | `1000`                        | In-memory event ring size                         |
-| `MCP_CAPTURE_TRANSPORT`                                                        | `0`                           | Also buffer noisy `transport_*` events            |
-| `MCP_HISTORY_DISABLED`                                                         | `0`                           | Disable history sync on connect                   |
-| `MCP_TRANSPORT`                                                                | `stdio`                       | `stdio` or `http` (StreamableHTTPServerTransport) |
-| `MCP_HTTP_HOST` / `MCP_HTTP_PORT` / `MCP_HTTP_PATH`                            | `127.0.0.1` / `3737` / `/mcp` | HTTP listener config                              |
-| `MCP_FAKE_NOISE_PUBKEY_HEX` + `MCP_FAKE_NOISE_SERIAL` + `MCP_CHAT_SOCKET_URLS` | unset                         | Point at `@zapo-js/fake-server` for tests         |
+| Var                                                                            | Default                       | Purpose                                               |
+| ------------------------------------------------------------------------------ | ----------------------------- | ----------------------------------------------------- |
+| `MCP_AUTH_PATH`                                                                | `<cwd>/.auth/state.sqlite`    | SQLite credential store path                          |
+| `MCP_SESSION_ID`                                                               | `default_2`                   | Default session id (tools that omit `session` use it) |
+| `MCP_MAX_SESSIONS`                                                             | `16`                          | Max concurrently-live sessions in the process         |
+| `MCP_LOG_LEVEL`                                                                | `info`                        | `trace` / `debug` / `info` / `warn` / `error`         |
+| `MCP_LOG_FILE`                                                                 | unset                         | Append every log line as JSONL                        |
+| `MCP_LOG_BUFFER_SIZE`                                                          | `500`                         | In-memory log ring size                               |
+| `MCP_EVENT_BUFFER_SIZE`                                                        | `1000`                        | In-memory event ring size                             |
+| `MCP_CAPTURE_TRANSPORT`                                                        | `0`                           | Also buffer noisy `transport_*` events                |
+| `MCP_HISTORY_DISABLED`                                                         | `0`                           | Disable history sync on connect                       |
+| `MCP_TRANSPORT`                                                                | `stdio`                       | `stdio` or `http` (StreamableHTTPServerTransport)     |
+| `MCP_HTTP_HOST` / `MCP_HTTP_PORT` / `MCP_HTTP_PATH`                            | `127.0.0.1` / `3737` / `/mcp` | HTTP listener config                                  |
+| `MCP_FAKE_NOISE_PUBKEY_HEX` + `MCP_FAKE_NOISE_SERIAL` + `MCP_CHAT_SOCKET_URLS` | unset                         | Point at `@zapo-js/fake-server` for tests             |
 
 ## Notes / limits
 
 - The cwd of the spawned MCP process determines the default `.auth/`
   location. When Claude Code spawns it, that's wherever Claude Code was
   started.
-- One `WaClient` per process. Multi-session needs multiple servers with
-  distinct `MCP_AUTH_PATH` + `MCP_SESSION_ID`.
+- One process runs many sessions over one shared store: pass `session` to any
+  tool (default `MCP_SESSION_ID`), bounded by `MCP_MAX_SESSIONS`. All sessions
+  share the single `MCP_AUTH_PATH` backend - use separate processes only when
+  you want isolated stores / auth files.
 - `WaClient` has no auto-reconnect. On `connection: close`, call `connect`
-  again manually.
+  again manually (per session).
 - `restart` (`soft`) does **not** pick up code changes; `process_exit` +
   supervisor reconnect does.
 - `node --watch` is not a full supervisor: it restarts on file changes

--- a/packages/mcp-server/src/__tests__/fake-server.cross-check.test.ts
+++ b/packages/mcp-server/src/__tests__/fake-server.cross-check.test.ts
@@ -211,9 +211,9 @@ test('mcp runtime drives pairing + send/receive against fake-server', async () =
         assert.ok(stateResult.state !== null)
     } finally {
         try {
-            await runtime.destroyClient()
+            await runtime.destroyAll()
         } catch (error) {
-            process.stderr.write(`destroyClient error: ${(error as Error)?.stack ?? error}\n`)
+            process.stderr.write(`destroyAll error: ${(error as Error)?.stack ?? error}\n`)
         }
         try {
             await server.stop()

--- a/packages/mcp-server/src/__tests__/multi-session.test.ts
+++ b/packages/mcp-server/src/__tests__/multi-session.test.ts
@@ -116,6 +116,25 @@ test('maxSessions caps lazy session creation', () => {
     assert.equal(runtime.bufferSize('one'), 2)
 })
 
+test('destroying a session reclaims its maxSessions slot', async () => {
+    const runtime = new McpRuntime(cfg({ maxSessions: 2 }))
+    recordEvent(runtime, 'message', {}, 'one')
+    recordEvent(runtime, 'message', {}, 'two')
+    assert.throws(() => recordEvent(runtime, 'message', {}, 'three'), /max sessions reached/)
+
+    // destroy removes the state entirely: frees the slot AND drops its buffer
+    await runtime.destroyClient('one')
+    assert.equal(runtime.bufferSize('one'), 0)
+    assert.deepStrictEqual(
+        runtime.listSessions().map((s) => s.sessionId),
+        ['two']
+    )
+
+    // the freed slot is now reusable
+    recordEvent(runtime, 'message', {}, 'three')
+    assert.equal(runtime.bufferSize('three'), 1)
+})
+
 test('events tool routes by session', async () => {
     const runtime = new McpRuntime(cfg())
     recordEvent(runtime, 'message', { id: 'A' }, 'a')

--- a/packages/mcp-server/src/__tests__/multi-session.test.ts
+++ b/packages/mcp-server/src/__tests__/multi-session.test.ts
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import { McpRuntime, type RuntimeConfig } from '../runtime'
+import { type ToolDefinition, TOOLS } from '../tools'
+
+const cfg = (overrides: Partial<RuntimeConfig> = {}): RuntimeConfig => ({
+    authPath: '/unused',
+    sessionId: 'default_2',
+    logLevel: 'error',
+    bufferSize: 100,
+    captureNoisyEvents: false,
+    historyEnabled: false,
+    logBufferSize: 100,
+    transport: 'stdio',
+    httpHost: '127.0.0.1',
+    httpPort: 0,
+    httpPath: '/mcp',
+    ...overrides
+})
+
+interface RecordEventCapable {
+    recordEvent: (type: string, payload: unknown, session?: string) => void
+}
+
+// recordEvent is private; the runtime-logger tests reach it the same way to
+// seed buffers without driving a real connection.
+const recordEvent = (
+    runtime: McpRuntime,
+    type: string,
+    payload: unknown,
+    session?: string
+): void => {
+    ;(runtime as unknown as RecordEventCapable).recordEvent(type, payload, session)
+}
+
+const findTool = (name: string): ToolDefinition => {
+    const tool = TOOLS.find((t) => t.name === name)
+    if (!tool) throw new Error(`tool ${name} not registered`)
+    return tool
+}
+
+test('events are partitioned per session with independent seq', () => {
+    const runtime = new McpRuntime(cfg())
+    recordEvent(runtime, 'message', { id: 'A1' }, 'alpha')
+    recordEvent(runtime, 'message', { id: 'A2' }, 'alpha')
+    recordEvent(runtime, 'message', { id: 'B1' }, 'beta')
+
+    const alpha = runtime.listEvents({}, 'alpha')
+    const beta = runtime.listEvents({}, 'beta')
+    assert.equal(alpha.length, 2)
+    assert.equal(beta.length, 1)
+    // seq is per-session: both sessions start at 1 independently
+    assert.deepStrictEqual(
+        alpha.map((e) => e.seq),
+        [1, 2]
+    )
+    assert.deepStrictEqual(
+        beta.map((e) => e.seq),
+        [1]
+    )
+    assert.equal(runtime.bufferSize('alpha'), 2)
+    assert.equal(runtime.bufferSize('beta'), 1)
+    // the default session saw nothing
+    assert.equal(runtime.listEvents({}).length, 0)
+    assert.equal(runtime.bufferSize(), 0)
+})
+
+test('omitting session resolves to the configured default session', () => {
+    const runtime = new McpRuntime(cfg({ sessionId: 'primary' }))
+    recordEvent(runtime, 'connection', { status: 'open' }) // no session -> default
+    assert.equal(runtime.listEvents({}, 'primary').length, 1)
+    assert.equal(runtime.listEvents({}).length, 1) // default read sees it
+    assert.equal(runtime.listEvents({}, 'other').length, 0)
+})
+
+test('clearEvents is scoped to one session', () => {
+    const runtime = new McpRuntime(cfg())
+    recordEvent(runtime, 'message', {}, 'a')
+    recordEvent(runtime, 'message', {}, 'b')
+    assert.equal(runtime.clearEvents('a'), 1)
+    assert.equal(runtime.bufferSize('a'), 0)
+    assert.equal(runtime.bufferSize('b'), 1)
+})
+
+test('reads on an unknown session return empty without creating it', () => {
+    const runtime = new McpRuntime(cfg())
+    assert.equal(runtime.listEvents({}, 'ghost').length, 0)
+    assert.equal(runtime.bufferSize('ghost'), 0)
+    assert.equal(runtime.getClient('ghost'), null)
+    assert.deepStrictEqual(runtime.listSessions(), [])
+})
+
+test('logs filter by session via the context.session tag', () => {
+    const runtime = new McpRuntime(cfg({ logLevel: 'trace' }))
+    runtime.getLogger().info('alpha line', { session: 'alpha' })
+    runtime.getLogger().info('beta line', { session: 'beta' })
+    runtime.getLogger().info('global line')
+
+    assert.equal(runtime.listLogs({ session: 'alpha' }).length, 1)
+    assert.equal(runtime.listLogs({ session: 'beta' }).length, 1)
+    // omitting session returns everything, including the untagged global line
+    assert.equal(runtime.listLogs({}).length, 3)
+})
+
+test('maxSessions caps lazy session creation', () => {
+    const runtime = new McpRuntime(cfg({ maxSessions: 2 }))
+    recordEvent(runtime, 'message', {}, 'one')
+    recordEvent(runtime, 'message', {}, 'two')
+    assert.throws(() => recordEvent(runtime, 'message', {}, 'three'), /max sessions reached/)
+    // existing sessions keep recording fine past the cap
+    recordEvent(runtime, 'message', {}, 'one')
+    assert.equal(runtime.bufferSize('one'), 2)
+})
+
+test('events tool routes by session', async () => {
+    const runtime = new McpRuntime(cfg())
+    recordEvent(runtime, 'message', { id: 'A' }, 'a')
+    recordEvent(runtime, 'message', { id: 'B' }, 'b')
+    const events = findTool('events')
+
+    const ra = (await events.handler({ session: 'a' }, runtime)) as {
+        count: number
+        session: string
+        events: { payload: { id: string } }[]
+    }
+    assert.equal(ra.count, 1)
+    assert.equal(ra.session, 'a')
+    assert.equal(ra.events[0].payload.id, 'A')
+
+    const rb = (await events.handler({ session: 'b' }, runtime)) as {
+        count: number
+        events: { payload: { id: string } }[]
+    }
+    assert.equal(rb.count, 1)
+    assert.equal(rb.events[0].payload.id, 'B')
+
+    // default session is empty and reports the configured default id
+    const rdefault = (await events.handler({}, runtime)) as { count: number; session: string }
+    assert.equal(rdefault.count, 0)
+    assert.equal(rdefault.session, 'default_2')
+})
+
+test('events_clear is scoped to the requested session', async () => {
+    const runtime = new McpRuntime(cfg())
+    recordEvent(runtime, 'message', {}, 'a')
+    recordEvent(runtime, 'message', {}, 'b')
+    const clear = findTool('events_clear')
+    const result = (await clear.handler({ session: 'a' }, runtime)) as {
+        dropped: number
+        session: string
+    }
+    assert.equal(result.dropped, 1)
+    assert.equal(result.session, 'a')
+    assert.equal(runtime.bufferSize('a'), 0)
+    assert.equal(runtime.bufferSize('b'), 1)
+})
+
+test('rejects a blank session id', async () => {
+    const runtime = new McpRuntime(cfg())
+    const events = findTool('events')
+    await assert.rejects(() => events.handler({ session: '   ' }, runtime), /non-empty string/)
+})
+
+test('lifecycle status summarizes every live session over one shared store', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mcp-multi-'))
+    const runtime = new McpRuntime(cfg({ authPath: join(dir, 'state.sqlite') }))
+    const lifecycle = findTool('lifecycle')
+    try {
+        await lifecycle.handler({ action: 'start', session: 'biz' }, runtime)
+        await lifecycle.handler({ action: 'start', session: 'personal' }, runtime)
+
+        const status = (await lifecycle.handler({ action: 'status', session: 'biz' }, runtime)) as {
+            session: string
+            clientCreated: boolean
+            sessions: { sessionId: string; clientCreated: boolean; isDefault: boolean }[]
+        }
+        assert.equal(status.session, 'biz')
+        assert.equal(status.clientCreated, true)
+        const ids = status.sessions.map((s) => s.sessionId).sort()
+        assert.deepStrictEqual(ids, ['biz', 'personal'])
+        assert.ok(status.sessions.every((s) => s.clientCreated))
+
+        // the default session was never started -> reported but not created
+        const def = (await lifecycle.handler({ action: 'status' }, runtime)) as {
+            session: string
+            clientCreated: boolean
+        }
+        assert.equal(def.session, 'default_2')
+        assert.equal(def.clientCreated, false)
+    } finally {
+        await runtime.destroyAll()
+        await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
+    }
+})
+
+test('destroyClient drops one session client but keeps the siblings', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mcp-multi-'))
+    const runtime = new McpRuntime(cfg({ authPath: join(dir, 'state.sqlite') }))
+    try {
+        await runtime.ensureClient('a')
+        await runtime.ensureClient('b')
+        assert.ok(runtime.getClient('a'))
+        assert.ok(runtime.getClient('b'))
+
+        await runtime.destroyClient('a')
+        assert.equal(runtime.getClient('a'), null)
+        assert.ok(runtime.getClient('b'), 'sibling session client should survive')
+    } finally {
+        await runtime.destroyAll()
+        await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
+    }
+})

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -118,6 +118,7 @@ const buildFakeRuntime = (client: FakeClient): SpyableFakeRuntime => {
         bufferLogsSize: () => logs.length,
         async closeLogFile() {},
         resetSequences: () => undefined,
+        listSessions: () => [],
         // test-only helpers: push synthetic entries + read last filter
         __pushLog: (entry: LogEntry) => {
             logs.push(entry)

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,7 +1,7 @@
 export { runMcpServer } from './server'
 export type { RunMcpServerOptions } from './server'
 export { McpRuntime, buildRuntimeConfigFromEnv } from './runtime'
-export type { BufferedEvent, LogEntry, RuntimeConfig } from './runtime'
+export type { BufferedEvent, LogEntry, RuntimeConfig, SessionSummary } from './runtime'
 export { TOOLS } from './tools'
 export type { ToolDefinition } from './tools'
 export { encodeForJson, decodeFromJson } from './serializer'

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -18,6 +18,7 @@ import { encodeForJson } from './serializer'
 
 const DEFAULT_BUFFER_SIZE = 1000
 const DEFAULT_LOG_BUFFER_SIZE = 500
+const DEFAULT_MAX_SESSIONS = 16
 
 const LOG_LEVEL_PRIORITY: Readonly<Record<LogLevel, number>> = {
     trace: 10,
@@ -98,17 +99,23 @@ class BufferedTeeLogger implements Logger {
             readonly drain?: boolean
             readonly q?: string
             readonly regex?: boolean
+            readonly session?: string
         } = {}
     ): readonly LogEntry[] {
         const levels = filter.levels && filter.levels.length > 0 ? new Set(filter.levels) : null
         const since = filter.since ?? 0
         const limit = filter.limit && filter.limit > 0 ? filter.limit : 100
         const matchQuery = buildQueryMatcher(filter.q ?? '', filter.regex === true)
+        // Logs share one ring; per-session entries are tagged via context.session
+        // by the per-session child logger. A `session` filter keeps only those;
+        // omitting it returns everything, including untagged server/global lines.
+        const session = filter.session
         const matched: LogEntry[] = []
         for (let i = 0; i < this.buffer.length; i += 1) {
             const entry = this.buffer[i]
             if (entry.seq <= since) continue
             if (levels && !levels.has(entry.level)) continue
+            if (session !== undefined && entry.context?.session !== session) continue
             const haystack =
                 entry.message + (entry.context ? ' ' + safeStringify(entry.context) : '')
             if (!matchQuery(haystack)) continue
@@ -277,9 +284,21 @@ export type McpTransportMode = 'stdio' | 'http'
 
 export interface RuntimeConfig {
     readonly authPath: string
+    /**
+     * Default session id. Tool calls that omit `session` resolve to this one,
+     * and `lifecycle status` reports it as the default. Other session ids are
+     * created lazily on first use (all sharing the one store at `authPath`).
+     */
     readonly sessionId: string
     readonly logLevel: LogLevel
     readonly bufferSize: number
+    /**
+     * Upper bound on concurrently-live sessions in this process (bounded to
+     * avoid unbounded `WaClient`/buffer growth from arbitrary tool-supplied
+     * ids). Creating a session past this throws until one is destroyed.
+     * Defaults to 16 when omitted.
+     */
+    readonly maxSessions?: number
     readonly captureNoisyEvents: boolean
     readonly deviceBrowser?: string
     readonly deviceOsDisplayName?: string
@@ -319,6 +338,11 @@ export const buildRuntimeConfigFromEnv = (env = process.env): RuntimeConfig => {
         'MCP_EVENT_BUFFER_SIZE',
         DEFAULT_BUFFER_SIZE
     )
+    const maxSessions = parseEnvPositiveInt(
+        env.MCP_MAX_SESSIONS,
+        'MCP_MAX_SESSIONS',
+        DEFAULT_MAX_SESSIONS
+    )
     const captureNoisyEvents = env.MCP_CAPTURE_TRANSPORT === '1'
     const historyEnabled = env.MCP_HISTORY_DISABLED !== '1'
     const chatSocketUrls = parseUrlList(env.MCP_CHAT_SOCKET_URLS)
@@ -338,6 +362,7 @@ export const buildRuntimeConfigFromEnv = (env = process.env): RuntimeConfig => {
         sessionId,
         logLevel,
         bufferSize,
+        maxSessions,
         captureNoisyEvents,
         deviceBrowser: env.MCP_DEVICE_BROWSER,
         deviceOsDisplayName: env.MCP_DEVICE_OS_DISPLAY,
@@ -402,26 +427,51 @@ const parseEnvPositiveInt = (raw: string | undefined, name: string, fallback: nu
     return resolvePositive(Number.isFinite(parsed) ? parsed : Number.NaN, fallback, name)
 }
 
+/** Mutable per-session state held by {@link McpRuntime}. */
+interface SessionState {
+    readonly sessionId: string
+    client: WaClient | null
+    clientInitPromise: Promise<WaClient> | null
+    listenersDetach: Array<() => void>
+    readonly events: BufferedEvent[]
+    nextEventSeq: number
+}
+
+/** Per-session snapshot surfaced by `lifecycle status`. */
+export interface SessionSummary {
+    readonly sessionId: string
+    /** True for the session id tool calls resolve to when `session` is omitted. */
+    readonly isDefault: boolean
+    /** Whether a `WaClient` has been instantiated for this session. */
+    readonly clientCreated: boolean
+    /** Number of events currently buffered for this session. */
+    readonly bufferedEvents: number
+}
+
 /**
- * Owns the lifecycle of the underlying `WaClient` instance plus the
- * buffered event/log rings consumed by the `events` / `logs` tools. One
- * runtime per MCP server process; create/teardown via `start` / `destroy`
- * (which lets a supervisor reconnect cleanly).
+ * Owns N `WaClient` sessions multiplexed over one shared `WaStore` (a single
+ * backend / sqlite file at `config.authPath`), plus the per-session buffered
+ * event rings and the shared, session-tagged log ring consumed by the
+ * `events` / `logs` tools. One runtime per MCP server process.
+ *
+ * Sessions are created lazily: the first tool call referencing a session id
+ * (or omitting it, which resolves to `config.sessionId`) spins up a client
+ * bound to that id over the shared store. The store scopes every row by
+ * session id, so distinct sessions never collide while sharing one connection.
  *
  * Most users won't construct this directly - use {@link runMcpServer}.
  */
 export class McpRuntime {
     private readonly config: RuntimeConfig
     private readonly logger: BufferedTeeLogger
-    private readonly buffer: BufferedEvent[] = []
-    private nextSeq = 1
-    private client: WaClient | null = null
+    private readonly maxSessions: number
     private store: WaStore | null = null
-    private listenersDetach: Array<() => void> = []
-    private clientInitPromise: Promise<WaClient> | null = null
+    private readonly sessions = new Map<string, SessionState>()
 
     public constructor(config: RuntimeConfig) {
         this.config = config
+        this.maxSessions =
+            config.maxSessions && config.maxSessions > 0 ? config.maxSessions : DEFAULT_MAX_SESSIONS
         this.logger = new BufferedTeeLogger(
             config.logLevel,
             config.logBufferSize,
@@ -437,6 +487,7 @@ export class McpRuntime {
             readonly drain?: boolean
             readonly q?: string
             readonly regex?: boolean
+            readonly session?: string
         } = {}
     ): readonly LogEntry[] {
         return this.logger.listLogs(filter)
@@ -454,9 +505,16 @@ export class McpRuntime {
         await this.logger.closeFile()
     }
 
-    /** Reset event + log seq counters back to 1. Call after a hard state wipe. */
-    public resetSequences(): void {
-        this.nextSeq = 1
+    /**
+     * Reset a session's event seq counter (and the shared log seq) back to 1.
+     * Call after a soft restart wipes a session's buffers. Defaults to the
+     * default session when `session` is omitted.
+     */
+    public resetSequences(session?: string): void {
+        const state = this.peekSession(session)
+        if (state) {
+            state.nextEventSeq = 1
+        }
         this.logger.resetSequence()
     }
 
@@ -468,21 +526,54 @@ export class McpRuntime {
         return this.logger
     }
 
-    public ensureClient(): Promise<WaClient> {
-        if (this.client) {
-            return Promise.resolve(this.client)
+    /** Resolve `session` to a non-empty id, defaulting to `config.sessionId`. */
+    private resolveSessionId(session?: string): string {
+        const id = (session ?? this.config.sessionId).trim()
+        if (id.length === 0) {
+            throw new Error('session must be a non-empty string')
         }
-        if (this.clientInitPromise) {
-            return this.clientInitPromise
-        }
-        this.clientInitPromise = this.initClient().finally(() => {
-            this.clientInitPromise = null
-        })
-        return this.clientInitPromise
+        return id
     }
 
-    private async initClient(): Promise<WaClient> {
-        await mkdir(dirname(this.config.authPath), { recursive: true })
+    private getOrCreateSession(session?: string): SessionState {
+        const id = this.resolveSessionId(session)
+        const existing = this.sessions.get(id)
+        if (existing) return existing
+        if (this.sessions.size >= this.maxSessions) {
+            throw new Error(
+                `max sessions reached (${this.maxSessions}); destroy a session before creating "${id}"`
+            )
+        }
+        const state: SessionState = {
+            sessionId: id,
+            client: null,
+            clientInitPromise: null,
+            listenersDetach: [],
+            events: [],
+            nextEventSeq: 1
+        }
+        this.sessions.set(id, state)
+        return state
+    }
+
+    /** Look up an existing session without creating it. */
+    private peekSession(session?: string): SessionState | null {
+        return this.sessions.get(this.resolveSessionId(session)) ?? null
+    }
+
+    /** Snapshot of every live session, for `lifecycle status`. */
+    public listSessions(): readonly SessionSummary[] {
+        return Array.from(this.sessions.values(), (state) => ({
+            sessionId: state.sessionId,
+            isDefault: state.sessionId === this.config.sessionId,
+            clientCreated: state.client !== null,
+            bufferedEvents: state.events.length
+        }))
+    }
+
+    /** Lazily build the one store shared by every session in this process. */
+    private ensureStore(): WaStore {
+        if (this.store) return this.store
         this.store = createStore({
             backends: {
                 sqlite: createSqliteStore({
@@ -504,10 +595,31 @@ export class McpRuntime {
                 privacyToken: 'sqlite'
             }
         })
+        return this.store
+    }
+
+    public ensureClient(session?: string): Promise<WaClient> {
+        const state = this.getOrCreateSession(session)
+        if (state.client) {
+            return Promise.resolve(state.client)
+        }
+        if (state.clientInitPromise) {
+            return state.clientInitPromise
+        }
+        state.clientInitPromise = this.initClient(state).finally(() => {
+            state.clientInitPromise = null
+        })
+        return state.clientInitPromise
+    }
+
+    private async initClient(state: SessionState): Promise<WaClient> {
+        await mkdir(dirname(this.config.authPath), { recursive: true })
+        const store = this.ensureStore()
+        const sessionLogger = this.createSessionLogger(state.sessionId)
         const client = new WaClient(
             {
-                store: this.store,
-                sessionId: this.config.sessionId,
+                store,
+                sessionId: state.sessionId,
                 connectTimeoutMs: 60_000,
                 deviceBrowser: this.config.deviceBrowser ?? 'Chrome',
                 deviceOsDisplayName: this.config.deviceOsDisplayName ?? 'Windows',
@@ -519,40 +631,65 @@ export class McpRuntime {
                 chatSocketUrls: this.config.chatSocketUrls,
                 media: {
                     processor: createMediaProcessor({
-                        onWarning: (message) => this.logger.warn(message)
+                        onWarning: (message) => sessionLogger.warn(message)
                     })
                 },
                 testHooks: this.config.noiseRootCa
                     ? { noiseRootCa: this.config.noiseRootCa }
                     : undefined
             },
-            this.logger
+            sessionLogger
         )
-        this.attachListeners(client)
-        this.client = client
+        this.attachListeners(state, client)
+        state.client = client
         this.logger.info('mcp client created', {
-            sessionId: this.config.sessionId,
+            session: state.sessionId,
             authPath: this.config.authPath
         })
         return client
     }
 
-    public getClient(): WaClient | null {
-        return this.client
+    /**
+     * Wrap the shared logger so every line a session's `WaClient` emits is
+     * tagged with `context.session`. Lets the `logs` tool scope by session
+     * while keeping a single ring buffer (and a single optional log file).
+     */
+    private createSessionLogger(sessionId: string): Logger {
+        const base = this.logger
+        const tag = (context?: Record<string, unknown>): Record<string, unknown> =>
+            context ? { ...context, session: sessionId } : { session: sessionId }
+        return {
+            level: base.level,
+            trace: (message, context) => base.trace(message, tag(context)),
+            debug: (message, context) => base.debug(message, tag(context)),
+            info: (message, context) => base.info(message, tag(context)),
+            warn: (message, context) => base.warn(message, tag(context)),
+            error: (message, context) => base.error(message, tag(context))
+        }
     }
 
-    public async destroyClient(): Promise<void> {
-        if (this.client) {
-            try {
-                await this.client.disconnect()
-            } catch (error) {
-                this.logger.warn('disconnect during destroy failed', {
-                    message: toError(error).message
-                })
-            }
-            this.detachListeners()
-            this.client = null
+    public getClient(session?: string): WaClient | null {
+        return this.peekSession(session)?.client ?? null
+    }
+
+    /**
+     * Disconnect + drop one session's client (default session when omitted).
+     * The shared store stays open for the other sessions - use
+     * {@link destroyAll} to tear the whole runtime (store included) down.
+     */
+    public async destroyClient(session?: string): Promise<void> {
+        const state = this.peekSession(session)
+        if (state) {
+            await this.teardownSessionClient(state)
         }
+    }
+
+    /** Disconnect every session client and destroy the shared store. */
+    public async destroyAll(): Promise<void> {
+        for (const state of this.sessions.values()) {
+            await this.teardownSessionClient(state)
+        }
+        this.sessions.clear()
         if (this.store) {
             try {
                 await this.store.destroy()
@@ -565,6 +702,20 @@ export class McpRuntime {
         }
     }
 
+    private async teardownSessionClient(state: SessionState): Promise<void> {
+        if (!state.client) return
+        try {
+            await state.client.disconnect()
+        } catch (error) {
+            this.logger.warn('disconnect during destroy failed', {
+                session: state.sessionId,
+                message: toError(error).message
+            })
+        }
+        this.detachListeners(state)
+        state.client = null
+    }
+
     public listEvents(
         filter: {
             readonly types?: readonly string[]
@@ -573,15 +724,19 @@ export class McpRuntime {
             readonly drain?: boolean
             readonly q?: string
             readonly regex?: boolean
-        } = {}
+        } = {},
+        session?: string
     ): readonly BufferedEvent[] {
+        const state = this.peekSession(session)
+        if (!state) return []
+        const events = state.events
         const types = filter.types && filter.types.length > 0 ? new Set(filter.types) : null
         const since = filter.since ?? 0
         const limit = filter.limit && filter.limit > 0 ? filter.limit : 50
         const matchQuery = buildQueryMatcher(filter.q ?? '', filter.regex === true)
         const matched: BufferedEvent[] = []
-        for (let i = 0; i < this.buffer.length; i += 1) {
-            const ev = this.buffer[i]
+        for (let i = 0; i < events.length; i += 1) {
+            const ev = events[i]
             if (ev.seq <= since) continue
             if (types && !types.has(ev.type)) continue
             if (!matchQuery(ev.type + ' ' + safeStringify(ev.payload))) continue
@@ -590,55 +745,58 @@ export class McpRuntime {
         const tail = matched.length > limit ? matched.slice(matched.length - limit) : matched
         if (filter.drain && tail.length > 0) {
             const drainSet = new Set(tail.map((e) => e.seq))
-            for (let i = this.buffer.length - 1; i >= 0; i -= 1) {
-                if (drainSet.has(this.buffer[i].seq)) {
-                    this.buffer.splice(i, 1)
+            for (let i = events.length - 1; i >= 0; i -= 1) {
+                if (drainSet.has(events[i].seq)) {
+                    events.splice(i, 1)
                 }
             }
         }
         return tail
     }
 
-    public clearEvents(): number {
-        const n = this.buffer.length
-        this.buffer.length = 0
+    public clearEvents(session?: string): number {
+        const state = this.peekSession(session)
+        if (!state) return 0
+        const n = state.events.length
+        state.events.length = 0
         return n
     }
 
-    public bufferSize(): number {
-        return this.buffer.length
+    public bufferSize(session?: string): number {
+        return this.peekSession(session)?.events.length ?? 0
     }
 
-    private attachListeners(client: WaClient): void {
-        this.detachListeners()
+    private attachListeners(state: SessionState, client: WaClient): void {
+        this.detachListeners(state)
         for (const name of ALL_EVENT_NAMES) {
             if (!this.config.captureNoisyEvents && NOISY_EVENT_NAMES.has(name)) {
                 continue
             }
             const handler = (payload: unknown): void => {
-                this.recordEvent(name, payload)
+                this.recordEvent(name, payload, state.sessionId)
             }
             client.on(name, handler as never)
-            this.listenersDetach.push(() => {
+            state.listenersDetach.push(() => {
                 client.off(name, handler as never)
             })
         }
     }
 
-    private detachListeners(): void {
-        for (const detach of this.listenersDetach) {
+    private detachListeners(state: SessionState): void {
+        for (const detach of state.listenersDetach) {
             try {
                 detach()
             } catch {
                 /* ignore */
             }
         }
-        this.listenersDetach = []
+        state.listenersDetach = []
     }
 
-    private recordEvent(type: string, rawPayload: unknown): void {
-        const seq = this.nextSeq
-        this.nextSeq += 1
+    private recordEvent(type: string, rawPayload: unknown, session?: string): void {
+        const state = this.getOrCreateSession(session)
+        const seq = state.nextEventSeq
+        state.nextEventSeq += 1
         const encoded = encodeForJson(rawPayload)
         const event: BufferedEvent = {
             seq,
@@ -646,10 +804,10 @@ export class McpRuntime {
             timestampMs: Date.now(),
             payload: encoded
         }
-        this.buffer.push(event)
-        const overflow = this.buffer.length - this.config.bufferSize
+        state.events.push(event)
+        const overflow = state.events.length - this.config.bufferSize
         if (overflow > 0) {
-            this.buffer.splice(0, overflow)
+            state.events.splice(0, overflow)
         }
     }
 }

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -673,15 +673,18 @@ export class McpRuntime {
     }
 
     /**
-     * Disconnect + drop one session's client (default session when omitted).
-     * The shared store stays open for the other sessions - use
-     * {@link destroyAll} to tear the whole runtime (store included) down.
+     * Disconnect + drop one session (default session when omitted): tear down
+     * its client, detach listeners, and remove its state - freeing a
+     * `maxSessions` slot and discarding its buffered events. The shared store
+     * stays open for the other sessions; use {@link destroyAll} to tear the
+     * whole runtime (store included) down.
      */
     public async destroyClient(session?: string): Promise<void> {
-        const state = this.peekSession(session)
-        if (state) {
-            await this.teardownSessionClient(state)
-        }
+        const id = this.resolveSessionId(session)
+        const state = this.sessions.get(id)
+        if (!state) return
+        await this.teardownSessionClient(state)
+        this.sessions.delete(id)
     }
 
     /** Disconnect every session client and destroy the shared store. */

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -312,11 +312,13 @@ const runHttpTransport = async (
 }
 
 /**
- * Boots an MCP server that exposes a single `WaClient` instance plus
- * helpers (`call`, `inspect`, `events`, `logs`, `lifecycle`, `restart`)
- * as MCP tools. Reads its config from environment variables via
- * {@link buildRuntimeConfigFromEnv} - set `MCP_TRANSPORT=http` to switch
- * from stdio (default) to a Streamable-HTTP server.
+ * Boots an MCP server that exposes N `WaClient` sessions (multiplexed over
+ * one shared store) plus helpers (`call`, `inspect`, `events`, `logs`,
+ * `lifecycle`, `restart`, `eval`) as MCP tools. Each tool takes an optional
+ * `session` id (default `MCP_SESSION_ID`); new ids spin up additional
+ * sessions lazily on the same store. Reads its config from environment
+ * variables via {@link buildRuntimeConfigFromEnv} - set `MCP_TRANSPORT=http`
+ * to switch from stdio (default) to a Streamable-HTTP server.
  *
  * Used by the published `zapo-mcp-server` binary; you only need to call
  * it directly when embedding the server in another process.
@@ -339,7 +341,7 @@ export const runMcpServer = async (options: RunMcpServerOptions = {}): Promise<v
     const shutdown = async (signal: string): Promise<void> => {
         runtime.getLogger().info('shutting down', { signal })
         try {
-            await runtime.destroyClient()
+            await runtime.destroyAll()
         } catch {
             /* swallow */
         }

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -17,12 +17,13 @@ const ROOT_VALUES: readonly Root[] = ['client', 'lib']
 
 const resolveRoot = async (
     root: Root,
-    runtime: McpRuntime
+    runtime: McpRuntime,
+    session?: string
 ): Promise<{ readonly object: Record<string, unknown>; readonly label: string }> => {
     if (root === 'lib') {
         return { object: ZapoLib as unknown as Record<string, unknown>, label: 'zapo-js' }
     }
-    const client = await runtime.ensureClient()
+    const client = await runtime.ensureClient(session)
     return { object: client as unknown as Record<string, unknown>, label: 'WaClient' }
 }
 
@@ -33,6 +34,30 @@ const parseRoot = (raw: unknown): Root => {
     }
     throw new Error(`"root" must be one of ${ROOT_VALUES.join(' | ')}`)
 }
+
+const parseSession = (raw: unknown): string | undefined => {
+    if (raw === undefined || raw === null) return undefined
+    if (typeof raw !== 'string') {
+        throw new Error('"session" must be a string')
+    }
+    const id = raw.trim()
+    if (id.length === 0) {
+        throw new Error('"session" must be a non-empty string')
+    }
+    return id
+}
+
+/**
+ * Shared `session` input-schema property. Reused across tools so the wording
+ * (and the lazy-create behavior) stays consistent.
+ */
+const SESSION_PROP = {
+    type: 'string',
+    description:
+        'Target WaClient session id. Omit to use the default session (MCP_SESSION_ID). ' +
+        'Any other id lazily spins up an additional session that shares the same ' +
+        'store / auth backend (rows are scoped per session id). Capped by MCP_MAX_SESSIONS.'
+} as const
 
 const callTool: ToolDefinition = {
     name: 'call',
@@ -71,14 +96,15 @@ const callTool: ToolDefinition = {
                 type: 'boolean',
                 description:
                     'When true, invoke the function and return immediately without awaiting its Promise. Useful for client.connect() during pairing. Rejections are logged via the runtime logger.'
-            }
+            },
+            session: SESSION_PROP
         },
         required: ['path'],
         additionalProperties: false
     },
     handler: async (input, runtime) => {
-        const { path, args, root, noAwait } = parseCallInput(input)
-        const { object, label } = await resolveRoot(root, runtime)
+        const { path, args, root, noAwait, session } = parseCallInput(input)
+        const { object, label } = await resolveRoot(root, runtime, session)
         const { parent, value, lastKey } = resolvePath(object, path)
         if (typeof value === 'function') {
             const decoded = (decodeFromJson(args) as unknown[]) ?? []
@@ -88,6 +114,7 @@ const callTool: ToolDefinition = {
                     ;(invoked as Promise<unknown>).catch((error: unknown) => {
                         runtime.getLogger().warn('noAwait call rejected', {
                             path,
+                            session: session ?? null,
                             message: toError(error).message
                         })
                     })
@@ -149,13 +176,14 @@ const inspectTool: ToolDefinition = {
                 type: 'boolean',
                 description:
                     'Include EventEmitter-inherited methods (on/off/emit/etc). Default false.'
-            }
+            },
+            session: SESSION_PROP
         },
         additionalProperties: false
     },
     handler: async (input, runtime) => {
-        const { path, includeEventEmitter, root } = parseInspectInput(input)
-        const { object, label } = await resolveRoot(root, runtime)
+        const { path, includeEventEmitter, root, session } = parseInspectInput(input)
+        const { object, label } = await resolveRoot(root, runtime, session)
         const { value } = resolvePath(object, path)
         if (value === null || value === undefined) {
             return { root, rootLabel: label, path, value: encodeForJson(value), members: [] }
@@ -212,16 +240,18 @@ const eventsTool: ToolDefinition = {
             regex: {
                 type: 'boolean',
                 description: 'Treat `q` as a regex pattern (case-insensitive).'
-            }
+            },
+            session: SESSION_PROP
         },
         additionalProperties: false
     },
     handler: async (input, runtime) => {
-        const filter = parseEventsInput(input)
-        const events = runtime.listEvents(filter)
+        const { filter, session } = parseEventsInput(input)
+        const events = runtime.listEvents(filter, session)
         return {
             count: events.length,
-            bufferSize: runtime.bufferSize(),
+            session: session ?? runtime.getConfig().sessionId,
+            bufferSize: runtime.bufferSize(session),
             events
         }
     }
@@ -229,15 +259,21 @@ const eventsTool: ToolDefinition = {
 
 const eventsClearTool: ToolDefinition = {
     name: 'events_clear',
-    description: 'Clear the entire event buffer. Returns the number of events dropped.',
+    description:
+        "Clear a session's event buffer (default session when `session` is omitted). " +
+        'Returns the number of events dropped.',
     inputSchema: {
         type: 'object',
-        properties: {},
+        properties: {
+            session: SESSION_PROP
+        },
         additionalProperties: false
     },
-    handler: async (_input, runtime) => {
-        const dropped = runtime.clearEvents()
-        return { dropped }
+    handler: async (input, runtime) => {
+        const obj = (input ?? {}) as Record<string, unknown>
+        const session = parseSession(obj.session)
+        const dropped = runtime.clearEvents(session)
+        return { dropped, session: session ?? runtime.getConfig().sessionId }
     }
 }
 
@@ -280,6 +316,12 @@ const logsTool: ToolDefinition = {
             regex: {
                 type: 'boolean',
                 description: 'Treat `q` as a regex pattern (case-insensitive).'
+            },
+            session: {
+                type: 'string',
+                description:
+                    'Keep only log lines emitted by this session (matched on context.session). ' +
+                    'Omit to return every line, including untagged server/global logs.'
             }
         },
         additionalProperties: false
@@ -289,6 +331,7 @@ const logsTool: ToolDefinition = {
         const logs = runtime.listLogs(filter)
         return {
             count: logs.length,
+            session: filter.session ?? null,
             bufferSize: runtime.bufferLogsSize(),
             logs
         }
@@ -315,16 +358,17 @@ const RESTART_MODES = ['soft', 'process_exit'] as const
 const restartTool: ToolDefinition = {
     name: 'restart',
     description:
-        'Restart the runtime state. ' +
-        '"soft" (default): disconnect + drop the WaClient, clear the event and log buffers, ' +
-        'reset their seq counters; the process stays alive, and the next tool call recreates ' +
-        'everything from the same config – code changes loaded into the Node module cache ' +
-        'are NOT picked up. ' +
-        '"process_exit": same cleanup, then exit the process with code 0 so a supervisor ' +
-        '(nodemon, Claude Code respawn-on-reconnect, etc.) starts a fresh process. With no ' +
-        'supervisor, the caller must reconnect the MCP server manually (e.g. /mcp in Claude ' +
-        'Code) for the next tool call to land. The exit is scheduled ~150ms after the response ' +
-        'is sent so the JSON-RPC reply has time to flush.',
+        'Restart runtime state. ' +
+        '"soft" (default): disconnect + drop one session\'s WaClient (default session when ' +
+        '`session` is omitted), clear its event buffer + the shared log buffer, reset seq ' +
+        'counters; the process stays alive and the next tool call recreates the client from ' +
+        'the same config - code changes loaded into the Node module cache are NOT picked up. ' +
+        'Other sessions and the shared store are left untouched. ' +
+        '"process_exit": disconnect EVERY session, destroy the shared store, then exit with ' +
+        'code 0 so a supervisor (nodemon, Claude Code respawn-on-reconnect, etc.) starts a ' +
+        'fresh process. With no supervisor, reconnect the MCP server manually (e.g. /mcp in ' +
+        'Claude Code) for the next tool call to land. The exit is scheduled ~150ms after the ' +
+        'response is sent so the JSON-RPC reply has time to flush.',
     inputSchema: {
         type: 'object',
         properties: {
@@ -333,20 +377,19 @@ const restartTool: ToolDefinition = {
                 enum: RESTART_MODES as unknown as string[],
                 description:
                     '"soft" (default) keeps the process; "process_exit" terminates the process so a supervisor can respawn it.'
-            }
+            },
+            session: SESSION_PROP
         },
         additionalProperties: false
     },
     handler: async (input, runtime) => {
-        const mode = parseRestartInput(input)
-        const eventsBefore = runtime.bufferSize()
-        const logsBefore = runtime.bufferLogsSize()
-        await runtime.destroyClient()
-        runtime.clearEvents()
-        runtime.clearLogs()
-        runtime.resetSequences()
+        const { mode, session } = parseRestartInput(input)
+        const resolvedSession = session ?? runtime.getConfig().sessionId
 
         if (mode === 'process_exit') {
+            const eventsBefore = runtime.bufferSize(session)
+            const logsBefore = runtime.bufferLogsSize()
+            await runtime.destroyAll()
             setTimeout(() => {
                 runtime
                     .closeLogFile()
@@ -356,14 +399,25 @@ const restartTool: ToolDefinition = {
             return {
                 ok: true,
                 mode,
+                session: resolvedSession,
                 eventsCleared: eventsBefore,
                 logsCleared: logsBefore,
                 note: 'process will exit ~150ms after this response; reconnect the MCP transport for the next tool call'
             }
         }
+
+        // soft: reset just the targeted session. Logs share one ring for the
+        // whole process, so the log buffer is cleared wholesale either way.
+        const eventsBefore = runtime.bufferSize(session)
+        const logsBefore = runtime.bufferLogsSize()
+        await runtime.destroyClient(session)
+        runtime.clearEvents(session)
+        runtime.clearLogs()
+        runtime.resetSequences(session)
         return {
             ok: true,
             mode,
+            session: resolvedSession,
             eventsCleared: eventsBefore,
             logsCleared: logsBefore
         }
@@ -373,26 +427,31 @@ const restartTool: ToolDefinition = {
 const lifecycleTool: ToolDefinition = {
     name: 'lifecycle',
     description:
-        'Manage the underlying WaClient instance. Actions: ' +
-        '"status" reports config + whether client is created, ' +
-        '"start" creates the client (no connect), ' +
-        '"destroy" disconnects + drops the client (next call recreates it).',
+        'Manage a WaClient session (default session when `session` is omitted). Actions: ' +
+        '"status" reports config, the resolved session, whether its client is created, its ' +
+        'state, and a summary of every live session; ' +
+        '"start" creates the session client (no connect); ' +
+        '"destroy" disconnects + drops that session client (next call recreates it). ' +
+        'The shared store stays open for the other sessions - only `restart` with ' +
+        'mode "process_exit" tears the whole process (and store) down.',
     inputSchema: {
         type: 'object',
         properties: {
             action: {
                 type: 'string',
                 enum: ['status', 'start', 'destroy']
-            }
+            },
+            session: SESSION_PROP
         },
         required: ['action'],
         additionalProperties: false
     },
     handler: async (input, runtime) => {
-        const action = parseLifecycleInput(input)
+        const { action, session } = parseLifecycleInput(input)
+        const resolvedSession = session ?? runtime.getConfig().sessionId
         switch (action) {
             case 'status': {
-                const client = runtime.getClient()
+                const client = runtime.getClient(session)
                 let state: unknown = null
                 if (client) {
                     try {
@@ -403,18 +462,20 @@ const lifecycleTool: ToolDefinition = {
                 }
                 return {
                     config: runtime.getConfig(),
+                    session: resolvedSession,
                     clientCreated: client !== null,
                     state: encodeForJson(state),
-                    bufferSize: runtime.bufferSize()
+                    bufferSize: runtime.bufferSize(session),
+                    sessions: runtime.listSessions()
                 }
             }
             case 'start': {
-                await runtime.ensureClient()
-                return { ok: true }
+                await runtime.ensureClient(session)
+                return { ok: true, session: resolvedSession }
             }
             case 'destroy': {
-                await runtime.destroyClient()
-                return { ok: true }
+                await runtime.destroyClient(session)
+                return { ok: true, session: resolvedSession }
             }
         }
     }
@@ -427,8 +488,9 @@ const AsyncFunctionCtor = Object.getPrototypeOf(async function () {}).constructo
 const evalTool: ToolDefinition = {
     name: 'eval',
     description:
-        'Execute arbitrary JS in the MCP runtime with `client` (WaClient instance) and `lib` ' +
-        '(zapo-js module namespace) in scope. **Disabled by default**: requires ' +
+        'Execute arbitrary JS in the MCP runtime with `client` (the WaClient for the selected ' +
+        '`session`, default session when omitted) and `lib` (zapo-js module namespace) in ' +
+        'scope. **Disabled by default**: requires ' +
         '`MCP_EVAL_ENABLED=1` in the MCP process env, otherwise every call is rejected. ' +
         'The source is wrapped in an async function – top-level `await` works. ' +
         'Use `return <expr>` to surface a value; the result is encoded for JSON ' +
@@ -447,7 +509,8 @@ const evalTool: ToolDefinition = {
             noAwait: {
                 type: 'boolean',
                 description: 'Fire-and-forget mode. Defaults to false.'
-            }
+            },
+            session: SESSION_PROP
         },
         required: ['source'],
         additionalProperties: false
@@ -458,13 +521,14 @@ const evalTool: ToolDefinition = {
                 'eval tool is disabled; set MCP_EVAL_ENABLED=1 in the MCP process env to enable'
             )
         }
-        const { source, noAwait } = parseEvalInput(input)
-        const client = await runtime.ensureClient()
+        const { source, noAwait, session } = parseEvalInput(input)
+        const client = await runtime.ensureClient(session)
         const fn = new AsyncFunctionCtor('client', 'lib', source)
         const invoked = fn(client, ZapoLib)
         if (noAwait) {
             invoked.catch((error: unknown) => {
                 runtime.getLogger().warn('eval noAwait rejected', {
+                    session: session ?? null,
                     message: toError(error).message
                 })
             })
@@ -489,7 +553,7 @@ export const TOOLS: readonly ToolDefinition[] = Object.freeze([
 
 const parseCallInput = (
     input: unknown
-): { path: string; args: unknown[]; root: Root; noAwait: boolean } => {
+): { path: string; args: unknown[]; root: Root; noAwait: boolean; session?: string } => {
     if (!input || typeof input !== 'object') {
         throw new Error('call: input must be an object')
     }
@@ -500,28 +564,31 @@ const parseCallInput = (
     const args = Array.isArray(obj.args) ? (obj.args as unknown[]) : []
     const root = parseRoot(obj.root)
     const noAwait = obj.noAwait === true
-    return { path: obj.path, args, root, noAwait }
+    return { path: obj.path, args, root, noAwait, session: parseSession(obj.session) }
 }
 
 const parseInspectInput = (
     input: unknown
-): { path: string; includeEventEmitter: boolean; root: Root } => {
+): { path: string; includeEventEmitter: boolean; root: Root; session?: string } => {
     const obj = (input ?? {}) as Record<string, unknown>
     const path = typeof obj.path === 'string' ? obj.path : ''
     const includeEventEmitter = obj.includeEventEmitter === true
     const root = parseRoot(obj.root)
-    return { path, includeEventEmitter, root }
+    return { path, includeEventEmitter, root, session: parseSession(obj.session) }
 }
 
 const parseEventsInput = (
     input: unknown
 ): {
-    types?: readonly string[]
-    since?: number
-    limit?: number
-    drain?: boolean
-    q?: string
-    regex?: boolean
+    filter: {
+        types?: readonly string[]
+        since?: number
+        limit?: number
+        drain?: boolean
+        q?: string
+        regex?: boolean
+    }
+    session?: string
 } => {
     const obj = (input ?? {}) as Record<string, unknown>
     const types =
@@ -533,7 +600,10 @@ const parseEventsInput = (
     const drain = obj.drain === true
     const q = typeof obj.q === 'string' ? obj.q : undefined
     const regex = obj.regex === true
-    return { types, since, limit, drain, q, regex }
+    return {
+        filter: { types, since, limit, drain, q, regex },
+        session: parseSession(obj.session)
+    }
 }
 
 const parseLogsInput = (
@@ -545,6 +615,7 @@ const parseLogsInput = (
     drain?: boolean
     q?: string
     regex?: boolean
+    session?: string
 } => {
     const obj = (input ?? {}) as Record<string, unknown>
     let levels: readonly ('trace' | 'debug' | 'info' | 'warn' | 'error')[] | undefined
@@ -570,18 +641,20 @@ const parseLogsInput = (
     const drain = obj.drain === true
     const q = typeof obj.q === 'string' ? obj.q : undefined
     const regex = obj.regex === true
-    return { levels, since, limit, drain, q, regex }
+    return { levels, since, limit, drain, q, regex, session: parseSession(obj.session) }
 }
 
-const parseLifecycleInput = (input: unknown): 'status' | 'start' | 'destroy' => {
+const parseLifecycleInput = (
+    input: unknown
+): { action: 'status' | 'start' | 'destroy'; session?: string } => {
     const obj = (input ?? {}) as Record<string, unknown>
     if (obj.action === 'status' || obj.action === 'start' || obj.action === 'destroy') {
-        return obj.action
+        return { action: obj.action, session: parseSession(obj.session) }
     }
     throw new Error('lifecycle: "action" must be "status" | "start" | "destroy"')
 }
 
-const parseEvalInput = (input: unknown): { source: string; noAwait: boolean } => {
+const parseEvalInput = (input: unknown): { source: string; noAwait: boolean; session?: string } => {
     if (!input || typeof input !== 'object') {
         throw new Error('eval: input must be an object')
     }
@@ -589,13 +662,14 @@ const parseEvalInput = (input: unknown): { source: string; noAwait: boolean } =>
     if (typeof obj.source !== 'string' || obj.source.length === 0) {
         throw new Error('eval: "source" must be a non-empty string')
     }
-    return { source: obj.source, noAwait: obj.noAwait === true }
+    return { source: obj.source, noAwait: obj.noAwait === true, session: parseSession(obj.session) }
 }
 
-const parseRestartInput = (input: unknown): 'soft' | 'process_exit' => {
+const parseRestartInput = (input: unknown): { mode: 'soft' | 'process_exit'; session?: string } => {
     const obj = (input ?? {}) as Record<string, unknown>
-    if (obj.mode === undefined || obj.mode === null) return 'soft'
-    if (obj.mode === 'soft' || obj.mode === 'process_exit') return obj.mode
+    const session = parseSession(obj.session)
+    if (obj.mode === undefined || obj.mode === null) return { mode: 'soft', session }
+    if (obj.mode === 'soft' || obj.mode === 'process_exit') return { mode: obj.mode, session }
     throw new Error(`restart: "mode" must be one of ${RESTART_MODES.join(' | ')}`)
 }
 

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -431,7 +431,7 @@ const lifecycleTool: ToolDefinition = {
         '"status" reports config, the resolved session, whether its client is created, its ' +
         'state, and a summary of every live session; ' +
         '"start" creates the session client (no connect); ' +
-        '"destroy" disconnects + drops that session client (next call recreates it). ' +
+        '"destroy" disconnects + drops that session and frees its slot (next call recreates it). ' +
         'The shared store stays open for the other sessions - only `restart` with ' +
         'mode "process_exit" tears the whole process (and store) down.',
     inputSchema: {


### PR DESCRIPTION
Every tool takes an optional session id (default MCP_SESSION_ID); a new id lazily spins up an additional WaClient on the same store/auth backend, so one process drives many accounts. Event buffers and seq are per-session; client logs are tagged with context.session and the logs tool gains a session filter. Session count is bounded by MCP_MAX_SESSIONS. lifecycle status summarizes every live session; restart soft is scoped to one session while process_exit tears down all sessions plus the shared store.

Breaking (0.x): McpRuntime event/client methods take an optional trailing session argument, and destroyClient() no longer destroys the shared store (use the new destroyAll()). RuntimeConfig gains an optional maxSessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-session support: run many sessions over a single shared store with per-session event buffers, logs, and lifecycle operations.
  * Tools accept an optional session parameter and can list/query sessions.

* **Documentation**
  * Updated docs and READMEs to describe multi-session behavior, session lifecycle, and MCP_MAX_SESSIONS.

* **Tests**
  * Added multi-session coverage and session-related tool tests.

* **Bug Fixes**
  * Improved test cleanup to reliably destroy all session clients.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->