### PR TITLE
feat(client,messaging): add client.ignoreKey() for typed stanza drops

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -15,12 +15,14 @@ import type { WaPresenceCoordinator } from '@client/coordinators/WaPresenceCoord
 import type { WaPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordinator'
 import type { WaProfileCoordinator } from '@client/coordinators/WaProfileCoordinator'
 import type { WaStatusCoordinator } from '@client/coordinators/WaStatusCoordinator'
+import { createIgnoreKeyFilter, validateIgnoreKey } from '@client/messaging/ignore-key'
 import { runHistorySyncNotification } from '@client/persistence/history-sync'
 import { persistIncomingMailboxEntities } from '@client/persistence/mailbox'
 import { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
 import type {
     WaClientEventMap,
     WaClientOptions,
+    WaIgnoreKey,
     WaIncomingMessageEvent,
     WaIncomingProtocolMessageEvent
 } from '@client/types'
@@ -492,6 +494,27 @@ export class WaClient extends EventEmitter {
             isLogout: false,
             isNewLogin: false
         })
+    }
+
+    /**
+     * Drops matching inbound stanzas before any handler runs. Server still
+     * gets the ack so it stops re-delivering. Returns an `unregister` function.
+     * Throws when the descriptor has no match field or empty arrays.
+     *
+     * @example
+     * ```ts
+     * const off = client.ignoreKey({ remoteJid: spammerJid })
+     * client.ignoreKey({ remoteJid: spammerJid, only: ['message'] })
+     * client.ignoreKey({ fromMe: true, only: ['message'] })
+     * ```
+     */
+    public ignoreKey(descriptor: WaIgnoreKey): () => void {
+        validateIgnoreKey(descriptor)
+        const filter = createIgnoreKeyFilter(
+            descriptor,
+            () => this.deps.authClient.getCurrentCredentials()?.meJid
+        )
+        return this.deps.incomingNode.registerIncomingStanzaFilter(filter)
     }
 
     /** Auth client: pairing, credentials, registration state. */

