### PR TITLE
feat(client,message)!: proto-aligned message `key` + addressing consolidation

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -144,7 +144,7 @@ async function startSession(client: WaClient): Promise<void> {
         if (!text || text.trim().toLowerCase() !== 'ping') {
             return
         }
-        const to = event.chatJid ?? event.senderJid
+        const to = event.key.remoteJid
         if (!to) {
             console.log('[incoming_message] ping sem destino para responder')
             return

--- a/packages/fake-server/src/__tests__/bidirectional-group.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/bidirectional-group.cross-check.test.ts
@@ -82,13 +82,14 @@ test('bidirectional group ping-pong (peer\u2192client\u2192peer\u2192client) dec
 
         const round1ReceivedByLib = waitForMessage(
             client,
-            (event) => event.chatJid === groupJid && event.message?.conversation === 'peer-group #1'
+            (event) =>
+                event.key.remoteJid === groupJid && event.message?.conversation === 'peer-group #1'
         )
         await peer.sendGroupConversation(groupJid, 'peer-group #1')
         const round1 = await round1ReceivedByLib
-        assert.equal(round1.chatJid, groupJid)
-        assert.equal(round1.senderJid, peerJid)
-        assert.equal(round1.isGroupChat, true)
+        assert.equal(round1.key.remoteJid, groupJid)
+        assert.equal(round1.key.participant ?? round1.key.remoteJid, peerJid)
+        assert.equal(round1.key.isGroup, true)
         assert.equal(round1.message?.conversation, 'peer-group #1')
 
         const round2Promise = peer.expectGroupMessage(groupJid, {
@@ -102,7 +103,8 @@ test('bidirectional group ping-pong (peer\u2192client\u2192peer\u2192client) dec
 
         const round3ReceivedByLib = waitForMessage(
             client,
-            (event) => event.chatJid === groupJid && event.message?.conversation === 'peer-group #2'
+            (event) =>
+                event.key.remoteJid === groupJid && event.message?.conversation === 'peer-group #2'
         )
         await peer.sendGroupConversation(groupJid, 'peer-group #2')
         const round3 = await round3ReceivedByLib

--- a/packages/fake-server/src/__tests__/edit-revoke-reactions.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/edit-revoke-reactions.cross-check.test.ts
@@ -135,7 +135,7 @@ test('fake peer pushes a reaction message and the lib emits the message event', 
         })
 
         const event = await messagePromise
-        assert.equal(event.senderJid, peerJid)
+        assert.equal(event.key.participant ?? event.key.remoteJid, peerJid)
         assert.equal(event.message?.reactionMessage?.text, '\u2764\ufe0f')
         assert.equal(event.message?.reactionMessage?.key?.id, 'msg-to-react-to')
     } finally {

--- a/packages/fake-server/src/__tests__/ephemeral-message.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/ephemeral-message.cross-check.test.ts
@@ -66,7 +66,7 @@ test('fake peer pushes an ephemeral wrapped conversation and the lib emits messa
         const ephemeral = event.message?.ephemeralMessage
         assert.ok(ephemeral, 'ephemeralMessage wrapper should be present')
         assert.equal(ephemeral.message?.conversation, 'this self-destructs')
-        assert.equal(event.senderJid, peerJid)
+        assert.equal(event.key.participant ?? event.key.remoteJid, peerJid)
         assert.equal(expirationSeconds, 604_800)
     } finally {
         await client.disconnect().catch(() => undefined)

--- a/packages/fake-server/src/__tests__/fake-peer-group-message.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/fake-peer-group-message.cross-check.test.ts
@@ -37,7 +37,7 @@ test('fake peer sends a SenderKey-encrypted group message and lib emits message 
 
     const messagePromise = waitForMessage(
         client,
-        (event) => event.chatJid === groupJid && event.message?.conversation === 'hello group'
+        (event) => event.key.remoteJid === groupJid && event.message?.conversation === 'hello group'
     )
 
     try {
@@ -54,9 +54,9 @@ test('fake peer sends a SenderKey-encrypted group message and lib emits message 
         await peer.sendGroupConversation(groupJid, 'hello group')
 
         const event = await messagePromise
-        assert.equal(event.chatJid, groupJid)
-        assert.equal(event.senderJid, peerJid)
-        assert.equal(event.isGroupChat, true)
+        assert.equal(event.key.remoteJid, groupJid)
+        assert.equal(event.key.participant ?? event.key.remoteJid, peerJid)
+        assert.equal(event.key.isGroup, true)
         assert.equal(event.message?.conversation, 'hello group')
     } finally {
         await client.disconnect().catch(() => undefined)

--- a/packages/fake-server/src/__tests__/fake-peer-message.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/fake-peer-message.cross-check.test.ts
@@ -46,7 +46,7 @@ test('fake peer encrypts a Signal message and the lib emits message event', asyn
         const [event] = await messagePromise
         assert.ok(event.message, 'message event should carry a decoded Message proto')
         assert.equal(event.message?.conversation, 'hello from the fake server')
-        assert.equal(event.senderJid, '5511888888888@s.whatsapp.net')
+        assert.equal(event.key.participant ?? event.key.remoteJid, '5511888888888@s.whatsapp.net')
     } finally {
         await client.disconnect().catch(() => undefined)
         await server.stop()

--- a/packages/fake-server/src/__tests__/lid-addressing.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/lid-addressing.cross-check.test.ts
@@ -49,10 +49,8 @@ test('fake peer in @lid space pushes a Signal message and the lib emits message'
         await peer.sendConversation(inboundText)
         const inbound = await inboundPromise
         assert.equal(inbound.message?.conversation, inboundText)
-        assert.ok(
-            inbound.senderJid?.includes('@lid'),
-            `senderJid should be @lid, got ${inbound.senderJid}`
-        )
+        const senderJid = inbound.key.participant ?? inbound.key.remoteJid
+        assert.ok(senderJid.includes('@lid'), `senderJid should be @lid, got ${senderJid}`)
     } finally {
         await client.disconnect().catch(() => undefined)
         await server.stop()

--- a/packages/fake-server/src/__tests__/poll-message.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/poll-message.cross-check.test.ts
@@ -65,7 +65,7 @@ test('fake peer pushes a poll creation message and the lib emits message', async
         assert.equal(poll.options?.[0].optionName, 'Pizza')
         assert.equal(poll.options?.[1].optionName, 'Hambúrguer')
         assert.equal(poll.selectableOptionsCount, 1)
-        assert.equal(event.senderJid, peerJid)
+        assert.equal(event.key.participant ?? event.key.remoteJid, peerJid)
     } finally {
         await client.disconnect().catch(() => undefined)
         await server.stop()

--- a/packages/fake-server/src/__tests__/status-broadcast.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/status-broadcast.cross-check.test.ts
@@ -55,9 +55,9 @@ test('fake peer pushes a status@broadcast message and the lib emits isBroadcastC
 
         const event = await messagePromise
         assert.equal(event.message?.conversation, statusText)
-        assert.equal(event.chatJid, 'status@broadcast')
-        assert.equal(event.isBroadcastChat, true)
-        assert.equal(event.senderJid, peerJid)
+        assert.equal(event.key.remoteJid, 'status@broadcast')
+        assert.equal(event.key.isBroadcast, true)
+        assert.equal(event.key.participant ?? event.key.remoteJid, peerJid)
     } finally {
         await client.disconnect().catch(() => undefined)
         await server.stop()

--- a/src/appstate/sync/WaAppStateSyncClient.ts
+++ b/src/appstate/sync/WaAppStateSyncClient.ts
@@ -55,10 +55,15 @@ interface MacMutation {
 
 type DecryptedPatchMutation = WaAppStateMutation & { operationCode: number }
 
+/**
+ * Minimal message-key context for incoming app-state key protocol messages.
+ * Uses the proto `Proto.IMessageKey` attribute names so callers can pass an
+ * incoming message's `key` verbatim (no field remapping).
+ */
 export interface IncomingKeyEventContext {
-    readonly stanzaId?: string
-    readonly chatJid?: string
-    readonly senderJid?: string
+    readonly remoteJid?: string
+    readonly id?: string
+    readonly participant?: string
     readonly senderDevice?: number
 }
 
@@ -193,8 +198,8 @@ export class WaAppStateSyncClient {
         const share = protocolMessage.appStateSyncKeyShare
         if (!share) {
             this.logger.warn('incoming app-state key share protocol message without payload', {
-                id: context.stanzaId,
-                from: context.chatJid
+                id: context.id,
+                from: context.remoteJid
             })
             return
         }
@@ -202,23 +207,23 @@ export class WaAppStateSyncClient {
         try {
             const imported = await this.importSyncKeyShare(share)
             this.logger.info('imported app-state sync key share from protocol message', {
-                id: context.stanzaId,
-                from: context.chatJid,
+                id: context.id,
+                from: context.remoteJid,
                 imported
             })
             if (imported > 0 && this.triggerSync) {
                 void this.triggerSync().catch((error) => {
                     this.logger.warn('failed to sync app-state after key share import', {
-                        id: context.stanzaId,
-                        from: context.chatJid,
+                        id: context.id,
+                        from: context.remoteJid,
                         message: toError(error).message
                     })
                 })
             }
         } catch (error) {
             this.logger.warn('failed to import app-state sync key share from protocol message', {
-                id: context.stanzaId,
-                from: context.chatJid,
+                id: context.id,
+                from: context.remoteJid,
                 message: toError(error).message
             })
         }
@@ -232,30 +237,28 @@ export class WaAppStateSyncClient {
         const request = protocolMessage.appStateSyncKeyRequest
         if (!request) {
             this.logger.warn('incoming app-state key request protocol message without payload', {
-                id: context.stanzaId,
-                from: context.chatJid
+                id: context.id,
+                from: context.remoteJid
             })
             return
         }
 
-        const requesterSource = context.senderJid ?? context.chatJid
-        if (!requesterSource) {
+        const senderJid = context.participant ?? context.remoteJid
+        if (!senderJid) {
             this.logger.warn('incoming app-state key request missing sender jid', {
-                id: context.stanzaId
+                id: context.id
             })
             return
         }
 
         let requesterDeviceJid: string
         try {
-            const requesterRaw = context.senderJid
-                ? applyDeviceToJid(context.senderJid, context.senderDevice)
-                : requesterSource
+            const requesterRaw = applyDeviceToJid(senderJid, context.senderDevice)
             requesterDeviceJid = normalizeDeviceJid(requesterRaw)
         } catch (error) {
             this.logger.warn('incoming app-state key request has malformed sender jid', {
-                id: context.stanzaId,
-                from: requesterSource,
+                id: context.id,
+                from: senderJid,
                 message: toError(error).message
             })
             return
@@ -263,7 +266,7 @@ export class WaAppStateSyncClient {
 
         if (this.isOwnAccountDevice && !this.isOwnAccountDevice(requesterDeviceJid)) {
             this.logger.warn('incoming app-state key request ignored: sender is not own account', {
-                id: context.stanzaId,
+                id: context.id,
                 from: requesterDeviceJid
             })
             return
@@ -272,7 +275,7 @@ export class WaAppStateSyncClient {
         const requestedKeyIds = this.extractKeyRequestIds(request)
         if (requestedKeyIds.length === 0) {
             this.logger.warn('incoming app-state key request has no valid key ids', {
-                id: context.stanzaId,
+                id: context.id,
                 from: requesterDeviceJid
             })
             return
@@ -280,7 +283,7 @@ export class WaAppStateSyncClient {
 
         if (!this.sendKeyShare) {
             this.logger.warn('incoming app-state key request received but no sendKeyShare wired', {
-                id: context.stanzaId,
+                id: context.id,
                 from: requesterDeviceJid
             })
             return
@@ -301,7 +304,7 @@ export class WaAppStateSyncClient {
         try {
             await this.sendKeyShare(requesterDeviceJid, availableKeys, missingKeyIds)
             this.logger.info('responded to app-state key request', {
-                id: context.stanzaId,
+                id: context.id,
                 to: requesterDeviceJid,
                 requested: requestedKeyIds.length,
                 shared: availableKeys.length,
@@ -309,7 +312,7 @@ export class WaAppStateSyncClient {
             })
         } catch (error) {
             this.logger.warn('failed to respond to app-state key request', {
-                id: context.stanzaId,
+                id: context.id,
                 to: requesterDeviceJid,
                 requested: requestedKeyIds.length,
                 shared: availableKeys.length,

--- a/src/appstate/sync/WaAppStateSyncClient.ts
+++ b/src/appstate/sync/WaAppStateSyncClient.ts
@@ -60,11 +60,11 @@ type DecryptedPatchMutation = WaAppStateMutation & { operationCode: number }
  * Uses the proto `Proto.IMessageKey` attribute names so callers can pass an
  * incoming message's `key` verbatim (no field remapping).
  */
-export interface IncomingKeyEventContext {
+interface IncomingKeyEventContext {
     readonly remoteJid?: string
     readonly id?: string
     readonly participant?: string
-    readonly senderDevice?: number
+    readonly senderDevice: number
 }
 
 interface WaAppStateSyncClientOptions {

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -300,7 +300,7 @@ export class WaClient extends EventEmitter {
             if (this.options.addons?.autoDecrypt !== false && event.message) {
                 void this.deps.messageCoordinator.tryDecryptAddon(event).catch((err) => {
                     this.logger.warn('addon auto-decrypt failed', {
-                        id: event.stanzaId,
+                        id: event.key.id,
                         message: toError(err).message
                     })
                 })
@@ -310,7 +310,7 @@ export class WaClient extends EventEmitter {
             if (event.message) {
                 void this.deps.botCoordinator.tryDecryptChunk(event).catch((err) => {
                     this.logger.warn('bot chunk auto-decrypt failed', {
-                        id: event.stanzaId,
+                        id: event.key.id,
                         message: toError(err).message
                     })
                 })
@@ -328,19 +328,19 @@ export class WaClient extends EventEmitter {
             const protocolType = protocolMessage.type
             if (protocolType === null || protocolType === undefined) {
                 this.logger.debug('incoming protocol message without type', {
-                    id: event.stanzaId,
-                    from: event.chatJid
+                    id: event.key.id,
+                    from: event.key.remoteJid
                 })
                 return
             }
 
             if (protocolType === proto.Message.ProtocolMessage.Type.APP_STATE_SYNC_KEY_REQUEST) {
-                await this.appStateSync.handleIncomingKeyRequest(event, protocolMessage)
+                await this.appStateSync.handleIncomingKeyRequest(event.key, protocolMessage)
                 return
             }
 
             if (protocolType === proto.Message.ProtocolMessage.Type.APP_STATE_SYNC_KEY_SHARE) {
-                await this.appStateSync.handleIncomingKeyShare(event, protocolMessage)
+                await this.appStateSync.handleIncomingKeyShare(event.key, protocolMessage)
                 return
             }
 
@@ -370,16 +370,16 @@ export class WaClient extends EventEmitter {
 
             if (SYNC_RELATED_PROTOCOL_TYPES.has(protocolType)) {
                 this.logger.info('incoming sync-related protocol message', {
-                    id: event.stanzaId,
-                    from: event.chatJid,
+                    id: event.key.id,
+                    from: event.key.remoteJid,
                     protocolType
                 })
                 return
             }
 
             this.logger.debug('incoming protocol message received', {
-                id: event.stanzaId,
-                from: event.chatJid,
+                id: event.key.id,
+                from: event.key.remoteJid,
                 protocolType
             })
         } finally {

--- a/src/client/coordinators/WaBotCoordinator.ts
+++ b/src/client/coordinators/WaBotCoordinator.ts
@@ -457,25 +457,25 @@ export function createBotCoordinator(options: WaBotCoordinatorOptions): WaBotCoo
 
             const useEditTargetSalt =
                 editType === WA_BOT_MSG_EDIT_TYPES.INNER || editType === WA_BOT_MSG_EDIT_TYPES.LAST
-            const saltId = useEditTargetSalt ? editTargetId : event.stanzaId
+            const saltId = useEditTargetSalt ? editTargetId : event.key.id
             if (!saltId) {
                 logger.debug('bot chunk missing salt id', {
-                    id: event.stanzaId,
+                    id: event.key.id,
                     editType,
                     hasEditTargetId: !!editTargetId
                 })
                 return
             }
 
-            const senderJid = event.senderJid
+            const senderJid = event.key.participant ?? event.key.remoteJid
             if (!senderJid) {
-                logger.debug('bot chunk missing sender jid', { id: event.stanzaId })
+                logger.debug('bot chunk missing sender jid', { id: event.key.id })
                 return
             }
 
             const metaTargetSenderJid = metaNode?.attrs[WA_META_NODE_ATTRS_BOT.TARGET_SENDER_JID]
             const credentials = getCurrentCredentials()
-            const isFbidBotChat = event.chatJid ? isBotJid(event.chatJid) : false
+            const isFbidBotChat = event.key.remoteJid ? isBotJid(event.key.remoteJid) : false
             // FBID bot (`*@bot`) keys on user LID; legacy PN bot keys on user PN
             const meFallbackJid = isFbidBotChat
                 ? (credentials?.meLid ?? credentials?.meJid)
@@ -487,7 +487,7 @@ export function createBotCoordinator(options: WaBotCoordinatorOptions): WaBotCoo
                   : undefined
             if (!targetSenderJid) {
                 logger.debug('bot chunk missing target sender jid (no me jid)', {
-                    id: event.stanzaId,
+                    id: event.key.id,
                     isFbidBotChat
                 })
                 return
@@ -500,7 +500,7 @@ export function createBotCoordinator(options: WaBotCoordinatorOptions): WaBotCoo
             )
             if (!parentEntry) {
                 logger.debug('bot chunk parent message secret not found', {
-                    id: event.stanzaId,
+                    id: event.key.id,
                     targetId: targetMessageId
                 })
                 return
@@ -518,7 +518,7 @@ export function createBotCoordinator(options: WaBotCoordinatorOptions): WaBotCoo
                 })
             } catch (error) {
                 logger.warn('failed to decrypt bot chunk', {
-                    id: event.stanzaId,
+                    id: event.key.id,
                     targetId: targetMessageId,
                     editType,
                     message: toError(error).message
@@ -533,7 +533,7 @@ export function createBotCoordinator(options: WaBotCoordinatorOptions): WaBotCoo
                 decoded = proto.Message.decode(plaintext)
             } catch (error) {
                 logger.warn('failed to decode decrypted bot chunk', {
-                    id: event.stanzaId,
+                    id: event.key.id,
                     targetId: targetMessageId,
                     message: toError(error).message
                 })
@@ -542,11 +542,9 @@ export function createBotCoordinator(options: WaBotCoordinatorOptions): WaBotCoo
 
             emitBotChunk({
                 rawNode: event.rawNode,
-                stanzaId: event.stanzaId,
-                chatJid: event.chatJid,
+                key: event.key,
                 stanzaType: event.stanzaType,
                 offline: event.offline,
-                senderJid,
                 targetMessageId,
                 editType,
                 editTargetId,

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -347,7 +347,7 @@ export class WaMessageCoordinator {
         const options = (second as WaSendReceiptEventOptions | undefined) ?? {}
         const targets = events.map((event: WaIncomingMessageEvent) => {
             if (!event.key.remoteJid || !event.key.id) {
-                throw new Error('sendReceipt event is missing chatJid or stanzaId')
+                throw new Error('sendReceipt event is missing key.remoteJid or key.id')
             }
             const senderJid = event.key.participant ?? event.key.remoteJid
             return {

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -289,10 +289,10 @@ export class WaMessageCoordinator {
      * })
      *
      * // 4. React to an incoming message (empty emoji = unreact)
-     * await client.message.send(event.chatJid!, {
+     * await client.message.send(event.key.remoteJid, {
      *     type: 'reaction',
      *     emoji: '👍',
-     *     target: { stanzaId: event.stanzaId, fromMe: false, participant: event.senderJid }
+     *     target: event.key // or pass the whole event
      * })
      *
      * // 5. Poll
@@ -345,18 +345,19 @@ export class WaMessageCoordinator {
         }
         const events = Array.isArray(first) ? first : [first as WaIncomingMessageEvent]
         const options = (second as WaSendReceiptEventOptions | undefined) ?? {}
-        const targets = events.map((event) => {
-            if (!event.chatJid || !event.stanzaId) {
+        const targets = events.map((event: WaIncomingMessageEvent) => {
+            if (!event.key.remoteJid || !event.key.id) {
                 throw new Error('sendReceipt event is missing chatJid or stanzaId')
             }
+            const senderJid = event.key.participant ?? event.key.remoteJid
             return {
-                chatJid: event.chatJid,
-                id: event.stanzaId,
-                senderJid: event.senderJid
-                    ? applyDeviceToJid(event.senderJid, event.senderDevice)
+                chatJid: event.key.remoteJid,
+                id: event.key.id,
+                senderJid: senderJid
+                    ? applyDeviceToJid(senderJid, event.key.senderDevice)
                     : undefined,
-                isGroupChat: event.isGroupChat,
-                isBroadcastChat: event.isBroadcastChat
+                isGroupChat: event.key.isGroup,
+                isBroadcastChat: event.key.isBroadcast
             }
         })
         for (const group of aggregateReceiptTargets(targets)) {
@@ -461,14 +462,14 @@ export class WaMessageCoordinator {
         )
         if (!parentEntry) {
             this.logger.debug('addon parent message secret not found', {
-                id: event.stanzaId,
+                id: event.key.id,
                 targetId: targetMessageId
             })
             return
         }
 
         const parentMsgOriginalSender = parentEntry.senderJid
-        const modificationSender = event.senderJid ?? ''
+        const modificationSender = event.key.participant ?? event.key.remoteJid
 
         const plaintext = await decryptAddonPayload({
             messageSecret: parentEntry.secret,
@@ -496,13 +497,11 @@ export class WaMessageCoordinator {
         }
         this.emitAddon({
             rawNode: event.rawNode,
-            stanzaId: event.stanzaId,
-            chatJid: event.chatJid,
+            key: event.key,
             stanzaType: event.stanzaType,
             offline: event.offline,
             kind: addon.kind,
             targetMessageId,
-            senderJid: modificationSender,
             decrypted,
             raw: message
         })

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -330,20 +330,32 @@ export class WaMessageDispatchCoordinator {
         })
         const withCtx = ctx ? applyContextInfo(built.message, ctx) : built.message
         const withViewOnce = options.viewOnce ? wrapAsViewOnce(withCtx) : withCtx
-        const message = options.editKey
+        const editKey = options.editKey
+        let editId: string | undefined
+        let editParticipant: string | undefined
+        let editTimestamp: number | undefined
+        if (editKey) {
+            if ('rawNode' in editKey) {
+                editId = editKey.key?.id ?? undefined
+                editParticipant = editKey.key?.participant ?? undefined
+            } else {
+                editId = editKey.id
+                editParticipant = editKey.participant
+                editTimestamp = 'timestampMs' in editKey ? editKey.timestampMs : undefined
+            }
+        }
+        const message: Proto.IMessage = editKey
             ? {
                   protocolMessage: {
                       type: proto.Message.ProtocolMessage.Type.MESSAGE_EDIT,
                       key: {
                           remoteJid: recipientJid,
                           fromMe: true,
-                          id: options.editKey.stanzaId,
-                          ...(options.editKey.participant
-                              ? { participant: options.editKey.participant }
-                              : {})
+                          id: editId,
+                          ...(editParticipant ? { participant: editParticipant } : {})
                       },
                       editedMessage: withViewOnce,
-                      timestampMs: options.editKey.timestampMs ?? Date.now()
+                      timestampMs: editTimestamp ?? Date.now()
                   }
               }
             : withViewOnce

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -310,6 +310,9 @@ export class WaMessageDispatchCoordinator {
             ])
         }
         let optionsCtx = options.contextInfo
+        if (options.expirationSeconds !== undefined) {
+            optionsCtx = { ...optionsCtx, expirationSeconds: options.expirationSeconds }
+        }
         if (
             isGroupJid(recipientJid) &&
             optionsCtx?.expirationSeconds === undefined &&
@@ -417,7 +420,7 @@ export class WaMessageDispatchCoordinator {
         // omit enc.mediatype; sending type=media + mediatype=list/button alongside the
         // companion is rejected by the server as SMAX_INVALID (479).
         const type = buttonAddonKind ? 'text' : resolveMessageTypeAttr(messageWithIcdc)
-        const edit = resolveEditAttr(messageWithIcdc, sendOptions.subtype) ?? undefined
+        const edit = resolveEditAttr(messageWithIcdc) ?? undefined
         const mediatype = buttonAddonKind
             ? undefined
             : (resolveEncMediaType(messageWithIcdc) ?? undefined)
@@ -671,7 +674,7 @@ export class WaMessageDispatchCoordinator {
             type: resolveMessageTypeAttr(messageWithSecret),
             id: sendOptions.id,
             phash: extras.phash,
-            edit: resolveEditAttr(messageWithSecret, sendOptions.subtype) ?? undefined,
+            edit: resolveEditAttr(messageWithSecret) ?? undefined,
             mediatype: resolveEncMediaType(messageWithSecret) ?? undefined,
             decryptFail: resolveDecryptFailAttr(messageWithSecret),
             groupCiphertext: groupCiphertext.ciphertext,

--- a/src/client/coordinators/__tests__/retry-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/retry-coordinator.test.ts
@@ -335,8 +335,8 @@ test('placeholder resend: decodes WebMessageInfo and re-emits as incoming messag
     await flushPromise
     assert.equal(harness.emitted.length, 1)
     const event = harness.emitted[0]
-    assert.equal(event.stanzaId, 'recover-1')
-    assert.equal(event.chatJid, '551122223333@s.whatsapp.net')
+    assert.equal(event.key.id, 'recover-1')
+    assert.equal(event.key.remoteJid, '551122223333@s.whatsapp.net')
     assert.equal(event.encryptionType, 'placeholder_recovery')
     assert.equal(event.message?.conversation, 'recovered')
 })

--- a/src/client/messaging/__tests__/messaging.test.ts
+++ b/src/client/messaging/__tests__/messaging.test.ts
@@ -353,7 +353,8 @@ test('buildMediaMessageContent builds reaction message with key and emoji', asyn
             type: 'reaction',
             emoji: '🔥',
             target: {
-                stanzaId: 'STANZA1',
+                remoteJid: groupJid,
+                id: 'STANZA1',
                 fromMe: false,
                 participant: '551199999999@s.whatsapp.net'
             },
@@ -373,7 +374,11 @@ test('buildMediaMessageContent builds reaction message with key and emoji', asyn
 
     const revoke = await buildMediaMessageContent(
         BUILD_OPTIONS,
-        { type: 'reaction', emoji: '', target: { stanzaId: 'STANZA1', fromMe: true } },
+        {
+            type: 'reaction',
+            emoji: '',
+            target: { remoteJid: '551122222222@s.whatsapp.net', id: 'STANZA1', fromMe: true }
+        },
         { to: '551122222222@s.whatsapp.net' }
     )
     assert.equal(revoke.message.reactionMessage?.text, '')
@@ -385,7 +390,7 @@ test('buildMediaMessageContent builds reaction message with key and emoji', asyn
             buildMediaMessageContent(BUILD_OPTIONS, {
                 type: 'reaction',
                 emoji: '🔥',
-                target: { stanzaId: 'STANZA1', fromMe: true }
+                target: { remoteJid: '551122222222@s.whatsapp.net', id: 'STANZA1', fromMe: true }
             }),
         /requires to in build context/
     )
@@ -395,7 +400,7 @@ test('buildMediaMessageContent builds revoke protocolMessage', async () => {
     const chatJid = '551122222222@s.whatsapp.net'
     const own = await buildMediaMessageContent(
         BUILD_OPTIONS,
-        { type: 'revoke', stanzaId: 'STANZA2' },
+        { type: 'revoke', target: { remoteJid: chatJid, id: 'STANZA2', fromMe: true } },
         { to: chatJid }
     )
     assert.equal(own.message.protocolMessage?.type, proto.Message.ProtocolMessage.Type.REVOKE)
@@ -409,9 +414,12 @@ test('buildMediaMessageContent builds revoke protocolMessage', async () => {
         BUILD_OPTIONS,
         {
             type: 'revoke',
-            stanzaId: 'STANZA3',
-            fromMe: false,
-            participant: '551199999999@s.whatsapp.net'
+            target: {
+                remoteJid: '120363000000000000@g.us',
+                id: 'STANZA3',
+                fromMe: false,
+                participant: '551199999999@s.whatsapp.net'
+            }
         },
         { to: '120363000000000000@g.us' }
     )
@@ -423,7 +431,11 @@ test('buildMediaMessageContent builds revoke protocolMessage', async () => {
     })
 
     await assert.rejects(
-        () => buildMediaMessageContent(BUILD_OPTIONS, { type: 'revoke', stanzaId: 'X' }),
+        () =>
+            buildMediaMessageContent(BUILD_OPTIONS, {
+                type: 'revoke',
+                target: { remoteJid: '551122222222@s.whatsapp.net', id: 'X', fromMe: true }
+            }),
         /requires to in build context/
     )
 })
@@ -434,7 +446,7 @@ test('buildMediaMessageContent builds pin/unpin with PinInChatMessage Type enum'
         BUILD_OPTIONS,
         {
             type: 'pin',
-            target: { stanzaId: 'S1', fromMe: true },
+            target: { remoteJid: chatJid, id: 'S1', fromMe: true },
             senderTimestampMs: 1_700_000_000_000
         },
         { to: chatJid }
@@ -448,7 +460,7 @@ test('buildMediaMessageContent builds pin/unpin with PinInChatMessage Type enum'
 
     const unpin = await buildMediaMessageContent(
         BUILD_OPTIONS,
-        { type: 'unpin', target: { stanzaId: 'S1', fromMe: true } },
+        { type: 'unpin', target: { remoteJid: chatJid, id: 'S1', fromMe: true } },
         { to: chatJid }
     )
     assert.equal(
@@ -461,13 +473,13 @@ test('buildMediaMessageContent builds keep/unkeep with KeepType enum', async () 
     const chatJid = '551122222222@s.whatsapp.net'
     const keep = await buildMediaMessageContent(
         BUILD_OPTIONS,
-        { type: 'keep', target: { stanzaId: 'S3', fromMe: true } },
+        { type: 'keep', target: { remoteJid: chatJid, id: 'S3', fromMe: true } },
         { to: chatJid }
     )
     assert.equal(keep.message.keepInChatMessage?.keepType, proto.KeepType.KEEP_FOR_ALL)
     const unkeep = await buildMediaMessageContent(
         BUILD_OPTIONS,
-        { type: 'unkeep', target: { stanzaId: 'S3', fromMe: true } },
+        { type: 'unkeep', target: { remoteJid: chatJid, id: 'S3', fromMe: true } },
         { to: chatJid }
     )
     assert.equal(unkeep.message.keepInChatMessage?.keepType, proto.KeepType.UNDO_KEEP_FOR_ALL)
@@ -541,7 +553,7 @@ test('buildMediaMessageContent encrypts poll-vote with addon-crypto and hashes o
         {
             type: 'poll-vote',
             poll: {
-                stanzaId: 'POLL_PARENT',
+                id: 'POLL_PARENT',
                 fromMe: false,
                 authorJid: '551100000000@s.whatsapp.net',
                 participant: '551100000000@s.whatsapp.net',
@@ -575,7 +587,7 @@ test('buildMediaMessageContent encrypts poll-vote with addon-crypto and hashes o
                 {
                     type: 'poll-vote',
                     poll: {
-                        stanzaId: 'P',
+                        id: 'P',
                         fromMe: false,
                         authorJid: 'a',
                         messageSecret
@@ -595,7 +607,7 @@ test('buildMediaMessageContent encrypts event-response with addon-crypto and cho
         {
             type: 'event-response',
             event: {
-                stanzaId: 'EVENT_PARENT',
+                id: 'EVENT_PARENT',
                 fromMe: false,
                 authorJid: '551100000000@s.whatsapp.net',
                 participant: '551100000000@s.whatsapp.net',

--- a/src/client/messaging/messages.ts
+++ b/src/client/messaging/messages.ts
@@ -44,7 +44,8 @@ import {
     isSendPollVoteMessage,
     isSendReactionMessage,
     isSendRevokeMessage,
-    isSendTextMessage
+    isSendTextMessage,
+    resolveMessageTarget
 } from '@message/encode/content'
 import {
     toStickerPackProtoStickers,
@@ -53,6 +54,7 @@ import {
 } from '@message/kinds/sticker-pack'
 import type {
     WaMessageBuildResult,
+    WaMessageKey,
     WaMessageUploadInfo,
     WaSendEventMessage,
     WaSendEventResponseMessage,
@@ -70,7 +72,7 @@ import type {
 } from '@message/types'
 import { proto, type Proto } from '@proto'
 import { WA_DEFAULTS } from '@protocol/constants'
-import { toUserJid } from '@protocol/jid'
+import { isBroadcastJid, isGroupJid, toUserJid } from '@protocol/jid'
 import { buildMediaConnIq } from '@transport/node/builders/media'
 import type { BinaryNode } from '@transport/types'
 import { bytesToBase64, TEXT_ENCODER, toBytesView } from '@util/bytes'
@@ -129,6 +131,16 @@ function buildMessageKey(
     }
 }
 
+/**
+ * Builds the proto key for a reply/edit/reaction/revoke/pin target. `remoteJid`
+ * is forced to the send recipient and `participant` is dropped in 1:1 chats
+ * (only meaningful in groups/broadcasts).
+ */
+function targetMessageKey(remoteJid: string, key: WaMessageKey): Proto.IMessageKey {
+    const inGroup = isGroupJid(remoteJid) || isBroadcastJid(remoteJid)
+    return buildMessageKey(remoteJid, key.fromMe, key.id, inGroup ? key.participant : undefined)
+}
+
 function buildReactionMessage(
     content: WaSendReactionMessage,
     ctx?: WaBuildMessageContext
@@ -136,12 +148,7 @@ function buildReactionMessage(
     requireCtxField(ctx, 'to', 'reaction')
     return {
         reactionMessage: {
-            key: buildMessageKey(
-                ctx!.to,
-                content.target.fromMe,
-                content.target.stanzaId,
-                content.target.participant
-            ),
+            key: targetMessageKey(ctx!.to, resolveMessageTarget(content.target)),
             text: content.emoji,
             senderTimestampMs: content.senderTimestampMs ?? Date.now()
         }
@@ -156,12 +163,7 @@ function buildRevokeMessage(
     return {
         protocolMessage: {
             type: proto.Message.ProtocolMessage.Type.REVOKE,
-            key: buildMessageKey(
-                ctx!.to,
-                content.fromMe ?? true,
-                content.stanzaId,
-                content.participant
-            )
+            key: targetMessageKey(ctx!.to, resolveMessageTarget(content.target))
         }
     }
 }
@@ -170,12 +172,7 @@ function buildPinMessage(content: WaSendPinMessage, ctx?: WaBuildMessageContext)
     requireCtxField(ctx, 'to', content.type)
     return {
         pinInChatMessage: {
-            key: buildMessageKey(
-                ctx!.to,
-                content.target.fromMe,
-                content.target.stanzaId,
-                content.target.participant
-            ),
+            key: targetMessageKey(ctx!.to, resolveMessageTarget(content.target)),
             type:
                 content.type === 'pin'
                     ? proto.Message.PinInChatMessage.Type.PIN_FOR_ALL
@@ -189,12 +186,7 @@ function buildKeepMessage(content: WaSendKeepMessage, ctx?: WaBuildMessageContex
     requireCtxField(ctx, 'to', content.type)
     return {
         keepInChatMessage: {
-            key: buildMessageKey(
-                ctx!.to,
-                content.target.fromMe,
-                content.target.stanzaId,
-                content.target.participant
-            ),
+            key: targetMessageKey(ctx!.to, resolveMessageTarget(content.target)),
             keepType:
                 content.type === 'keep'
                     ? proto.KeepType.KEEP_FOR_ALL
@@ -298,7 +290,7 @@ async function buildPollVoteMessage(
     const payload = proto.Message.PollVoteMessage.encode({ selectedOptions }).finish()
     const { encPayload, encIv } = await encryptAddonForOutgoing({
         messageSecret: content.poll.messageSecret,
-        parentStanzaId: content.poll.stanzaId,
+        parentStanzaId: content.poll.id,
         parentMsgOriginalSender: toUserJid(content.poll.authorJid),
         modificationSender: toUserJid(ctx!.meJid!),
         modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.POLL_VOTE,
@@ -309,7 +301,7 @@ async function buildPollVoteMessage(
             pollCreationMessageKey: buildMessageKey(
                 ctx!.to,
                 content.poll.fromMe,
-                content.poll.stanzaId,
+                content.poll.id,
                 content.poll.participant
             ),
             vote: { encPayload, encIv },
@@ -334,7 +326,7 @@ async function buildEventResponseMessage(
     const payload = proto.Message.EventResponseMessage.encode(responseProto).finish()
     const { encPayload, encIv } = await encryptAddonForOutgoing({
         messageSecret: content.event.messageSecret,
-        parentStanzaId: content.event.stanzaId,
+        parentStanzaId: content.event.id,
         parentMsgOriginalSender: toUserJid(content.event.authorJid),
         modificationSender: toUserJid(ctx!.meJid!),
         modificationType: WA_USE_CASE_SECRET_MODIFICATION_TYPES.EVENT_RESPONSE,
@@ -345,7 +337,7 @@ async function buildEventResponseMessage(
             eventCreationMessageKey: buildMessageKey(
                 ctx!.to,
                 content.event.fromMe,
-                content.event.stanzaId,
+                content.event.id,
                 content.event.participant
             ),
             encPayload,

--- a/src/client/persistence/mailbox.ts
+++ b/src/client/persistence/mailbox.ts
@@ -19,7 +19,8 @@ function persistContacts(
     event: WaIncomingMessageEvent,
     nowMs: number
 ): void {
-    const senderJid = event.key.participant ?? event.key.remoteJid
+    const senderJid =
+        event.key.participant ?? event.rawNode.attrs.participant ?? event.key.remoteJid
     const rawParticipant = event.rawNode.attrs.participant
     const participantJid = rawParticipant ? toUserJid(rawParticipant) : undefined
     if (!senderJid && !participantJid) {
@@ -49,7 +50,8 @@ export function persistIncomingMailboxEntities(options: WaPersistIncomingMailbox
         writeBehind.persistMessage({
             id: stanzaId,
             threadJid: chatJid,
-            senderJid: event.key.participant ?? event.key.remoteJid,
+            senderJid:
+                event.key.participant ?? event.rawNode.attrs.participant ?? event.key.remoteJid,
             participantJid: event.rawNode.attrs.participant,
             fromMe: false,
             timestampMs:
@@ -66,7 +68,8 @@ export function persistIncomingMailboxEntities(options: WaPersistIncomingMailbox
             event.message &&
             needsSecretPersistence(event.message)
         ) {
-            const rawSender = event.key.participant ?? event.key.remoteJid
+            const rawSender =
+                event.key.participant ?? event.rawNode.attrs.participant ?? event.key.remoteJid
             const senderJid = rawSender ? toUserJid(rawSender) : ''
             void messageSecretStore
                 .set(stanzaId, { secret: rawSecret, senderJid })

--- a/src/client/persistence/mailbox.ts
+++ b/src/client/persistence/mailbox.ts
@@ -19,7 +19,7 @@ function persistContacts(
     event: WaIncomingMessageEvent,
     nowMs: number
 ): void {
-    const senderJid = event.senderJid
+    const senderJid = event.key.participant ?? event.key.remoteJid
     const rawParticipant = event.rawNode.attrs.participant
     const participantJid = rawParticipant ? toUserJid(rawParticipant) : undefined
     if (!senderJid && !participantJid) {
@@ -35,7 +35,8 @@ function persistContacts(
 
 export function persistIncomingMailboxEntities(options: WaPersistIncomingMailboxOptions): void {
     const { logger, writeBehind, messageSecretStore, event } = options
-    const { stanzaId, chatJid } = event
+    const stanzaId = event.key.id
+    const chatJid = event.key.remoteJid
     if (!stanzaId || !chatJid) {
         return
     }
@@ -48,7 +49,7 @@ export function persistIncomingMailboxEntities(options: WaPersistIncomingMailbox
         writeBehind.persistMessage({
             id: stanzaId,
             threadJid: chatJid,
-            senderJid: event.senderJid,
+            senderJid: event.key.participant ?? event.key.remoteJid,
             participantJid: event.rawNode.attrs.participant,
             fromMe: false,
             timestampMs:
@@ -65,7 +66,7 @@ export function persistIncomingMailboxEntities(options: WaPersistIncomingMailbox
             event.message &&
             needsSecretPersistence(event.message)
         ) {
-            const rawSender = event.senderJid ?? event.rawNode.attrs.participant
+            const rawSender = event.key.participant ?? event.key.remoteJid
             const senderJid = rawSender ? toUserJid(rawSender) : ''
             void messageSecretStore
                 .set(stanzaId, { secret: rawSecret, senderJid })

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -12,7 +12,12 @@ import type { WaMediaProcessor } from '@media/processor'
 import type { WaLinkPreviewOptions } from '@message/addons/link-preview/types'
 import type { WaQuoteRef, WaSendContextInfo } from '@message/context-info'
 import type { WaDecodedAddon } from '@message/crypto/addon-crypto'
-import type { WaMessagePublishOptions, WaSendEditKey } from '@message/types'
+import type {
+    WaMessageKey,
+    WaMessagePublishOptions,
+    WaMessageRef,
+    WaSendEditKey
+} from '@message/types'
 import type { Proto } from '@proto'
 import type { WaBotMsgEditType } from '@protocol/bot'
 import type { WaBusinessHoursDay, WaBusinessHoursMode } from '@protocol/business'
@@ -321,7 +326,7 @@ export interface WaSendMessageOptions extends WaMessagePublishOptions {
      * pre-built `WaQuoteRef`) and the coordinator fills the quote fields in
      * `contextInfo` for you.
      */
-    readonly quote?: WaIncomingMessageEvent | WaQuoteRef
+    readonly quote?: WaIncomingMessageEvent | WaQuoteRef | WaMessageKey
     /**
      * Mark as forwarded. `true` increments the forward score; `{ score }`
      * sets it explicitly (use the score from the source message's contextInfo
@@ -345,9 +350,11 @@ export interface WaSendMessageOptions extends WaMessagePublishOptions {
     readonly viewOnce?: boolean
     /**
      * Edit a previously-sent message: the `content` argument becomes the new payload
-     * and gets wrapped in a `MESSAGE_EDIT` protocolMessage targeting `editKey.stanzaId`.
+     * and gets wrapped in a `MESSAGE_EDIT` protocolMessage targeting the message id.
+     * Pass a received `message` event verbatim, its `key`, or an explicit
+     * {@link WaSendEditKey} (`fromMe` is forced true, `remoteJid` is the recipient).
      */
-    readonly editKey?: WaSendEditKey
+    readonly editKey?: WaMessageKey | WaSendEditKey | WaMessageRef
     /**
      * Override the auto-generated `messageContextInfo.messageSecret` (32 bytes).
      * Use to share a known secret across follow-up addons or for deterministic tests.
@@ -420,21 +427,42 @@ export interface WaIncomingBaseEvent {
     readonly offline?: boolean
 }
 
-export interface WaIncomingMessageEvent extends WaIncomingBaseEvent {
-    readonly timestampSeconds?: number
-    readonly senderJid?: string
-    readonly senderAlt?: string
-    readonly senderDevice?: number
+/**
+ * A received message's key. Extends the proto {@link WaMessageKey}
+ * (`remoteJid`/`id`/`fromMe`/`participant`) with the message's addressing and
+ * sender metadata. It stays assignable to `Proto.IMessageKey` (the extra fields
+ * are ignored there) and can be passed verbatim to reply / edit / react /
+ * revoke / pin / quote.
+ */
+export interface WaIncomingMessageKey extends WaMessageKey {
+    readonly isGroup: boolean
+    readonly isBroadcast: boolean
+    readonly isNewsletter: boolean
+    /** The `remoteJid`'s alternate addressing — the pn when addressed by lid, or vice-versa (1:1 chats). */
+    readonly remoteJidAlt?: string
+    /** The `participant`'s alternate addressing — the pn when addressed by lid, or vice-versa (group chats). */
+    readonly participantAlt?: string
+    /** Sender's device id — `0` when the source JID has no `:device` segment. */
+    readonly senderDevice: number
     readonly senderUsername?: string
     readonly recipientJid?: string
     readonly recipientAlt?: string
+    /** Server-assigned message id (newsletters / channel messages). */
+    readonly serverId?: number
+}
+
+export interface WaIncomingMessageEvent extends Omit<WaIncomingBaseEvent, 'chatJid' | 'stanzaId'> {
+    /**
+     * The message key: the proto fields (`remoteJid` = chat, `id` = stanza id,
+     * `fromMe`, `participant` = author) plus chat/sender addressing metadata
+     * (`isGroup`, `participantAlt`, ...). Pass it (or the whole event) verbatim to
+     * reply / edit / react / revoke / pin / quote. `remoteJid`/`id` supersede the
+     * old top-level `chatJid`/`stanzaId`.
+     */
+    readonly key: WaIncomingMessageKey
+    readonly timestampSeconds?: number
     readonly pushName?: string
     readonly encryptionType?: string
-    readonly isGroupChat: boolean
-    readonly isBroadcastChat: boolean
-    readonly isNewsletterChat?: boolean
-    readonly serverId?: number
-    readonly isSender?: boolean
     readonly plaintext?: Uint8Array
     readonly message?: Proto.IMessage
 }
@@ -671,16 +699,26 @@ export type WaAddonKind =
     | 'poll_edit'
     | 'poll_add_option'
 
-export interface WaIncomingAddonEvent extends WaIncomingBaseEvent {
+export interface WaIncomingAddonEvent extends Omit<WaIncomingBaseEvent, 'chatJid' | 'stanzaId'> {
+    /**
+     * The addon message's key (proto fields + addressing metadata). The sender is
+     * `key.participant ?? key.remoteJid`. Supersedes the old `chatJid` / `stanzaId`
+     * / `senderJid`.
+     */
+    readonly key: WaIncomingMessageKey
     readonly kind: WaAddonKind
     readonly targetMessageId: string
-    readonly senderJid: string
     readonly decrypted: WaDecodedAddon
     readonly raw: Proto.IMessage
 }
 
-export interface WaIncomingBotChunkEvent extends WaIncomingBaseEvent {
-    readonly senderJid: string
+export interface WaIncomingBotChunkEvent extends Omit<WaIncomingBaseEvent, 'chatJid' | 'stanzaId'> {
+    /**
+     * The chunk message's key (proto fields + addressing metadata). The sender is
+     * `key.participant ?? key.remoteJid`. Supersedes the old `chatJid` / `stanzaId`
+     * / `senderJid`.
+     */
+    readonly key: WaIncomingMessageKey
     readonly targetMessageId: string
     readonly editType: WaBotMsgEditType
     readonly editTargetId?: string

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -309,14 +309,6 @@ export interface WaSendMessageOptions extends WaMessagePublishOptions {
      */
     readonly expectedIdentity?: Uint8Array
     /**
-     * Disambiguator for the resolved `edit` stanza attribute. Today only
-     * `'admin_revoke'` is meaningful – pass it when a group admin is
-     * revoking another participant's message so the outgoing stanza is
-     * tagged `edit="8"` (admin revoke) instead of `edit="7"` (sender revoke).
-     * Any other value is ignored.
-     */
-    readonly subtype?: string
-    /**
      * Optional context info to merge into the outgoing message – quoted message,
      * mentioned JIDs, forward score, link-preview override, etc. (see {@link WaSendContextInfo}).
      */
@@ -339,9 +331,24 @@ export interface WaSendMessageOptions extends WaMessagePublishOptions {
      */
     readonly mentions?: readonly string[]
     /**
+     * Disappearing-message expiration in seconds for this message. When set (any
+     * value, including `0`), this is the winner: it overrides both
+     * `contextInfo.expirationSeconds` and the automatic group-ephemeral inject
+     * (the latter is short-circuited because the value is now defined). To send a
+     * single message with NO expiration into a group with disappearing-mode on,
+     * prefer `disableGroupEphemeralAutoInject: true` over `expirationSeconds: 0` —
+     * the latter still writes `expiration=0` into the outgoing `contextInfo`.
+     */
+    readonly expirationSeconds?: number
+    /**
      * Skip the automatic `ephemeralSettingTimestamp`/`expiration` injection
-     * applied for messages sent into groups with disappearing-mode on. Off by
-     * default – only set when you're managing those fields manually.
+     * applied to messages sent into groups with disappearing-mode on (the cached
+     * group ephemeral is otherwise fetched and applied for you). Off by default.
+     *
+     * Relationship with {@link expirationSeconds}: a non-undefined
+     * `expirationSeconds` already short-circuits the auto-inject, so this flag is
+     * redundant in that case. Use this flag when you want to suppress the
+     * auto-inject AND not set any expiration yourself.
      */
     readonly disableGroupEphemeralAutoInject?: boolean
     /** Raw child nodes appended to the `<message>` stanza. Escape hatch for protocol features the typed API doesn't cover. */
@@ -461,6 +468,13 @@ export interface WaIncomingMessageEvent extends Omit<WaIncomingBaseEvent, 'chatJ
      */
     readonly key: WaIncomingMessageKey
     readonly timestampSeconds?: number
+    /**
+     * Disappearing-message TTL the sender attached to this message, in seconds.
+     * Read from the first submessage carrying `contextInfo.expiration`
+     * (`extendedTextMessage`, `imageMessage`, …). Undefined when the message is
+     * not ephemeral.
+     */
+    readonly expirationSeconds?: number
     readonly pushName?: string
     readonly encryptionType?: string
     readonly plaintext?: Uint8Array

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export type {
     WaIncomingErrorStanzaEvent,
     WaIncomingFailureEvent,
     WaIncomingMessageEvent,
+    WaIncomingMessageKey,
     WaIncomingNewsletterEvent,
     WaIncomingNewsletterMessageUpdateEvent,
     WaIncomingNodeHandler,
@@ -176,8 +177,11 @@ export type {
 export type {
     WaEncryptedMessageInput,
     WaMessageAckMetadata,
+    WaMessageKey,
     WaMessagePublishOptions,
     WaMessagePublishResult,
+    WaMessageRef,
+    WaMessageTargetInput,
     WaSendEditKey,
     WaSendEventLocation,
     WaSendEventMessage,
@@ -187,14 +191,12 @@ export type {
     WaSendKeepMessage,
     WaSendMediaMessage,
     WaSendMessageContent,
-    WaSendMessageTarget,
     WaSendPinMessage,
     WaSendPollMessage,
     WaSendPollOptionInput,
     WaSendPollParent,
     WaSendPollVoteMessage,
     WaSendReactionMessage,
-    WaSendReactionTarget,
     WaSendReceiptEventOptions,
     WaSendReceiptInput,
     WaSendReceiptOptions,
@@ -204,7 +206,7 @@ export type {
     WaSendStickerPackTrayIcon,
     WaSendTextMessage
 } from '@message/types'
-export { getContentType } from '@message/encode/content'
+export { getContentType, resolveMessageTarget } from '@message/encode/content'
 export type { WaSendContextInfo } from '@message/context-info'
 export type {
     WaLinkPreviewFetcher,

--- a/src/message/__tests__/context-info.test.ts
+++ b/src/message/__tests__/context-info.test.ts
@@ -90,7 +90,7 @@ test('resolveSendContextInfo returns null when nothing was provided', () => {
 
 test('resolveSendContextInfo resolves quote from WaIncomingMessageEvent shape', () => {
     const result = resolveSendContextInfo({
-        quote: { stanzaId: 'm-1', chatJid: 'group@g.us', senderJid: 'a@s.whatsapp.net' }
+        quote: { key: { id: 'm-1', remoteJid: 'group@g.us', participant: 'a@s.whatsapp.net' } }
     })
     assert.deepEqual(result, {
         quotedMessageId: 'm-1',
@@ -103,7 +103,7 @@ test('resolveSendContextInfo resolves quote from WaIncomingMessageEvent shape', 
 test('resolveSendContextInfo resolves quote from WaQuoteRef shape', () => {
     const result = resolveSendContextInfo({
         quote: {
-            stanzaId: 'm-2',
+            id: 'm-2',
             participant: 'a@s.whatsapp.net',
             remoteJid: 'group@g.us',
             message: { conversation: 'orig' }
@@ -142,7 +142,7 @@ test('resolveSendContextInfo merges content-level + options-level + quote + forw
     const result = resolveSendContextInfo({
         contentLevel: { isSpoiler: true },
         optionsLevel: { groupSubject: 'G' },
-        quote: { stanzaId: 'q-1', chatJid: 'g@g.us', senderJid: 'a@s.whatsapp.net' },
+        quote: { key: { id: 'q-1', remoteJid: 'g@g.us', participant: 'a@s.whatsapp.net' } },
         forward: true,
         mentions: ['a@s.whatsapp.net']
     })

--- a/src/message/__tests__/message.test.ts
+++ b/src/message/__tests__/message.test.ts
@@ -85,18 +85,24 @@ test('content helpers detect media payload and resolve message type', () => {
         isSendReactionMessage({
             type: 'reaction',
             emoji: '👍',
-            target: { stanzaId: 'A', fromMe: false }
+            target: { remoteJid: 'x@s.whatsapp.net', id: 'A', fromMe: false }
         }),
         true
     )
     assert.equal(isSendReactionMessage({ type: 'reaction', emoji: '👍' }), false)
     assert.equal(isSendReactionMessage({ type: 'text', text: 'hi' }), false)
 
-    assert.equal(isSendRevokeMessage({ type: 'revoke', stanzaId: 'A' }), true)
+    assert.equal(
+        isSendRevokeMessage({
+            type: 'revoke',
+            target: { remoteJid: 'x@s.whatsapp.net', id: 'A', fromMe: true }
+        }),
+        true
+    )
     assert.equal(isSendRevokeMessage({ type: 'revoke' }), false)
     assert.equal(isSendRevokeMessage({ type: 'text', text: 'hi' }), false)
 
-    const target = { stanzaId: 'A', fromMe: true }
+    const target = { remoteJid: 'x@s.whatsapp.net', id: 'A', fromMe: true }
     assert.equal(isSendPinMessage({ type: 'pin', target }), true)
     assert.equal(isSendPinMessage({ type: 'unpin', target }), true)
     assert.equal(isSendPinMessage({ type: 'pin' }), false)
@@ -110,7 +116,7 @@ test('content helpers detect media payload and resolve message type', () => {
     assert.equal(
         isSendPollVoteMessage({
             type: 'poll-vote',
-            poll: { stanzaId: 'A', fromMe: false, authorJid: 'x', messageSecret: new Uint8Array() },
+            poll: { id: 'A', fromMe: false, authorJid: 'x', messageSecret: new Uint8Array() },
             selectedOptionNames: ['x']
         }),
         true
@@ -124,7 +130,7 @@ test('content helpers detect media payload and resolve message type', () => {
         isSendEventResponseMessage({
             type: 'event-response',
             event: {
-                stanzaId: 'A',
+                id: 'A',
                 fromMe: false,
                 authorJid: 'x',
                 messageSecret: new Uint8Array()
@@ -138,7 +144,7 @@ test('content helpers detect media payload and resolve message type', () => {
     assert.equal(
         isSendAddonCryptoMessage({
             type: 'poll-vote',
-            poll: { stanzaId: 'A', fromMe: false, authorJid: 'x', messageSecret: new Uint8Array() },
+            poll: { id: 'A', fromMe: false, authorJid: 'x', messageSecret: new Uint8Array() },
             selectedOptionNames: ['x']
         }),
         true
@@ -785,15 +791,15 @@ test('processIncomingNewsletterMessage decodes plaintext message and emits event
     assert.equal(unhandled, null)
     assert.ok(emitted)
     const event = emitted as unknown as WaIncomingMessageEvent
-    assert.equal(event.chatJid, '120363025343298869@newsletter')
-    assert.equal(event.senderJid, '120363025343298869@newsletter')
+    assert.equal(event.key.remoteJid, '120363025343298869@newsletter')
+    assert.equal(event.key.participant, undefined)
     assert.equal(event.encryptionType, 'plaintext')
-    assert.equal(event.isNewsletterChat, true)
-    assert.equal(event.isGroupChat, false)
-    assert.equal(event.isBroadcastChat, false)
+    assert.equal(event.key.isNewsletter, true)
+    assert.equal(event.key.isGroup, false)
+    assert.equal(event.key.isBroadcast, false)
     assert.equal(event.timestampSeconds, 1700000000)
-    assert.equal(event.serverId, 12345)
-    assert.equal(event.isSender, true)
+    assert.equal(event.key.serverId, 12345)
+    assert.equal(event.key.fromMe, true)
     assert.equal(event.message?.conversation, 'hello channel')
 })
 

--- a/src/message/__tests__/message.test.ts
+++ b/src/message/__tests__/message.test.ts
@@ -287,7 +287,8 @@ test('content helpers unwrap deeply nested wrappers for edit and media attrs', (
 test('resolveEditAttr maps protobuf to correct edit attribute values', () => {
     assert.equal(resolveEditAttr({ conversation: 'hello' }), null)
     assert.equal(resolveEditAttr({ protocolMessage: { type: 0 } }), '7')
-    assert.equal(resolveEditAttr({ protocolMessage: { type: 0 } }, 'admin_revoke'), '8')
+    assert.equal(resolveEditAttr({ protocolMessage: { type: 0, key: { fromMe: true } } }), '7')
+    assert.equal(resolveEditAttr({ protocolMessage: { type: 0, key: { fromMe: false } } }), '8')
     assert.equal(resolveEditAttr({ protocolMessage: { type: 14 } }), '1')
     assert.equal(resolveEditAttr({ reactionMessage: { text: '' } }), '7')
     assert.equal(resolveEditAttr({ reactionMessage: { text: '\u{1F44D}' } }), null)

--- a/src/message/context-info.ts
+++ b/src/message/context-info.ts
@@ -86,6 +86,33 @@ export function applyContextInfo(
     return next
 }
 
+/**
+ * Reads the disappearing-message TTL (`contextInfo.expiration`) from the first
+ * submessage that carries it. Unwraps `ephemeralMessage` if present. Returns
+ * `undefined` when no submessage has an `expiration` set.
+ */
+export function pickIncomingExpirationSeconds(
+    message: Proto.IMessage | undefined
+): number | undefined {
+    if (!message) return undefined
+    const inner = message.ephemeralMessage?.message ?? message
+    for (const key of Object.keys(inner)) {
+        const value = (inner as Record<string, unknown>)[key]
+        if (
+            value &&
+            typeof value === 'object' &&
+            !Array.isArray(value) &&
+            !(value instanceof Uint8Array)
+        ) {
+            const ctx = (value as ContextInfoCarrier).contextInfo
+            if (ctx?.expiration !== undefined && ctx.expiration !== null) {
+                return ctx.expiration
+            }
+        }
+    }
+    return undefined
+}
+
 function pickContextInfoTarget(message: Proto.IMessage): ContextInfoCarrier | null {
     for (const key of Object.keys(message)) {
         const value = (message as Record<string, unknown>)[key]
@@ -108,7 +135,11 @@ function pickContextInfoTarget(message: Proto.IMessage): ContextInfoCarrier | nu
  * public `quote` option type enforces the concrete shape.
  */
 type WaQuoteSource = {
-    readonly key?: { readonly id?: string; readonly remoteJid?: string; readonly participant?: string }
+    readonly key?: {
+        readonly id?: string
+        readonly remoteJid?: string
+        readonly participant?: string
+    }
     readonly id?: string
     readonly remoteJid?: string
     readonly participant?: string

--- a/src/message/context-info.ts
+++ b/src/message/context-info.ts
@@ -21,7 +21,7 @@ export interface WaSendContextInfo {
 }
 
 export interface WaQuoteRef {
-    readonly stanzaId: string
+    readonly id: string
     readonly participant?: string
     readonly remoteJid?: string
     readonly message?: Proto.IMessage
@@ -101,14 +101,19 @@ function pickContextInfoTarget(message: Proto.IMessage): ContextInfoCarrier | nu
     return null
 }
 
-type WaQuoteSource =
-    | WaQuoteRef
-    | {
-          readonly stanzaId?: string
-          readonly chatJid?: string
-          readonly senderJid?: string
-          readonly message?: Proto.IMessage
-      }
+/**
+ * Anything that identifies a quoted message. Accepts a {@link WaQuoteRef}, a
+ * {@link WaMessageKey} (bare proto key), or a full incoming message event (its
+ * `key` + `message` are read). All fields are optional structurally — the
+ * public `quote` option type enforces the concrete shape.
+ */
+type WaQuoteSource = {
+    readonly key?: { readonly id?: string; readonly remoteJid?: string; readonly participant?: string }
+    readonly id?: string
+    readonly remoteJid?: string
+    readonly participant?: string
+    readonly message?: Proto.IMessage
+}
 
 type WaForwardSource = boolean | { readonly score?: number }
 
@@ -130,15 +135,9 @@ export function resolveSendContextInfo(input: WaSendContextResolveInput): WaSend
 
     if (input.quote) {
         const q = input.quote
-        ctx.quotedMessageId = q.stanzaId ?? ctx.quotedMessageId
-        ctx.quotedParticipant =
-            ('participant' in q ? q.participant : undefined) ??
-            ('senderJid' in q ? q.senderJid : undefined) ??
-            ctx.quotedParticipant
-        ctx.quotedRemoteJid =
-            ('remoteJid' in q ? q.remoteJid : undefined) ??
-            ('chatJid' in q ? q.chatJid : undefined) ??
-            ctx.quotedRemoteJid
+        ctx.quotedMessageId = q.id ?? q.key?.id ?? ctx.quotedMessageId
+        ctx.quotedParticipant = q.participant ?? q.key?.participant ?? ctx.quotedParticipant
+        ctx.quotedRemoteJid = q.remoteJid ?? q.key?.remoteJid ?? ctx.quotedRemoteJid
         ctx.quotedMessage = q.message ?? ctx.quotedMessage
     }
 

--- a/src/message/encode/content.ts
+++ b/src/message/encode/content.ts
@@ -1,4 +1,6 @@
 import type {
+    WaMessageKey,
+    WaMessageTargetInput,
     WaSendEventMessage,
     WaSendEventResponseMessage,
     WaSendKeepMessage,
@@ -34,6 +36,23 @@ export function getContentType(
             (k === 'conversation' || k.includes('Message')) && k !== 'senderKeyDistributionMessage'
     )
     return key as keyof Proto.IMessage | undefined
+}
+
+/**
+ * Normalizes a reply/edit/reaction/revoke/pin target into a {@link WaMessageKey}:
+ * an explicit key is returned as-is, while a received `message` event
+ * ({@link WaMessageRef}, identified by its `rawNode`) yields its pre-computed
+ * `key`.
+ */
+export function resolveMessageTarget(ref: WaMessageTargetInput): WaMessageKey {
+    if (!('rawNode' in ref)) {
+        return ref
+    }
+    const key = ref.key
+    if (key === undefined || typeof key.id !== 'string') {
+        throw new Error('message event used as a target is missing key.id')
+    }
+    return key
 }
 
 export function isSendMediaMessage(content: unknown): content is WaSendMediaMessage {
@@ -72,7 +91,7 @@ export function isSendRevokeMessage(content: unknown): content is WaSendRevokeMe
         typeof content === 'object' &&
         'type' in content &&
         (content as { type: unknown }).type === 'revoke' &&
-        'stanzaId' in content
+        'target' in content
     )
 }
 

--- a/src/message/encode/content.ts
+++ b/src/message/encode/content.ts
@@ -314,13 +314,13 @@ export function needsSecretPersistence(message: Proto.IMessage): boolean {
     )
 }
 
-export function resolveEditAttr(message: Proto.IMessage, subtype?: string): string | null {
+export function resolveEditAttr(message: Proto.IMessage): string | null {
     const msg = unwrapMessage(message)
 
     if (msg.protocolMessage) {
         const protocolType = msg.protocolMessage.type
         if (protocolType === proto.Message.ProtocolMessage.Type.REVOKE) {
-            return subtype === 'admin_revoke'
+            return msg.protocolMessage.key?.fromMe === false
                 ? WA_EDIT_ATTRS.ADMIN_REVOKE
                 : WA_EDIT_ATTRS.SENDER_REVOKE
         }

--- a/src/message/kinds/newsletter.ts
+++ b/src/message/kinds/newsletter.ts
@@ -7,6 +7,7 @@ import type {
     WaNewsletterReactionEntry
 } from '@client/types'
 import type { Logger } from '@infra/log/types'
+import { pickIncomingExpirationSeconds } from '@message/context-info'
 import { proto } from '@proto'
 import { WA_NODE_TAGS } from '@protocol/constants'
 import { WA_EDIT_ATTRS } from '@protocol/message'
@@ -136,6 +137,7 @@ export function processIncomingNewsletterMessage(
 
     const chatJid = node.attrs.from
     const serverId = parseOptionalInt(node.attrs.server_id)
+    const expirationSeconds = pickIncomingExpirationSeconds(decoded.message)
     options.emitIncomingMessage?.({
         rawNode: node,
         key: {
@@ -151,6 +153,7 @@ export function processIncomingNewsletterMessage(
         stanzaType: messageType,
         offline: node.attrs.offline !== undefined,
         timestampSeconds: parseOptionalInt(node.attrs.t),
+        ...(expirationSeconds !== undefined ? { expirationSeconds } : {}),
         encryptionType: 'plaintext',
         plaintext: decoded.plaintext,
         message: decoded.message

--- a/src/message/kinds/newsletter.ts
+++ b/src/message/kinds/newsletter.ts
@@ -135,20 +135,23 @@ export function processIncomingNewsletterMessage(
     }
 
     const chatJid = node.attrs.from
+    const serverId = parseOptionalInt(node.attrs.server_id)
     options.emitIncomingMessage?.({
         rawNode: node,
-        stanzaId: node.attrs.id,
-        chatJid,
+        key: {
+            remoteJid: chatJid ?? '',
+            id: node.attrs.id ?? '',
+            fromMe: node.attrs.is_sender === 'true',
+            isGroup: false,
+            isBroadcast: false,
+            isNewsletter: true,
+            senderDevice: 0,
+            ...(serverId !== undefined ? { serverId } : {})
+        },
         stanzaType: messageType,
         offline: node.attrs.offline !== undefined,
         timestampSeconds: parseOptionalInt(node.attrs.t),
-        senderJid: chatJid,
         encryptionType: 'plaintext',
-        isGroupChat: false,
-        isBroadcastChat: false,
-        isNewsletterChat: true,
-        serverId: parseOptionalInt(node.attrs.server_id),
-        isSender: node.attrs.is_sender === 'true',
         plaintext: decoded.plaintext,
         message: decoded.message
     })

--- a/src/message/primitives/__tests__/peer-data-operation.test.ts
+++ b/src/message/primitives/__tests__/peer-data-operation.test.ts
@@ -65,8 +65,15 @@ function createHarness(opts?: {
     const emitResponse: RequesterHarness['emitResponse'] = (stanzaId, results = []) => {
         emitProtocol({
             rawNode: { tag: 'message', attrs: {} },
-            isGroupChat: false,
-            isBroadcastChat: false,
+            key: {
+                remoteJid: '',
+                id: stanzaId ?? '',
+                fromMe: false,
+                isGroup: false,
+                isBroadcast: false,
+                isNewsletter: false,
+                senderDevice: 0
+            },
             protocolMessage: {
                 type: proto.Message.ProtocolMessage.Type
                     .PEER_DATA_OPERATION_REQUEST_RESPONSE_MESSAGE,
@@ -168,8 +175,15 @@ test('irrelevant or unmatched protocol messages do not resolve pending requests'
     )
     harness.emitProtocol({
         rawNode: { tag: 'message', attrs: {} },
-        isGroupChat: false,
-        isBroadcastChat: false,
+        key: {
+            remoteJid: '',
+            id: '',
+            fromMe: false,
+            isGroup: false,
+            isBroadcast: false,
+            isNewsletter: false,
+            senderDevice: 0
+        },
         protocolMessage: {
             type: proto.Message.ProtocolMessage.Type.APP_STATE_SYNC_KEY_REQUEST
         }

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -4,6 +4,7 @@ import type {
     WaIncomingUnhandledStanzaEvent
 } from '@client/types'
 import type { Logger } from '@infra/log/types'
+import { pickIncomingExpirationSeconds } from '@message/context-info'
 import { unwrapDeviceSentMessage } from '@message/encode/device-sent'
 import { unpadPkcs7 } from '@message/encode/padding'
 import { processIncomingNewsletterMessage } from '@message/kinds/newsletter'
@@ -133,6 +134,8 @@ export function buildRecoveredIncomingEvent(
             ? longToNumber(webMessageInfo.messageTimestamp)
             : undefined
     const stanzaId = key.id ?? undefined
+    const message = webMessageInfo.message ?? undefined
+    const expirationSeconds = pickIncomingExpirationSeconds(message)
     const rawNode: BinaryNode = {
         tag: WA_MESSAGE_TAGS.MESSAGE,
         attrs: {
@@ -155,7 +158,8 @@ export function buildRecoveredIncomingEvent(
         },
         timestampSeconds,
         encryptionType: 'placeholder_recovery',
-        message: webMessageInfo.message ?? undefined
+        ...(expirationSeconds !== undefined ? { expirationSeconds } : {}),
+        message
     }
 }
 
@@ -408,6 +412,7 @@ async function decryptAndProcessEncNode(
             const isBroadcast = chatJid ? isBroadcastJid(chatJid) : false
             const senderUserJid = `${senderAddress.user}@${senderAddress.server}`
             const { pushName, ...keyIdentity } = extractMessageIdentityAttrs(node.attrs)
+            const expirationSeconds = pickIncomingExpirationSeconds(message)
             options.emitIncomingMessage?.({
                 rawNode: buildIncomingEventRawNode(node),
                 key: {
@@ -424,6 +429,7 @@ async function decryptAndProcessEncNode(
                 stanzaType: node.attrs.type,
                 offline: node.attrs.offline !== undefined,
                 timestampSeconds: parseOptionalInt(node.attrs.t),
+                ...(expirationSeconds !== undefined ? { expirationSeconds } : {}),
                 pushName,
                 encryptionType: encType,
                 plaintext: unpaddedPlaintext,

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -42,23 +42,30 @@ interface WaIncomingMessageAckHandlerOptions {
 }
 
 interface MessageIdentityAttrs {
-    readonly senderAlt: string | undefined
-    readonly senderUsername: string | undefined
-    readonly recipientJid: string | undefined
-    readonly recipientAlt: string | undefined
+    readonly remoteJidAlt?: string
+    readonly participantAlt?: string
+    readonly senderUsername?: string
+    readonly recipientJid?: string
+    readonly recipientAlt?: string
     readonly pushName: string | undefined
 }
 
+// Addressing fields use conditional includes so they're absent (not own-undefined) when
+// the source attr isn't present — the `...keyIdentity` spread then only injects defined
+// keys into the event's `key`. `pushName` is destructured straight to the event top-level
+// and stays present-as-undefined there.
 function extractMessageIdentityAttrs(attrs: BinaryNode['attrs']): MessageIdentityAttrs {
-    const rawAlt =
-        attrs.participant_pn ?? attrs.sender_pn ?? attrs.participant_lid ?? attrs.sender_lid
+    const rawRemoteJidAlt = attrs.sender_pn ?? attrs.sender_lid
+    const rawParticipantAlt = attrs.participant_pn ?? attrs.participant_lid
     const rawRecipientAlt = attrs.peer_recipient_pn ?? attrs.peer_recipient_lid
     const rawRecipient = attrs.recipient
+    const senderUsername = attrs.participant_username ?? attrs.username
     return {
-        senderAlt: rawAlt ? toUserJid(rawAlt) : undefined,
-        senderUsername: attrs.participant_username ?? attrs.username,
-        recipientJid: rawRecipient ? toUserJid(rawRecipient) : undefined,
-        recipientAlt: rawRecipientAlt ? toUserJid(rawRecipientAlt) : undefined,
+        ...(rawRemoteJidAlt ? { remoteJidAlt: toUserJid(rawRemoteJidAlt) } : {}),
+        ...(rawParticipantAlt ? { participantAlt: toUserJid(rawParticipantAlt) } : {}),
+        ...(senderUsername !== undefined ? { senderUsername } : {}),
+        ...(rawRecipient ? { recipientJid: toUserJid(rawRecipient) } : {}),
+        ...(rawRecipientAlt ? { recipientAlt: toUserJid(rawRecipientAlt) } : {}),
         pushName: attrs.notify
     }
 }
@@ -120,7 +127,6 @@ export function buildRecoveredIncomingEvent(
     const isBroadcast = chatJid ? isBroadcastJid(chatJid) : false
     const rawSender = fromMe ? undefined : isGroup || isBroadcast ? participant : chatJid
     const sender = rawSender ? parseJidFull(rawSender) : null
-    const senderJid = sender?.userJid
     const senderDevice = sender?.address.device
     const timestampSeconds =
         webMessageInfo.messageTimestamp !== null && webMessageInfo.messageTimestamp !== undefined
@@ -137,15 +143,18 @@ export function buildRecoveredIncomingEvent(
     }
     return {
         rawNode,
-        stanzaId,
-        chatJid,
+        key: {
+            remoteJid: chatJid ?? '',
+            id: stanzaId ?? '',
+            fromMe,
+            isGroup,
+            isBroadcast,
+            isNewsletter: false,
+            ...(participant !== undefined ? { participant } : {}),
+            senderDevice: senderDevice ?? 0
+        },
         timestampSeconds,
-        senderJid,
-        senderDevice,
         encryptionType: 'placeholder_recovery',
-        isGroupChat: isGroup,
-        isBroadcastChat: isBroadcast,
-        isSender: fromMe,
         message: webMessageInfo.message ?? undefined
     }
 }
@@ -307,20 +316,29 @@ function processMsmsgEncNode(
         }
         const chatJid = node.attrs.from
         const sender = senderJid ? parseJidFull(senderJid) : null
-        const identity = extractMessageIdentityAttrs(node.attrs)
+        const isGroup = chatJid ? isGroupJid(chatJid) : false
+        const isBroadcast = chatJid ? isBroadcastJid(chatJid) : false
+        const { pushName, ...keyIdentity } = extractMessageIdentityAttrs(node.attrs)
         options.emitIncomingMessage?.({
             rawNode: buildIncomingEventRawNode(node),
-            stanzaId: node.attrs.id,
-            chatJid,
+            key: {
+                remoteJid: chatJid ?? '',
+                id: node.attrs.id ?? '',
+                fromMe: false,
+                isGroup,
+                isBroadcast,
+                isNewsletter: false,
+                ...keyIdentity,
+                ...((isGroup || isBroadcast) && sender?.userJid
+                    ? { participant: sender.userJid }
+                    : {}),
+                senderDevice: sender?.address.device ?? 0
+            },
             stanzaType: node.attrs.type,
             offline: node.attrs.offline !== undefined,
             timestampSeconds: parseOptionalInt(node.attrs.t),
-            senderJid: sender?.userJid,
-            senderDevice: sender?.address.device,
-            ...identity,
+            pushName,
             encryptionType: 'msmsg',
-            isGroupChat: chatJid ? isGroupJid(chatJid) : false,
-            isBroadcastChat: chatJid ? isBroadcastJid(chatJid) : false,
             plaintext: payload,
             message
         })
@@ -386,20 +404,28 @@ async function decryptAndProcessEncNode(
         }
         if (shouldEmitIncomingMessage(message)) {
             const chatJid = node.attrs.from
-            const identity = extractMessageIdentityAttrs(node.attrs)
+            const isGroup = chatJid ? isGroupJid(chatJid) : false
+            const isBroadcast = chatJid ? isBroadcastJid(chatJid) : false
+            const senderUserJid = `${senderAddress.user}@${senderAddress.server}`
+            const { pushName, ...keyIdentity } = extractMessageIdentityAttrs(node.attrs)
             options.emitIncomingMessage?.({
                 rawNode: buildIncomingEventRawNode(node),
-                stanzaId: node.attrs.id,
-                chatJid,
+                key: {
+                    remoteJid: chatJid ?? '',
+                    id: node.attrs.id ?? '',
+                    fromMe: false,
+                    isGroup,
+                    isBroadcast,
+                    isNewsletter: false,
+                    ...keyIdentity,
+                    senderDevice: senderAddress.device,
+                    ...(isGroup || isBroadcast ? { participant: senderUserJid } : {})
+                },
                 stanzaType: node.attrs.type,
                 offline: node.attrs.offline !== undefined,
                 timestampSeconds: parseOptionalInt(node.attrs.t),
-                senderJid: `${senderAddress.user}@${senderAddress.server}`,
-                senderDevice: senderAddress.device,
-                ...identity,
+                pushName,
                 encryptionType: encType,
-                isGroupChat: chatJid ? isGroupJid(chatJid) : false,
-                isBroadcastChat: chatJid ? isBroadcastJid(chatJid) : false,
                 plaintext: unpaddedPlaintext,
                 message
             })

--- a/src/message/primitives/peer-data-operation.ts
+++ b/src/message/primitives/peer-data-operation.ts
@@ -86,7 +86,7 @@ export function createPeerDataOperationRequester(
         const results = response.peerDataOperationResult ?? []
         if (!stanzaId) {
             logger.debug('pdo response without stanzaId', {
-                from: event.chatJid,
+                from: event.key.remoteJid,
                 resultCount: results.length
             })
             return

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -88,44 +88,62 @@ export interface WaSendTextMessage {
     readonly linkPreview?: boolean | WaLinkPreviewOverride
 }
 
-export interface WaSendMessageTarget {
-    readonly stanzaId: string
+/**
+ * A message key in the protobuf {@link Proto.IMessageKey} shape, used to target
+ * an existing message (reply / edit / reaction / revoke / pin / keep). Every
+ * field is filled on a received `message` event's `key`, so they are required
+ * here (and assignable to the looser `Proto.IMessageKey`). When sending, the
+ * builder forces `remoteJid` to the recipient and drops `participant` in 1:1
+ * chats.
+ */
+export interface WaMessageKey {
+    readonly remoteJid: string
+    readonly id: string
     readonly fromMe: boolean
-    /** Required in groups when targeting a message sent by another participant. */
+    /** The author - set in groups/broadcasts; omitted in 1:1 (the author is `remoteJid`). */
     readonly participant?: string
 }
 
-/** @deprecated use {@link WaSendMessageTarget} */
-export type WaSendReactionTarget = WaSendMessageTarget
+/**
+ * A received `message` event passed verbatim as a target. Its `key` (a
+ * {@link WaMessageKey}, the same shape the event exposes) is what gets used;
+ * `rawNode` - always present on real events - discriminates it from an explicit
+ * {@link WaMessageKey}.
+ */
+export interface WaMessageRef {
+    readonly key?: WaMessageKey
+    readonly rawNode: unknown
+}
+
+/** An explicit {@link WaMessageKey}, or a received `message` event ({@link WaMessageRef}). */
+export type WaMessageTargetInput = WaMessageKey | WaMessageRef
 
 export interface WaSendReactionMessage {
     readonly type: 'reaction'
     /** Emoji to attach. Pass an empty string to revoke an existing reaction. */
     readonly emoji: string
-    readonly target: WaSendMessageTarget
+    /** An explicit {@link WaMessageKey} or a received `message` event passed verbatim. */
+    readonly target: WaMessageTargetInput
     /** Defaults to `Date.now()` when omitted. */
     readonly senderTimestampMs?: number
 }
 
 export interface WaSendRevokeMessage {
     readonly type: 'revoke'
-    /** Stanza id of the message being revoked. */
-    readonly stanzaId: string
-    /** Defaults to `true` (revoking your own messages). */
-    readonly fromMe?: boolean
-    /** Original author jid; required when an admin revokes someone else's message in a group. */
-    readonly participant?: string
+    /** An explicit {@link WaMessageKey} or a received `message` event passed verbatim. */
+    readonly target: WaMessageTargetInput
 }
 
 export interface WaSendPinMessage {
     readonly type: 'pin' | 'unpin'
-    readonly target: WaSendMessageTarget
+    /** An explicit {@link WaMessageKey} or a received `message` event passed verbatim. */
+    readonly target: WaMessageTargetInput
     readonly senderTimestampMs?: number
 }
 
 export interface WaSendEditKey {
-    /** Stanza id of the message being edited (must be `fromMe: true`). */
-    readonly stanzaId: string
+    /** Id of the message being edited (`fromMe` is forced true, `remoteJid` is the recipient). */
+    readonly id: string
     /** Required in groups when the original message uses lid/pn addressing on the participant. */
     readonly participant?: string
     /** Defaults to `Date.now()` when omitted. */
@@ -134,7 +152,8 @@ export interface WaSendEditKey {
 
 export interface WaSendKeepMessage {
     readonly type: 'keep' | 'unkeep'
-    readonly target: WaSendMessageTarget
+    /** An explicit {@link WaMessageKey} or a received `message` event passed verbatim. */
+    readonly target: WaMessageTargetInput
     /** Defaults to `Date.now()` when omitted. */
     readonly timestampMs?: number
 }
@@ -156,8 +175,8 @@ export interface WaSendPollMessage {
 }
 
 export interface WaSendPollParent {
-    /** Stanza id of the original poll creation message. */
-    readonly stanzaId: string
+    /** Id of the original poll creation message. */
+    readonly id: string
     readonly fromMe: boolean
     /** Group participant jid; required outside 1:1 chats. */
     readonly participant?: string
@@ -205,8 +224,8 @@ export interface WaSendEventMessage {
 export type WaSendEventResponseType = 'going' | 'not_going' | 'maybe'
 
 export interface WaSendEventParent {
-    /** Stanza id of the original event creation message. */
-    readonly stanzaId: string
+    /** Id of the original event creation message. */
+    readonly id: string
     readonly fromMe: boolean
     readonly participant?: string
     /** Creator of the event (parentMsgOriginalSender for the use-case secret). */


### PR DESCRIPTION
- WaIncomingMessageEvent now exposes a rich `key` (superset of Proto.IMessageKey): remoteJid/id/fromMe/participant + isGroup/isBroadcast/isNewsletter
  + remoteJidAlt/participantAlt + senderDevice/senderUsername
  + recipientJid/recipientAlt + serverId
- drop top-level chatJid/stanzaId/senderJid/isGroupChat/isBroadcastChat /isNewsletterChat/senderAlt/senderDevice/senderUsername/recipientJid /recipientAlt/serverId from the message event (all moved into `key`)
- reply/edit/react/revoke/pin/keep targets accept `WaMessageKey | WaMessageRef` — pass the event verbatim. WaSendRevokeMessage uses `target` like the rest; stanzaId → id in edit/poll/event parents
- senderAlt split into remoteJidAlt + participantAlt (proto-aligned, unambiguous)
- senderDevice is required (number, default 0; JIDs without `:device` map to 0)
- WaIncomingAddonEvent / WaIncomingBotChunkEvent expose `key` instead of stanzaId/chatJid/senderJid
- appstate IncomingKeyEventContext uses proto-key attr names so `event.key` flows through verbatim (no remapping adapter in WaClient)
- WaQuoteRef.stanzaId → id; WaQuoteSource drops legacy stanzaId/chatJid/senderJid
- omit undefined optional `key` fields (absent, not own-property-undefined/null)
- fix latent sendReceipt bug: Array.isArray widened the event array to any[] and hid the key migration miss (callback param now annotated)
- export getContentType + resolveMessageTarget; add queryInviteCode group getter; type-safe business hours (WaBusinessHoursDay / WaBusinessHoursMode)

BREAKING: shape of WaIncomingMessageEvent / WaIncomingMessageKey / WaIncomingAddonEvent / WaIncomingBotChunkEvent; WaQuoteRef.stanzaId renamed to id; WaSendRevokeMessage is now { type: 'revoke', target }; senderDevice is required on the message key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized message identity to a unified message-key model across edits, reactions, revokes, pins, polls and addon flows.
  * Quote/edit/target references now use the new id/remoteJid/participant key shape; incoming messages carry consolidated key+expirationSeconds metadata.
  * Internal APIs and event payloads updated for consistent routing and logging (no user-visible behavior changes).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->