### PR TITLE
fix(client,signal,store): send DMs in LID form to fix retry eligibility

### DIFF
--- a/packages/store-mongo/src/device-list.store.ts
+++ b/packages/store-mongo/src/device-list.store.ts
@@ -5,6 +5,7 @@ import type { WaMongoStorageOptions } from './types'
 
 interface DeviceListDoc {
     _id: { session_id: string; user_jid: string }
+    alt_user_jid?: string
     device_jids: string[]
     updated_at_ms: number
     expires_at: Date
@@ -26,25 +27,36 @@ export class WaDeviceListMongoStore extends BaseMongoStore implements WaDeviceLi
     protected override async createIndexes(): Promise<void> {
         const col = this.col<DeviceListDoc>('device_list_cache')
         await col.createIndex({ expires_at: 1 }, { expireAfterSeconds: 0 })
+        await col.createIndex(
+            { '_id.session_id': 1, alt_user_jid: 1 },
+            { name: 'alt_user_jid_lookup', sparse: true }
+        )
     }
 
     public async upsertUserDevicesBatch(snapshots: readonly WaDeviceListSnapshot[]): Promise<void> {
         if (snapshots.length === 0) return
         await this.ensureIndexes()
         const col = this.col<DeviceListDoc>('device_list_cache')
-        const ops = snapshots.map((snapshot) => ({
-            updateOne: {
-                filter: { _id: { session_id: this.sessionId, user_jid: snapshot.userJid } },
-                update: {
-                    $set: {
-                        device_jids: snapshot.deviceJids as string[],
-                        updated_at_ms: snapshot.updatedAtMs,
-                        expires_at: new Date(snapshot.updatedAtMs + this.ttlMs)
-                    }
-                },
-                upsert: true
+        const ops = snapshots.map((snapshot) => {
+            const set: Record<string, unknown> = {
+                device_jids: snapshot.deviceJids as string[],
+                updated_at_ms: snapshot.updatedAtMs,
+                expires_at: new Date(snapshot.updatedAtMs + this.ttlMs)
             }
-        }))
+            const update: Record<string, unknown> = { $set: set }
+            if (snapshot.altUserJid !== undefined) {
+                set.alt_user_jid = snapshot.altUserJid
+            } else {
+                update.$unset = { alt_user_jid: '' }
+            }
+            return {
+                updateOne: {
+                    filter: { _id: { session_id: this.sessionId, user_jid: snapshot.userJid } },
+                    update,
+                    upsert: true
+                }
+            }
+        })
         await col.bulkWrite(ops)
     }
 
@@ -66,13 +78,24 @@ export class WaDeviceListMongoStore extends BaseMongoStore implements WaDeviceLi
 
         const byUserJid = new Map<string, WaDeviceListSnapshot>()
         for (const doc of docs) {
-            byUserJid.set(doc._id.user_jid, {
-                userJid: doc._id.user_jid,
-                deviceJids: doc.device_jids,
-                updatedAtMs: doc.updated_at_ms
-            })
+            byUserJid.set(doc._id.user_jid, docToSnapshot(doc))
         }
         return userJids.map((jid) => byUserJid.get(jid) ?? null)
+    }
+
+    public async findByAnyUserJid(
+        jid: string,
+        nowMs = Date.now()
+    ): Promise<WaDeviceListSnapshot | null> {
+        await this.ensureIndexes()
+        const col = this.col<DeviceListDoc>('device_list_cache')
+        const doc = await col.findOne({
+            '_id.session_id': this.sessionId,
+            $or: [{ '_id.user_jid': jid }, { alt_user_jid: jid }],
+            expires_at: { $gt: new Date(nowMs) }
+        })
+        if (!doc) return null
+        return docToSnapshot(doc)
     }
 
     public async deleteUserDevices(userJid: string): Promise<number> {
@@ -92,5 +115,14 @@ export class WaDeviceListMongoStore extends BaseMongoStore implements WaDeviceLi
         await this.ensureIndexes()
         const col = this.col<DeviceListDoc>('device_list_cache')
         await col.deleteMany({ '_id.session_id': this.sessionId })
+    }
+}
+
+function docToSnapshot(doc: DeviceListDoc): WaDeviceListSnapshot {
+    return {
+        userJid: doc._id.user_jid,
+        ...(doc.alt_user_jid !== undefined ? { altUserJid: doc.alt_user_jid } : {}),
+        deviceJids: doc.device_jids,
+        updatedAtMs: doc.updated_at_ms
     }
 }

--- a/packages/store-mysql/src/connection.ts
+++ b/packages/store-mysql/src/connection.ts
@@ -317,6 +317,15 @@ const MIGRATIONS: readonly Migration[] = [
             ALTER TABLE \`__PREFIX__group_participants_cache\`
                 ADD COLUMN ephemeral BIGINT
         `
+    },
+    {
+        name: '0013_device_list_cache_alt_user_jid',
+        domain: 'deviceList',
+        sql: `
+            ALTER TABLE \`__PREFIX__device_list_cache\`
+                ADD COLUMN alt_user_jid VARCHAR(255) NULL,
+                ADD INDEX \`__PREFIX__idx_device_list_alt_user_jid\` (session_id, alt_user_jid)
+        `
     }
 ]
 

--- a/packages/store-mysql/src/device-list.store.ts
+++ b/packages/store-mysql/src/device-list.store.ts
@@ -152,10 +152,7 @@ export class WaDeviceListMysqlStore extends BaseMysqlStore implements WaDeviceLi
     }
 }
 
