### PR TITLE
feat(media,message): auto-detect mimetype via WaMediaProcessor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,17 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@borewit/text-codec": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+            "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
         "node_modules/@changesets/apply-release-plan": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.0.tgz",
@@ -1833,6 +1844,20 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
             "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@sec-ant/readable-stream": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tokenizer/token": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
             "dev": true,
             "license": "MIT"
         },
@@ -4679,6 +4704,25 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/file-type": {
+            "version": "19.6.0",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
+            "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-stream": "^9.0.1",
+                "strtok3": "^9.0.1",
+                "token-types": "^6.0.0",
+                "uint8array-extras": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+            }
+        },
         "node_modules/file-uri-to-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -4951,6 +4995,23 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-symbol-description": {
@@ -5735,6 +5796,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-string": {
@@ -6786,6 +6860,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/peek-readable": {
+            "version": "5.4.2",
+            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
+            "integrity": "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/pg": {
@@ -8221,6 +8309,24 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strtok3": {
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-9.1.1.tgz",
+            "integrity": "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/token": "^0.3.0",
+                "peek-readable": "^5.3.1"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8369,6 +8475,25 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.6"
+            }
+        },
+        "node_modules/token-types": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+            "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@borewit/text-codec": "^0.2.1",
+                "@tokenizer/token": "^0.3.0",
+                "ieee754": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/tr46": {
@@ -8655,6 +8780,19 @@
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/uint8array-extras": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+            "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/unbox-primitive": {
@@ -9104,6 +9242,7 @@
             "version": "0.1.0",
             "license": "MIT",
             "devDependencies": {
+                "file-type": "^19.0.0",
                 "sharp": "^0.33.0",
                 "zapo-js": "file:../.."
             },
@@ -9111,8 +9250,14 @@
                 "node": ">=20.9.0"
             },
             "peerDependencies": {
+                "file-type": ">=19.0.0",
                 "sharp": ">=0.33.0",
                 "zapo-js": ">=0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "file-type": {
+                    "optional": true
+                }
             }
         },
         "packages/store-mongo": {

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -28,10 +28,17 @@
     },
     "peerDependencies": {
         "zapo-js": ">=0.1.0",
-        "sharp": ">=0.33.0"
+        "sharp": ">=0.33.0",
+        "file-type": ">=19.0.0"
+    },
+    "peerDependenciesMeta": {
+        "file-type": {
+            "optional": true
+        }
     },
     "devDependencies": {
         "sharp": "^0.33.0",
+        "file-type": "^19.0.0",
         "zapo-js": "file:../.."
     },
     "engines": {

--- a/packages/media-utils/src/index.ts
+++ b/packages/media-utils/src/index.ts
@@ -1,4 +1,5 @@
 import type { WaMediaProcessor, WaMediaProcessorInput } from 'zapo-js/media'
+import { toError } from 'zapo-js/util'
 
 import {
     computeWaveformWithFfmpeg,
@@ -80,6 +81,20 @@ export function createMediaProcessor(options?: WaMediaProcessorOptions): WaMedia
 
         async generateStickerThumbnail(input: WaMediaProcessorInput, maxEdge: number) {
             return generateStickerThumbnail(input, maxEdge)
+        },
+
+        async detectMimetype(input: string | Uint8Array) {
+            try {
+                const fileType = await import('file-type')
+                const result =
+                    typeof input === 'string'
+                        ? await fileType.fileTypeFromFile(input)
+                        : await fileType.fileTypeFromBuffer(input)
+                return result?.mime ?? null
+            } catch (error) {
+                warn?.(`detectMimetype failed: ${toError(error).message}`)
+                return null
+            }
         }
     }
 }

--- a/src/client/messaging/messages.ts
+++ b/src/client/messaging/messages.ts
@@ -427,10 +427,21 @@ function resolveUploadType(
     return content.type as MediaCryptoType
 }
 
