### PR TITLE
feat: content-type + group invite getters, type-safe business hours

### DIFF
--- a/src/client/coordinators/WaGroupCoordinator.ts
+++ b/src/client/coordinators/WaGroupCoordinator.ts
@@ -345,6 +345,13 @@ export interface WaGroupCoordinator {
     /** Leaves one or more groups (batched in a single IQ). */
     readonly leaveGroup: (groupJids: readonly string[]) => Promise<void>
     /**
+     * Fetches the current invite code for `groupJid` (the path segment of the
+     * `chat.whatsapp.com/<code>` link) without rotating it. Group admin
+     * operation - non-admins receive a `403 not-authorized` error. Use
+     * {@link revokeInvite} to issue a fresh code and invalidate the old one.
+     */
+    readonly queryInviteCode: (groupJid: string) => Promise<string>
+    /**
      * Revokes the current invite link. The server rotates the code
      * immediately - every previously-shared `chat.whatsapp.com/<code>` link
      * stops working. Returns the freshly-issued code.
@@ -815,6 +822,23 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
         return parseParticipantActionResults(result, action)
     }
 
+    const queryInvite = async (
+        type: Parameters<typeof buildIqNode>[0],
+        groupJid: string,
+        context: string
+    ): Promise<{ readonly result: BinaryNode; readonly code: string }> => {
+        const node = buildIqNode(type, groupJid, WA_XMLNS.GROUPS, [
+            { tag: WA_NODE_TAGS.INVITE, attrs: {} }
+        ])
+        const result = await queryWithContext(context, node)
+        assertIqResult(result, context)
+        const code = findNodeChild(result, WA_NODE_TAGS.INVITE)?.attrs.code
+        if (!code) {
+            throw new Error(`${context}: missing invite code in response`)
+        }
+        return { result, code }
+    }
+
     return {
         queryGroupMetadata: async (groupJid) => {
             const node = buildIqNode(WA_IQ_TYPES.GET, groupJid, WA_XMLNS.GROUPS, [
@@ -981,17 +1005,17 @@ export function createGroupCoordinator(options: WaGroupCoordinatorOptions): WaGr
             assertIqResult(result, 'group.leave')
         },
 
+        queryInviteCode: async (groupJid) => {
+            const { code } = await queryInvite(WA_IQ_TYPES.GET, groupJid, 'group.queryInviteCode')
+            return code
+        },
+
         revokeInvite: async (groupJid) => {
-            const node = buildIqNode(WA_IQ_TYPES.SET, groupJid, WA_XMLNS.GROUPS, [
-                { tag: WA_NODE_TAGS.INVITE, attrs: {} }
-            ])
-            const result = await queryWithContext('group.revokeInvite', node)
-            assertIqResult(result, 'group.revokeInvite')
-            const inviteNode = findNodeChild(result, WA_NODE_TAGS.INVITE)
-            const code = inviteNode?.attrs.code
-            if (!code) {
-                throw new Error('group.revokeInvite: missing invite code in response')
-            }
+            const { result, code } = await queryInvite(
+                WA_IQ_TYPES.SET,
+                groupJid,
+                'group.revokeInvite'
+            )
             const participantNodes = getNodeChildrenByTag(result, WA_NODE_TAGS.PARTICIPANT)
             const affectedParticipants: WaParticipantActionResult[] = new Array(
                 participantNodes.length

--- a/src/client/coordinators/__tests__/group-community-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/group-community-coordinator.test.ts
@@ -610,3 +610,21 @@ test('approve/reject/cancel/joinLinkedGroup send the correct stanza shape', asyn
     assert.equal(joinRoot.tag, 'join_linked_group')
     assert.equal(joinRoot.attrs.jid, 'sub@g.us')
 })
+
+test('queryInviteCode sends a get invite stanza and returns the code', async () => {
+    const mock = createMockQuery([iqResult([{ tag: 'invite', attrs: { code: 'ABC123code' } }])])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    const code = await coordinator.queryInviteCode('120363@g.us')
+    assert.equal(code, 'ABC123code')
+    assert.equal(mock.calls[0].node.attrs.type, 'get')
+    assert.equal(mock.calls[0].node.attrs.to, '120363@g.us')
+    assert.equal((mock.calls[0].node.content as BinaryNode[])[0].tag, 'invite')
+})
+
+test('queryInviteCode throws when the response has no code', async () => {
+    const mock = createMockQuery([iqResult([{ tag: 'invite', attrs: {} }])])
+    const coordinator = createGroupCoordinator({ queryWithContext: mock.queryWithContext })
+
+    await assert.rejects(coordinator.queryInviteCode('120363@g.us'), /missing invite code/)
+})

--- a/src/client/events/business.ts
+++ b/src/client/events/business.ts
@@ -13,6 +13,7 @@ import type {
     WaVerifiedNameResult
 } from '@client/types'
 import { proto } from '@proto'
+import type { WaBusinessHoursDay, WaBusinessHoursMode } from '@protocol/business'
 import { WA_BUSINESS_NOTIFICATION_TAGS, WA_NOTIFICATION_TYPES } from '@protocol/constants'
 import { WA_NODE_TAGS } from '@protocol/nodes'
 import {
@@ -115,12 +116,12 @@ function parseBusinessHoursNode(node: BinaryNode): WaBusinessHours {
     for (let i = 0; i < children.length; i += 1) {
         const child = children[i]
         if (child.tag !== 'business_hours_config') continue
-        const dayOfWeek = child.attrs.day_of_week as string | undefined
-        const mode = child.attrs.mode as string | undefined
+        const dayOfWeek = child.attrs.day_of_week as WaBusinessHoursDay | undefined
+        const mode = child.attrs.mode as WaBusinessHoursMode | undefined
         if (!dayOfWeek || !mode) continue
         const entry: {
-            dayOfWeek: string
-            mode: string
+            dayOfWeek: WaBusinessHoursDay
+            mode: WaBusinessHoursMode
             openTime?: number
             closeTime?: number
         } = { dayOfWeek, mode }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -15,6 +15,7 @@ import type { WaDecodedAddon } from '@message/crypto/addon-crypto'
 import type { WaMessagePublishOptions, WaSendEditKey } from '@message/types'
 import type { Proto } from '@proto'
 import type { WaBotMsgEditType } from '@protocol/bot'
+import type { WaBusinessHoursDay, WaBusinessHoursMode } from '@protocol/business'
 import type { WaConnectionCode, WaConnectionOpenReason, WaDisconnectReason } from '@protocol/stream'
 import type { WaStore } from '@store/types'
 import type { ChatstateMedia, ChatstateState } from '@transport/node/builders/chatstate'
@@ -845,8 +846,8 @@ export interface WaBusinessCategory {
 }
 
 export interface WaBusinessHoursEntry {
-    readonly dayOfWeek: string
-    readonly mode: string
+    readonly dayOfWeek: WaBusinessHoursDay
+    readonly mode: WaBusinessHoursMode
     readonly openTime?: number
     readonly closeTime?: number
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,6 +204,7 @@ export type {
     WaSendStickerPackTrayIcon,
     WaSendTextMessage
 } from '@message/types'
+export { getContentType } from '@message/encode/content'
 export type { WaSendContextInfo } from '@message/context-info'
 export type {
     WaLinkPreviewFetcher,

--- a/src/message/encode/content.ts
+++ b/src/message/encode/content.ts
@@ -19,6 +19,23 @@ import {
     WA_STANZA_MSG_TYPES
 } from '@protocol/constants'
 
+/**
+ * Returns the content-type key of a message - `'conversation'`,
+ * `'imageMessage'`, `'extendedTextMessage'`, etc. - or `undefined` for an empty
+ * message. `senderKeyDistributionMessage` is skipped so group messages report
+ * their real payload type rather than the piggy-backed sender-key.
+ */
+export function getContentType(
+    content: Proto.IMessage | undefined
+): keyof Proto.IMessage | undefined {
+    if (!content) return undefined
+    const key = Object.keys(content).find(
+        (k) =>
+            (k === 'conversation' || k.includes('Message')) && k !== 'senderKeyDistributionMessage'
+    )
+    return key as keyof Proto.IMessage | undefined
+}
+
 export function isSendMediaMessage(content: unknown): content is WaSendMediaMessage {
     if (!content || typeof content !== 'object' || !('type' in content)) {
         return false

--- a/src/protocol/business.ts
+++ b/src/protocol/business.ts
@@ -1,0 +1,26 @@
+export const WA_BUSINESS_HOURS_DAYS = Object.freeze({
+    SUN: 'sun',
+    MON: 'mon',
+    TUE: 'tue',
+    WED: 'wed',
+    THU: 'thu',
+    FRI: 'fri',
+    SAT: 'sat'
+} as const)
+
+export type WaBusinessHoursDay =
+    (typeof WA_BUSINESS_HOURS_DAYS)[keyof typeof WA_BUSINESS_HOURS_DAYS]
+
+/**
+ * Per-day open mode accepted by the `business_profile` edit IQ. A closed day is
+ * expressed by omitting it from the config entirely, not by a dedicated mode.
+ * `open_time` / `close_time` are only meaningful for `specific_hours`.
+ */
+export const WA_BUSINESS_HOURS_MODES = Object.freeze({
+    OPEN_24H: 'open_24h',
+    SPECIFIC_HOURS: 'specific_hours',
+    APPOINTMENT_ONLY: 'appointment_only'
+} as const)
+
+export type WaBusinessHoursMode =
+    (typeof WA_BUSINESS_HOURS_MODES)[keyof typeof WA_BUSINESS_HOURS_MODES]

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -57,6 +57,8 @@ export {
     WA_NOTIFICATION_TYPES,
     WA_REGISTRATION_NOTIFICATION_TAGS
 } from '@protocol/notification'
+export { WA_BUSINESS_HOURS_DAYS, WA_BUSINESS_HOURS_MODES } from '@protocol/business'
+export type { WaBusinessHoursDay, WaBusinessHoursMode } from '@protocol/business'
 export {
     WA_CHATSTATE_MEDIA,
     WA_PRESENCE_LAST_SENTINELS,

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+    WA_BUSINESS_HOURS_MODES,
     WA_DEFAULTS,
     WA_EMAIL_CONTEXTS,
     WA_EMAIL_TAGS,
@@ -25,6 +26,7 @@ import {
     buildNewsletterMetadataSyncIq
 } from '@transport/node/builders/account-sync'
 import { buildBotListIq } from '@transport/node/builders/bot'
+import { buildEditBusinessProfileIq } from '@transport/node/builders/business'
 import { buildChatstateNode } from '@transport/node/builders/chatstate'
 import {
     buildDeactivateCommunityIq,
@@ -1843,4 +1845,44 @@ test('bot list builder targets s.whatsapp.net with xmlns="bot"', () => {
     const v3 = buildBotListIq('3')
     assert.ok(Array.isArray(v3.content))
     assert.equal(v3.content[0].attrs.v, '3')
+})
+
+test('buildEditBusinessProfileIq encodes business hours and rejects unknown mode', () => {
+    const iq = buildEditBusinessProfileIq({
+        businessHours: {
+            timezone: 'America/Sao_Paulo',
+            config: [
+                { dayOfWeek: 'mon', mode: 'specific_hours', openTime: 540, closeTime: 1080 },
+                { dayOfWeek: 'tue', mode: 'open_24h', openTime: 0, closeTime: 1440 },
+                { dayOfWeek: 'wed', mode: 'appointment_only' }
+            ]
+        }
+    })
+    const profile = (iq.content as readonly BinaryNode[])[0]
+    assert.equal(profile.tag, 'business_profile')
+    assert.equal(profile.attrs.mutation_type, 'delta')
+    const hours = (profile.content as readonly BinaryNode[]).find((c) => c.tag === 'business_hours')
+    assert.ok(hours)
+    assert.equal(hours.attrs.timezone, 'America/Sao_Paulo')
+    const configs = hours.content as readonly BinaryNode[]
+    assert.equal(configs.length, 3)
+    // specific_hours keeps open/close
+    assert.equal(configs[0].attrs.mode, WA_BUSINESS_HOURS_MODES.SPECIFIC_HOURS)
+    assert.equal(configs[0].attrs.open_time, '540')
+    assert.equal(configs[0].attrs.close_time, '1080')
+    // open_24h drops open/close even when supplied
+    assert.equal(configs[1].attrs.mode, WA_BUSINESS_HOURS_MODES.OPEN_24H)
+    assert.equal(configs[1].attrs.open_time, undefined)
+    assert.equal(configs[1].attrs.close_time, undefined)
+    // appointment_only carries no times
+    assert.equal(configs[2].attrs.mode, WA_BUSINESS_HOURS_MODES.APPOINTMENT_ONLY)
+    assert.equal(configs[2].attrs.open_time, undefined)
+
+    assert.throws(
+        () =>
+            buildEditBusinessProfileIq({
+                businessHours: { config: [{ dayOfWeek: 'sun', mode: 'open' as never }] }
+            }),
+        /invalid business hours mode/
+    )
 })

--- a/src/transport/node/builders/business.ts
+++ b/src/transport/node/builders/business.ts
@@ -1,4 +1,12 @@
-import { WA_DEFAULTS, WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
+import {
+    WA_BUSINESS_HOURS_MODES,
+    WA_DEFAULTS,
+    WA_IQ_TYPES,
+    WA_NODE_TAGS,
+    WA_XMLNS,
+    type WaBusinessHoursDay,
+    type WaBusinessHoursMode
+} from '@protocol/constants'
 import { WA_BUSINESS_NOTIFICATION_TAGS } from '@protocol/notification'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
@@ -11,11 +19,18 @@ export interface WaEditBusinessProfileInput {
     readonly email?: string
     readonly websites?: readonly { readonly url: string }[]
     readonly categories?: readonly { readonly id: string }[]
+    /**
+     * Weekly opening schedule. List one entry per **open** day; closed days are
+     * expressed by omitting them, not by a separate mode. `openTime` / `closeTime`
+     * (minutes from midnight, e.g. `540` = 09:00) only apply to `specific_hours`
+     * and are ignored for `open_24h` / `appointment_only`. An unknown `mode` is
+     * rejected by the server with a `406 not-acceptable`.
+     */
     readonly businessHours?: {
         readonly timezone?: string
         readonly config: readonly {
-            readonly dayOfWeek: string
-            readonly mode: string
+            readonly dayOfWeek: WaBusinessHoursDay
+            readonly mode: WaBusinessHoursMode
             readonly openTime?: number
             readonly closeTime?: number
         }[]
@@ -94,21 +109,34 @@ export function buildEditBusinessProfileIq(input: WaEditBusinessProfileInput): B
     ])
 }
 
+const VALID_BUSINESS_HOURS_MODES: ReadonlySet<string> = new Set(
+    Object.values(WA_BUSINESS_HOURS_MODES)
+)
+
 function buildBusinessHoursNode(
     hours: NonNullable<WaEditBusinessProfileInput['businessHours']>
 ): BinaryNode {
     const configNodes: BinaryNode[] = new Array(hours.config.length)
     for (let i = 0; i < hours.config.length; i += 1) {
         const entry = hours.config[i]
+        if (!VALID_BUSINESS_HOURS_MODES.has(entry.mode)) {
+            throw new Error(
+                `invalid business hours mode '${entry.mode}' (expected one of ${Object.values(WA_BUSINESS_HOURS_MODES).join(', ')}; closed days must be omitted)`
+            )
+        }
         const attrs: Record<string, string> = {
             day_of_week: entry.dayOfWeek,
             mode: entry.mode
         }
-        if (entry.openTime !== undefined) {
-            attrs.open_time = `${entry.openTime}`
-        }
-        if (entry.closeTime !== undefined) {
-            attrs.close_time = `${entry.closeTime}`
+        // open_time / close_time only apply to specific_hours; the server drops
+        // them for open_24h / appointment_only.
+        if (entry.mode === WA_BUSINESS_HOURS_MODES.SPECIFIC_HOURS) {
+            if (entry.openTime !== undefined) {
+                attrs.open_time = `${entry.openTime}`
+            }
+            if (entry.closeTime !== undefined) {
+                attrs.close_time = `${entry.closeTime}`
+            }
         }
         configNodes[i] = { tag: 'business_hours_config', attrs }
     }


### PR DESCRIPTION
- export getContentType(message) to resolve a message's content key
- add group.queryInviteCode() to fetch the current invite link without revoking (shares the invite IQ helper with revokeInvite)
- type business-hours dayOfWeek/mode as unions and reject unknown modes with a clear local error instead of a server 406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added method to retrieve current group invite codes without rotating them.
  * Exported `getContentType` utility function for determining message content types.

* **Improvements**
  * Strengthened type safety for business hours configuration with proper enum types for days and modes.
  * Enhanced business profile builder with stricter mode validation and conditional inclusion of time attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->