-function decodeMysqlSnapshot(
-    userJid: string,
-    row: Record<string, unknown>
-): WaDeviceListSnapshot {
+function decodeMysqlSnapshot(userJid: string, row: Record<string, unknown>): WaDeviceListSnapshot {
     const rawJson =
         row.device_jids_json instanceof Uint8Array
             ? TEXT_DECODER.decode(row.device_jids_json)

--- a/packages/store-mysql/src/device-list.store.ts
+++ b/packages/store-mysql/src/device-list.store.ts
@@ -1,4 +1,5 @@
 import type { WaDeviceListSnapshot, WaDeviceListStore } from 'zapo-js/store'
+import { TEXT_DECODER } from 'zapo-js/util'
 
 import { BaseMysqlStore } from './BaseMysqlStore'
 import { affectedRows, queryRows } from './helpers'
@@ -25,15 +26,17 @@ export class WaDeviceListMysqlStore extends BaseMysqlStore implements WaDeviceLi
             for (const snapshot of snapshots) {
                 await conn.execute(
                     `INSERT INTO ${this.t('device_list_cache')} (
-                        session_id, user_jid, device_jids_json, updated_at_ms, expires_at_ms
-                    ) VALUES (?, ?, ?, ?, ?)
+                        session_id, user_jid, alt_user_jid, device_jids_json, updated_at_ms, expires_at_ms
+                    ) VALUES (?, ?, ?, ?, ?, ?)
                     ON DUPLICATE KEY UPDATE
+                        alt_user_jid = VALUES(alt_user_jid),
                         device_jids_json = VALUES(device_jids_json),
                         updated_at_ms = VALUES(updated_at_ms),
                         expires_at_ms = VALUES(expires_at_ms)`,
                     [
                         this.sessionId,
                         snapshot.userJid,
+                        snapshot.altUserJid ?? null,
                         JSON.stringify(snapshot.deviceJids),
                         snapshot.updatedAtMs,
                         snapshot.updatedAtMs + this.ttlMs
@@ -59,7 +62,7 @@ export class WaDeviceListMysqlStore extends BaseMysqlStore implements WaDeviceLi
             while (batch.length < BATCH_SIZE) batch.push('')
             const rows = queryRows(
                 await this.pool.execute(
-                    `SELECT user_jid, device_jids_json, updated_at_ms, expires_at_ms
+                    `SELECT user_jid, alt_user_jid, device_jids_json, updated_at_ms, expires_at_ms
                      FROM ${this.t('device_list_cache')}
                      WHERE session_id = ? AND user_jid IN (${FIXED_IN_PLACEHOLDERS})`,
                     [this.sessionId, ...batch]
@@ -72,19 +75,7 @@ export class WaDeviceListMysqlStore extends BaseMysqlStore implements WaDeviceLi
                     expiredUserJids.push(userJid)
                     continue
                 }
-                const rawJson =
-                    row.device_jids_json instanceof Uint8Array
-                        ? new TextDecoder().decode(row.device_jids_json)
-                        : String(row.device_jids_json)
-                const parsed: unknown = JSON.parse(rawJson)
-                if (!Array.isArray(parsed)) {
-                    throw new Error('device_list_cache.device_jids_json must be an array')
-                }
-                activeByUserJid.set(userJid, {
-                    userJid,
-                    deviceJids: parsed.map((entry: unknown) => String(entry)),
-                    updatedAtMs: Number(row.updated_at_ms)
-                })
+                activeByUserJid.set(userJid, decodeMysqlSnapshot(userJid, row))
             }
         }
 
@@ -101,6 +92,34 @@ export class WaDeviceListMysqlStore extends BaseMysqlStore implements WaDeviceLi
         }
 
         return userJids.map((jid) => activeByUserJid.get(jid) ?? null)
+    }
+
+    public async findByAnyUserJid(
+        jid: string,
+        nowMs = Date.now()
+    ): Promise<WaDeviceListSnapshot | null> {
+        await this.ensureReady()
+        const rows = queryRows(
+            await this.pool.execute(
+                `SELECT user_jid, alt_user_jid, device_jids_json, updated_at_ms, expires_at_ms
+                 FROM ${this.t('device_list_cache')}
+                 WHERE session_id = ? AND (user_jid = ? OR alt_user_jid = ?)
+                 LIMIT 1`,
+                [this.sessionId, jid, jid]
+            )
+        )
+        if (rows.length === 0) return null
+        const row = rows[0]
+        const expiresAtMs = Number(row.expires_at_ms)
+        if (expiresAtMs <= nowMs) {
+            const expiredUserJid = String(row.user_jid)
+            await this.pool.execute(
+                `DELETE FROM ${this.t('device_list_cache')} WHERE session_id = ? AND user_jid = ?`,
+                [this.sessionId, expiredUserJid]
+            )
+            return null
+        }
+        return decodeMysqlSnapshot(String(row.user_jid), row)
     }
 
     public async deleteUserDevices(userJid: string): Promise<number> {
@@ -130,5 +149,29 @@ export class WaDeviceListMysqlStore extends BaseMysqlStore implements WaDeviceLi
         await this.pool.execute(`DELETE FROM ${this.t('device_list_cache')} WHERE session_id = ?`, [
             this.sessionId
         ])
+    }
+}
+
+function decodeMysqlSnapshot(
+    userJid: string,
+    row: Record<string, unknown>
+): WaDeviceListSnapshot {
+    const rawJson =
+        row.device_jids_json instanceof Uint8Array
+            ? TEXT_DECODER.decode(row.device_jids_json)
+            : String(row.device_jids_json)
+    const parsed: unknown = JSON.parse(rawJson)
+    if (!Array.isArray(parsed)) {
+        throw new Error('device_list_cache.device_jids_json must be an array')
+    }
+    const altUserJid =
+        row.alt_user_jid === null || row.alt_user_jid === undefined
+            ? undefined
+            : String(row.alt_user_jid)
+    return {
+        userJid,
+        ...(altUserJid !== undefined ? { altUserJid } : {}),
+        deviceJids: parsed.map((entry: unknown) => String(entry)),
+        updatedAtMs: Number(row.updated_at_ms)
     }
 }

--- a/packages/store-postgres/src/connection.ts
+++ b/packages/store-postgres/src/connection.ts
@@ -331,6 +331,16 @@ const MIGRATIONS: readonly Migration[] = [
         sql: `
             ALTER TABLE "__PREFIX__group_participants_cache" ADD COLUMN IF NOT EXISTS ephemeral BIGINT
         `
+    },
+    {
+        name: '0013_device_list_cache_alt_user_jid',
+        domain: 'deviceList',
+        sql: `
+            ALTER TABLE "__PREFIX__device_list_cache" ADD COLUMN IF NOT EXISTS alt_user_jid TEXT;
+
+            CREATE INDEX IF NOT EXISTS "__PREFIX__idx_device_list_alt_user_jid"
+                ON "__PREFIX__device_list_cache" (session_id, alt_user_jid)
+        `
     }
 ]
 

--- a/packages/store-postgres/src/device-list.store.ts
+++ b/packages/store-postgres/src/device-list.store.ts
@@ -162,10 +162,7 @@ export class WaDeviceListPgStore extends BasePgStore implements WaDeviceListStor
     }
 }
 
-function decodePgSnapshot(
-    userJid: string,
-    row: Record<string, unknown>
-): WaDeviceListSnapshot {
+function decodePgSnapshot(userJid: string, row: Record<string, unknown>): WaDeviceListSnapshot {
     const parsed: unknown = JSON.parse(row.device_jids_json as string)
     if (!Array.isArray(parsed)) {
         throw new Error('device_list_cache.device_jids_json must be an array')

--- a/packages/store-postgres/src/device-list.store.ts
+++ b/packages/store-postgres/src/device-list.store.ts
@@ -25,15 +25,17 @@ export class WaDeviceListPgStore extends BasePgStore implements WaDeviceListStor
                 await client.query({
                     name: this.stmtName('devlist_upsert'),
                     text: `INSERT INTO ${this.t('device_list_cache')} (
-                        session_id, user_jid, device_jids_json, updated_at_ms, expires_at_ms
-                    ) VALUES ($1, $2, $3, $4, $5)
+                        session_id, user_jid, alt_user_jid, device_jids_json, updated_at_ms, expires_at_ms
+                    ) VALUES ($1, $2, $3, $4, $5, $6)
                     ON CONFLICT (session_id, user_jid) DO UPDATE SET
+                        alt_user_jid = EXCLUDED.alt_user_jid,
                         device_jids_json = EXCLUDED.device_jids_json,
                         updated_at_ms = EXCLUDED.updated_at_ms,
                         expires_at_ms = EXCLUDED.expires_at_ms`,
                     values: [
                         this.sessionId,
                         snapshot.userJid,
+                        snapshot.altUserJid ?? null,
                         JSON.stringify(snapshot.deviceJids),
                         snapshot.updatedAtMs,
                         snapshot.updatedAtMs + this.ttlMs
@@ -61,7 +63,7 @@ export class WaDeviceListPgStore extends BasePgStore implements WaDeviceListStor
             const params: PgParam[] = [this.sessionId, ...batch]
             const rows = queryRows(
                 await this.pool.query(
-                    `SELECT user_jid, device_jids_json, updated_at_ms, expires_at_ms
+                    `SELECT user_jid, alt_user_jid, device_jids_json, updated_at_ms, expires_at_ms
                      FROM ${this.t('device_list_cache')}
                      WHERE session_id = $1 AND user_jid IN (${placeholders})`,
                     params
@@ -74,15 +76,7 @@ export class WaDeviceListPgStore extends BasePgStore implements WaDeviceListStor
                     expiredUserJids.push(userJid)
                     continue
                 }
-                const parsed: unknown = JSON.parse(row.device_jids_json as string)
-                if (!Array.isArray(parsed)) {
-                    throw new Error('device_list_cache.device_jids_json must be an array')
-                }
-                activeByUserJid.set(userJid, {
-                    userJid,
-                    deviceJids: parsed.map((entry: unknown) => String(entry)),
-                    updatedAtMs: Number(row.updated_at_ms)
-                })
+                activeByUserJid.set(userJid, decodePgSnapshot(userJid, row))
             }
         }
 
@@ -101,6 +95,37 @@ export class WaDeviceListPgStore extends BasePgStore implements WaDeviceListStor
         }
 
         return userJids.map((jid) => activeByUserJid.get(jid) ?? null)
+    }
+
+    public async findByAnyUserJid(
+        jid: string,
+        nowMs = Date.now()
+    ): Promise<WaDeviceListSnapshot | null> {
+        await this.ensureReady()
+        const rows = queryRows(
+            await this.pool.query({
+                name: this.stmtName('devlist_find_any'),
+                text: `SELECT user_jid, alt_user_jid, device_jids_json, updated_at_ms, expires_at_ms
+                       FROM ${this.t('device_list_cache')}
+                       WHERE session_id = $1 AND (user_jid = $2 OR alt_user_jid = $2)
+                       LIMIT 1`,
+                values: [this.sessionId, jid]
+            })
+        )
+        if (rows.length === 0) return null
+        const row = rows[0]
+        const expiresAtMs = Number(row.expires_at_ms)
+        if (expiresAtMs <= nowMs) {
+            const expiredUserJid = String(row.user_jid)
+            await this.pool.query({
+                name: this.stmtName('devlist_delete_user'),
+                text: `DELETE FROM ${this.t('device_list_cache')}
+                       WHERE session_id = $1 AND user_jid = $2`,
+                values: [this.sessionId, expiredUserJid]
+            })
+            return null
+        }
+        return decodePgSnapshot(String(row.user_jid), row)
     }
 
     public async deleteUserDevices(userJid: string): Promise<number> {
@@ -134,5 +159,25 @@ export class WaDeviceListPgStore extends BasePgStore implements WaDeviceListStor
             text: `DELETE FROM ${this.t('device_list_cache')} WHERE session_id = $1`,
             values: [this.sessionId]
         })
