### PR TITLE
fix(message): use push_priority=high_force for peer data operation requests

### DIFF
--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -504,7 +504,7 @@ export class WaMessageDispatchCoordinator {
     public async publishProtocolMessageToDevice(
         deviceJid: string,
         protocolMessage: Proto.Message.IProtocolMessage,
-        options?: { readonly id?: string }
+        options?: { readonly id?: string; readonly pushPriority?: 'high' | 'high_force' }
     ): Promise<WaMessagePublishResult> {
         return this.publishSignalMessage({
             to: deviceJid,
@@ -512,7 +512,7 @@ export class WaMessageDispatchCoordinator {
             id: options?.id,
             type: 'text',
             category: 'peer',
-            pushPriority: 'high'
+            pushPriority: options?.pushPriority ?? 'high'
         })
     }
 

--- a/src/client/messaging/key-protocol.ts
+++ b/src/client/messaging/key-protocol.ts
@@ -10,7 +10,7 @@ import { bytesToHex } from '@util/bytes'
 export type PublishProtocolMessageToDeviceFn = (
     deviceJid: string,
     protocolMessage: Proto.Message.IProtocolMessage,
-    options?: { readonly id?: string }
+    options?: { readonly id?: string; readonly pushPriority?: 'high' | 'high_force' }
 ) => Promise<WaMessagePublishResult>
 
 export type AppStateSyncKeyProtocol = {

--- a/src/message/primitives/peer-data-operation.ts
+++ b/src/message/primitives/peer-data-operation.ts
@@ -116,7 +116,7 @@ export function createPeerDataOperationRequester(
         const result = await publishProtocolMessageToDevice(
             toUserJid(meJid),
             buildRequestProtocolMessage(type, body),
-            { id }
+            { id, pushPriority: 'high_force' }
         )
         return result.id
     }


### PR DESCRIPTION
WhatsApp Mobile silently drops PDO requests sent with the default push_priority=high - it never wakes up the receive path on the primary device when in background, so requests like PLACEHOLDER_MESSAGE_RESEND and HISTORY_SYNC_ON_DEMAND time out without ever being processed.

Match wa-web (`WAWebSendNonMessageDataRequest.A()`), which uses push_priority=high_force for all gated PDO types. Add an opt-in pushPriority field to publishProtocolMessageToDevice so non-PDO callers (app-state sync key share, key request) keep the existing default.

Validated end-to-end: PDO round-trip dropped from 30s timeout to ~1.2s (server ack -> peer_msg receipt -> protocol response with placeholderMessageResendResponse).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced message delivery system with support for configurable priority levels.
  * Message dispatch now accepts optional priority settings for improved delivery control.
  * Critical peer data operations updated to use elevated priority handling for enhanced reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->