--- a/src/client/coordinators/WaIncomingNodeCoordinator.ts
+++ b/src/client/coordinators/WaIncomingNodeCoordinator.ts
@@ -202,6 +202,12 @@ export class WaIncomingNodeCoordinator {
             if (!verdict) {
                 continue
             }
+            this.logger.debug('incoming stanza dropped by filter', {
+                tag: node.tag,
+                id: node.attrs.id,
+                type: node.attrs.type,
+                from: node.attrs.from
+            })
             const ack = buildInboundAck(node)
             if (ack) {
                 await sendSafeAck(this.logger, this.runtime.sendNode, ack)

--- a/src/client/messaging/__tests__/ignore-key.test.ts
+++ b/src/client/messaging/__tests__/ignore-key.test.ts
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { matchesIgnoreKey, validateIgnoreKey } from '@client/messaging/ignore-key'
+import type { WaIgnoreKey } from '@client/types'
+import type { BinaryNode } from '@transport/types'
+
+const PN = '5511999990000@s.whatsapp.net'
+const LID = '99887766554433@lid'
+const ME_JID = '5511777770000:25@s.whatsapp.net'
+
+function message(attrs: Record<string, string>): BinaryNode {
+    return { tag: 'message', attrs }
+}
+
+function receipt(attrs: Record<string, string>): BinaryNode {
+    return { tag: 'receipt', attrs }
+}
+
+function notification(attrs: Record<string, string>): BinaryNode {
+    return { tag: 'notification', attrs }
+}
+
+function presence(attrs: Record<string, string>): BinaryNode {
+    return { tag: 'presence', attrs }
+}
+
+function call(attrs: Record<string, string>): BinaryNode {
+    return { tag: 'call', attrs }
+}
+
+test('matches remoteJid literally against from attr', () => {
+    const node = message({ from: PN, id: 'X' })
+    assert.equal(matchesIgnoreKey(node, { remoteJid: PN }, null), true)
+    assert.equal(matchesIgnoreKey(node, { remoteJid: 'other@s.whatsapp.net' }, null), false)
+})
+
+test('message remoteJid matches via sender_pn and sender_lid alt attrs', () => {
+    const lidAddressed = message({ from: LID, sender_pn: PN, id: 'X' })
+    assert.equal(matchesIgnoreKey(lidAddressed, { remoteJid: PN }, null), true)
+
+    const pnAddressed = message({ from: PN, sender_lid: LID, id: 'X' })
+    assert.equal(matchesIgnoreKey(pnAddressed, { remoteJid: LID }, null), true)
+})
+
+test('remoteJid array means OR across candidates', () => {
+    const node = message({ from: PN, id: 'X' })
+    assert.equal(matchesIgnoreKey(node, { remoteJid: ['other@s.whatsapp.net', PN] }, null), true)
+    assert.equal(
+        matchesIgnoreKey(
+            node,
+            { remoteJid: ['other@s.whatsapp.net', 'another@s.whatsapp.net'] },
+            null
+        ),
+        false
+    )
+})
+
+test('malformed JID candidates are skipped, not thrown', () => {
+    const node = message({ from: PN, id: 'X' })
+    assert.equal(matchesIgnoreKey(node, { remoteJid: ['not-a-jid', PN] }, null), true)
+    assert.equal(matchesIgnoreKey(node, { remoteJid: ['not-a-jid'] }, null), false)
+})
+
+test('participant matches via participant_pn / participant_lid for messages', () => {
+    const node = message({
+        from: 'group@g.us',
+        participant: LID,
+        participant_pn: PN,
+        id: 'X'
+    })
+    assert.equal(matchesIgnoreKey(node, { participant: PN }, null), true)
+    assert.equal(matchesIgnoreKey(node, { participant: LID }, null), true)
+    assert.equal(
+        matchesIgnoreKey(node, { participant: 'someone-else@s.whatsapp.net' }, null),
+        false
+    )
+})
+
+test('AND between multiple fields: all must match', () => {
+    const node = message({ from: PN, id: 'X' })
+    const matchAll: WaIgnoreKey = { remoteJid: PN, id: 'X' }
+    const idMismatch: WaIgnoreKey = { remoteJid: PN, id: 'Y' }
+    assert.equal(matchesIgnoreKey(node, matchAll, null), true)
+    assert.equal(matchesIgnoreKey(node, idMismatch, null), false)
+})
+
+test('fromMe true matches when stanza from attr resolves to meJid user', () => {
+    const ownEcho = message({ from: ME_JID, id: 'X' })
+    const peer = message({ from: PN, id: 'X' })
+    assert.equal(matchesIgnoreKey(ownEcho, { fromMe: true }, ME_JID), true)
+    assert.equal(matchesIgnoreKey(peer, { fromMe: true }, ME_JID), false)
+})
+
+test('fromMe false matches only peer-sourced stanzas', () => {
+    const ownEcho = message({ from: ME_JID, id: 'X' })
+    const peer = message({ from: PN, id: 'X' })
+    assert.equal(matchesIgnoreKey(ownEcho, { fromMe: false }, ME_JID), false)
+    assert.equal(matchesIgnoreKey(peer, { fromMe: false }, ME_JID), true)
+})
+
+test('fromMe against missing meJid yields no match', () => {
+    const node = message({ from: ME_JID, id: 'X' })
+    assert.equal(matchesIgnoreKey(node, { fromMe: true }, null), false)
+})
+
+test('only restricts matching to listed kinds', () => {
+    const msg = message({ from: PN, id: 'X' })
+    const ack = receipt({ from: PN, id: 'X' })
+    const desc: WaIgnoreKey = { remoteJid: PN, only: ['message'] }
+    assert.equal(matchesIgnoreKey(msg, desc, null), true)
+    assert.equal(matchesIgnoreKey(ack, desc, null), false)
+})
+
+test('default scope covers receipt, notification, presence, chatstate, call', () => {
+    const desc: WaIgnoreKey = { remoteJid: PN }
+    assert.equal(matchesIgnoreKey(receipt({ from: PN }), desc, null), true)
+    assert.equal(matchesIgnoreKey(notification({ from: PN }), desc, null), true)
+    assert.equal(matchesIgnoreKey(presence({ from: PN }), desc, null), true)
+    assert.equal(matchesIgnoreKey(call({ from: PN }), desc, null), true)
+})
+
+test('id only meaningful for message/receipt/notification/call', () => {
+    assert.equal(matchesIgnoreKey(presence({ from: PN }), { id: 'X' }, null), false)
+})
+
+test('non-addressed tags never match', () => {
+    const irrelevant: BinaryNode = { tag: 'iq', attrs: { from: PN, id: 'X' } }
+    assert.equal(matchesIgnoreKey(irrelevant, { remoteJid: PN }, null), false)
+})
+
+test('call sender_lid serves as an additional from candidate', () => {
+    const node = call({ from: LID, sender_lid: LID, id: 'C1' })
+    assert.equal(matchesIgnoreKey(node, { remoteJid: LID }, null), true)
+})
+
+test('validate rejects empty descriptor', () => {
+    assert.throws(() => validateIgnoreKey({}), /at least one match field/)
+})
+
+test('validate rejects empty remoteJid array', () => {
+    assert.throws(() => validateIgnoreKey({ remoteJid: [] }), /remoteJid array is empty/)
+})
+
+test('validate rejects empty only array', () => {
+    assert.throws(() => validateIgnoreKey({ remoteJid: PN, only: [] }), /only array is empty/)
+})
+
+test('validate accepts valid combinations', () => {
+    validateIgnoreKey({ remoteJid: PN })
+    validateIgnoreKey({ remoteJid: [PN, LID], only: ['message'] })
+    validateIgnoreKey({ fromMe: true, only: ['message'] })
+    validateIgnoreKey({ participant: PN, only: ['message', 'notification'] })
+    validateIgnoreKey({ id: 'X', only: ['message'] })
+})

--- a/src/client/messaging/ignore-key.ts
+++ b/src/client/messaging/ignore-key.ts
@@ -1,0 +1,104 @@
+import type { WaIgnoreKey, WaIgnoreStanzaKind, WaIncomingStanzaFilter } from '@client/types'
+import { parseJidFull } from '@protocol/jid'
+import { WA_MESSAGE_TAGS } from '@protocol/message'
+import { WA_NODE_TAGS } from '@protocol/nodes'
+import type { BinaryNode } from '@transport/types'
+
+const TAG_TO_KIND: Readonly<Record<string, WaIgnoreStanzaKind>> = {
+    [WA_MESSAGE_TAGS.MESSAGE]: 'message',
+    [WA_MESSAGE_TAGS.RECEIPT]: 'receipt',
+    [WA_NODE_TAGS.NOTIFICATION]: 'notification',
+    [WA_NODE_TAGS.PRESENCE]: 'presence',
+    [WA_NODE_TAGS.CHATSTATE]: 'chatstate',
+    [WA_NODE_TAGS.CALL]: 'call'
+}
+
+export function validateIgnoreKey(d: WaIgnoreKey): void {
+    if (
+        d.remoteJid === undefined &&
+        d.fromMe === undefined &&
+        d.id === undefined &&
+        d.participant === undefined
+    ) {
+        throw new Error('ignoreKey: at least one match field required')
+    }
+    if (Array.isArray(d.remoteJid) && d.remoteJid.length === 0) {
+        throw new Error('ignoreKey: remoteJid array is empty')
+    }
+    if (d.only !== undefined && d.only.length === 0) {
+        throw new Error('ignoreKey: only array is empty')
+    }
+}
+
+function tryParseJid(jid: string | null | undefined) {
+    if (!jid) return null
+    try {
+        return parseJidFull(jid)
+    } catch {
+        return null
+    }
+}
+
+function matchesAnyJid(actual: string | undefined, candidates: readonly string[]): boolean {
+    const a = tryParseJid(actual)
+    if (a === null) return false
+    for (const c of candidates) {
+        if (tryParseJid(c)?.userJid === a.userJid) return true
+    }
+    return false
+}
+
+/** Pure matcher. Exported for direct testing without a coordinator. */
+export function matchesIgnoreKey(
+    node: BinaryNode,
+    d: WaIgnoreKey,
+    meJid: string | null | undefined
+): boolean {
+    const kind = TAG_TO_KIND[node.tag]
+    if (kind === undefined) return false
+    if (d.only !== undefined && !d.only.includes(kind)) return false
+
+    const a = node.attrs
+    const fromCandidates: string[] = []
+    if (a.from) fromCandidates.push(a.from)
+    if (kind === 'message') {
+        if (a.sender_pn) fromCandidates.push(a.sender_pn)
+        if (a.sender_lid) fromCandidates.push(a.sender_lid)
+    } else if (kind === 'call' && a.sender_lid) {
+        fromCandidates.push(a.sender_lid)
+    }
+
+    if (d.remoteJid !== undefined) {
+        const candidates = Array.isArray(d.remoteJid) ? d.remoteJid : [d.remoteJid]
+        if (!fromCandidates.some((f) => matchesAnyJid(f, candidates))) return false
+    }
+
+    if (d.participant !== undefined) {
+        const pCandidates: string[] = []
+        if (a.participant) pCandidates.push(a.participant)
+        if (kind === 'message') {
+            if (a.participant_pn) pCandidates.push(a.participant_pn)
+            if (a.participant_lid) pCandidates.push(a.participant_lid)
+        }
+        if (!pCandidates.some((p) => matchesAnyJid(p, [d.participant!]))) return false
+    }
+
+    if (d.id !== undefined && a.id !== d.id) return false
+
+    if (d.fromMe !== undefined) {
+        const me = tryParseJid(meJid)
+        const isFromMe =
+            me !== null &&
+            fromCandidates.some((f) => tryParseJid(f)?.address.user === me.address.user)
+        if (d.fromMe !== isFromMe) return false
+    }
+
+    return true
+}
+
+export function createIgnoreKeyFilter(
+    descriptor: WaIgnoreKey,
+    getMeJid: () => string | null | undefined
+): WaIncomingStanzaFilter {
+    return (node) => matchesIgnoreKey(node, descriptor, getMeJid())
+}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -426,6 +426,31 @@ export interface WaIncomingNodeHandlerRegistration {
  */
 export type WaIncomingStanzaFilter = (node: BinaryNode) => boolean | Promise<boolean>
 
+/** Stanza tags addressable through {@link WaIgnoreKey}. */
+export type WaIgnoreStanzaKind =
+    | 'message'
+    | 'receipt'
+    | 'notification'
+    | 'presence'
+    | 'chatstate'
+    | 'call'
+
+/**
+ * Match descriptor for {@link WaClient.ignoreKey}. Fields AND; `remoteJid`
+ * array ORs. `remoteJid` and `participant` also match the `sender_pn` /
+ * `sender_lid` / `participant_pn` / `participant_lid` alt attrs on `<message>`
+ * (and `sender_lid` on `<call>`), so one JID form catches the other for those
+ * tags. At least one of `remoteJid` / `fromMe` / `id` / `participant` required.
+ */
+export interface WaIgnoreKey {
+    readonly remoteJid?: string | readonly string[]
+    readonly fromMe?: boolean
+    readonly id?: string
+    readonly participant?: string
+    /** Restrict to specific kinds. Default: all six. */
+    readonly only?: readonly WaIgnoreStanzaKind[]
+}
+
 export interface WaIncomingBaseEvent {
     /** The raw decoded stanza, kept for forward-compat parsing of fields the typed event does not expose. */
     readonly rawNode: BinaryNode

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ export type {
     WaGroupEventMembershipRequest,
     WaGroupEventParticipant,
     WaGroupEventSubgroupSuggestion,
+    WaIgnoreKey,
+    WaIgnoreStanzaKind,
     WaIncomingAddonEvent,
     WaIncomingBaseEvent,
     WaIncomingBotChunkEvent,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stanza filtering capability to selectively ignore incoming messages based on sender, message ID, stanza type, and participant information, with granular control over which stanza kinds to filter.

* **Improvements**
  * Enhanced debug logging for filtered stanzas to improve troubleshooting visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->