+    }
+}
+
+function decodePgSnapshot(
+    userJid: string,
+    row: Record<string, unknown>
+): WaDeviceListSnapshot {
+    const parsed: unknown = JSON.parse(row.device_jids_json as string)
+    if (!Array.isArray(parsed)) {
+        throw new Error('device_list_cache.device_jids_json must be an array')
+    }
+    const altUserJid =
+        row.alt_user_jid === null || row.alt_user_jid === undefined
+            ? undefined
+            : String(row.alt_user_jid)
+    return {
+        userJid,
+        ...(altUserJid !== undefined ? { altUserJid } : {}),
+        deviceJids: parsed.map((entry: unknown) => String(entry)),
+        updatedAtMs: Number(row.updated_at_ms)
     }
 }

--- a/packages/store-redis/src/device-list.store.ts
+++ b/packages/store-redis/src/device-list.store.ts
@@ -19,14 +19,34 @@ export class WaDeviceListRedisStore extends BaseRedisStore implements WaDeviceLi
 
     public async upsertUserDevicesBatch(snapshots: readonly WaDeviceListSnapshot[]): Promise<void> {
         if (snapshots.length === 0) return
+        const previousAltKeys = await Promise.all(
+            snapshots.map((snapshot) =>
+                this.redis.hget(this.k('devlist', this.sessionId, snapshot.userJid), 'alt_user_jid')
+            )
+        )
         const pipeline = this.redis.pipeline()
-        for (const snapshot of snapshots) {
+        for (let index = 0; index < snapshots.length; index += 1) {
+            const snapshot = snapshots[index]
             const key = this.k('devlist', this.sessionId, snapshot.userJid)
-            pipeline.hset(key, {
+            const previousAlt = previousAltKeys[index]
+            if (previousAlt && previousAlt !== snapshot.altUserJid) {
+                pipeline.del(this.k('devlistalt', this.sessionId, previousAlt))
+            }
+            const fields: Record<string, string> = {
                 device_jids_json: JSON.stringify(snapshot.deviceJids),
                 updated_at_ms: String(snapshot.updatedAtMs)
-            })
+            }
+            if (snapshot.altUserJid !== undefined) {
+                fields.alt_user_jid = snapshot.altUserJid
+            } else {
+                pipeline.hdel(key, 'alt_user_jid')
+            }
+            pipeline.hset(key, fields)
             pipeline.pexpire(key, this.ttlMs)
+            if (snapshot.altUserJid !== undefined) {
+                const altKey = this.k('devlistalt', this.sessionId, snapshot.altUserJid)
+                pipeline.set(altKey, snapshot.userJid, 'PX', this.ttlMs)
+            }
         }
         await pipeline.exec()
     }
@@ -44,28 +64,30 @@ export class WaDeviceListRedisStore extends BaseRedisStore implements WaDeviceLi
         const results = await pipeline.exec()
         if (!results) return userJids.map(() => null)
 
-        return userJids.map((userJid, index) => {
-            const [err, data] = results[index]
-            if (err || !data || typeof data !== 'object') return null
-            const record = data as Record<string, string>
-            if (Object.keys(record).length === 0) return null
+        return userJids.map((userJid, index) => decodeSnapshot(userJid, results[index]))
+    }
 
-            const parsed: unknown = JSON.parse(record.device_jids_json)
-            if (!Array.isArray(parsed)) {
-                throw new Error('device_jids_json must be an array')
-            }
-
-            return {
-                userJid,
-                deviceJids: parsed.map((entry: unknown) => String(entry)),
-                updatedAtMs: Number(record.updated_at_ms)
-            }
-        })
+    public async findByAnyUserJid(
+        jid: string,
+        _nowMs?: number
+    ): Promise<WaDeviceListSnapshot | null> {
+        const direct = await this.redis.hgetall(this.k('devlist', this.sessionId, jid))
+        const directSnapshot = decodeSnapshot(jid, [null, direct])
+        if (directSnapshot) return directSnapshot
+        const primary = await this.redis.get(this.k('devlistalt', this.sessionId, jid))
+        if (!primary) return null
+        const data = await this.redis.hgetall(this.k('devlist', this.sessionId, primary))
+        return decodeSnapshot(primary, [null, data])
     }
 
     public async deleteUserDevices(userJid: string): Promise<number> {
         const key = this.k('devlist', this.sessionId, userJid)
-        return this.redis.del(key)
+        const altUserJid = await this.redis.hget(key, 'alt_user_jid')
+        const removed = await this.redis.del(key)
+        if (altUserJid) {
+            await this.redis.del(this.k('devlistalt', this.sessionId, altUserJid))
+        }
+        return removed
     }
 
     public async cleanupExpired(_nowMs: number): Promise<number> {
@@ -73,10 +95,37 @@ export class WaDeviceListRedisStore extends BaseRedisStore implements WaDeviceLi
     }
 
     public async clear(): Promise<void> {
-        const pattern = this.k('devlist', this.sessionId, '*')
-        const keys = await scanKeys(this.redis, pattern)
-        if (keys.length > 0) {
-            await deleteKeysChunked(this.redis, keys)
+        const patterns = [
+            this.k('devlist', this.sessionId, '*'),
+            this.k('devlistalt', this.sessionId, '*')
+        ]
+        for (const pattern of patterns) {
+            const keys = await scanKeys(this.redis, pattern)
+            if (keys.length > 0) {
+                await deleteKeysChunked(this.redis, keys)
+            }
         }
+    }
+}
+
+function decodeSnapshot(
+    userJid: string,
+    result: [Error | null, unknown] | undefined
+): WaDeviceListSnapshot | null {
+    if (!result) return null
+    const [err, data] = result
+    if (err || !data || typeof data !== 'object') return null
+    const record = data as Record<string, string>
+    if (Object.keys(record).length === 0) return null
+    const parsed: unknown = JSON.parse(record.device_jids_json)
+    if (!Array.isArray(parsed)) {
+        throw new Error('device_jids_json must be an array')
+    }
+    const altUserJid = record.alt_user_jid
+    return {
+        userJid,
+        ...(altUserJid ? { altUserJid } : {}),
+        deviceJids: parsed.map((entry: unknown) => String(entry)),
+        updatedAtMs: Number(record.updated_at_ms)
     }
 }

