### PR TITLE
feat(fake-server,bench): e2e benches for messaging-with-media and retry

### DIFF
--- a/packages/fake-server/bench/messaging-media.bench.ts
+++ b/packages/fake-server/bench/messaging-media.bench.ts
@@ -1,0 +1,709 @@
+/**
+ * End-to-end messaging-with-media bench driven through @zapo-js/fake-server.
+ *
+ * Complements `media-upload.bench.ts` (which sweeps image payload sizes)
+ * by sweeping over the WhatsApp media TYPES and exercising both 1:1
+ * send, group send (SKDM + SKMSG fanout), and receive + download.
+ *
+ * Scenarios (selectable via ZAPO_BENCH_MEDIA_SCENARIOS):
+ *   - send_media_image, send_media_video, send_media_audio,
+ *     send_media_ptt, send_media_document, send_media_sticker
+ *       Each issues N `client.message.send(peerJid, { type, media, ... })`
+ *       which runs the full encrypt + upload + signal-encrypt + wire send
+ *       pipeline for the corresponding media type.
+ *   - send_media_group_image
+ *       Same shape but to a group of K members. First send pays the
+ *       SKDM fanout cost; the timed window runs after a warmup send
+ *       so it reflects steady-state SKMSG throughput.
+ *   - recv_media_image, recv_media_video
+ *       Fake peer publishes an encrypted blob to the fake media HTTPS
+ *       endpoint, then pushes an imageMessage/videoMessage referencing
+ *       it. The bench measures the round-trip from peer push through
+ *       lib decrypt of the proto + `client.message.downloadBytes(event)`
+ *       (the actual HTTPS download + decrypt) for every iteration.
+ *
+ * Tunables (env vars):
+ *   ZAPO_BENCH_MEDIA_MESSAGES         (default 50)
+ *   ZAPO_BENCH_MEDIA_BYTES            (default 65_536)
+ *   ZAPO_BENCH_MEDIA_CHUNK_BYTES      (default 65_536, stream chunk size)
+ *   ZAPO_BENCH_MEDIA_GROUP_MEMBERS    (default 8)
+ *   ZAPO_BENCH_MEDIA_INPUT            (stream | buffer; default stream)
+ *   ZAPO_BENCH_MEDIA_SCENARIOS        (csv; default = all)
+ *   ZAPO_BENCH_STORE                  (memory | sqlite | mysql | ...)
+ *   ZAPO_BENCH_VERBOSE                (=1 to print lib warn/error)
+ *   ZAPO_BENCH_JSON                   (=1 to also print as JSON)
+ *
+ * `MEDIA_INPUT=stream` (default) feeds `client.message.send` a
+ * `Readable` so the lib walks its streaming upload path (spool to temp
+ * file + streamed HTTPS upload), matching how a user would pass
+ * `fs.createReadStream(path)` for a real file. `buffer` keeps the
+ * payload as a plain Uint8Array so the lib stays in-memory; useful as
+ * a baseline to compare streaming overhead.
+ *
+ * Profiling flags (same shape as messaging.bench.ts):
+ *   --cpu / --heap / --snapshot / --per-scenario /
+ *   --snapshot-per-scenario / --out-dir=<path>
+ *   --separate-process    fake-server runs in a forked child
+ *   --no-server-prof      skip profiling the server child (when --separate-process)
+ *
+ * Run with:
+ *   node --expose-gc --import tsx \
+ *     packages/fake-server/bench/messaging-media.bench.ts
+ */
+
+import { randomBytes } from 'node:crypto'
+import { Readable } from 'node:stream'
+
+import type { WaClient, WaClientEventMap } from 'zapo-js'
+
+import type { FakePeer } from '../src/api/FakePeer'
+import type { FakeWaServer, WaFakeConnectionPipeline } from '../src/api/FakeWaServer'
+import type { FakeMediaType } from '../src/state/fake-media-store'
+
+import {
+    BenchProfiler,
+    forceGcIfAvailable,
+    formatBytesPerSec,
+    formatMiB,
+    installEmergencyStop,
+    maybePrintJson,
+    printResult,
+    readPositiveIntEnv,
+    readProfilerOptions,
+    runScenario,
+    startServerProfilingIfRequested,
+    stopServerProfilingIfRequested,
+    takeServerSnapshotIfRequested,
+    type ScenarioResult
+} from './_common'
+import {
+    bringUpPairedClient,
+    bringUpPairedClientViaRpc,
+    ensurePreKeyPool,
+    teardownFixture,
+    teardownRpcFixture
+} from './_fixtures'
+import { buildBenchStore } from './_store-factory'
+import type { ServerRpc } from './server-rpc'
+
+const SEND_SCENARIOS = [
+    'send_media_image',
+    'send_media_video',
+    'send_media_audio',
+    'send_media_ptt',
+    'send_media_document',
+    'send_media_sticker'
+] as const
+
+const GROUP_SCENARIOS = ['send_media_group_image'] as const
+
+const RECV_SCENARIOS = ['recv_media_image', 'recv_media_video'] as const
+
+const ALL_SCENARIOS = new Set<string>([...SEND_SCENARIOS, ...GROUP_SCENARIOS, ...RECV_SCENARIOS])
+
+function readScenarioFilter(): ReadonlySet<string> {
+    const raw = process.env.ZAPO_BENCH_MEDIA_SCENARIOS
+    if (!raw) return ALL_SCENARIOS
+    const out = new Set<string>()
+    for (const part of raw.split(',')) {
+        const trimmed = part.trim()
+        if (!trimmed) continue
+        if (!ALL_SCENARIOS.has(trimmed)) {
+            throw new Error(
+                `unknown ZAPO_BENCH_MEDIA_SCENARIOS entry "${trimmed}"; valid: ${[...ALL_SCENARIOS].join(',')}`
+            )
+        }
+        out.add(trimmed)
+    }
+    return out
+}
+
+type MediaInputMode = 'stream' | 'buffer'
+
+interface BenchConfig {
+    readonly messages: number
+    readonly payloadBytes: number
+    readonly chunkBytes: number
+    readonly groupMembers: number
+    readonly inputMode: MediaInputMode
+    readonly scenarios: ReadonlySet<string>
+}
+
+function readInputMode(): MediaInputMode {
+    const raw = process.env.ZAPO_BENCH_MEDIA_INPUT
+    if (!raw) return 'stream'
+    if (raw === 'stream' || raw === 'buffer') return raw
+    throw new Error(`invalid ZAPO_BENCH_MEDIA_INPUT: ${raw} (expected 'stream' or 'buffer')`)
+}
+
+function readConfig(): BenchConfig {
+    return {
+        messages: readPositiveIntEnv('ZAPO_BENCH_MEDIA_MESSAGES', 50),
+        payloadBytes: readPositiveIntEnv('ZAPO_BENCH_MEDIA_BYTES', 64 * 1024),
+        chunkBytes: readPositiveIntEnv('ZAPO_BENCH_MEDIA_CHUNK_BYTES', 64 * 1024),
+        groupMembers: readPositiveIntEnv('ZAPO_BENCH_MEDIA_GROUP_MEMBERS', 8),
+        inputMode: readInputMode(),
+        scenarios: readScenarioFilter()
+    }
+}
+
+/**
+ * Builds the `media` argument for `client.message.send` based on the
+ * configured input mode. Stream mode wraps the payload in a chunked
+ * Readable so the lib walks its streaming-upload pipeline (temp file
+ * spool + chunked HTTPS upload); buffer mode passes the Uint8Array
+ * verbatim so the lib stays in-memory.
+ */
+function buildMediaInput(media: Uint8Array, config: BenchConfig): Uint8Array | Readable {
+    if (config.inputMode === 'buffer') return media
+    return Readable.from(chunkIterator(media, config.chunkBytes))
+}
+
+function* chunkIterator(payload: Uint8Array, chunkSize: number): IterableIterator<Uint8Array> {
+    for (let offset = 0; offset < payload.byteLength; offset += chunkSize) {
+        yield payload.subarray(offset, Math.min(offset + chunkSize, payload.byteLength))
+    }
+}
+
+interface SendCase {
+    readonly name: (typeof SEND_SCENARIOS)[number]
+    readonly send: (
+        client: WaClient,
+        peerJid: string,
+        media: Uint8Array | Readable,
+        index: number
+    ) => Promise<unknown>
+}
+
+const SEND_CASES: readonly SendCase[] = [
+    {
+        name: 'send_media_image',
+        send: (client, jid, media, i) =>
+            client.message.send(jid, {
+                type: 'image',
+                media,
+                mimetype: 'image/jpeg',
+                caption: `media bench image ${i}`
+            })
+    },
+    {
+        name: 'send_media_video',
+        send: (client, jid, media, i) =>
+            client.message.send(jid, {
+                type: 'video',
+                media,
+                mimetype: 'video/mp4',
+                caption: `media bench video ${i}`
+            })
+    },
+    {
+        name: 'send_media_audio',
+        send: (client, jid, media) =>
+            client.message.send(jid, {
+                type: 'audio',
+                media,
+                mimetype: 'audio/mp4'
+            })
+    },
+    {
+        name: 'send_media_ptt',
+        send: (client, jid, media) =>
+            client.message.send(jid, {
+                type: 'audio',
+                media,
+                mimetype: 'audio/ogg',
+                ptt: true
+            })
+    },
+    {
+        name: 'send_media_document',
+        send: (client, jid, media, i) =>
+            client.message.send(jid, {
+                type: 'document',
+                media,
+                mimetype: 'application/pdf',
+                fileName: `bench-${i}.pdf`
+            })
+    },
+    {
+        name: 'send_media_sticker',
+        send: (client, jid, media) =>
+            client.message.send(jid, {
+                type: 'sticker',
+                media,
+                mimetype: 'image/webp'
+            })
+    }
+]
+
+interface RecvCase {
+    readonly name: (typeof RECV_SCENARIOS)[number]
+    readonly mediaType: FakeMediaType
+    readonly mimetype: string
+    readonly matches: (event: Parameters<WaClientEventMap['message']>[0]) => boolean
+}
+
+const RECV_CASES: readonly RecvCase[] = [
+    {
+        name: 'recv_media_image',
+        mediaType: 'image',
+        mimetype: 'image/jpeg',
+        matches: (event) =>
+            event.message?.imageMessage !== undefined && event.message?.imageMessage !== null
+    },
+    {
+        name: 'recv_media_video',
+        mediaType: 'video',
+        mimetype: 'video/mp4',
+        matches: (event) =>
+            event.message?.videoMessage !== undefined && event.message?.videoMessage !== null
+    }
+]
+
+function fillRandom(size: number): Uint8Array {
+    return new Uint8Array(randomBytes(size).buffer)
+}
+
+function waitForMessage(
+    client: WaClient,
+    predicate: (event: Parameters<WaClientEventMap['message']>[0]) => boolean,
+    timeoutMs: number
+): Promise<Parameters<WaClientEventMap['message']>[0]> {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(
+            () => reject(new Error('timed out waiting for matching message')),
+            timeoutMs
+        )
+        const listener: WaClientEventMap['message'] = (event) => {
+            if (predicate(event)) {
+                clearTimeout(timer)
+                client.off('message', listener)
+                resolve(event)
+            }
+        }
+        client.on('message', listener)
+    })
+}
+
+// ─── Send-side helpers ────────────────────────────────────────────────
+
+async function runSendScenarioInProcess(
+    server: FakeWaServer,
+    client: WaClient,
+    pipeline: WaFakeConnectionPipeline,
+    profiler: BenchProfiler,
+    testCase: SendCase,
+    config: BenchConfig
+): Promise<{ result: ScenarioResult; totalBytes: number }> {
+    await ensurePreKeyPool(server, pipeline, 2)
+    const peerJid = randomPeerJid('777')
+    await server.createFakePeer({ jid: peerJid }, pipeline)
+    return runSendScenarioWithJid(client, profiler, testCase, config, peerJid)
+}
+
+async function runSendScenarioRpc(
+    rpc: ServerRpc,
+    client: WaClient,
+    profiler: BenchProfiler,
+    testCase: SendCase,
+    config: BenchConfig
+): Promise<{ result: ScenarioResult; totalBytes: number }> {
+    await rpc.ensurePreKeyPool(2)
+    const peerJid = randomPeerJid('777')
+    await rpc.createFakePeer({ jid: peerJid })
+    return runSendScenarioWithJid(client, profiler, testCase, config, peerJid)
+}
+
+async function runSendScenarioWithJid(
+    client: WaClient,
+    profiler: BenchProfiler,
+    testCase: SendCase,
+    config: BenchConfig,
+    peerJid: string
+): Promise<{ result: ScenarioResult; totalBytes: number }> {
+    const media = fillRandom(config.payloadBytes)
+    const totalBytes = config.payloadBytes * config.messages
+    await profiler.beforeScenario(testCase.name)
+    const result = await runScenario(
+        testCase.name,
+        config.messages,
+        async () => {
+            for (let i = 0; i < config.messages; i += 1) {
+                // Build a FRESH Readable per iteration: streams are
+                // single-use, and reusing one would let the lib consume
+                // it once on send #0 and then receive 'end' immediately
+                // on subsequent sends.
+                await testCase.send(client, peerJid, buildMediaInput(media, config), i)
+            }
+        },
+        'messages'
+    )
+    await profiler.afterScenario(testCase.name)
+    return { result, totalBytes }
+}
+
+// ─── Group-send helper ────────────────────────────────────────────────
+
+async function runGroupSendScenarioInProcess(
+    server: FakeWaServer,
+    client: WaClient,
+    pipeline: WaFakeConnectionPipeline,
+    profiler: BenchProfiler,
+    config: BenchConfig
+): Promise<{ result: ScenarioResult; totalBytes: number }> {
+    const groupJid = randomGroupJid()
+    const members: FakePeer[] = []
+    for (let m = 0; m < config.groupMembers; m += 1) {
+        await ensurePreKeyPool(server, pipeline, 1)
+        const memberJid = `5511${String(8_500_000_000 + m).padStart(10, '0')}@s.whatsapp.net`
+        const peer = await server.createFakePeer({ jid: memberJid }, pipeline)
+        members.push(peer)
+    }
+    server.createFakeGroup({
+        groupJid,
+        subject: 'Bench Media Group',
+        participants: members
+    })
+    return runGroupSendBody(client, profiler, config, groupJid)
+}
+
+async function runGroupSendScenarioRpc(
+    rpc: ServerRpc,
+    client: WaClient,
+    profiler: BenchProfiler,
+    config: BenchConfig
+): Promise<{ result: ScenarioResult; totalBytes: number }> {
+    const groupJid = randomGroupJid()
+    const memberPeerIds: string[] = []
+    for (let m = 0; m < config.groupMembers; m += 1) {
+        await rpc.ensurePreKeyPool(1)
+        const memberJid = `5511${String(8_500_000_000 + m).padStart(10, '0')}@s.whatsapp.net`
+        const { peerId } = await rpc.createFakePeer({ jid: memberJid })
+        memberPeerIds.push(peerId)
+    }
+    await rpc.createFakeGroup({
+        groupJid,
+        subject: 'Bench Media Group',
+        participantPeerIds: memberPeerIds
+    })
+    return runGroupSendBody(client, profiler, config, groupJid)
+}
+
+async function runGroupSendBody(
+    client: WaClient,
+    profiler: BenchProfiler,
+    config: BenchConfig,
+    groupJid: string
+): Promise<{ result: ScenarioResult; totalBytes: number }> {
+    const media = fillRandom(config.payloadBytes)
+    // Warmup outside the timed window so SKDM fanout is amortised.
+    await client.message.send(groupJid, {
+        type: 'image',
+        media: buildMediaInput(media, config),
+        mimetype: 'image/jpeg',
+        caption: 'warmup'
+    })
+    const totalBytes = config.payloadBytes * config.messages
+    const name = 'send_media_group_image'
+    await profiler.beforeScenario(name)
+    const result = await runScenario(
+        name,
+        config.messages,
+        async () => {
+            for (let i = 0; i < config.messages; i += 1) {
+                await client.message.send(groupJid, {
+                    type: 'image',
+                    media: buildMediaInput(media, config),
+                    mimetype: 'image/jpeg',
+                    caption: `group media ${i}`
+                })
+            }
+        },
+        'messages'
+    )
+    await profiler.afterScenario(name)
+    return { result, totalBytes }
+}
+
+// ─── Recv-side helpers ────────────────────────────────────────────────
+
+async function runRecvScenarioInProcess(
+    server: FakeWaServer,
+    client: WaClient,
+    pipeline: WaFakeConnectionPipeline,
+    profiler: BenchProfiler,
+    testCase: RecvCase,
+    config: BenchConfig
+): Promise<{ result: ScenarioResult; totalBytes: number }> {
+    await ensurePreKeyPool(server, pipeline, 2)
+    const peerJid = randomPeerJid('666')
+    const peer = await server.createFakePeer({ jid: peerJid }, pipeline)
+    const plaintext = fillRandom(config.payloadBytes)
+    const blob = await server.publishMediaBlob({ mediaType: testCase.mediaType, plaintext })
+    const directPath = server.mediaUrl(blob.path)
+    const totalBytes = config.payloadBytes * config.messages
+
+    await profiler.beforeScenario(testCase.name)
+    const result = await runScenario(
+        testCase.name,
+        config.messages,
+        async () => {
+            for (let i = 0; i < config.messages; i += 1) {
+                const eventPromise = waitForMessage(client, testCase.matches, 10_000)
+                await sendPeerMediaInProcess(peer, testCase.mediaType, {
+                    directPath,
+                    mediaKey: blob.mediaKey,
+                    fileSha256: blob.fileSha256,
+                    fileEncSha256: blob.fileEncSha256,
+                    fileLength: blob.fileLength,
+                    mimetype: testCase.mimetype
+                })
+                const event = await eventPromise
+                const downloaded = await client.message.downloadBytes(event)
+                if (downloaded.byteLength !== plaintext.byteLength) {
+                    throw new Error(
+                        `${testCase.name}: downloaded ${downloaded.byteLength} != expected ${plaintext.byteLength}`
+                    )
+                }
+            }
+        },
+        'messages'
+    )
+    await profiler.afterScenario(testCase.name)
+    return { result, totalBytes }
+}
+
+async function runRecvScenarioRpc(
+    rpc: ServerRpc,
+    client: WaClient,
+    profiler: BenchProfiler,
+    testCase: RecvCase,
+    config: BenchConfig
+): Promise<{ result: ScenarioResult; totalBytes: number }> {
+    await rpc.ensurePreKeyPool(2)
+    const peerJid = randomPeerJid('666')
+    const { peerId } = await rpc.createFakePeer({ jid: peerJid })
+    const plaintext = fillRandom(config.payloadBytes)
+    const blob = await rpc.publishMediaBlob({ mediaType: testCase.mediaType, plaintext })
+    const directPath = await rpc.mediaUrl(blob.path)
+    const totalBytes = config.payloadBytes * config.messages
+
+    await profiler.beforeScenario(testCase.name)
+    const result = await runScenario(
+        testCase.name,
+        config.messages,
+        async () => {
+            for (let i = 0; i < config.messages; i += 1) {
+                const eventPromise = waitForMessage(client, testCase.matches, 10_000)
+                await sendPeerMediaRpc(rpc, peerId, testCase.mediaType, {
+                    directPath,
+                    mediaKey: blob.mediaKey,
+                    fileSha256: blob.fileSha256,
+                    fileEncSha256: blob.fileEncSha256,
+                    fileLength: blob.fileLength,
+                    mimetype: testCase.mimetype
+                })
+                const event = await eventPromise
+                const downloaded = await client.message.downloadBytes(event)
+                if (downloaded.byteLength !== plaintext.byteLength) {
+                    throw new Error(
+                        `${testCase.name}: downloaded ${downloaded.byteLength} != expected ${plaintext.byteLength}`
+                    )
+                }
+            }
+        },
+        'messages'
+    )
+    await profiler.afterScenario(testCase.name)
+    return { result, totalBytes }
+}
+
+async function sendPeerMediaInProcess(
+    peer: FakePeer,
+    mediaType: FakeMediaType,
+    descriptor: {
+        directPath: string
+        mediaKey: Uint8Array
+        fileSha256: Uint8Array
+        fileEncSha256: Uint8Array
+        fileLength: number
+        mimetype: string
+    }
+): Promise<void> {
+    if (mediaType === 'image') return peer.sendImageMessage(descriptor)
+    if (mediaType === 'video') return peer.sendVideoMessage(descriptor)
+    throw new Error(`unsupported recv mediaType: ${mediaType}`)
+}
+
+async function sendPeerMediaRpc(
+    rpc: ServerRpc,
+    peerId: string,
+    mediaType: FakeMediaType,
+    descriptor: {
+        directPath: string
+        mediaKey: Uint8Array
+        fileSha256: Uint8Array
+        fileEncSha256: Uint8Array
+        fileLength: number
+        mimetype: string
+    }
+): Promise<void> {
+    if (mediaType === 'image') return rpc.peerSendImageMessage(peerId, descriptor)
+    if (mediaType === 'video') return rpc.peerSendVideoMessage(peerId, descriptor)
+    throw new Error(`unsupported recv mediaType: ${mediaType}`)
+}
+
+function randomPeerJid(prefix: string): string {
+    return `5511${prefix}${Math.floor(Math.random() * 1_000_000_000)
+        .toString()
+        .padStart(7, '0')}@s.whatsapp.net`
+}
+
+function randomGroupJid(): string {
+    return `120363${String(950_000_000_000 + (Date.now() % 1_000_000)).padStart(15, '0')}@g.us`
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+    installEmergencyStop()
+    const argSet = new Set(process.argv.slice(2))
+    const profiler = new BenchProfiler(readProfilerOptions(argSet))
+    await profiler.start()
+
+    const config = readConfig()
+    const backendName = process.env.ZAPO_BENCH_STORE ?? 'memory'
+    const separate = argSet.has('--separate-process')
+
+    console.log('zapo-js messaging-with-media bench')
+    console.log('──────────────────────────────────')
+    console.log(`  messages/scenario : ${config.messages}`)
+    console.log(
+        `  payload           : ${formatMiB(config.payloadBytes)} (${config.payloadBytes} B)`
+    )
+    console.log(`  media input       : ${config.inputMode} (chunk ${config.chunkBytes} B)`)
+    console.log(`  group members     : ${config.groupMembers}`)
+    console.log(`  scenarios         : ${[...config.scenarios].join(', ')}`)
+    console.log(`  store             : ${backendName}`)
+    console.log(`  mode              : ${separate ? 'separate-process' : 'in-process'}`)
+    console.log('')
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('start').catch((err) => console.error('[snapshot]', err))
+    }
+
+    const aggregated: ScenarioResult[] = []
+    if (separate) {
+        await runSeparateProcess(config, profiler, argSet, aggregated)
+    } else {
+        await runInProcess(config, profiler, aggregated)
+    }
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('end').catch((err) => console.error('[snapshot]', err))
+    }
+    await profiler.stop()
+
+    maybePrintJson(aggregated)
+}
+
+async function runInProcess(
+    config: BenchConfig,
+    profiler: BenchProfiler,
+    aggregated: ScenarioResult[]
+): Promise<void> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClient(storeFixture, { sessionId: 'zapo-bench-media' })
+    const { server, client, pipeline } = fixture
+    try {
+        for (const testCase of SEND_CASES) {
+            if (!config.scenarios.has(testCase.name)) continue
+            const r = await runSendScenarioInProcess(
+                server,
+                client,
+                pipeline,
+                profiler,
+                testCase,
+                config
+            )
+            recordResult(aggregated, r)
+        }
+        if (config.scenarios.has('send_media_group_image')) {
+            const r = await runGroupSendScenarioInProcess(
+                server,
+                client,
+                pipeline,
+                profiler,
+                config
+            )
+            recordResult(aggregated, r)
+        }
+        for (const testCase of RECV_CASES) {
+            if (!config.scenarios.has(testCase.name)) continue
+            const r = await runRecvScenarioInProcess(
+                server,
+                client,
+                pipeline,
+                profiler,
+                testCase,
+                config
+            )
+            recordResult(aggregated, r)
+        }
+    } finally {
+        await teardownFixture(fixture)
+    }
+}
+
+async function runSeparateProcess(
+    config: BenchConfig,
+    profiler: BenchProfiler,
+    argSet: ReadonlySet<string>,
+    aggregated: ScenarioResult[]
+): Promise<void> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClientViaRpc(storeFixture, { sessionId: 'zapo-bench-media' })
+    const { rpc, client } = fixture
+    try {
+        await startServerProfilingIfRequested(rpc, profiler.options, argSet)
+        await takeServerSnapshotIfRequested(rpc, 'server-pre', profiler.options, argSet)
+
+        for (const testCase of SEND_CASES) {
+            if (!config.scenarios.has(testCase.name)) continue
+            const r = await runSendScenarioRpc(rpc, client, profiler, testCase, config)
+            recordResult(aggregated, r)
+        }
+        if (config.scenarios.has('send_media_group_image')) {
+            const r = await runGroupSendScenarioRpc(rpc, client, profiler, config)
+            recordResult(aggregated, r)
+        }
+        for (const testCase of RECV_CASES) {
+            if (!config.scenarios.has(testCase.name)) continue
+            const r = await runRecvScenarioRpc(rpc, client, profiler, testCase, config)
+            recordResult(aggregated, r)
+        }
+
+        await takeServerSnapshotIfRequested(rpc, 'server-post', profiler.options, argSet)
+    } finally {
+        await stopServerProfilingIfRequested(rpc, profiler.options, argSet).catch(() => undefined)
+        await teardownRpcFixture(fixture)
+    }
+}
+
+function recordResult(
+    aggregated: ScenarioResult[],
+    payload: { result: ScenarioResult; totalBytes: number }
+): void {
+    aggregated.push(payload.result)
+    printResult(payload.result)
+    console.log(
+        `  total transferred : ${formatMiB(payload.totalBytes)}  →  ${formatBytesPerSec(payload.totalBytes, payload.result.elapsedMs)}`
+    )
+    console.log('')
+    forceGcIfAvailable()
+}
+
+void main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/fake-server/bench/messaging-media.bench.ts
+++ b/packages/fake-server/bench/messaging-media.bench.ts
@@ -270,10 +270,10 @@ function waitForMessage(
     timeoutMs: number
 ): Promise<Parameters<WaClientEventMap['message']>[0]> {
     return new Promise((resolve, reject) => {
-        const timer = setTimeout(
-            () => reject(new Error('timed out waiting for matching message')),
-            timeoutMs
-        )
+        const timer = setTimeout(() => {
+            client.off('message', listener)
+            reject(new Error('timed out waiting for matching message'))
+        }, timeoutMs)
         const listener: WaClientEventMap['message'] = (event) => {
             if (predicate(event)) {
                 clearTimeout(timer)
@@ -296,7 +296,7 @@ async function runSendScenarioInProcess(
     config: BenchConfig
 ): Promise<{ result: ScenarioResult; totalBytes: number }> {
     await ensurePreKeyPool(server, pipeline, 2)
-    const peerJid = randomPeerJid('777')
+    const peerJid = buildRandomPeerJid('777')
     await server.createFakePeer({ jid: peerJid }, pipeline)
     return runSendScenarioWithJid(client, profiler, testCase, config, peerJid)
 }
@@ -309,7 +309,7 @@ async function runSendScenarioRpc(
     config: BenchConfig
 ): Promise<{ result: ScenarioResult; totalBytes: number }> {
     await rpc.ensurePreKeyPool(2)
-    const peerJid = randomPeerJid('777')
+    const peerJid = buildRandomPeerJid('777')
     await rpc.createFakePeer({ jid: peerJid })
     return runSendScenarioWithJid(client, profiler, testCase, config, peerJid)
 }
@@ -351,7 +351,7 @@ async function runGroupSendScenarioInProcess(
     profiler: BenchProfiler,
     config: BenchConfig
 ): Promise<{ result: ScenarioResult; totalBytes: number }> {
-    const groupJid = randomGroupJid()
+    const groupJid = buildRandomGroupJid()
     const members: FakePeer[] = []
     for (let m = 0; m < config.groupMembers; m += 1) {
         await ensurePreKeyPool(server, pipeline, 1)
@@ -373,7 +373,7 @@ async function runGroupSendScenarioRpc(
     profiler: BenchProfiler,
     config: BenchConfig
 ): Promise<{ result: ScenarioResult; totalBytes: number }> {
-    const groupJid = randomGroupJid()
+    const groupJid = buildRandomGroupJid()
     const memberPeerIds: string[] = []
     for (let m = 0; m < config.groupMembers; m += 1) {
         await rpc.ensurePreKeyPool(1)
@@ -436,7 +436,7 @@ async function runRecvScenarioInProcess(
     config: BenchConfig
 ): Promise<{ result: ScenarioResult; totalBytes: number }> {
     await ensurePreKeyPool(server, pipeline, 2)
-    const peerJid = randomPeerJid('666')
+    const peerJid = buildRandomPeerJid('666')
     const peer = await server.createFakePeer({ jid: peerJid }, pipeline)
     const plaintext = fillRandom(config.payloadBytes)
     const blob = await server.publishMediaBlob({ mediaType: testCase.mediaType, plaintext })
@@ -481,7 +481,7 @@ async function runRecvScenarioRpc(
     config: BenchConfig
 ): Promise<{ result: ScenarioResult; totalBytes: number }> {
     await rpc.ensurePreKeyPool(2)
-    const peerJid = randomPeerJid('666')
+    const peerJid = buildRandomPeerJid('666')
     const { peerId } = await rpc.createFakePeer({ jid: peerJid })
     const plaintext = fillRandom(config.payloadBytes)
     const blob = await rpc.publishMediaBlob({ mediaType: testCase.mediaType, plaintext })
@@ -518,17 +518,19 @@ async function runRecvScenarioRpc(
     return { result, totalBytes }
 }
 
+interface MediaDescriptor {
+    readonly directPath: string
+    readonly mediaKey: Uint8Array
+    readonly fileSha256: Uint8Array
+    readonly fileEncSha256: Uint8Array
+    readonly fileLength: number
+    readonly mimetype: string
+}
+
 async function sendPeerMediaInProcess(
     peer: FakePeer,
     mediaType: FakeMediaType,
-    descriptor: {
-        directPath: string
-        mediaKey: Uint8Array
-        fileSha256: Uint8Array
-        fileEncSha256: Uint8Array
-        fileLength: number
-        mimetype: string
-    }
+    descriptor: MediaDescriptor
 ): Promise<void> {
     if (mediaType === 'image') return peer.sendImageMessage(descriptor)
     if (mediaType === 'video') return peer.sendVideoMessage(descriptor)
@@ -539,27 +541,20 @@ async function sendPeerMediaRpc(
     rpc: ServerRpc,
     peerId: string,
     mediaType: FakeMediaType,
-    descriptor: {
-        directPath: string
-        mediaKey: Uint8Array
-        fileSha256: Uint8Array
-        fileEncSha256: Uint8Array
-        fileLength: number
-        mimetype: string
-    }
+    descriptor: MediaDescriptor
 ): Promise<void> {
     if (mediaType === 'image') return rpc.peerSendImageMessage(peerId, descriptor)
     if (mediaType === 'video') return rpc.peerSendVideoMessage(peerId, descriptor)
     throw new Error(`unsupported recv mediaType: ${mediaType}`)
 }
 
-function randomPeerJid(prefix: string): string {
+function buildRandomPeerJid(prefix: string): string {
     return `5511${prefix}${Math.floor(Math.random() * 1_000_000_000)
         .toString()
         .padStart(7, '0')}@s.whatsapp.net`
 }
 
-function randomGroupJid(): string {
+function buildRandomGroupJid(): string {
     return `120363${String(950_000_000_000 + (Date.now() % 1_000_000)).padStart(15, '0')}@g.us`
 }
 

--- a/packages/fake-server/bench/retry.bench.ts
+++ b/packages/fake-server/bench/retry.bench.ts
@@ -1,0 +1,650 @@
+/**
+ * End-to-end retry bench driven through @zapo-js/fake-server.
+ *
+ * Exercises the full retry round-trip in BOTH directions, validated
+ * against `WAWebRetryRequestParser` from the WhatsApp Web bundle.
+ *
+ *   - `incoming_retry`
+ *       Fake peers ship a tampered ciphertext, the lib's signal decrypt
+ *       fails, and the lib emits a `<receipt type="retry">` back to the
+ *       sender. Measures throughput in retries/s of the detect+emit
+ *       pipeline.
+ *
+ *   - `incoming_retry_recovery`
+ *       Full incoming recovery loop: peer sends tampered ciphertext →
+ *       lib emits retry receipt → bench observes the receipt → peer
+ *       `replaySentMessage(id)` puts the original pristine ciphertext
+ *       (same Signal counter + ratchet key) back on the wire → lib
+ *       decrypts and emits `message`. Measures recoveries/s.
+ *
+ *   - `outbound_retry_replay`
+ *       Full outbound replay loop: lib sends 1:1 message (pkmsg) → peer
+ *       drains it → peer `rotateForRetry()` (rotates signed prekey +
+ *       one-time prekey, resets ratchet) → peer sends
+ *       `<receipt type="retry">` carrying the new `<keys>` block → lib
+ *       tears down session, re-runs X3DH against the new keys, and
+ *       re-emits the message as a fresh pkmsg → peer decrypts the
+ *       resend via the rotated bundle. Measures replays/s.
+ *
+ * Tunables (env vars):
+ *   ZAPO_BENCH_RETRY_MESSAGES         (default 100)
+ *   ZAPO_BENCH_RETRY_SCENARIOS        (csv; default = all)
+ *   ZAPO_BENCH_STORE                  (memory | sqlite | mysql | ...)
+ *   ZAPO_BENCH_VERBOSE                (=1 to print lib warn/error)
+ *   ZAPO_BENCH_JSON                   (=1 to also print as JSON)
+ *
+ * Profiling flags:
+ *   --cpu / --heap / --snapshot / --per-scenario /
+ *   --snapshot-per-scenario / --out-dir=<path>
+ *   --separate-process    fake-server runs in a forked child
+ *   --no-server-prof      skip profiling the server child (when --separate-process)
+ *
+ * Run with:
+ *   node --expose-gc --import tsx \
+ *     packages/fake-server/bench/retry.bench.ts
+ */
+
+import assert from 'node:assert/strict'
+
+import type { WaClient, WaClientEventMap } from 'zapo-js'
+
+import type { FakePeer } from '../src/api/FakePeer'
+import type { FakeWaServer, WaFakeConnectionPipeline } from '../src/api/FakeWaServer'
+import type { BinaryNode } from '../src/transport/codec'
+
+import {
+    BenchProfiler,
+    forceGcIfAvailable,
+    installEmergencyStop,
+    maybePrintJson,
+    printResult,
+    readPositiveIntEnv,
+    readProfilerOptions,
+    runScenario,
+    startServerProfilingIfRequested,
+    stopServerProfilingIfRequested,
+    takeServerSnapshotIfRequested,
+    type ScenarioResult
+} from './_common'
+import {
+    bringUpPairedClient,
+    bringUpPairedClientViaRpc,
+    ensurePreKeyPool,
+    teardownFixture,
+    teardownRpcFixture
+} from './_fixtures'
+import { buildBenchStore } from './_store-factory'
+import type { ServerRpc } from './server-rpc'
+
+const ALL_SCENARIOS = new Set<string>([
+    'incoming_retry',
+    'incoming_retry_recovery',
+    'outbound_retry_replay'
+])
+
+function readScenarioFilter(): ReadonlySet<string> {
+    const raw = process.env.ZAPO_BENCH_RETRY_SCENARIOS
+    if (!raw) return ALL_SCENARIOS
+    const out = new Set<string>()
+    for (const part of raw.split(',')) {
+        const trimmed = part.trim()
+        if (!trimmed) continue
+        if (!ALL_SCENARIOS.has(trimmed)) {
+            throw new Error(
+                `unknown ZAPO_BENCH_RETRY_SCENARIOS entry "${trimmed}"; valid: ${[...ALL_SCENARIOS].join(',')}`
+            )
+        }
+        out.add(trimmed)
+    }
+    return out
+}
+
+interface BenchConfig {
+    readonly messages: number
+    readonly scenarios: ReadonlySet<string>
+}
+
+function readConfig(): BenchConfig {
+    return {
+        messages: readPositiveIntEnv('ZAPO_BENCH_RETRY_MESSAGES', 100),
+        scenarios: readScenarioFilter()
+    }
+}
+
+function tamperLastByte(bytes: Uint8Array): Uint8Array {
+    const out = new Uint8Array(bytes)
+    out[out.byteLength - 1] ^= 0xff
+    return out
+}
+
+function isRetryReceipt(stanza: BinaryNode): boolean {
+    if (stanza.tag !== 'receipt') return false
+    return stanza.attrs.type === 'retry'
+}
+
+// ─── In-process peer provisioning ─────────────────────────────────────
+
+interface BenchPeer {
+    readonly peer: FakePeer
+    readonly jid: string
+}
+
+async function provisionPeers(
+    server: FakeWaServer,
+    pipeline: WaFakeConnectionPipeline,
+    count: number,
+    jidPrefix: string
+): Promise<readonly BenchPeer[]> {
+    const out: BenchPeer[] = new Array(count)
+    for (let i = 0; i < count; i += 1) {
+        await ensurePreKeyPool(server, pipeline, 1)
+        const jid = `5511${jidPrefix}${String(i).padStart(7, '0')}@s.whatsapp.net`
+        const peer = await server.createFakePeer({ jid }, pipeline)
+        out[i] = { peer, jid }
+    }
+    return out
+}
+
+interface RpcBenchPeer {
+    readonly peerId: string
+    readonly jid: string
+}
+
+async function provisionPeersRpc(
+    rpc: ServerRpc,
+    count: number,
+    jidPrefix: string
+): Promise<readonly RpcBenchPeer[]> {
+    const out: RpcBenchPeer[] = new Array(count)
+    for (let i = 0; i < count; i += 1) {
+        await rpc.ensurePreKeyPool(1)
+        const jid = `5511${jidPrefix}${String(i).padStart(7, '0')}@s.whatsapp.net`
+        const { peerId } = await rpc.createFakePeer({ jid })
+        out[i] = { peerId, jid }
+    }
+    return out
+}
+
+// ─── incoming_retry ───────────────────────────────────────────────────
+
+async function scenarioIncomingRetryInProcess(
+    server: FakeWaServer,
+    pipeline: WaFakeConnectionPipeline,
+    profiler: BenchProfiler,
+    config: BenchConfig
+): Promise<ScenarioResult> {
+    const peers = await provisionPeers(server, pipeline, config.messages, '9100')
+    const name = 'incoming_retry'
+    await profiler.beforeScenario(name)
+    const result = await runScenario(
+        name,
+        config.messages,
+        async () => {
+            let received = 0
+            const allReceived = new Promise<void>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    offCapture()
+                    reject(new Error(`incoming_retry stalled at ${received}/${config.messages}`))
+                }, 60_000)
+                timer.unref?.()
+                const offCapture = server.onCapturedStanza((stanza) => {
+                    if (!isRetryReceipt(stanza)) return
+                    received += 1
+                    if (received >= config.messages) {
+                        clearTimeout(timer)
+                        offCapture()
+                        resolve()
+                    }
+                })
+            })
+            const sends = peers.map(({ peer }, i) =>
+                peer.sendConversation(`tampered ${i}`, {
+                    id: `incoming-retry-${i}`,
+                    tamperCiphertext: tamperLastByte
+                })
+            )
+            await Promise.all(sends)
+            await allReceived
+        },
+        'retries'
+    )
+    await profiler.afterScenario(name)
+    return result
+}
+
+async function scenarioIncomingRetryRpc(
+    rpc: ServerRpc,
+    profiler: BenchProfiler,
+    config: BenchConfig
+): Promise<ScenarioResult> {
+    const peers = await provisionPeersRpc(rpc, config.messages, '9100')
+    const name = 'incoming_retry'
+    await profiler.beforeScenario(name)
+    const result = await runScenario(
+        name,
+        config.messages,
+        async () => {
+            const waitAll = rpc.waitForRetryReceipts(config.messages, 60_000)
+            const sends = peers.map(({ peerId }, i) =>
+                rpc.peerSendConversation(peerId, `tampered ${i}`, {
+                    id: `incoming-retry-${i}`,
+                    tamperMode: 'last-byte-xor-ff'
+                })
+            )
+            await Promise.all(sends)
+            await waitAll
+        },
+        'retries'
+    )
+    await profiler.afterScenario(name)
+    return result
+}
+
+// ─── incoming_retry_recovery ──────────────────────────────────────────
+
+async function scenarioIncomingRetryRecoveryInProcess(
+    server: FakeWaServer,
+    client: WaClient,
+    pipeline: WaFakeConnectionPipeline,
+    profiler: BenchProfiler,
+    config: BenchConfig
+): Promise<ScenarioResult> {
+    const peers = await provisionPeers(server, pipeline, config.messages, '9200')
+    const name = 'incoming_retry_recovery'
+    await profiler.beforeScenario(name)
+    const result = await runScenario(
+        name,
+        config.messages,
+        async () => {
+            const expectedTexts = new Set<string>()
+            for (let i = 0; i < config.messages; i += 1) {
+                expectedTexts.add(`recovery-${i}`)
+            }
+            const { allRecovered, attachListener, detachListener } = buildRecoveryWaiter(
+                client,
+                expectedTexts,
+                config.messages
+            )
+            attachListener()
+
+            const replayTriggers = new Map<string, () => Promise<void>>()
+            const offCapture = server.onCapturedStanza((stanza) => {
+                if (!isRetryReceipt(stanza)) return
+                const id = stanza.attrs.id
+                if (!id) return
+                const trigger = replayTriggers.get(id)
+                if (!trigger) return
+                replayTriggers.delete(id)
+                void trigger()
+            })
+
+            try {
+                const flows = peers.map(async ({ peer }, i) => {
+                    const id = `recovery-retry-${i}`
+                    const replayed = new Promise<void>((resolve, reject) => {
+                        const t = setTimeout(() => {
+                            replayTriggers.delete(id)
+                            reject(new Error(`recovery: no retry receipt for ${id}`))
+                        }, 60_000)
+                        t.unref?.()
+                        replayTriggers.set(id, async () => {
+                            clearTimeout(t)
+                            try {
+                                await peer.replaySentMessage(id, { resendId: `${id}-replay` })
+                                resolve()
+                            } catch (err) {
+                                reject(err as Error)
+                            }
+                        })
+                    })
+                    await peer.sendConversation(`recovery-${i}`, {
+                        id,
+                        tamperCiphertext: tamperLastByte
+                    })
+                    await replayed
+                })
+                await Promise.all(flows)
+                await allRecovered
+            } finally {
+                offCapture()
+                detachListener()
+            }
+        },
+        'recoveries'
+    )
+    await profiler.afterScenario(name)
+    return result
+}
+
+async function scenarioIncomingRetryRecoveryRpc(
+    rpc: ServerRpc,
+    client: WaClient,
+    profiler: BenchProfiler,
+    config: BenchConfig
+): Promise<ScenarioResult> {
+    const peers = await provisionPeersRpc(rpc, config.messages, '9200')
+    const name = 'incoming_retry_recovery'
+    await profiler.beforeScenario(name)
+    const result = await runScenario(
+        name,
+        config.messages,
+        async () => {
+            const expectedTexts = new Set<string>()
+            for (let i = 0; i < config.messages; i += 1) {
+                expectedTexts.add(`recovery-${i}`)
+            }
+            const { allRecovered, attachListener, detachListener } = buildRecoveryWaiter(
+                client,
+                expectedTexts,
+                config.messages
+            )
+            attachListener()
+            try {
+                const flows = peers.map(async ({ peerId }, i) => {
+                    const id = `recovery-retry-${i}`
+                    const receiptPromise = rpc.waitForRetryReceipt(id, 60_000)
+                    await rpc.peerSendConversation(peerId, `recovery-${i}`, {
+                        id,
+                        tamperMode: 'last-byte-xor-ff'
+                    })
+                    await receiptPromise
+                    await rpc.peerReplaySentMessage(peerId, id, { resendId: `${id}-replay` })
+                })
+                await Promise.all(flows)
+                await allRecovered
+            } finally {
+                detachListener()
+            }
+        },
+        'recoveries'
+    )
+    await profiler.afterScenario(name)
+    return result
+}
+
+function buildRecoveryWaiter(
+    client: WaClient,
+    expectedTexts: Set<string>,
+    target: number
+): {
+    readonly allRecovered: Promise<void>
+    readonly attachListener: () => void
+    readonly detachListener: () => void
+} {
+    let recovered = 0
+    let listener: WaClientEventMap['message'] | null = null
+    let resolveAll: (() => void) | null = null
+    let rejectAll: ((err: Error) => void) | null = null
+    let timer: NodeJS.Timeout | null = null
+    const allRecovered = new Promise<void>((resolve, reject) => {
+        resolveAll = resolve
+        rejectAll = reject
+    })
+    const attachListener = (): void => {
+        timer = setTimeout(() => {
+            if (listener) client.off('message', listener)
+            rejectAll?.(new Error(`incoming_retry_recovery stalled at ${recovered}/${target}`))
+        }, 120_000)
+        timer.unref?.()
+        listener = (event) => {
+            const text = event.message?.conversation
+            if (typeof text !== 'string') return
+            if (!expectedTexts.has(text)) return
+            expectedTexts.delete(text)
+            recovered += 1
+            if (recovered >= target) {
+                if (timer) clearTimeout(timer)
+                if (listener) client.off('message', listener)
+                resolveAll?.()
+            }
+        }
+        client.on('message', listener)
+    }
+    const detachListener = (): void => {
+        if (timer) clearTimeout(timer)
+        if (listener) client.off('message', listener)
+    }
+    return { allRecovered, attachListener, detachListener }
+}
+
+// ─── outbound_retry_replay ────────────────────────────────────────────
+
+async function scenarioOutboundRetryReplayInProcess(
+    server: FakeWaServer,
+    client: WaClient,
+    pipeline: WaFakeConnectionPipeline,
+    profiler: BenchProfiler,
+    config: BenchConfig
+): Promise<ScenarioResult> {
+    const peers = await provisionPeers(server, pipeline, config.messages, '9300')
+    interface Pending {
+        readonly peer: FakePeer
+        readonly originalMsgId: string
+        readonly expectedPlaintext: string
+    }
+    const pending: Pending[] = []
+    for (let i = 0; i < config.messages; i += 1) {
+        const { peer, jid } = peers[i]
+        const plaintext = `replay-target-${i}`
+        const receivedPromise = peer.expectMessage({ timeoutMs: 30_000 })
+        const result = await client.message.send(jid, { conversation: plaintext })
+        const received = await receivedPromise
+        assert.equal(received.message.conversation, plaintext, 'initial drain plaintext mismatch')
+        pending.push({ peer, originalMsgId: result.id, expectedPlaintext: plaintext })
+    }
+
+    const name = 'outbound_retry_replay'
+    await profiler.beforeScenario(name)
+    const result = await runScenario(
+        name,
+        config.messages,
+        async () => {
+            await Promise.all(pending.map(({ peer }) => peer.rotateForRetry()))
+            const drains = pending.map(({ peer, expectedPlaintext }, i) =>
+                peer.expectMessage({ timeoutMs: 60_000 }).then((received) => {
+                    assert.equal(
+                        received.encType,
+                        'pkmsg',
+                        `replay ${i}: expected pkmsg, got ${received.encType}`
+                    )
+                    assert.equal(
+                        received.message.conversation,
+                        expectedPlaintext,
+                        `replay ${i}: plaintext mismatch`
+                    )
+                })
+            )
+            const requests = pending.map(({ peer, originalMsgId }) =>
+                peer.sendRetryReceipt(originalMsgId, { includeKeys: true })
+            )
+            await Promise.all(requests)
+            await Promise.all(drains)
+        },
+        'replays'
+    )
+    await profiler.afterScenario(name)
+    return result
+}
+
+async function scenarioOutboundRetryReplayRpc(
+    rpc: ServerRpc,
+    client: WaClient,
+    profiler: BenchProfiler,
+    config: BenchConfig
+): Promise<ScenarioResult> {
+    const peers = await provisionPeersRpc(rpc, config.messages, '9300')
+    interface Pending {
+        readonly peerId: string
+        readonly originalMsgId: string
+        readonly expectedPlaintext: string
+    }
+    const pending: Pending[] = []
+    for (let i = 0; i < config.messages; i += 1) {
+        const { peerId, jid } = peers[i]
+        const plaintext = `replay-target-${i}`
+        const receivedPromise = rpc.peerExpectMessage(peerId, 30_000)
+        const result = await client.message.send(jid, { conversation: plaintext })
+        const received = await receivedPromise
+        assert.equal(received.conversation, plaintext, 'initial drain plaintext mismatch')
+        pending.push({ peerId, originalMsgId: result.id, expectedPlaintext: plaintext })
+    }
+
+    const name = 'outbound_retry_replay'
+    await profiler.beforeScenario(name)
+    const result = await runScenario(
+        name,
+        config.messages,
+        async () => {
+            await Promise.all(pending.map(({ peerId }) => rpc.peerRotateForRetry(peerId)))
+            const drains = pending.map(({ peerId, expectedPlaintext }, i) =>
+                rpc.peerExpectMessage(peerId, 60_000).then((received) => {
+                    assert.equal(
+                        received.encType,
+                        'pkmsg',
+                        `replay ${i}: expected pkmsg, got ${received.encType}`
+                    )
+                    assert.equal(
+                        received.conversation,
+                        expectedPlaintext,
+                        `replay ${i}: plaintext mismatch`
+                    )
+                })
+            )
+            const requests = pending.map(({ peerId, originalMsgId }) =>
+                rpc.peerSendRetryReceipt(peerId, originalMsgId, { includeKeys: true })
+            )
+            await Promise.all(requests)
+            await Promise.all(drains)
+        },
+        'replays'
+    )
+    await profiler.afterScenario(name)
+    return result
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+    installEmergencyStop()
+    const argSet = new Set(process.argv.slice(2))
+    const profiler = new BenchProfiler(readProfilerOptions(argSet))
+    await profiler.start()
+
+    const config = readConfig()
+    const backendName = process.env.ZAPO_BENCH_STORE ?? 'memory'
+    const separate = argSet.has('--separate-process')
+
+    console.log('zapo-js retry bench')
+    console.log('───────────────────')
+    console.log(`  messages/scenario : ${config.messages}`)
+    console.log(`  scenarios         : ${[...config.scenarios].join(', ')}`)
+    console.log(`  store             : ${backendName}`)
+    console.log(`  mode              : ${separate ? 'separate-process' : 'in-process'}`)
+    console.log('')
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('start').catch((err) => console.error('[snapshot]', err))
+    }
+
+    const aggregated: ScenarioResult[] = []
+    if (separate) {
+        await runSeparateProcess(config, profiler, argSet, aggregated)
+    } else {
+        await runInProcess(config, profiler, aggregated)
+    }
+
+    if (argSet.has('--snapshot')) {
+        await profiler.takeHeapSnapshot('end').catch((err) => console.error('[snapshot]', err))
+    }
+    await profiler.stop()
+
+    maybePrintJson(aggregated)
+}
+
+async function runInProcess(
+    config: BenchConfig,
+    profiler: BenchProfiler,
+    aggregated: ScenarioResult[]
+): Promise<void> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClient(storeFixture, { sessionId: 'zapo-bench-retry' })
+    const { server, client, pipeline } = fixture
+    try {
+        if (config.scenarios.has('incoming_retry')) {
+            const r = await scenarioIncomingRetryInProcess(server, pipeline, profiler, config)
+            aggregated.push(r)
+            printResult(r)
+            forceGcIfAvailable()
+        }
+        if (config.scenarios.has('incoming_retry_recovery')) {
+            const r = await scenarioIncomingRetryRecoveryInProcess(
+                server,
+                client,
+                pipeline,
+                profiler,
+                config
+            )
+            aggregated.push(r)
+            printResult(r)
+            forceGcIfAvailable()
+        }
+        if (config.scenarios.has('outbound_retry_replay')) {
+            const r = await scenarioOutboundRetryReplayInProcess(
+                server,
+                client,
+                pipeline,
+                profiler,
+                config
+            )
+            aggregated.push(r)
+            printResult(r)
+            forceGcIfAvailable()
+        }
+    } finally {
+        await teardownFixture(fixture)
+    }
+}
+
+async function runSeparateProcess(
+    config: BenchConfig,
+    profiler: BenchProfiler,
+    argSet: ReadonlySet<string>,
+    aggregated: ScenarioResult[]
+): Promise<void> {
+    const storeFixture = await buildBenchStore()
+    const fixture = await bringUpPairedClientViaRpc(storeFixture, { sessionId: 'zapo-bench-retry' })
+    const { rpc, client } = fixture
+    try {
+        await startServerProfilingIfRequested(rpc, profiler.options, argSet)
+        await takeServerSnapshotIfRequested(rpc, 'server-pre', profiler.options, argSet)
+
+        if (config.scenarios.has('incoming_retry')) {
+            const r = await scenarioIncomingRetryRpc(rpc, profiler, config)
+            aggregated.push(r)
+            printResult(r)
+            forceGcIfAvailable()
+        }
+        if (config.scenarios.has('incoming_retry_recovery')) {
+            const r = await scenarioIncomingRetryRecoveryRpc(rpc, client, profiler, config)
+            aggregated.push(r)
+            printResult(r)
+            forceGcIfAvailable()
+        }
+        if (config.scenarios.has('outbound_retry_replay')) {
+            const r = await scenarioOutboundRetryReplayRpc(rpc, client, profiler, config)
+            aggregated.push(r)
+            printResult(r)
+            forceGcIfAvailable()
+        }
+
+        await takeServerSnapshotIfRequested(rpc, 'server-post', profiler.options, argSet)
+    } finally {
+        await stopServerProfilingIfRequested(rpc, profiler.options, argSet).catch(() => undefined)
+        await teardownRpcFixture(fixture)
+    }
+}
+
+void main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/fake-server/bench/retry.bench.ts
+++ b/packages/fake-server/bench/retry.bench.ts
@@ -133,13 +133,17 @@ async function provisionPeers(
     server: FakeWaServer,
     pipeline: WaFakeConnectionPipeline,
     count: number,
-    jidPrefix: string
+    jidPrefix: string,
+    options: { readonly enableReplayCache?: boolean } = {}
 ): Promise<readonly BenchPeer[]> {
     const out: BenchPeer[] = new Array(count)
     for (let i = 0; i < count; i += 1) {
         await ensurePreKeyPool(server, pipeline, 1)
         const jid = `5511${jidPrefix}${String(i).padStart(7, '0')}@s.whatsapp.net`
-        const peer = await server.createFakePeer({ jid }, pipeline)
+        const peer = await server.createFakePeer(
+            { jid, enableReplayCache: options.enableReplayCache },
+            pipeline
+        )
         out[i] = { peer, jid }
     }
     return out
@@ -153,13 +157,17 @@ interface RpcBenchPeer {
 async function provisionPeersRpc(
     rpc: ServerRpc,
     count: number,
-    jidPrefix: string
+    jidPrefix: string,
+    options: { readonly enableReplayCache?: boolean } = {}
 ): Promise<readonly RpcBenchPeer[]> {
     const out: RpcBenchPeer[] = new Array(count)
     for (let i = 0; i < count; i += 1) {
         await rpc.ensurePreKeyPool(1)
         const jid = `5511${jidPrefix}${String(i).padStart(7, '0')}@s.whatsapp.net`
-        const { peerId } = await rpc.createFakePeer({ jid })
+        const { peerId } = await rpc.createFakePeer({
+            jid,
+            enableReplayCache: options.enableReplayCache
+        })
         out[i] = { peerId, jid }
     }
     return out
@@ -249,7 +257,9 @@ async function scenarioIncomingRetryRecoveryInProcess(
     profiler: BenchProfiler,
     config: BenchConfig
 ): Promise<ScenarioResult> {
-    const peers = await provisionPeers(server, pipeline, config.messages, '9200')
+    const peers = await provisionPeers(server, pipeline, config.messages, '9200', {
+        enableReplayCache: true
+    })
     const name = 'incoming_retry_recovery'
     await profiler.beforeScenario(name)
     const result = await runScenario(
@@ -322,7 +332,9 @@ async function scenarioIncomingRetryRecoveryRpc(
     profiler: BenchProfiler,
     config: BenchConfig
 ): Promise<ScenarioResult> {
-    const peers = await provisionPeersRpc(rpc, config.messages, '9200')
+    const peers = await provisionPeersRpc(rpc, config.messages, '9200', {
+        enableReplayCache: true
+    })
     const name = 'incoming_retry_recovery'
     await profiler.beforeScenario(name)
     const result = await runScenario(

--- a/packages/fake-server/bench/server-process.ts
+++ b/packages/fake-server/bench/server-process.ts
@@ -142,10 +142,15 @@ async function handleCreateFakePeerWithDevices(params: {
 async function handleCreateFakePeer(params: {
     jid: string
     skipOneTimePreKey?: boolean
+    enableReplayCache?: boolean
 }): Promise<{ peerId: string }> {
     if (!server || !pipeline) throw new Error('no pipeline')
     const peer = await server.createFakePeer(
-        { jid: params.jid, skipOneTimePreKey: params.skipOneTimePreKey },
+        {
+            jid: params.jid,
+            skipOneTimePreKey: params.skipOneTimePreKey,
+            enableReplayCache: params.enableReplayCache
+        },
         pipeline
     )
     const id = `peer-${peerIdCounter++}`
@@ -200,49 +205,34 @@ async function handlePeerSendConversation(params: {
     })
 }
 
-interface MediaDescriptorBytes {
-    readonly directPath: string
-    readonly mediaKeyBytes: number[]
-    readonly fileSha256Bytes: number[]
-    readonly fileEncSha256Bytes: number[]
-    readonly fileLength: number
-    readonly mimetype?: string
-}
-
-function unpackMediaDescriptor(input: MediaDescriptorBytes): {
+// IPC runs with `serialization: 'advanced'` (see ServerRpc.spawn), so
+// Uint8Array fields cross the boundary intact – no number[] round-trip
+// here.
+interface MediaDescriptorInput {
     readonly directPath: string
     readonly mediaKey: Uint8Array
     readonly fileSha256: Uint8Array
     readonly fileEncSha256: Uint8Array
     readonly fileLength: number
     readonly mimetype?: string
-} {
-    return {
-        directPath: input.directPath,
-        mediaKey: new Uint8Array(input.mediaKeyBytes),
-        fileSha256: new Uint8Array(input.fileSha256Bytes),
-        fileEncSha256: new Uint8Array(input.fileEncSha256Bytes),
-        fileLength: input.fileLength,
-        mimetype: input.mimetype
-    }
 }
 
 async function handlePeerSendImageMessage(params: {
     peerId: string
-    descriptor: MediaDescriptorBytes
+    descriptor: MediaDescriptorInput
 }): Promise<void> {
     const peer = peersById.get(params.peerId)
     if (!peer) throw new Error(`peer ${params.peerId} not found`)
-    await peer.sendImageMessage(unpackMediaDescriptor(params.descriptor))
+    await peer.sendImageMessage(params.descriptor)
 }
 
 async function handlePeerSendVideoMessage(params: {
     peerId: string
-    descriptor: MediaDescriptorBytes
+    descriptor: MediaDescriptorInput
 }): Promise<void> {
     const peer = peersById.get(params.peerId)
     if (!peer) throw new Error(`peer ${params.peerId} not found`)
-    await peer.sendVideoMessage(unpackMediaDescriptor(params.descriptor))
+    await peer.sendVideoMessage(params.descriptor)
 }
 
 async function handlePublishMediaBlob(params: {
@@ -256,24 +246,24 @@ async function handlePublishMediaBlob(params: {
         | 'ptt'
         | 'history'
         | 'md-app-state'
-    plaintextBytes: number[]
+    plaintext: Uint8Array
 }): Promise<{
     path: string
-    mediaKeyBytes: number[]
-    fileSha256Bytes: number[]
-    fileEncSha256Bytes: number[]
+    mediaKey: Uint8Array
+    fileSha256: Uint8Array
+    fileEncSha256: Uint8Array
     fileLength: number
 }> {
     if (!server) throw new Error('server not started')
     const blob = await server.publishMediaBlob({
         mediaType: params.mediaType,
-        plaintext: new Uint8Array(params.plaintextBytes)
+        plaintext: params.plaintext
     })
     return {
         path: blob.path,
-        mediaKeyBytes: Array.from(blob.mediaKey),
-        fileSha256Bytes: Array.from(blob.fileSha256),
-        fileEncSha256Bytes: Array.from(blob.fileEncSha256),
+        mediaKey: blob.mediaKey,
+        fileSha256: blob.fileSha256,
+        fileEncSha256: blob.fileEncSha256,
         fileLength: blob.fileLength
     }
 }
@@ -332,11 +322,32 @@ async function handlePeerSendRetryReceipt(params: {
     })
 }
 
+function isMatchingRetryReceipt(
+    stanza: BinaryNode,
+    stanzaId?: string
+): { readonly id: string } | null {
+    if (stanza.tag !== 'receipt') return null
+    if (stanza.attrs.type !== 'retry') return null
+    const id = stanza.attrs.id
+    if (!id) return null
+    if (stanzaId !== undefined && id !== stanzaId) return null
+    return { id }
+}
+
 async function handleWaitForRetryReceipt(params: {
     stanzaId: string
     timeoutMs?: number
 }): Promise<void> {
     if (!server) throw new Error('server not started')
+    // onCapturedStanza is future-only: the receipt may have already
+    // landed before this handler installs its listener (the bench fires
+    // the tampered send via an earlier RPC call, and capture happens on
+    // the child's event loop independent of waitForRetryReceipt arrival
+    // order). Scan the existing snapshot first; only subscribe if the
+    // receipt has not been seen yet.
+    for (const captured of server.capturedStanzaSnapshot()) {
+        if (isMatchingRetryReceipt(captured, params.stanzaId)) return
+    }
     const timeoutMs = params.timeoutMs ?? 60_000
     await new Promise<void>((resolve, reject) => {
         const timer = setTimeout(() => {
@@ -347,9 +358,7 @@ async function handleWaitForRetryReceipt(params: {
         }, timeoutMs)
         timer.unref?.()
         const offCapture = server!.onCapturedStanza((stanza) => {
-            if (stanza.tag !== 'receipt') return
-            if (stanza.attrs.type !== 'retry') return
-            if (stanza.attrs.id !== params.stanzaId) return
+            if (!isMatchingRetryReceipt(stanza, params.stanzaId)) return
             clearTimeout(timer)
             offCapture()
             resolve()
@@ -362,8 +371,20 @@ async function handleWaitForRetryReceipts(params: {
     timeoutMs?: number
 }): Promise<{ ids: string[] }> {
     if (!server) throw new Error('server not started')
-    const timeoutMs = params.timeoutMs ?? 60_000
     const ids: string[] = []
+    // Drain any retry receipts already captured before this handler ran
+    // (same race as handleWaitForRetryReceipt). De-dupe by id so a single
+    // receipt isn't counted twice if it also slips into the future
+    // listener.
+    const seen = new Set<string>()
+    for (const captured of server.capturedStanzaSnapshot()) {
+        const match = isMatchingRetryReceipt(captured)
+        if (!match || seen.has(match.id)) continue
+        seen.add(match.id)
+        ids.push(match.id)
+        if (ids.length >= params.count) return { ids }
+    }
+    const timeoutMs = params.timeoutMs ?? 60_000
     await new Promise<void>((resolve, reject) => {
         const timer = setTimeout(() => {
             offCapture()
@@ -375,10 +396,10 @@ async function handleWaitForRetryReceipts(params: {
         }, timeoutMs)
         timer.unref?.()
         const offCapture = server!.onCapturedStanza((stanza) => {
-            if (stanza.tag !== 'receipt') return
-            if (stanza.attrs.type !== 'retry') return
-            if (!stanza.attrs.id) return
-            ids.push(stanza.attrs.id)
+            const match = isMatchingRetryReceipt(stanza)
+            if (!match || seen.has(match.id)) return
+            seen.add(match.id)
+            ids.push(match.id)
             if (ids.length >= params.count) {
                 clearTimeout(timer)
                 offCapture()

--- a/packages/fake-server/bench/server-process.ts
+++ b/packages/fake-server/bench/server-process.ts
@@ -178,10 +178,215 @@ async function handleEnsurePreKeyPool(params: { requiredHeadroom: number }): Pro
     await server.triggerPreKeyUpload(pipeline, { force: true })
 }
 
-async function handlePeerSendConversation(params: { peerId: string; text: string }): Promise<void> {
+async function handlePeerSendConversation(params: {
+    peerId: string
+    text: string
+    id?: string
+    tamperMode?: 'last-byte-xor-ff'
+}): Promise<void> {
     const peer = peersById.get(params.peerId)
     if (!peer) throw new Error(`peer ${params.peerId} not found`)
-    await peer.sendConversation(params.text)
+    const tamper =
+        params.tamperMode === 'last-byte-xor-ff'
+            ? (bytes: Uint8Array): Uint8Array => {
+                  const out = new Uint8Array(bytes)
+                  out[out.byteLength - 1] ^= 0xff
+                  return out
+              }
+            : undefined
+    await peer.sendConversation(params.text, {
+        ...(params.id !== undefined ? { id: params.id } : {}),
+        ...(tamper ? { tamperCiphertext: tamper } : {})
+    })
+}
+
+interface MediaDescriptorBytes {
+    readonly directPath: string
+    readonly mediaKeyBytes: number[]
+    readonly fileSha256Bytes: number[]
+    readonly fileEncSha256Bytes: number[]
+    readonly fileLength: number
+    readonly mimetype?: string
+}
+
+function unpackMediaDescriptor(input: MediaDescriptorBytes): {
+    readonly directPath: string
+    readonly mediaKey: Uint8Array
+    readonly fileSha256: Uint8Array
+    readonly fileEncSha256: Uint8Array
+    readonly fileLength: number
+    readonly mimetype?: string
+} {
+    return {
+        directPath: input.directPath,
+        mediaKey: new Uint8Array(input.mediaKeyBytes),
+        fileSha256: new Uint8Array(input.fileSha256Bytes),
+        fileEncSha256: new Uint8Array(input.fileEncSha256Bytes),
+        fileLength: input.fileLength,
+        mimetype: input.mimetype
+    }
+}
+
+async function handlePeerSendImageMessage(params: {
+    peerId: string
+    descriptor: MediaDescriptorBytes
+}): Promise<void> {
+    const peer = peersById.get(params.peerId)
+    if (!peer) throw new Error(`peer ${params.peerId} not found`)
+    await peer.sendImageMessage(unpackMediaDescriptor(params.descriptor))
+}
+
+async function handlePeerSendVideoMessage(params: {
+    peerId: string
+    descriptor: MediaDescriptorBytes
+}): Promise<void> {
+    const peer = peersById.get(params.peerId)
+    if (!peer) throw new Error(`peer ${params.peerId} not found`)
+    await peer.sendVideoMessage(unpackMediaDescriptor(params.descriptor))
+}
+
+async function handlePublishMediaBlob(params: {
+    mediaType:
+        | 'image'
+        | 'video'
+        | 'audio'
+        | 'document'
+        | 'sticker'
+        | 'gif'
+        | 'ptt'
+        | 'history'
+        | 'md-app-state'
+    plaintextBytes: number[]
+}): Promise<{
+    path: string
+    mediaKeyBytes: number[]
+    fileSha256Bytes: number[]
+    fileEncSha256Bytes: number[]
+    fileLength: number
+}> {
+    if (!server) throw new Error('server not started')
+    const blob = await server.publishMediaBlob({
+        mediaType: params.mediaType,
+        plaintext: new Uint8Array(params.plaintextBytes)
+    })
+    return {
+        path: blob.path,
+        mediaKeyBytes: Array.from(blob.mediaKey),
+        fileSha256Bytes: Array.from(blob.fileSha256),
+        fileEncSha256Bytes: Array.from(blob.fileEncSha256),
+        fileLength: blob.fileLength
+    }
+}
+
+async function handleMediaUrl(params: { path: string }): Promise<{ url: string }> {
+    if (!server) throw new Error('server not started')
+    return { url: server.mediaUrl(params.path) }
+}
+
+async function handlePeerExpectMessage(params: {
+    peerId: string
+    timeoutMs?: number
+}): Promise<{ conversation: string | null; encType: 'pkmsg' | 'msg' | 'skmsg' }> {
+    const peer = peersById.get(params.peerId)
+    if (!peer) throw new Error(`peer ${params.peerId} not found`)
+    const received = await peer.expectMessage({ timeoutMs: params.timeoutMs ?? 30_000 })
+    return {
+        conversation: received.message.conversation ?? null,
+        encType: received.encType
+    }
+}
+
+async function handlePeerReplaySentMessage(params: {
+    peerId: string
+    originalMsgId: string
+    resendId?: string
+}): Promise<void> {
+    const peer = peersById.get(params.peerId)
+    if (!peer) throw new Error(`peer ${params.peerId} not found`)
+    await peer.replaySentMessage(params.originalMsgId, {
+        ...(params.resendId !== undefined ? { resendId: params.resendId } : {})
+    })
+}
+
+async function handlePeerRotateForRetry(params: { peerId: string }): Promise<void> {
+    const peer = peersById.get(params.peerId)
+    if (!peer) throw new Error(`peer ${params.peerId} not found`)
+    await peer.rotateForRetry()
+}
+
+async function handlePeerSendRetryReceipt(params: {
+    peerId: string
+    originalMsgId: string
+    includeKeys?: boolean
+    count?: number
+    receiptId?: string
+    t?: number
+}): Promise<void> {
+    const peer = peersById.get(params.peerId)
+    if (!peer) throw new Error(`peer ${params.peerId} not found`)
+    await peer.sendRetryReceipt(params.originalMsgId, {
+        ...(params.count !== undefined ? { count: params.count } : {}),
+        ...(params.receiptId !== undefined ? { receiptId: params.receiptId } : {}),
+        ...(params.t !== undefined ? { t: params.t } : {}),
+        ...(params.includeKeys !== undefined ? { includeKeys: params.includeKeys } : {})
+    })
+}
+
+async function handleWaitForRetryReceipt(params: {
+    stanzaId: string
+    timeoutMs?: number
+}): Promise<void> {
+    if (!server) throw new Error('server not started')
+    const timeoutMs = params.timeoutMs ?? 60_000
+    await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            offCapture()
+            reject(
+                new Error(`waitForRetryReceipt(${params.stanzaId}) timed out after ${timeoutMs}ms`)
+            )
+        }, timeoutMs)
+        timer.unref?.()
+        const offCapture = server!.onCapturedStanza((stanza) => {
+            if (stanza.tag !== 'receipt') return
+            if (stanza.attrs.type !== 'retry') return
+            if (stanza.attrs.id !== params.stanzaId) return
+            clearTimeout(timer)
+            offCapture()
+            resolve()
+        })
+    })
+}
+
+async function handleWaitForRetryReceipts(params: {
+    count: number
+    timeoutMs?: number
+}): Promise<{ ids: string[] }> {
+    if (!server) throw new Error('server not started')
+    const timeoutMs = params.timeoutMs ?? 60_000
+    const ids: string[] = []
+    await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            offCapture()
+            reject(
+                new Error(
+                    `waitForRetryReceipts stalled at ${ids.length}/${params.count} after ${timeoutMs}ms`
+                )
+            )
+        }, timeoutMs)
+        timer.unref?.()
+        const offCapture = server!.onCapturedStanza((stanza) => {
+            if (stanza.tag !== 'receipt') return
+            if (stanza.attrs.type !== 'retry') return
+            if (!stanza.attrs.id) return
+            ids.push(stanza.attrs.id)
+            if (ids.length >= params.count) {
+                clearTimeout(timer)
+                offCapture()
+                resolve()
+            }
+        })
+    })
+    return { ids }
 }
 
 async function handlePeerSendGroupConversation(params: {
@@ -554,6 +759,26 @@ const handlers: Record<
     peerSendGroupConversation: handlePeerSendGroupConversation as (
         p: Record<string, unknown>
     ) => Promise<void>,
+    peerSendImageMessage: handlePeerSendImageMessage as (
+        p: Record<string, unknown>
+    ) => Promise<void>,
+    peerSendVideoMessage: handlePeerSendVideoMessage as (
+        p: Record<string, unknown>
+    ) => Promise<void>,
+    publishMediaBlob: handlePublishMediaBlob as (p: Record<string, unknown>) => Promise<unknown>,
+    mediaUrl: handleMediaUrl as (p: Record<string, unknown>) => Promise<unknown>,
+    peerExpectMessage: handlePeerExpectMessage as (p: Record<string, unknown>) => Promise<unknown>,
+    peerReplaySentMessage: handlePeerReplaySentMessage as (
+        p: Record<string, unknown>
+    ) => Promise<void>,
+    peerRotateForRetry: handlePeerRotateForRetry as (p: Record<string, unknown>) => Promise<void>,
+    peerSendRetryReceipt: handlePeerSendRetryReceipt as (
+        p: Record<string, unknown>
+    ) => Promise<void>,
+    waitForRetryReceipt: handleWaitForRetryReceipt as (p: Record<string, unknown>) => Promise<void>,
+    waitForRetryReceipts: handleWaitForRetryReceipts as (
+        p: Record<string, unknown>
+    ) => Promise<unknown>,
     preKeysAvailable: handlePreKeysAvailable as () => number,
     dispenserMisses: handleDispenserMisses as () => number,
     stop: handleStop,

--- a/packages/fake-server/bench/server-rpc.ts
+++ b/packages/fake-server/bench/server-rpc.ts
@@ -21,6 +21,31 @@ interface RpcResponse {
     readonly error?: string
 }
 
+function serializeDescriptor(descriptor: {
+    directPath: string
+    mediaKey: Uint8Array
+    fileSha256: Uint8Array
+    fileEncSha256: Uint8Array
+    fileLength: number
+    mimetype?: string
+}): {
+    directPath: string
+    mediaKeyBytes: number[]
+    fileSha256Bytes: number[]
+    fileEncSha256Bytes: number[]
+    fileLength: number
+    mimetype?: string
+} {
+    return {
+        directPath: descriptor.directPath,
+        mediaKeyBytes: Array.from(descriptor.mediaKey),
+        fileSha256Bytes: Array.from(descriptor.fileSha256),
+        fileEncSha256Bytes: Array.from(descriptor.fileEncSha256),
+        fileLength: descriptor.fileLength,
+        mimetype: descriptor.mimetype
+    }
+}
+
 export interface RemotePeerHandle {
     readonly peerId: string
     sendConversation(text: string): Promise<void>
@@ -109,7 +134,10 @@ export class ServerRpc {
             publicKey: new Uint8Array(result.noiseRootCa.publicKey),
             serial: result.noiseRootCa.serial
         }
-        this.mediaProxyAgent = new https.Agent({ rejectUnauthorized: false })
+        // keepAlive: true mirrors what real-world WhatsApp clients do and
+        // matches the in-process FakeWaServer.mediaProxyAgent so the
+        // --separate-process bench numbers stay comparable.
+        this.mediaProxyAgent = new https.Agent({ rejectUnauthorized: false, keepAlive: true })
     }
 
     public async waitForAuthenticatedPipeline(): Promise<void> {
@@ -177,8 +205,148 @@ export class ServerRpc {
         await this.call('ensurePreKeyPool', { requiredHeadroom })
     }
 
-    public async peerSendConversation(peerId: string, text: string): Promise<void> {
-        await this.call('peerSendConversation', { peerId, text })
+    public async peerSendConversation(
+        peerId: string,
+        text: string,
+        options: { id?: string; tamperMode?: 'last-byte-xor-ff' } = {}
+    ): Promise<void> {
+        await this.call('peerSendConversation', {
+            peerId,
+            text,
+            ...(options.id !== undefined ? { id: options.id } : {}),
+            ...(options.tamperMode !== undefined ? { tamperMode: options.tamperMode } : {})
+        })
+    }
+
+    public async peerSendImageMessage(
+        peerId: string,
+        descriptor: {
+            directPath: string
+            mediaKey: Uint8Array
+            fileSha256: Uint8Array
+            fileEncSha256: Uint8Array
+            fileLength: number
+            mimetype?: string
+        }
+    ): Promise<void> {
+        await this.call('peerSendImageMessage', {
+            peerId,
+            descriptor: serializeDescriptor(descriptor)
+        })
+    }
+
+    public async peerSendVideoMessage(
+        peerId: string,
+        descriptor: {
+            directPath: string
+            mediaKey: Uint8Array
+            fileSha256: Uint8Array
+            fileEncSha256: Uint8Array
+            fileLength: number
+            mimetype?: string
+        }
+    ): Promise<void> {
+        await this.call('peerSendVideoMessage', {
+            peerId,
+            descriptor: serializeDescriptor(descriptor)
+        })
+    }
+
+    public async publishMediaBlob(input: {
+        mediaType:
+            | 'image'
+            | 'video'
+            | 'audio'
+            | 'document'
+            | 'sticker'
+            | 'gif'
+            | 'ptt'
+            | 'history'
+            | 'md-app-state'
+        plaintext: Uint8Array
+    }): Promise<{
+        path: string
+        mediaKey: Uint8Array
+        fileSha256: Uint8Array
+        fileEncSha256: Uint8Array
+        fileLength: number
+    }> {
+        const result = (await this.call('publishMediaBlob', {
+            mediaType: input.mediaType,
+            plaintextBytes: Array.from(input.plaintext)
+        })) as {
+            path: string
+            mediaKeyBytes: number[]
+            fileSha256Bytes: number[]
+            fileEncSha256Bytes: number[]
+            fileLength: number
+        }
+        return {
+            path: result.path,
+            mediaKey: new Uint8Array(result.mediaKeyBytes),
+            fileSha256: new Uint8Array(result.fileSha256Bytes),
+            fileEncSha256: new Uint8Array(result.fileEncSha256Bytes),
+            fileLength: result.fileLength
+        }
+    }
+
+    public async mediaUrl(path: string): Promise<string> {
+        const result = (await this.call('mediaUrl', { path })) as { url: string }
+        return result.url
+    }
+
+    public async peerExpectMessage(
+        peerId: string,
+        timeoutMs = 30_000
+    ): Promise<{ conversation: string | null; encType: 'pkmsg' | 'msg' | 'skmsg' }> {
+        return (await this.call('peerExpectMessage', { peerId, timeoutMs })) as {
+            conversation: string | null
+            encType: 'pkmsg' | 'msg' | 'skmsg'
+        }
+    }
+
+    public async peerReplaySentMessage(
+        peerId: string,
+        originalMsgId: string,
+        options: { resendId?: string } = {}
+    ): Promise<void> {
+        await this.call('peerReplaySentMessage', {
+            peerId,
+            originalMsgId,
+            ...(options.resendId !== undefined ? { resendId: options.resendId } : {})
+        })
+    }
+
+    public async peerRotateForRetry(peerId: string): Promise<void> {
+        await this.call('peerRotateForRetry', { peerId })
+    }
+
+    public async peerSendRetryReceipt(
+        peerId: string,
+        originalMsgId: string,
+        options: {
+            includeKeys?: boolean
+            count?: number
+            receiptId?: string
+            t?: number
+        } = {}
+    ): Promise<void> {
+        await this.call('peerSendRetryReceipt', {
+            peerId,
+            originalMsgId,
+            ...options
+        })
+    }
+
+    public async waitForRetryReceipt(stanzaId: string, timeoutMs = 60_000): Promise<void> {
+        await this.call('waitForRetryReceipt', { stanzaId, timeoutMs })
+    }
+
+    public async waitForRetryReceipts(count: number, timeoutMs = 60_000): Promise<string[]> {
+        const result = (await this.call('waitForRetryReceipts', { count, timeoutMs })) as {
+            ids: string[]
+        }
+        return result.ids
     }
 
     public async peerSendGroupConversation(

--- a/packages/fake-server/bench/server-rpc.ts
+++ b/packages/fake-server/bench/server-rpc.ts
@@ -21,29 +21,24 @@ interface RpcResponse {
     readonly error?: string
 }
 
-function serializeDescriptor(descriptor: {
-    directPath: string
-    mediaKey: Uint8Array
-    fileSha256: Uint8Array
-    fileEncSha256: Uint8Array
-    fileLength: number
-    mimetype?: string
-}): {
-    directPath: string
-    mediaKeyBytes: number[]
-    fileSha256Bytes: number[]
-    fileEncSha256Bytes: number[]
-    fileLength: number
-    mimetype?: string
-} {
-    return {
-        directPath: descriptor.directPath,
-        mediaKeyBytes: Array.from(descriptor.mediaKey),
-        fileSha256Bytes: Array.from(descriptor.fileSha256),
-        fileEncSha256Bytes: Array.from(descriptor.fileEncSha256),
-        fileLength: descriptor.fileLength,
-        mimetype: descriptor.mimetype
-    }
+/**
+ * Shape of a media-receive descriptor that the lib needs to download +
+ * decrypt an inbound media message. Used by {@link peerSendImageMessage}
+ * and {@link peerSendVideoMessage} as the payload sent to the child to
+ * have a FakePeer publish a media-bearing stanza.
+ *
+ * `Uint8Array` fields cross the IPC boundary in place because the child
+ * is forked with `serialization: 'advanced'` (V8 structured clone),
+ * which preserves typed-array byte buffers without the `number[]`
+ * round-trip the default JSON serializer would force.
+ */
+export interface MediaDescriptor {
+    readonly directPath: string
+    readonly mediaKey: Uint8Array
+    readonly fileSha256: Uint8Array
+    readonly fileEncSha256: Uint8Array
+    readonly fileLength: number
+    readonly mimetype?: string
 }
 
 export interface RemotePeerHandle {
@@ -81,9 +76,15 @@ export class ServerRpc {
 
     public async spawn(): Promise<void> {
         const entry = resolvePath(__dirname, 'server-process.ts')
+        // serialization: 'advanced' switches IPC to V8's structured
+        // clone, which preserves Uint8Array / Buffer in place. Without
+        // it every typed-array crossing the boundary would round-trip
+        // through `number[]` + JSON, inflating memory and CPU for
+        // multi-MB media payloads (publishMediaBlob, peerSend*Message).
         this.child = fork(entry, [], {
             execArgv: ['--import', 'tsx'],
-            stdio: ['pipe', 'inherit', 'inherit', 'ipc']
+            stdio: ['pipe', 'inherit', 'inherit', 'ipc'],
+            serialization: 'advanced'
         })
         this.child.on('message', (msg: RpcResponse & { ready?: boolean }) => {
             if (msg.ready) return // handled by readyPromise
@@ -189,6 +190,7 @@ export class ServerRpc {
     public async createFakePeer(input: {
         jid: string
         skipOneTimePreKey?: boolean
+        enableReplayCache?: boolean
     }): Promise<{ peerId: string }> {
         return (await this.call('createFakePeer', input)) as { peerId: string }
     }
@@ -218,42 +220,16 @@ export class ServerRpc {
         })
     }
 
-    public async peerSendImageMessage(
-        peerId: string,
-        descriptor: {
-            directPath: string
-            mediaKey: Uint8Array
-            fileSha256: Uint8Array
-            fileEncSha256: Uint8Array
-            fileLength: number
-            mimetype?: string
-        }
-    ): Promise<void> {
-        await this.call('peerSendImageMessage', {
-            peerId,
-            descriptor: serializeDescriptor(descriptor)
-        })
+    public async peerSendImageMessage(peerId: string, descriptor: MediaDescriptor): Promise<void> {
+        await this.call('peerSendImageMessage', { peerId, descriptor })
     }
 
-    public async peerSendVideoMessage(
-        peerId: string,
-        descriptor: {
-            directPath: string
-            mediaKey: Uint8Array
-            fileSha256: Uint8Array
-            fileEncSha256: Uint8Array
-            fileLength: number
-            mimetype?: string
-        }
-    ): Promise<void> {
-        await this.call('peerSendVideoMessage', {
-            peerId,
-            descriptor: serializeDescriptor(descriptor)
-        })
+    public async peerSendVideoMessage(peerId: string, descriptor: MediaDescriptor): Promise<void> {
+        await this.call('peerSendVideoMessage', { peerId, descriptor })
     }
 
     public async publishMediaBlob(input: {
-        mediaType:
+        readonly mediaType:
             | 'image'
             | 'video'
             | 'audio'
@@ -263,30 +239,23 @@ export class ServerRpc {
             | 'ptt'
             | 'history'
             | 'md-app-state'
-        plaintext: Uint8Array
+        readonly plaintext: Uint8Array
     }): Promise<{
-        path: string
-        mediaKey: Uint8Array
-        fileSha256: Uint8Array
-        fileEncSha256: Uint8Array
-        fileLength: number
+        readonly path: string
+        readonly mediaKey: Uint8Array
+        readonly fileSha256: Uint8Array
+        readonly fileEncSha256: Uint8Array
+        readonly fileLength: number
     }> {
-        const result = (await this.call('publishMediaBlob', {
+        return (await this.call('publishMediaBlob', {
             mediaType: input.mediaType,
-            plaintextBytes: Array.from(input.plaintext)
+            plaintext: input.plaintext
         })) as {
-            path: string
-            mediaKeyBytes: number[]
-            fileSha256Bytes: number[]
-            fileEncSha256Bytes: number[]
-            fileLength: number
-        }
-        return {
-            path: result.path,
-            mediaKey: new Uint8Array(result.mediaKeyBytes),
-            fileSha256: new Uint8Array(result.fileSha256Bytes),
-            fileEncSha256: new Uint8Array(result.fileEncSha256Bytes),
-            fileLength: result.fileLength
+            readonly path: string
+            readonly mediaKey: Uint8Array
+            readonly fileSha256: Uint8Array
+            readonly fileEncSha256: Uint8Array
+            readonly fileLength: number
         }
     }
 

--- a/packages/fake-server/package.json
+++ b/packages/fake-server/package.json
@@ -35,6 +35,8 @@
         "bench:usync": "node --expose-gc --import tsx bench/bulk-usync.bench.ts",
         "bench:group": "node --expose-gc --import tsx bench/group-provision.bench.ts",
         "bench:media": "node --expose-gc --import tsx bench/media-upload.bench.ts",
+        "bench:media:messaging": "node --expose-gc --import tsx bench/messaging-media.bench.ts",
+        "bench:retry": "node --expose-gc --import tsx bench/retry.bench.ts",
         "bench:receipts": "node --expose-gc --import tsx bench/receipts-flood.bench.ts",
         "bench:reconnect": "node --expose-gc --import tsx bench/reconnect-resume.bench.ts",
         "bench:appstate": "node --expose-gc --import tsx bench/appstate.bench.ts",

--- a/packages/fake-server/src/api/FakePeer.ts
+++ b/packages/fake-server/src/api/FakePeer.ts
@@ -67,18 +67,23 @@ interface FakePeerDeps {
 export class FakePeer {
     public readonly jid: string
     public readonly displayName?: string
-    public readonly keyBundle: FakePeerKeyBundle
+    public keyBundle: FakePeerKeyBundle
     public readonly identity: FakePeerIdentity
 
     private readonly deps: FakePeerDeps
-    private readonly ratchet: FakePeerDoubleRatchet
+    private ratchet: FakePeerDoubleRatchet
     private readonly skipOneTimePreKey: boolean
-    private readonly reservedOneTimePreKey: {
+    private reservedOneTimePreKey: {
         readonly keyId: number
         readonly publicKey: Uint8Array
     } | null
     private ratchetInitiated = false
     private nextMessageCounter = 0
+    private readonly sentPlaintextById = new Map<string, proto.IMessage>()
+    private readonly sentEncryptedById = new Map<
+        string,
+        { readonly type: 'pkmsg' | 'msg'; readonly ciphertext: Uint8Array }
+    >()
     private readonly senderKeysByGroup = new Map<string, FakeSenderKey>()
     private readonly groupsBootstrapped = new Set<string>()
     private readonly groupRecvSession = new FakePeerGroupRecvSession()
@@ -126,6 +131,15 @@ export class FakePeer {
 
         const enc: FakeEncChild = { type, ciphertext: finalCiphertext }
         const id = options.id ?? this.nextId()
+        // Stash the plaintext so the bench / a test can replay this
+        // exact payload later in response to an incoming retry receipt
+        // from the lib (replaySentMessage). Also stash the PRISTINE
+        // ciphertext (pre-tamper) + signal type so a replay can put the
+        // original frame back on the wire – this matches how a real
+        // Signal sender re-sends after a recipient asks for retry: the
+        // same counter + ratchet key, just an uncorrupted body.
+        this.sentPlaintextById.set(id, message)
+        this.sentEncryptedById.set(id, { type, ciphertext })
         const stanza = buildMessage({
             id,
             from: options.from ?? this.jid,
@@ -136,6 +150,82 @@ export class FakePeer {
             enc: [enc]
         })
         await this.deps.pushStanza(stanza)
+    }
+
+    /**
+     * Re-encrypts and re-pushes a previously sent message identified by
+     * `originalMsgId`. Used by tests / benches that exercise the lib's
+     * incoming-retry path: after the lib emits `<receipt type="retry">`
+     * back to this peer, the peer is expected to re-send the same
+     * plaintext so the lib can decrypt it successfully on the second
+     * attempt.
+     *
+     * The replay reuses the original stanza id by default so the lib's
+     * dedup logic (and tests that wait for a specific id) see the resend
+     * as a continuation of the same outbound. Pass `resendId` to use a
+     * different id.
+     */
+    public async replaySentMessage(
+        originalMsgId: string,
+        options: { readonly resendId?: string } = {}
+    ): Promise<void> {
+        const stored = this.sentEncryptedById.get(originalMsgId)
+        if (stored) {
+            // Re-send the pristine ciphertext – same Signal counter +
+            // ratchet key as the original send, just without the
+            // tamper. The lib's recv chain still has the message key
+            // for that counter, so this is the recovery path real
+            // WhatsApp peers walk after observing a retry receipt for
+            // a frame the recipient failed to decrypt.
+            const enc: FakeEncChild = { type: stored.type, ciphertext: stored.ciphertext }
+            const id = options.resendId ?? originalMsgId
+            const stanza = buildMessage({
+                id,
+                from: this.jid,
+                type: 'text',
+                notify: this.displayName,
+                enc: [enc]
+            })
+            await this.deps.pushStanza(stanza)
+            return
+        }
+        const message = this.sentPlaintextById.get(originalMsgId)
+        if (!message) {
+            throw new Error(`FakePeer.replaySentMessage: no sent plaintext for id ${originalMsgId}`)
+        }
+        await this.sendMessage(message, { id: options.resendId ?? originalMsgId })
+    }
+
+    /**
+     * Rotates the peer's prekey material and resets the Signal session
+     * state so the lib has to re-run X3DH on the next outbound. Keeps
+     * the identity key pair (same user) but issues a new signed prekey
+     * + new one-time prekey set. After this call:
+     *   - `keyBundle` reflects the new material;
+     *   - the underlying `FakePeerDoubleRatchet` is fresh – the next
+     *     inbound from the lib must be a `pkmsg` (initial signal
+     *     message), which the new `keyBundle` is wired to decrypt;
+     *   - any cached one-time prekey reservation in the dispenser is
+     *     dropped so subsequent retry-receipts include this peer's new
+     *     keys directly via {@link sendRetryReceipt}.
+     *
+     * Use this to simulate the "session lost" scenario that real
+     * WhatsApp clients trigger when they need the sender to fully
+     * re-bootstrap the Signal session via the retry-receipt path.
+     */
+    public async rotateForRetry(): Promise<void> {
+        const refreshed = await generateFakePeerKeyBundle({
+            identityKeyPair: this.keyBundle.identityKeyPair,
+            registrationId: this.keyBundle.registrationId,
+            signedPreKeyId: this.keyBundle.signedPreKey.id + 1,
+            firstOneTimePreKeyId:
+                (this.keyBundle.oneTimePreKeys[this.keyBundle.oneTimePreKeys.length - 1]?.id ?? 0) +
+                1
+        })
+        this.keyBundle = refreshed
+        this.ratchet = new FakePeerDoubleRatchet(refreshed)
+        this.ratchetInitiated = false
+        this.reservedOneTimePreKey = null
     }
 
     public sendConversation(text: string, options: SendMessageOptions = {}): Promise<void> {
@@ -459,6 +549,127 @@ export class FakePeer {
         await this.deps.pushStanza(groupStanza)
     }
 
+    /**
+     * Sends a `<receipt type="retry">` stanza to the lib asking it to
+     * re-encrypt and re-send the message identified by `originalMsgId`.
+     * Used by benches / tests that exercise the lib's outbound retry
+     * replay path.
+     *
+     * Shape matches WhatsApp Web's `WAWebRetryRequestParser`:
+     * `<receipt id type=retry from t><retry id count?/><registration>4B</registration>[<keys>...</keys>]</receipt>`.
+     *
+     * When `includeKeys` is true (default), the `<keys>` block carries
+     * the peer's current identity + signed prekey + one-time prekey.
+     * This forces the lib's `WaRetryCoordinator` to tear down the
+     * existing session and re-run X3DH against these fresh keys before
+     * re-encrypting the original payload, so the resend lands as a
+     * `pkmsg` against the peer's *new* prekey state. Pair this with
+     * {@link rotateForRetry} to simulate full session loss + recovery.
+     *
+     * `<device-identity>` is omitted: it's `maybeChild` in wa-web and
+     * also optional in the lib's parser. The fake-peer fixture doesn't
+     * have an ADV primary-device to sign one, and the lib's outbound
+     * retry replay path does not require it.
+     */
+    public async sendRetryReceipt(
+        originalMsgId: string,
+        options: {
+            readonly count?: number
+            readonly receiptId?: string
+            readonly t?: number
+            readonly error?: number
+            readonly includeKeys?: boolean
+        } = {}
+    ): Promise<void> {
+        const receiptId = options.receiptId ?? originalMsgId
+        const retryCount = options.count ?? 1
+        const t = options.t ?? Math.floor(Date.now() / 1_000)
+        const error = options.error
+        const includeKeys = options.includeKeys !== false
+        const registration = new Uint8Array(4)
+        const regId = this.keyBundle.registrationId & 0xffffffff
+        registration[0] = (regId >>> 24) & 0xff
+        registration[1] = (regId >>> 16) & 0xff
+        registration[2] = (regId >>> 8) & 0xff
+        registration[3] = regId & 0xff
+
+        const retryAttrs: Record<string, string> = {
+            v: '1',
+            count: String(retryCount),
+            id: originalMsgId,
+            t: String(t)
+        }
+        if (error !== undefined && error !== 0) {
+            retryAttrs.error = String(error)
+        }
+
+        const content: BinaryNode[] = [
+            {
+                tag: 'retry',
+                attrs: retryAttrs
+            },
+            {
+                tag: 'registration',
+                attrs: {},
+                content: registration
+            }
+        ]
+
+        if (includeKeys) {
+            content.push(this.buildRetryKeysNode())
+        }
+
+        const receipt: BinaryNode = {
+            tag: 'receipt',
+            attrs: {
+                id: receiptId,
+                from: this.jid,
+                type: 'retry',
+                t: String(t)
+            },
+            content
+        }
+        await this.deps.pushStanza(receipt)
+    }
+
+    private buildRetryKeysNode(): BinaryNode {
+        const skey = this.keyBundle.signedPreKey
+        const oneTime = this.keyBundle.oneTimePreKeys[0]
+        if (!oneTime) {
+            throw new Error('FakePeer.sendRetryReceipt: no one-time prekey available')
+        }
+        const skeyIdBytes = encodeUint3(skey.id)
+        const keyIdBytes = encodeUint3(oneTime.id)
+        return {
+            tag: 'keys',
+            attrs: {},
+            content: [
+                {
+                    tag: 'identity',
+                    attrs: {},
+                    content: this.keyBundle.identityKeyPair.pubKey
+                },
+                {
+                    tag: 'skey',
+                    attrs: {},
+                    content: [
+                        { tag: 'id', attrs: {}, content: skeyIdBytes },
+                        { tag: 'value', attrs: {}, content: skey.keyPair.pubKey },
+                        { tag: 'signature', attrs: {}, content: skey.signature }
+                    ]
+                },
+                {
+                    tag: 'key',
+                    attrs: {},
+                    content: [
+                        { tag: 'id', attrs: {}, content: keyIdBytes },
+                        { tag: 'value', attrs: {}, content: oneTime.keyPair.pubKey }
+                    ]
+                }
+            ]
+        }
+    }
+
     public expectMessage(options: ExpectMessageOptions = {}): Promise<ReceivedMessage> {
         const timeoutMs = options.timeoutMs ?? 5_000
         return new Promise<ReceivedMessage>((resolve, reject) => {
@@ -625,6 +836,17 @@ function findTopLevelEnc(stanza: BinaryNode, type: string): BinaryNode | null {
         }
     }
     return null
+}
+
+function encodeUint3(value: number): Uint8Array {
+    if (!Number.isInteger(value) || value < 0 || value > 0xffffff) {
+        throw new Error(`encodeUint3: value out of range: ${value}`)
+    }
+    const out = new Uint8Array(3)
+    out[0] = (value >>> 16) & 0xff
+    out[1] = (value >>> 8) & 0xff
+    out[2] = value & 0xff
+    return out
 }
 
 function encodePlaintextWithPadding(message: proto.IMessage): Uint8Array {

--- a/packages/fake-server/src/api/FakePeer.ts
+++ b/packages/fake-server/src/api/FakePeer.ts
@@ -28,6 +28,13 @@ export interface CreateFakePeerOptions {
     readonly displayName?: string
     readonly keyBundle?: FakePeerKeyBundle
     readonly skipOneTimePreKey?: boolean
+    /**
+     * Stash every outbound (id → plaintext + pristine ciphertext) so
+     * tests / benches can drive replays via {@link FakePeer.replaySentMessage}.
+     * Off by default to avoid inflating the fixture's heap on long
+     * memory-focused runs that never replay.
+     */
+    readonly enableReplayCache?: boolean
 }
 
 export interface SendMessageOptions {
@@ -79,6 +86,7 @@ export class FakePeer {
     } | null
     private ratchetInitiated = false
     private nextMessageCounter = 0
+    private readonly replayCacheEnabled: boolean
     private readonly sentPlaintextById = new Map<string, proto.IMessage>()
     private readonly sentEncryptedById = new Map<
         string,
@@ -102,6 +110,7 @@ export class FakePeer {
         this.displayName = options.displayName
         this.deps = deps
         this.skipOneTimePreKey = options.skipOneTimePreKey === true
+        this.replayCacheEnabled = options.enableReplayCache === true
         this.reservedOneTimePreKey =
             !this.skipOneTimePreKey && deps.reserveOneTimePreKey
                 ? deps.reserveOneTimePreKey()
@@ -131,15 +140,18 @@ export class FakePeer {
 
         const enc: FakeEncChild = { type, ciphertext: finalCiphertext }
         const id = options.id ?? this.nextId()
-        // Stash the plaintext so the bench / a test can replay this
-        // exact payload later in response to an incoming retry receipt
-        // from the lib (replaySentMessage). Also stash the PRISTINE
-        // ciphertext (pre-tamper) + signal type so a replay can put the
-        // original frame back on the wire – this matches how a real
-        // Signal sender re-sends after a recipient asks for retry: the
-        // same counter + ratchet key, just an uncorrupted body.
-        this.sentPlaintextById.set(id, message)
-        this.sentEncryptedById.set(id, { type, ciphertext })
+        if (this.replayCacheEnabled) {
+            // Stash the plaintext so the bench / a test can replay this
+            // exact payload later in response to an incoming retry
+            // receipt from the lib (replaySentMessage). Also stash the
+            // PRISTINE ciphertext (pre-tamper) + signal type so a
+            // replay can put the original frame back on the wire –
+            // matches how a real Signal sender re-sends after a
+            // recipient asks for retry: same counter + ratchet key,
+            // just an uncorrupted body.
+            this.sentPlaintextById.set(id, message)
+            this.sentEncryptedById.set(id, { type, ciphertext })
+        }
         const stanza = buildMessage({
             id,
             from: options.from ?? this.jid,

--- a/packages/fake-server/src/api/FakeWaServer.ts
+++ b/packages/fake-server/src/api/FakeWaServer.ts
@@ -129,6 +129,7 @@ export class FakeWaServer {
     private readonly pendingStanzaExpectations = new Set<PendingStanzaExpectation>()
     private readonly authenticatedListeners = new Set<AuthenticatedPipelineListener>()
     private readonly inboundStanzaListeners = new Set<(node: BinaryNode) => void>()
+    private readonly capturedStanzaListeners = new Set<(node: BinaryNode) => void>()
     private rootCa: FakeNoiseRootCa | null = null
     private serverStaticKeyPair: SignalKeyPair | null = null
     private listenInfo: WaFakeWsServerListenInfo | null = null
@@ -428,6 +429,22 @@ export class FakeWaServer {
         return this.capturedStanzas.slice()
     }
 
+    /**
+     * Subscribes to every stanza captured from the client side (the lib).
+     * The listener is called synchronously for each new stanza as it
+     * arrives, in addition to `capturedStanzas` being appended. Returns
+     * an unsubscribe function. Useful for benches that need to count or
+     * react to a stream of receipts/messages without paying the O(N²)
+     * cost of polling `capturedStanzaSnapshot()` or queuing one
+     * `expectStanza(...)` per iteration.
+     */
+    public onCapturedStanza(listener: (node: BinaryNode) => void): () => void {
+        this.capturedStanzaListeners.add(listener)
+        return () => {
+            this.capturedStanzaListeners.delete(listener)
+        }
+    }
+
     public expectStanza(
         matcher: StanzaMatcher,
         options: ExpectStanzaOptions = {}
@@ -521,7 +538,16 @@ export class FakeWaServer {
 
     public get mediaProxyAgent(): HttpsAgent {
         if (!this.cachedMediaProxyAgent) {
-            this.cachedMediaProxyAgent = new HttpsAgent({ rejectUnauthorized: false })
+            // keepAlive is required for representative perf measurements
+            // and matches what real-world WhatsApp clients do – every
+            // media upload/download would otherwise pay a full TLS
+            // handshake. The `src/media/__tests__/media.test.ts` fixtures
+            // and a production-quality `proxy.mediaUpload` configuration
+            // all set this; mirroring it here keeps benches in line.
+            this.cachedMediaProxyAgent = new HttpsAgent({
+                rejectUnauthorized: false,
+                keepAlive: true
+            })
         }
         return this.cachedMediaProxyAgent
     }
@@ -721,6 +747,14 @@ export class FakeWaServer {
 
     private handleCapturedStanza(node: BinaryNode): void {
         this.capturedStanzas.push(node)
+
+        for (const listener of this.capturedStanzaListeners) {
+            try {
+                listener(node)
+            } catch (error) {
+                void error
+            }
+        }
 
         for (const listener of this.inboundStanzaListeners) {
             try {


### PR DESCRIPTION
Add two fake-server-driven benches that exercise end-to-end protocol paths the existing suite did not cover, plus the FakePeer + FakeWaServer extensions they need.

bench/messaging-media.bench.ts sweeps WhatsApp media TYPES across 1:1 send (image / video / audio / ptt / document / sticker), group send with SKDM+SKMSG fanout, and receive + download. Defaults to streaming input (`Readable.from(chunkIterator(...))`) so the lib walks its streaming-upload path; switch via ZAPO_BENCH_MEDIA_INPUT=buffer to compare in-memory mode.

bench/retry.bench.ts validates the full retry round-trip against wa-web's WAWebRetryRequestParser:

- incoming_retry: tampered ciphertext -> lib emits <receipt type=retry>
- incoming_retry_recovery: tampered -> retry -> peer replays the pristine ciphertext (same Signal counter + ratchet key) -> lib decrypts and emits `message`
- outbound_retry_replay: lib sends -> peer rotateForRetry() rotates signed prekey + one-time prekey and resets ratchet -> peer sends <receipt type=retry> carrying the new <keys> block -> lib tears down session, re-runs X3DH, re-emits as fresh pkmsg -> peer decrypts via rotated bundle, plaintext verified to match.

Both benches mirror messaging.bench.ts: support --separate-process, --cpu/--heap/--snapshot profiling, ZAPO_BENCH_STORE backend selection, ZAPO_BENCH_JSON.

FakeWaServer:
- onCapturedStanza(listener) push subscription for stanzas captured from the lib (used by retry bench to drive replays without paying the O(N^2) cost of expectStanza-per-iteration).
- mediaProxyAgent and ServerRpc.start now set keepAlive: true – the previous default left TLS handshakes uncached, distorting media benches with ~11% CPU spent in connect/setSession/destroySSL.

FakePeer:
- sendRetryReceipt(originalMsgId, { includeKeys? }) builds the receipt in wa-web's exact shape: <retry id count? t?/>, <registration> with the 4-byte regId, optional <keys> with <identity><skey id/value/signature><key id/value>.
- rotateForRetry() refreshes signed prekey + one-time prekey (keeping the identity), swaps in a fresh FakePeerDoubleRatchet and clears the reserved one-time-prekey so subsequent inbound from the lib must be a pkmsg.
- replaySentMessage(originalMsgId, { resendId? }) re-pushes the pristine pre-tamper ciphertext (or re-encrypts if none was stashed), supporting either the same id or a fresh one.
- sendMessage now stashes (id -> plaintext) and (id -> pristine ciphertext) so replaySentMessage has the material it needs.

server-process.ts + server-rpc.ts expose new RPC surface required by both benches under --separate-process: publishMediaBlob, mediaUrl, peerSendImageMessage / peerSendVideoMessage, peerExpectMessage, peerReplaySentMessage, peerRotateForRetry, peerSendRetryReceipt, waitForRetryReceipt, waitForRetryReceipts. peerSendConversation grew optional id + tamperMode fields so the corrupted-ciphertext path crosses the IPC boundary without shipping a function reference.

bench scripts: package.json gains bench:media:messaging and bench:retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end benchmarks for messaging with media (image/video/audio/ptt/document/sticker/gif) and group sends
  * Added end-to-end benchmarks for retry and replay/recovery scenarios with measurement and profiling options
  * Extended RPC control surface to support media publish/download, peer media sends, replay/rotate/retry operations, and waiters for receipts
  * Server now exposes captured-stanza subscriptions for observing inbound events

* **Chores**
  * Added npm scripts to run media and retry benchmarks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->