-function resolveMimetype(content: Exclude<WaSendMediaMessage, WaSendStickerPackMessage>): string {
+async function resolveMimetype(
+    content: Exclude<WaSendMediaMessage, WaSendStickerPackMessage>,
+    media: WaMediaOptions | undefined,
+    processorInput: string | Uint8Array | undefined
+): Promise<string> {
     if (content.mimetype) return content.mimetype
     if (content.type === 'sticker') return 'image/webp'
-    throw new Error(`mimetype is required for ${content.type} messages`)
+    const detect = media?.processor?.detectMimetype
+    if (detect && processorInput !== undefined) {
+        const detected = await detect(processorInput)
+        if (detected) return detected
+    }
+    throw new Error(
+        `mimetype is required for ${content.type} messages (or configure a WaMediaProcessor with detectMimetype)`
+    )
 }
 
 async function buildMediaMessage(
@@ -459,6 +470,7 @@ async function buildMediaMessage(
         hasMediaProcessingTasks(options.media, content) ||
         (content.type === 'sticker' && content.firstFrameLength === undefined)
     const resolved = await resolveMediaInputs(needsTempFile, content.media)
+    const mimetype = await resolveMimetype(content, options.media, resolved.processorInput)
 
     try {
         let detectedFirstFrameLength: number | undefined
@@ -478,8 +490,8 @@ async function buildMediaMessage(
                 : undefined
 
         const uploadPromise = isReadableStream(resolved.uploadMedia)
-            ? uploadMediaStream(options, content, resolved.uploadMedia, firstFrameLength)
-            : uploadMediaBytes(options, content, resolved.uploadMedia, firstFrameLength)
+            ? uploadMediaStream(options, content, resolved.uploadMedia, firstFrameLength, mimetype)
+            : uploadMediaBytes(options, content, resolved.uploadMedia, firstFrameLength, mimetype)
         const processPromise = runMediaProcessor(
             options.media,
             resolved.processorInput,
@@ -503,7 +515,7 @@ async function buildMediaMessage(
             fileEncSha256: uploaded.fileEncSha256,
             directPath: uploaded.directPath,
             mediaKeyTimestamp,
-            mimetype: resolveMimetype(content)
+            mimetype
         }
         const uploadSummary: WaMessageUploadInfo = {
             url: uploaded.url,
@@ -681,7 +693,8 @@ async function uploadMediaBytes(
     options: WaMediaMessageOptions,
     content: Exclude<WaSendMediaMessage, WaSendStickerPackMessage>,
     mediaBytes: Uint8Array,
-    firstFrameLength?: number
+    firstFrameLength: number | undefined,
+    mimetype: string
 ): Promise<UploadResult> {
     const uploadType = resolveUploadType(content)
     const mediaKey = await WaMediaCrypto.generateMediaKey()
@@ -710,7 +723,7 @@ async function uploadMediaBytes(
         method: 'POST',
         body: encrypted.ciphertextHmac,
         contentLength: encrypted.ciphertextHmac.byteLength,
-        contentType: resolveMimetype(content)
+        contentType: mimetype
     })
     const responseBody = await options.mediaTransfer.readResponseBytes(uploadResponse)
     const parsed = parseUploadResponse(responseBody, uploadResponse.status)
@@ -799,7 +812,8 @@ async function uploadMediaStream(
     options: WaMediaMessageOptions,
     content: Exclude<WaSendMediaMessage, WaSendStickerPackMessage>,
     stream: Readable,
-    firstFrameLength?: number
+    firstFrameLength: number | undefined,
+    mimetype: string
 ): Promise<UploadResult> {
     const cryptoType = resolveUploadType(content)
     return uploadEncryptedStream(options, {
@@ -807,7 +821,7 @@ async function uploadMediaStream(
         mediaKey: await WaMediaCrypto.generateMediaKey(),
         cryptoType,
         uploadPath: resolveUploadPath(cryptoType),
-        contentType: resolveMimetype(content),
+        contentType: mimetype,
         logLabel: 'sending media stream upload request',
         sidecar: needsSidecar(content),
         firstFrameLength

--- a/src/client/messaging/messages.ts
+++ b/src/client/messaging/messages.ts
@@ -466,9 +466,15 @@ async function buildMediaMessage(
             })
         }
     }
+    const needsMimetypeDetection =
+        !content.mimetype &&
+        content.type !== 'sticker' &&
+        !!options.media?.processor?.detectMimetype &&
+        isReadableStream(content.media)
     const needsTempFile =
         hasMediaProcessingTasks(options.media, content) ||
-        (content.type === 'sticker' && content.firstFrameLength === undefined)
+        (content.type === 'sticker' && content.firstFrameLength === undefined) ||
+        needsMimetypeDetection
     const resolved = await resolveMediaInputs(needsTempFile, content.media)
     const mimetype = await resolveMimetype(content, options.media, resolved.processorInput)
 

--- a/src/media/processor.ts
+++ b/src/media/processor.ts
@@ -51,7 +51,7 @@ export interface WaMediaProcessor {
 
     /**
      * Infers the input's mime type (e.g. via magic-byte sniffing). Accepts the
-     * resolved on-disk shape — a path or a buffer; the message builder always
+     * resolved on-disk shape: a path or a buffer; the message builder always
      * stages streams to a temp file before calling this. Returns `null` when
      * the type can't be determined.
      */

--- a/src/media/processor.ts
+++ b/src/media/processor.ts
@@ -48,4 +48,12 @@ export interface WaMediaProcessor {
         input: WaMediaProcessorInput,
         maxEdge: number
     ) => Promise<WaMediaProcessorStickerThumbnailResult>
+
+    /**
+     * Infers the input's mime type (e.g. via magic-byte sniffing). Accepts the
+     * resolved on-disk shape — a path or a buffer; the message builder always
+     * stages streams to a temp file before calling this. Returns `null` when
+     * the type can't be determined.
+     */
+    readonly detectMimetype?: (input: string | Uint8Array) => Promise<string | null>
 }

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -67,7 +67,7 @@ interface WaSendMediaBase {
     /**
      * Mime type of the media. Optional when a {@link WaMediaProcessor} with
      * `detectMimetype` is configured (e.g. `@zapo-js/media-utils` with
-     * `file-type` installed) — the builder infers it from the input. Required
+     * `file-type` installed): the builder infers it from the input. Required
      * otherwise; a missing mimetype throws at build time.
      */
     readonly mimetype?: string

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -64,13 +64,12 @@ type UserMediaFields<T> = {
 
 interface WaSendMediaBase {
     readonly media: MediaInput
-    readonly mimetype: string
-    readonly fileLength?: number
-    readonly contextInfo?: WaSendContextInfo
-}
-
-interface WaSendMediaBaseOptionalMime {
-    readonly media: MediaInput
+    /**
+     * Mime type of the media. Optional when a {@link WaMediaProcessor} with
+     * `detectMimetype` is configured (e.g. `@zapo-js/media-utils` with
+     * `file-type` installed) — the builder infers it from the input. Required
+     * otherwise; a missing mimetype throws at build time.
+     */
     readonly mimetype?: string
     readonly fileLength?: number
     readonly contextInfo?: WaSendContextInfo
@@ -265,7 +264,7 @@ interface WaSendDocumentMessage
 }
 
 interface WaSendStickerMessage
-    extends WaSendMediaBaseOptionalMime, UserMediaFields<Proto.Message.IStickerMessage> {
+    extends WaSendMediaBase, UserMediaFields<Proto.Message.IStickerMessage> {
     readonly type: 'sticker'
 }
 


### PR DESCRIPTION
- new WaMediaProcessor.detectMimetype?(input: string | Uint8Array) => Promise<string | null> in the core interface
- @zapo-js/media-utils: implementation backed by file-type ^19 (added as optional peerDependency). Lazy `await import('file-type')` keeps the dual CJS/ESM build working.
- WaSendMediaBase.mimetype is now optional. The message builder resolves it once via resolveMimetype(content, media, processorInput): caller value wins, then processor.detectMimetype, then a clear throw for image/video/audio/document/ptv when neither path is available.
- the resolved mimetype is threaded through uploadMediaBytes / uploadMediaStream as a parameter (single source of truth, no more duplicate resolveMimetype calls inside the upload helpers).
- WaSendMediaBaseOptionalMime collapsed into the unified base (WaSendStickerMessage still defaults to image/webp).
- the detectMimetype signature uses string | Uint8Array (not the wider WaMediaProcessorInput): streams are always staged to a temp file by resolveMediaInputs before this is called, so the Readable branch was unreachable.

Validated live via MCP: image sent as a Readable stream with no mimetype is staged to a temp file, sniffed via file-type, and accepted by the WhatsApp CDN (count: 8 broadcast, fileLength matches the JPEG).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic MIME type detection for media files and buffers; mimetype can be omitted and will be inferred when available.
  * Stickers are treated as image/webp by default.
  * Emits warnings when MIME detection fails.

* **Refactor**
  * Media message construction now resolves MIME types asynchronously once per send and reuses the result during upload for more efficient, consistent handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->