--- a/packages/store-redis/src/device-list.store.ts
+++ b/packages/store-redis/src/device-list.store.ts
@@ -19,10 +19,13 @@ export class WaDeviceListRedisStore extends BaseRedisStore implements WaDeviceLi
 
     public async upsertUserDevicesBatch(snapshots: readonly WaDeviceListSnapshot[]): Promise<void> {
         if (snapshots.length === 0) return
-        const previousAltKeys = await Promise.all(
-            snapshots.map((snapshot) =>
-                this.redis.hget(this.k('devlist', this.sessionId, snapshot.userJid), 'alt_user_jid')
-            )
+        const readPipeline = this.redis.pipeline()
+        for (const snapshot of snapshots) {
+            readPipeline.hget(this.k('devlist', this.sessionId, snapshot.userJid), 'alt_user_jid')
+        }
+        const readResults = (await readPipeline.exec()) ?? []
+        const previousAltKeys = readResults.map(
+            (result): string | null => (result?.[1] as string | null) ?? null
         )
         const pipeline = this.redis.pipeline()
         for (let index = 0; index < snapshots.length; index += 1) {

--- a/packages/store-sqlite/src/device-list.store.ts
+++ b/packages/store-sqlite/src/device-list.store.ts
@@ -8,6 +8,7 @@ import type { WaSqliteStorageOptions } from './types'
 
 interface DeviceListRow extends Record<string, unknown> {
     readonly user_jid: unknown
+    readonly alt_user_jid: unknown
     readonly device_jids_json: unknown
     readonly updated_at_ms: unknown
     readonly expires_at_ms: unknown
@@ -70,7 +71,7 @@ export class WaDeviceListSqliteStore extends BaseSqliteStore implements WaDevice
                     params.push(uniqueUserJids[index])
                 }
                 const rows = db.all<DeviceListRow>(
-                    `SELECT user_jid, device_jids_json, updated_at_ms, expires_at_ms
+                    `SELECT user_jid, alt_user_jid, device_jids_json, updated_at_ms, expires_at_ms
                      FROM device_list_cache
                      WHERE session_id = ? AND user_jid IN (${placeholders})`,
                     params
@@ -85,11 +86,7 @@ export class WaDeviceListSqliteStore extends BaseSqliteStore implements WaDevice
                         expiredUserJids.push(userJid)
                         continue
                     }
-                    activeByUserJid.set(userJid, {
-                        userJid,
-                        deviceJids: decodeDeviceJids(row.device_jids_json),
-                        updatedAtMs: asNumber(row.updated_at_ms, 'device_list_cache.updated_at_ms')
-                    })
+                    activeByUserJid.set(userJid, decodeSnapshotRow(userJid, row))
                 }
             }
             if (expiredUserJids.length > 0) {
@@ -101,6 +98,32 @@ export class WaDeviceListSqliteStore extends BaseSqliteStore implements WaDevice
             }
             return snapshots
         })
+    }
+
+    public async findByAnyUserJid(
+        jid: string,
+        nowMs = Date.now()
+    ): Promise<WaDeviceListSnapshot | null> {
+        const db = await this.getConnection()
+        const row = db.get<DeviceListRow>(
+            `SELECT user_jid, alt_user_jid, device_jids_json, updated_at_ms, expires_at_ms
+             FROM device_list_cache
+             WHERE session_id = ? AND (user_jid = ? OR alt_user_jid = ?)
+             LIMIT 1`,
+            [this.options.sessionId, jid, jid]
+        )
+        if (!row) return null
+        const expiresAtMs = asNumber(row.expires_at_ms, 'device_list_cache.expires_at_ms')
+        if (expiresAtMs <= nowMs) {
+            const expiredUserJid = asString(row.user_jid, 'device_list_cache.user_jid')
+            db.run(
+                `DELETE FROM device_list_cache WHERE session_id = ? AND user_jid = ?`,
+                [this.options.sessionId, expiredUserJid]
+            )
+            return null
+        }
+        const userJid = asString(row.user_jid, 'device_list_cache.user_jid')
+        return decodeSnapshotRow(userJid, row)
     }
 
     public async deleteUserDevices(userJid: string): Promise<number> {
@@ -135,17 +158,20 @@ export class WaDeviceListSqliteStore extends BaseSqliteStore implements WaDevice
             `INSERT INTO device_list_cache (
                 session_id,
                 user_jid,
+                alt_user_jid,
                 device_jids_json,
                 updated_at_ms,
                 expires_at_ms
-            ) VALUES (?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?)
             ON CONFLICT(session_id, user_jid) DO UPDATE SET
+                alt_user_jid=excluded.alt_user_jid,
                 device_jids_json=excluded.device_jids_json,
                 updated_at_ms=excluded.updated_at_ms,
                 expires_at_ms=excluded.expires_at_ms`,
             [
                 this.options.sessionId,
                 snapshot.userJid,
+                snapshot.altUserJid ?? null,
                 JSON.stringify(snapshot.deviceJids),
                 snapshot.updatedAtMs,
                 snapshot.updatedAtMs + this.ttlMs
@@ -171,6 +197,19 @@ export class WaDeviceListSqliteStore extends BaseSqliteStore implements WaDevice
                 params
             )
         }
+    }
+}
+
+function decodeSnapshotRow(userJid: string, row: DeviceListRow): WaDeviceListSnapshot {
+    const altUserJid =
+        row.alt_user_jid === null || row.alt_user_jid === undefined
+            ? undefined
+            : String(row.alt_user_jid)
+    return {
+        userJid,
+        ...(altUserJid !== undefined ? { altUserJid } : {}),
+        deviceJids: decodeDeviceJids(row.device_jids_json),
+        updatedAtMs: asNumber(row.updated_at_ms, 'device_list_cache.updated_at_ms')
     }
 }
 

--- a/packages/store-sqlite/src/device-list.store.ts
+++ b/packages/store-sqlite/src/device-list.store.ts
@@ -116,10 +116,10 @@ export class WaDeviceListSqliteStore extends BaseSqliteStore implements WaDevice
         const expiresAtMs = asNumber(row.expires_at_ms, 'device_list_cache.expires_at_ms')
         if (expiresAtMs <= nowMs) {
             const expiredUserJid = asString(row.user_jid, 'device_list_cache.user_jid')
-            db.run(
-                `DELETE FROM device_list_cache WHERE session_id = ? AND user_jid = ?`,
-                [this.options.sessionId, expiredUserJid]
-            )
+            db.run(`DELETE FROM device_list_cache WHERE session_id = ? AND user_jid = ?`, [
+                this.options.sessionId,
+                expiredUserJid
+            ])
             return null
         }
         const userJid = asString(row.user_jid, 'device_list_cache.user_jid')

--- a/packages/store-sqlite/src/migrations.ts
+++ b/packages/store-sqlite/src/migrations.ts
@@ -368,6 +368,18 @@ const SQLITE_MIGRATIONS: readonly WaSqliteMigration[] = [
                 ALTER TABLE group_participants_cache ADD COLUMN ephemeral INTEGER;
             `)
         }
+    },
+    {
+        id: '0013_device_list_cache_alt_user_jid',
+        domain: 'deviceList',
+        up: (db) => {
+            db.exec(`
+                ALTER TABLE device_list_cache ADD COLUMN alt_user_jid TEXT;
+
+                CREATE INDEX IF NOT EXISTS device_list_cache_by_alt_user_jid
+                    ON device_list_cache (session_id, alt_user_jid);
+            `)
+        }
     }
 ]
 

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -728,6 +728,7 @@ export function buildWaClientDependencies(input: {
         sessionStore: sessionStore.session,
         identityStore: sessionStore.identity,
         deviceListStore: sessionStore.deviceList,
+        signalDeviceSync,
         messageSecretStore: sessionStore.messageSecret,
         getCurrentCredentials,
         resolvePrivacyTokenNode: (recipientJid) =>

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -331,7 +331,8 @@ export class WaMessageDispatchCoordinator {
             optionsLevel: optionsCtx,
             quote: options.quote,
             forward: options.forward,
-            mentions: options.mentions
+            mentions: options.mentions,
+            meLid: this.deps.getCurrentCredentials()?.meLid
         })
         const withCtx = ctx ? applyContextInfo(built.message, ctx) : built.message
         const withViewOnce = options.viewOnce ? wrapAsViewOnce(withCtx) : withCtx

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -62,6 +62,7 @@ import {
 } from '@protocol/jid'
 import type { OutboundRetryTracker } from '@retry/tracker'
 import type { WaRetryReplayPayload } from '@retry/types'
+import type { SignalDeviceSyncApi } from '@signal/api/SignalDeviceSyncApi'
 import type { SenderKeyManager } from '@signal/group/SenderKeyManager'
 import type { SignalResolvedSessionTarget, SignalSessionResolver } from '@signal/session/resolver'
 import type { SignalProtocol } from '@signal/session/SignalProtocol'
@@ -104,6 +105,7 @@ interface WaMessageDispatchCoordinatorOptions {
     readonly sessionStore: WaSessionStore
     readonly identityStore: WaIdentityStore
     readonly deviceListStore: WaDeviceListStore
+    readonly signalDeviceSync: SignalDeviceSyncApi
     readonly messageSecretStore: WaMessageSecretStore
     readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly resolvePrivacyTokenNode: (recipientJid: string) => Promise<BinaryNode | null>
@@ -447,12 +449,43 @@ export class WaMessageDispatchCoordinator {
             sendOptions
         }
 
+        const directRecipientJid = isGroup
+            ? recipientJid
+            : await this.resolveDirectRecipientLid(toUserJid(recipientJid))
         const publishResult = isGroup
             ? this.shouldUseGroupDirectPath(messageWithIcdc)
                 ? await this.publishGroupDirectMessage(recipientJid, envelope)
                 : await this.publishGroupSenderKeyMessage(recipientJid, envelope)
-            : await this.publishDirectSignalMessageWithFanout(toUserJid(recipientJid), envelope)
+            : await this.publishDirectSignalMessageWithFanout(directRecipientJid, envelope)
         return upload ? { ...publishResult, upload } : publishResult
+    }
+
+    /**
+     * For a 1:1 recipient passed in PN form, returns the LID-addressed user JID
+     * (cache-first; falls back to a one-shot `queryLidsByPhoneJids`). Switching
+     * to LID before fanout ensures the envelope, eligible-requester list, and
+     * retry-receipt addressing all agree, which keeps the retry tracker from
+     * rejecting receipts that arrive in LID form. Returns the original PN if
+     * no LID is known/resolvable. Inputs already in LID form pass through.
+     */
+    private async resolveDirectRecipientLid(pnUserJid: string): Promise<string> {
+        if (isLidJid(pnUserJid)) return pnUserJid
+        const cached = await this.deps.deviceListStore.findByAnyUserJid(pnUserJid)
+        if (cached) {
+            if (isLidJid(cached.userJid)) return cached.userJid
+            if (cached.altUserJid && isLidJid(cached.altUserJid)) return cached.altUserJid
+        }
+        try {
+            const results = await this.deps.signalDeviceSync.queryLidsByPhoneJids([pnUserJid])
+            const match = results.find((entry) => entry.phoneJid === pnUserJid)
+            if (match?.lidJid) return match.lidJid
+        } catch (error) {
+            this.deps.logger.debug('lid resolution failed for direct recipient', {
+                pnUserJid,
+                message: toError(error).message
+            })
+        }
+        return pnUserJid
     }
 
     public async syncSignalSession(jid: string, reasonIdentity = false): Promise<void> {

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -832,7 +832,7 @@ export class WaRetryCoordinator {
         try {
             requesterStatus = await this.deps.retryStore.getOutboundRequesterStatus(
                 outbound.messageId,
-                requesterNormalizedDeviceJid
+                toUserJid(requesterNormalizedDeviceJid)
             )
         } catch (error) {
             this.deps.logger.warn('failed to resolve outbound requester status from retry store', {

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -134,6 +134,7 @@ function createMessageDispatchCoordinator(
         sessionStore: {} as never,
         identityStore: {} as never,
         deviceListStore: {} as never,
+        signalDeviceSync: {} as never,
         messageSecretStore: {
             set: async (_id: string, _entry: { secret: Uint8Array; senderJid: string }) => {}
         } as never,

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,6 +291,8 @@ export {
     WA_APP_STATE_KEY_TYPES,
     WA_APP_STATE_SYNC_DATA_TYPE,
     WA_BROWSERS,
+    WA_BUSINESS_HOURS_DAYS,
+    WA_BUSINESS_HOURS_MODES,
     WA_COMPANION_PLATFORM_IDS,
     WA_DEFAULTS,
     WA_DIRTY_PROTOCOLS,
@@ -319,6 +321,8 @@ export {
 } from '@protocol'
 export type {
     ParsedJid,
+    WaBusinessHoursDay,
+    WaBusinessHoursMode,
     WaConnectionCode,
     WaConnectionOpenReason,
     WaDisconnectReason,

--- a/src/message/__tests__/context-info.test.ts
+++ b/src/message/__tests__/context-info.test.ts
@@ -114,6 +114,44 @@ test('resolveSendContextInfo resolves quote from WaQuoteRef shape', () => {
     assert.deepEqual(result?.quotedMessage, { conversation: 'orig' })
 })
 
+test('resolveSendContextInfo derives DM quote participant from remoteJid when peer-authored', () => {
+    const result = resolveSendContextInfo({
+        quote: { key: { id: 'm-3', remoteJid: 'peer@lid', fromMe: false } }
+    })
+    assert.equal(result?.quotedParticipant, 'peer@lid')
+    assert.equal(result?.quotedRemoteJid, 'peer@lid')
+})
+
+test('resolveSendContextInfo derives DM quote participant from meLid when fromMe', () => {
+    const result = resolveSendContextInfo({
+        quote: { key: { id: 'm-4', remoteJid: 'peer@lid', fromMe: true } },
+        meLid: 'me@lid'
+    })
+    assert.equal(result?.quotedParticipant, 'me@lid')
+    assert.equal(result?.quotedRemoteJid, 'peer@lid')
+})
+
+test('resolveSendContextInfo does not derive DM fallback for group quote remoteJid', () => {
+    const result = resolveSendContextInfo({
+        quote: { key: { id: 'm-5', remoteJid: 'g@g.us', fromMe: false } }
+    })
+    assert.equal(result?.quotedParticipant, undefined)
+})
+
+test('resolveSendContextInfo prefers explicit quote participant over DM fallback', () => {
+    const result = resolveSendContextInfo({
+        quote: {
+            key: {
+                id: 'm-6',
+                remoteJid: 'peer@lid',
+                participant: 'explicit@lid',
+                fromMe: false
+            }
+        }
+    })
+    assert.equal(result?.quotedParticipant, 'explicit@lid')
+})
+
 test('resolveSendContextInfo applies forward with default score', () => {
     const result = resolveSendContextInfo({ forward: true })
     assert.equal(result?.isForwarded, true)

--- a/src/message/context-info.ts
+++ b/src/message/context-info.ts
@@ -1,4 +1,5 @@
 import type { Proto } from '@proto'
+import { isGroupOrBroadcastJid } from '@protocol/jid'
 
 export interface WaSendContextInfo {
     readonly quotedMessageId?: string
@@ -139,6 +140,7 @@ type WaQuoteSource = {
         readonly id?: string
         readonly remoteJid?: string
         readonly participant?: string
+        readonly fromMe?: boolean
     }
     readonly id?: string
     readonly remoteJid?: string
@@ -154,6 +156,13 @@ export interface WaSendContextResolveInput {
     readonly quote?: WaQuoteSource
     readonly forward?: WaForwardSource
     readonly mentions?: readonly string[]
+    /**
+     * LID-form self user JID. Used as the DM-quote `participant` fallback when
+     * the quoted message is `fromMe` and no explicit participant was provided.
+     * Mirrors wa-web's `getSender(msg)` (returns `msg.from`, which for 1:1 is
+     * `fromMe ? me : peer`).
+     */
+    readonly meLid?: string
 }
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] }
@@ -167,8 +176,16 @@ export function resolveSendContextInfo(input: WaSendContextResolveInput): WaSend
     if (input.quote) {
         const q = input.quote
         ctx.quotedMessageId = q.id ?? q.key?.id ?? ctx.quotedMessageId
-        ctx.quotedParticipant = q.participant ?? q.key?.participant ?? ctx.quotedParticipant
-        ctx.quotedRemoteJid = q.remoteJid ?? q.key?.remoteJid ?? ctx.quotedRemoteJid
+        const explicit = q.participant ?? q.key?.participant
+        const quotedRemote = q.remoteJid ?? q.key?.remoteJid
+        const dmFallback =
+            explicit === undefined && quotedRemote && !isGroupOrBroadcastJid(quotedRemote)
+                ? q.key?.fromMe
+                    ? input.meLid
+                    : quotedRemote
+                : undefined
+        ctx.quotedParticipant = explicit ?? dmFallback ?? ctx.quotedParticipant
+        ctx.quotedRemoteJid = quotedRemote ?? ctx.quotedRemoteJid
         ctx.quotedMessage = q.message ?? ctx.quotedMessage
     }
 

--- a/src/retry/tracker.ts
+++ b/src/retry/tracker.ts
@@ -1,6 +1,6 @@
 import type { Logger } from '@infra/log/types'
 import type { WaMessagePublishResult } from '@message/types'
-import { isGroupOrBroadcastJid, normalizeDeviceJid } from '@protocol/jid'
+import { isGroupOrBroadcastJid, toUserJid } from '@protocol/jid'
 import { encodeRetryReplayPayload } from '@retry/codec'
 import { RETRY_OUTBOUND_TTL_MS } from '@retry/constants'
 import type { WaRetryOutboundMessageRecord, WaRetryReplayPayload } from '@retry/types'
@@ -55,7 +55,7 @@ export function createOutboundRetryTracker(options: {
                 continue
             }
             try {
-                deduped.add(normalizeDeviceJid(raw))
+                deduped.add(toUserJid(raw))
             } catch {
                 continue
             }
@@ -102,7 +102,7 @@ export function createOutboundRetryTracker(options: {
                 !isGroupOrBroadcastJid(resolvedToJid)
             ) {
                 try {
-                    eligibleRequesterDeviceJids = [normalizeDeviceJid(resolvedToJid)]
+                    eligibleRequesterDeviceJids = [toUserJid(resolvedToJid)]
                 } catch {
                     eligibleRequesterDeviceJids = undefined
                 }

--- a/src/signal/api/SignalDeviceSyncApi.ts
+++ b/src/signal/api/SignalDeviceSyncApi.ts
@@ -203,7 +203,53 @@ export class SignalDeviceSyncApi {
             users: result.length,
             found
         })
+        await this.propagateAltUserJids(result)
         return result
+    }
+
+    /**
+     * Enriches existing device-list snapshots with the resolved LID equivalents
+     * so {@link WaDeviceListStore.findByAnyUserJid} can later match a retry
+     * receipt arriving in LID form against an eligible list stored in PN form
+     * (and vice versa). Skips users with no cached snapshot — the alt gets
+     * recorded on the next {@link syncDeviceList} sweep.
+     */
+    private async propagateAltUserJids(
+        results: readonly SignalLidSyncResult[]
+    ): Promise<void> {
+        if (!this.deviceListStore || results.length === 0) return
+        const lidByPhoneJid = new Map<string, string>()
+        const phoneJids: string[] = []
+        for (const entry of results) {
+            if (entry.lidJid && entry.phoneJid) {
+                lidByPhoneJid.set(entry.phoneJid, entry.lidJid)
+                phoneJids.push(entry.phoneJid)
+            }
+        }
+        if (phoneJids.length === 0) return
+        const existing = await this.deviceListStore.getUserDevicesBatch(phoneJids)
+        const updates: {
+            readonly userJid: string
+            readonly altUserJid: string
+            readonly deviceJids: readonly string[]
+            readonly updatedAtMs: number
+        }[] = []
+        for (let index = 0; index < phoneJids.length; index += 1) {
+            const snapshot = existing[index]
+            if (!snapshot) continue
+            const phoneJid = phoneJids[index]
+            const lidJid = lidByPhoneJid.get(phoneJid)
+            if (!lidJid || snapshot.altUserJid === lidJid) continue
+            updates.push({
+                userJid: snapshot.userJid,
+                altUserJid: lidJid,
+                deviceJids: snapshot.deviceJids,
+                updatedAtMs: snapshot.updatedAtMs
+            })
+        }
+        if (updates.length > 0) {
+            await this.deviceListStore.upsertUserDevicesBatch(updates)
+        }
     }
 
     private async collectUsersToQuery(

--- a/src/signal/api/SignalDeviceSyncApi.ts
+++ b/src/signal/api/SignalDeviceSyncApi.ts
@@ -214,10 +214,9 @@ export class SignalDeviceSyncApi {
      * (and vice versa). Skips users with no cached snapshot — the alt gets
      * recorded on the next {@link syncDeviceList} sweep.
      */
-    private async propagateAltUserJids(
-        results: readonly SignalLidSyncResult[]
-    ): Promise<void> {
+    private async propagateAltUserJids(results: readonly SignalLidSyncResult[]): Promise<void> {
         if (!this.deviceListStore || results.length === 0) return
+        const nowMs = Date.now()
         const lidByPhoneJid = new Map<string, string>()
         const phoneJids: string[] = []
         for (const entry of results) {
@@ -227,7 +226,7 @@ export class SignalDeviceSyncApi {
             }
         }
         if (phoneJids.length === 0) return
-        const existing = await this.deviceListStore.getUserDevicesBatch(phoneJids)
+        const existing = await this.deviceListStore.getUserDevicesBatch(phoneJids, nowMs)
         const updates: {
             readonly userJid: string
             readonly altUserJid: string
@@ -244,7 +243,7 @@ export class SignalDeviceSyncApi {
                 userJid: snapshot.userJid,
                 altUserJid: lidJid,
                 deviceJids: snapshot.deviceJids,
-                updatedAtMs: snapshot.updatedAtMs
+                updatedAtMs: nowMs
             })
         }
         if (updates.length > 0) {

--- a/src/store/contracts/device-list.store.ts
+++ b/src/store/contracts/device-list.store.ts
@@ -1,5 +1,12 @@
 export interface WaDeviceListSnapshot {
     readonly userJid: string
+    /**
+     * The equivalent user-base JID in the other addressing form (PN if `userJid`
+     * is LID and vice versa). Populated by the lid usync resolver at send time.
+     * Used by retry-receipt eligibility to match the same user across
+     * `@s.whatsapp.net` and `@lid` forms.
+     */
+    readonly altUserJid?: string
     readonly deviceJids: readonly string[]
     readonly updatedAtMs: number
 }
@@ -11,6 +18,12 @@ export interface WaDeviceListStore {
         userJids: readonly string[],
         nowMs?: number
     ): Promise<readonly (WaDeviceListSnapshot | null)[]>
+    /**
+     * Resolves a snapshot by either `userJid` (primary) or `altUserJid`
+     * (alternate addressing). Returns the snapshot whose user matches `jid` in
+     * either form, or `null` when unknown / expired.
+     */
+    findByAnyUserJid(jid: string, nowMs?: number): Promise<WaDeviceListSnapshot | null>
     deleteUserDevices(userJid: string): Promise<number>
     cleanupExpired(nowMs: number): Promise<number>
     clear(): Promise<void>

--- a/src/store/locks/device-list.lock.ts
+++ b/src/store/locks/device-list.lock.ts
@@ -23,8 +23,7 @@ export function withDeviceListLock(store: WaDeviceListStore): WaDeviceListStore 
             ),
         getUserDevicesBatch: (userJids, nowMs) =>
             gate.runShared(() => store.getUserDevicesBatch(userJids, nowMs)),
-        findByAnyUserJid: (jid, nowMs) =>
-            gate.runShared(() => store.findByAnyUserJid(jid, nowMs)),
+        findByAnyUserJid: (jid, nowMs) => gate.runShared(() => store.findByAnyUserJid(jid, nowMs)),
         deleteUserDevices: (userJid) =>
             gate.runShared(() =>
                 lock.run(`deviceList:user:${userJid}`, () => store.deleteUserDevices(userJid))

--- a/src/store/locks/device-list.lock.ts
+++ b/src/store/locks/device-list.lock.ts
@@ -23,6 +23,8 @@ export function withDeviceListLock(store: WaDeviceListStore): WaDeviceListStore 
             ),
         getUserDevicesBatch: (userJids, nowMs) =>
             gate.runShared(() => store.getUserDevicesBatch(userJids, nowMs)),
+        findByAnyUserJid: (jid, nowMs) =>
+            gate.runShared(() => store.findByAnyUserJid(jid, nowMs)),
         deleteUserDevices: (userJid) =>
             gate.runShared(() =>
                 lock.run(`deviceList:user:${userJid}`, () => store.deleteUserDevices(userJid))

--- a/src/store/memory/device-list.store.ts
+++ b/src/store/memory/device-list.store.ts
@@ -21,6 +21,7 @@ export interface WaDeviceListMemoryStoreOptions {
 
 export class WaDeviceListMemoryStore implements WaDeviceListStore {
     private readonly records: Map<string, WaDeviceListMemoryStoreRecord>
+    private readonly altIndex: Map<string, string>
     private readonly ttlMs: number
     private readonly maxUsers: number
     private readonly cleanup: PeriodicCleanupHandle
@@ -30,6 +31,7 @@ export class WaDeviceListMemoryStore implements WaDeviceListStore {
             throw new Error('device-list ttlMs must be a positive finite number')
         }
         this.records = new Map()
+        this.altIndex = new Map()
         this.ttlMs = ttlMs
         this.maxUsers = resolvePositive(
             options.maxUsers,
@@ -44,6 +46,10 @@ export class WaDeviceListMemoryStore implements WaDeviceListStore {
     public async upsertUserDevicesBatch(snapshots: readonly WaDeviceListSnapshot[]): Promise<void> {
         for (let index = 0; index < snapshots.length; index += 1) {
             const snapshot = snapshots[index]
+            const previous = this.records.get(snapshot.userJid)
+            if (previous?.altUserJid && previous.altUserJid !== snapshot.altUserJid) {
+                this.altIndex.delete(previous.altUserJid)
+            }
             setBoundedMapEntry(
                 this.records,
                 snapshot.userJid,
@@ -53,6 +59,9 @@ export class WaDeviceListMemoryStore implements WaDeviceListStore {
                 },
                 this.maxUsers
             )
+            if (snapshot.altUserJid) {
+                this.altIndex.set(snapshot.altUserJid, snapshot.userJid)
+            }
         }
     }
 
@@ -62,30 +71,35 @@ export class WaDeviceListMemoryStore implements WaDeviceListStore {
     ): Promise<readonly (WaDeviceListSnapshot | null)[]> {
         const snapshots = new Array<WaDeviceListSnapshot | null>(userJids.length)
         for (let index = 0; index < userJids.length; index += 1) {
-            const userJid = userJids[index]
-            const record = this.records.get(userJid)
-            if (!record) {
-                snapshots[index] = null
-                continue
-            }
-            if (record.expiresAtMs <= nowMs) {
-                this.records.delete(userJid)
-                snapshots[index] = null
-                continue
-            }
-            snapshots[index] = record
+            snapshots[index] = this.readLive(userJids[index], nowMs)
         }
         return snapshots
     }
 
+    public async findByAnyUserJid(
+        jid: string,
+        nowMs = Date.now()
+    ): Promise<WaDeviceListSnapshot | null> {
+        const direct = this.readLive(jid, nowMs)
+        if (direct) return direct
+        const primary = this.altIndex.get(jid)
+        if (!primary) return null
+        return this.readLive(primary, nowMs)
+    }
+
     public async deleteUserDevices(userJid: string): Promise<number> {
-        return this.records.delete(userJid) ? 1 : 0
+        const record = this.records.get(userJid)
+        if (!record) return 0
+        if (record.altUserJid) this.altIndex.delete(record.altUserJid)
+        this.records.delete(userJid)
+        return 1
     }
 
     public async cleanupExpired(nowMs: number): Promise<number> {
         let removed = 0
         for (const [userJid, record] of this.records) {
             if (record.expiresAtMs > nowMs) continue
+            if (record.altUserJid) this.altIndex.delete(record.altUserJid)
             this.records.delete(userJid)
             removed += 1
         }
@@ -94,10 +108,22 @@ export class WaDeviceListMemoryStore implements WaDeviceListStore {
 
     public async clear(): Promise<void> {
         this.records.clear()
+        this.altIndex.clear()
     }
 
     public async destroy(): Promise<void> {
         this.cleanup.destroy()
         await this.clear()
+    }
+
+    private readLive(userJid: string, nowMs: number): WaDeviceListSnapshot | null {
+        const record = this.records.get(userJid)
+        if (!record) return null
+        if (record.expiresAtMs <= nowMs) {
+            if (record.altUserJid) this.altIndex.delete(record.altUserJid)
+            this.records.delete(userJid)
+            return null
+        }
+        return record
     }
 }

--- a/src/store/noop.store.ts
+++ b/src/store/noop.store.ts
@@ -98,6 +98,10 @@ export const NOOP_DEVICE_LIST_STORE: WaDeviceListStore = Object.freeze({
         _nowMs?: number
     ): Promise<readonly (WaDeviceListSnapshot | null)[]> =>
         new Array<WaDeviceListSnapshot | null>(userJids.length).fill(null),
+    findByAnyUserJid: async (
+        _jid: string,
+        _nowMs?: number
+    ): Promise<WaDeviceListSnapshot | null> => null,
     deleteUserDevices: async (_userJid: string): Promise<number> => 0,
     cleanupExpired: async (_nowMs: number): Promise<number> => 0,
     clear: async (): Promise<void> => {},

--- a/src/store/noop.store.ts
+++ b/src/store/noop.store.ts
@@ -98,10 +98,8 @@ export const NOOP_DEVICE_LIST_STORE: WaDeviceListStore = Object.freeze({
         _nowMs?: number
     ): Promise<readonly (WaDeviceListSnapshot | null)[]> =>
         new Array<WaDeviceListSnapshot | null>(userJids.length).fill(null),
-    findByAnyUserJid: async (
-        _jid: string,
-        _nowMs?: number
-    ): Promise<WaDeviceListSnapshot | null> => null,
+    findByAnyUserJid: async (_jid: string, _nowMs?: number): Promise<WaDeviceListSnapshot | null> =>
+        null,
     deleteUserDevices: async (_userJid: string): Promise<number> => 0,
     cleanupExpired: async (_nowMs: number): Promise<number> => 0,
     clear: async (): Promise<void> => {},

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -5,6 +5,7 @@ export {
     bytesToHex,
     decodeBase64Url,
     hexToBytes,
+    TEXT_DECODER,
     toBytesView,
     uint8Equal
 } from '@util/bytes'


### PR DESCRIPTION
Resolves `requester_device_not_eligible` retry rejections on DMs caused by send-time PN addressing vs retry-receipt LID addressing mismatch.

- Resolve recipient PN -> LID at dispatch time (cache-first, one-shot `queryLidsByPhoneJids` fallback) so envelope, eligible list, and retry receipts all agree.
- Add `altUserJid` to device-list snapshots + `findByAnyUserJid` lookup across memory/sqlite/postgres/mysql/mongo/redis backends (sqlite migration `0013_device_list_cache_alt_user_jid`).
- Propagate LID alt onto cached PN snapshots after lid sync so future retry receipts arriving in LID form match the eligible list.
- Track eligible requesters at user-base in the outbound retry record (strip device via `toUserJid`); keep delivered tracking device-level so sibling-device retries are not falsely rejected as `requester_already_delivered`.
- Expose shared `TEXT_DECODER` from `@util/bytes` to avoid reinstancing in the mysql backend Uint8Array decode path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device list caches now track an optional alternate user JID and support lookups by either primary or alternate JID across all stores
  * Message dispatch integrates device-sync to resolve phone-number recipients to LID addresses; send context includes meLid for DM quote resolution

* **Chores**
  * Exposed business hours constants and types in public API

* **Tests**
  * Added unit tests covering DM quote participant resolution and meLid fallback behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->