### PR TITLE
feat(client,store,messaging)!: lid-canonical contacts, server clock plumbing, and store cleanups

### DIFF
--- a/bench/store-memory.bench.ts
+++ b/bench/store-memory.bench.ts
@@ -133,7 +133,6 @@ function buildRecords(config: StoreBenchConfig): readonly WaStoredMessageRecord[
             senderJid: `5511999900${index % 512}@s.whatsapp.net`,
             fromMe: (index & 1) === 0,
             timestampMs: 1_700_000_000_000 + index,
-            plaintext: payload,
             messageBytes: payload
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2945,7 +2945,6 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -2979,7 +2978,6 @@
             "version": "12.6.2",
             "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
             "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
@@ -3007,7 +3005,6 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
             "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "file-uri-to-path": "1.0.0"
@@ -3017,7 +3014,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "buffer": "^5.5.0",
@@ -3089,7 +3085,6 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -3277,7 +3272,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/cliui": {
@@ -3556,7 +3550,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
             "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mimic-response": "^3.1.0"
@@ -3572,7 +3565,6 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4.0.0"
@@ -3654,7 +3646,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
             "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
@@ -3726,7 +3717,6 @@
             "version": "1.4.5",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
             "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "once": "^1.4.0"
@@ -4509,7 +4499,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "dev": true,
             "license": "(MIT OR WTFPL)",
             "engines": {
                 "node": ">=6"
@@ -4727,7 +4716,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fill-range": {
@@ -4857,7 +4845,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fs-extra": {
@@ -5049,7 +5036,6 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
             "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/glob": {
@@ -5325,7 +5311,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -5389,7 +5374,6 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/internal-slot": {
@@ -6285,7 +6269,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
             "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -6314,7 +6297,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -6334,7 +6316,6 @@
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/mongodb": {
@@ -6465,7 +6446,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
             "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/napi-postinstall": {
@@ -6504,7 +6484,6 @@
             "version": "3.88.0",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.88.0.tgz",
             "integrity": "sha512-At6b4UqIEVudaqPsXjmUO1r/N5BUr4yhDGs5PkBE8/oG5+TfLPhFechiskFsnT6Ql0VfUXbalUUCbfXxtj7K+w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "semver": "^7.3.5"
@@ -7161,7 +7140,6 @@
             "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
             "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
             "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "detect-libc": "^2.0.0",
@@ -7244,7 +7222,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
             "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.1.0",
@@ -7359,7 +7336,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "dev": true,
             "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
             "dependencies": {
                 "deep-extend": "^0.6.0",
@@ -7375,7 +7351,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -7425,7 +7400,6 @@
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
@@ -7674,7 +7648,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -7763,7 +7736,6 @@
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -8022,7 +7994,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
             "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -8043,7 +8014,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
             "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -8193,7 +8163,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.2.0"
@@ -8371,7 +8340,6 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
             "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chownr": "^1.1.1",
@@ -8384,7 +8352,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bl": "^4.0.3",
@@ -8612,7 +8579,6 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "safe-buffer": "^5.0.1"
@@ -8889,7 +8855,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/v8-to-istanbul": {
@@ -9201,7 +9166,7 @@
                 "node": ">=20.9.0"
             },
             "peerDependencies": {
-                "zapo-js": ">=0.1.0"
+                "zapo-js": "^0.3.0"
             }
         },
         "packages/mcp-server": {
@@ -9209,32 +9174,21 @@
             "version": "0.0.0",
             "license": "MIT",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.29.0"
+                "@modelcontextprotocol/sdk": "^1.29.0",
+                "@zapo-js/media-utils": "^0.1.0",
+                "@zapo-js/store-sqlite": "^0.3.0",
+                "better-sqlite3": "^12.6.2",
+                "zapo-js": "^0.3.0"
             },
             "bin": {
                 "zapo-mcp-server": "dist/bin.js"
             },
             "devDependencies": {
                 "@zapo-js/fake-server": "file:../fake-server",
-                "@zapo-js/media-utils": "file:../media-utils",
-                "@zapo-js/store-sqlite": "file:../store-sqlite",
-                "better-sqlite3": "^12.6.2",
-                "cross-env": "^7.0.3",
-                "zapo-js": "file:../.."
+                "cross-env": "^7.0.3"
             },
             "engines": {
                 "node": ">=20.9.0"
-            },
-            "peerDependencies": {
-                "@zapo-js/media-utils": ">=0.1.0",
-                "@zapo-js/store-sqlite": ">=0.1.0",
-                "better-sqlite3": ">=11.0.0",
-                "zapo-js": ">=0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "better-sqlite3": {
-                    "optional": true
-                }
             }
         },
         "packages/media-utils": {
@@ -9252,7 +9206,7 @@
             "peerDependencies": {
                 "file-type": ">=19.0.0",
                 "sharp": ">=0.33.0",
-                "zapo-js": ">=0.1.0"
+                "zapo-js": "^0.3.0"
             },
             "peerDependenciesMeta": {
                 "file-type": {
@@ -9273,12 +9227,7 @@
             },
             "peerDependencies": {
                 "mongodb": ">=6.0.0",
-                "zapo-js": ">=0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "zapo-js": {
-                    "optional": true
-                }
+                "zapo-js": "^0.3.0"
             }
         },
         "packages/store-mysql": {
@@ -9294,12 +9243,7 @@
             },
             "peerDependencies": {
                 "mysql2": ">=3.0.0",
-                "zapo-js": ">=0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "zapo-js": {
-                    "optional": true
-                }
+                "zapo-js": "^0.3.0"
             }
         },
         "packages/store-postgres": {
@@ -9316,12 +9260,7 @@
             },
             "peerDependencies": {
                 "pg": ">=8.0.0",
-                "zapo-js": ">=0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "zapo-js": {
-                    "optional": true
-                }
+                "zapo-js": "^0.3.0"
             }
         },
         "packages/store-redis": {
@@ -9337,12 +9276,7 @@
             },
             "peerDependencies": {
                 "ioredis": ">=5.0.0",
-                "zapo-js": ">=0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "zapo-js": {
-                    "optional": true
-                }
+                "zapo-js": "^0.3.0"
             }
         },
         "packages/store-sqlite": {
@@ -9358,12 +9292,7 @@
             },
             "peerDependencies": {
                 "better-sqlite3": ">=11.0.0",
-                "zapo-js": ">=0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "zapo-js": {
-                    "optional": true
-                }
+                "zapo-js": "^0.3.0"
             }
         }
     }

--- a/packages/fake-server/package.json
+++ b/packages/fake-server/package.json
@@ -43,7 +43,7 @@
         "bench:all-stores": "node bench/run-all-stores.cjs"
     },
     "peerDependencies": {
-        "zapo-js": ">=0.1.0"
+        "zapo-js": "^0.3.0"
     },
     "dependencies": {
         "ws": "^8.18.0"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -32,26 +32,15 @@
         "dev": "cross-env MCP_TRANSPORT=http MCP_EVAL_ENABLED=1 MCP_LOG_LEVEL=trace MCP_AUTH_PATH=../../.auth/state.sqlite node --watch --import tsx src/bin.ts"
     },
     "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0"
-    },
-    "peerDependencies": {
-        "@zapo-js/media-utils": ">=0.1.0",
-        "@zapo-js/store-sqlite": ">=0.1.0",
-        "better-sqlite3": ">=11.0.0",
-        "zapo-js": ">=0.1.0"
-    },
-    "peerDependenciesMeta": {
-        "better-sqlite3": {
-            "optional": true
-        }
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@zapo-js/media-utils": "^0.1.0",
+        "@zapo-js/store-sqlite": "^0.3.0",
+        "better-sqlite3": "^12.6.2",
+        "zapo-js": "^0.3.0"
     },
     "devDependencies": {
         "@zapo-js/fake-server": "file:../fake-server",
-        "@zapo-js/media-utils": "file:../media-utils",
-        "@zapo-js/store-sqlite": "file:../store-sqlite",
-        "better-sqlite3": "^12.6.2",
-        "cross-env": "^7.0.3",
-        "zapo-js": "file:../.."
+        "cross-env": "^7.0.3"
     },
     "engines": {
         "node": ">=20.9.0"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -35,12 +35,15 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@zapo-js/media-utils": "^0.1.0",
         "@zapo-js/store-sqlite": "^0.3.0",
-        "better-sqlite3": "^12.6.2",
+        "better-sqlite3": "^12.6.2"
+    },
+    "peerDependencies": {
         "zapo-js": "^0.3.0"
     },
     "devDependencies": {
         "@zapo-js/fake-server": "file:../fake-server",
-        "cross-env": "^7.0.3"
+        "cross-env": "^7.0.3",
+        "zapo-js": "file:../.."
     },
     "engines": {
         "node": ">=20.9.0"

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -27,7 +27,7 @@
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
     },
     "peerDependencies": {
-        "zapo-js": ">=0.1.0",
+        "zapo-js": "^0.3.0",
         "sharp": ">=0.33.0",
         "file-type": ">=19.0.0"
     },

--- a/packages/store-mongo/package.json
+++ b/packages/store-mongo/package.json
@@ -27,13 +27,8 @@
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
     },
     "peerDependencies": {
-        "zapo-js": ">=0.1.0",
+        "zapo-js": "^0.3.0",
         "mongodb": ">=6.0.0"
-    },
-    "peerDependenciesMeta": {
-        "zapo-js": {
-            "optional": true
-        }
     },
     "devDependencies": {
         "mongodb": "^6.16.0",

--- a/packages/store-mongo/src/__tests__/integration.test.ts
+++ b/packages/store-mongo/src/__tests__/integration.test.ts
@@ -164,11 +164,9 @@ describe('store-mongo integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([1, 2, 3]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs: now + 60_000,
             eligibleRequesterDeviceJids: ['dev1@s.whatsapp.net'],
@@ -347,11 +345,9 @@ describe('store-mongo integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-status-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([1, 2, 3]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs,
             eligibleRequesterDeviceJids: ['dev1@s.whatsapp.net', 'dev2@s.whatsapp.net'],
@@ -641,11 +637,9 @@ describe('store-mongo integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-update-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([31, 32]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs
         })
@@ -872,8 +866,6 @@ describe('store-mongo integration', { timeout: 60_000 }, () => {
             participantJid: 'alice:1@s.whatsapp.net',
             fromMe: false,
             timestampMs: 4_321,
-            encType: 'msg',
-            plaintext: new Uint8Array([1, 2, 3]),
             messageBytes: new Uint8Array([4, 5, 6, 7])
         })
 
@@ -881,8 +873,6 @@ describe('store-mongo integration', { timeout: 60_000 }, () => {
         assert.ok(loaded)
         assert.equal(loaded.senderJid, 'alice@s.whatsapp.net')
         assert.equal(loaded.participantJid, 'alice:1@s.whatsapp.net')
-        assert.equal(loaded.encType, 'msg')
-        assert.deepEqual(Array.from(loaded.plaintext ?? []), [1, 2, 3])
         assert.deepEqual(Array.from(loaded.messageBytes ?? []), [4, 5, 6, 7])
 
         const listed = await messages.listByThread('thread-bin@s.whatsapp.net')
@@ -939,11 +929,9 @@ describe('store-mongo integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-no-eligible-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([1]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs
         })

--- a/packages/store-mongo/src/contact.store.ts
+++ b/packages/store-mongo/src/contact.store.ts
@@ -1,3 +1,4 @@
+import { isUserJid } from 'zapo-js'
 import type { WaContactStore, WaStoredContactRecord } from 'zapo-js/store'
 
 import { BaseMongoStore } from './BaseMongoStore'
@@ -70,11 +71,30 @@ export class WaContactMongoStore extends BaseMongoStore implements WaContactStor
         await this.col<ContactDoc>(COLLECTION).bulkWrite(ops, { ordered: false })
     }
 
+    protected override async createIndexes(): Promise<void> {
+        await this.col<ContactDoc>(COLLECTION).createIndex(
+            { '_id.session_id': 1, phone_number: 1 },
+            { partialFilterExpression: { phone_number: { $type: 'string' } } }
+        )
+    }
+
     public async getByJid(jid: string): Promise<WaStoredContactRecord | null> {
         await this.ensureIndexes()
         const doc = await this.col<ContactDoc>(COLLECTION).findOne({ _id: this.makeId(jid) })
-        if (!doc) return null
-        return docToRecord(doc)
+        if (doc) return docToRecord(doc)
+        if (isUserJid(jid)) {
+            return this.getByPhoneNumber(jid)
+        }
+        return null
+    }
+
+    public async getByPhoneNumber(pn: string): Promise<WaStoredContactRecord | null> {
+        await this.ensureIndexes()
+        const doc = await this.col<ContactDoc>(COLLECTION).findOne({
+            '_id.session_id': this.sessionId,
+            phone_number: pn
+        })
+        return doc ? docToRecord(doc) : null
     }
 
     public async deleteByJid(jid: string): Promise<number> {

--- a/packages/store-mongo/src/message.store.ts
+++ b/packages/store-mongo/src/message.store.ts
@@ -14,8 +14,6 @@ interface MessageDoc {
     participant_jid: string | null
     from_me: boolean
     timestamp_ms: number | null
-    enc_type: string | null
-    plaintext: Binary | null
     message_bytes: Binary | null
 }
 
@@ -27,8 +25,6 @@ function docToRecord(doc: MessageDoc): WaStoredMessageRecord {
         participantJid: doc.participant_jid ?? undefined,
         fromMe: doc.from_me,
         timestampMs: doc.timestamp_ms ?? undefined,
-        encType: doc.enc_type ?? undefined,
-        plaintext: fromBinaryOrNull(doc.plaintext) ?? undefined,
         messageBytes: fromBinaryOrNull(doc.message_bytes) ?? undefined
     }
 }
@@ -57,8 +53,6 @@ export class WaMessageMongoStore extends BaseMongoStore implements WaMessageStor
             participant_jid: record.participantJid ?? null,
             from_me: record.fromMe,
             timestamp_ms: record.timestampMs ?? null,
-            enc_type: record.encType ?? null,
-            plaintext: record.plaintext ? toBinary(record.plaintext) : null,
             message_bytes: record.messageBytes ? toBinary(record.messageBytes) : null
         }
     }

--- a/packages/store-mongo/src/retry.store.ts
+++ b/packages/store-mongo/src/retry.store.ts
@@ -14,14 +14,10 @@ interface RetryRequesterStatusPayload {
 interface OutboundDoc {
     _id: { session_id: string; message_id: string }
     to_jid: string
-    participant_jid: string | null
-    recipient_jid: string | null
-    message_type: string
     replay_mode: string
     replay_payload: Binary
     requesters_json: string | null
     state: string
-    created_at_ms: number
     updated_at_ms: number
     expires_at: Date
 }
@@ -118,14 +114,10 @@ export class WaRetryMongoStore extends BaseMongoStore implements WaRetryStore {
             {
                 $set: {
                     to_jid: record.toJid,
-                    participant_jid: record.participantJid ?? null,
-                    recipient_jid: record.recipientJid ?? null,
-                    message_type: record.messageType,
                     replay_mode: record.replayMode,
                     replay_payload: toBinary(record.replayPayload),
                     requesters_json: requestersJson,
                     state: record.state,
-                    created_at_ms: record.createdAtMs,
                     updated_at_ms: record.updatedAtMs,
                     expires_at: new Date(record.expiresAtMs)
                 }
@@ -160,17 +152,13 @@ export class WaRetryMongoStore extends BaseMongoStore implements WaRetryStore {
         return {
             messageId: doc._id.message_id,
             toJid: doc.to_jid,
-            participantJid: doc.participant_jid ?? undefined,
-            recipientJid: doc.recipient_jid ?? undefined,
             eligibleRequesterDeviceJids:
                 requesters.eligible.length > 0 ? requesters.eligible : undefined,
             deliveredRequesterDeviceJids:
                 requesters.delivered.length > 0 ? requesters.delivered : undefined,
-            messageType: doc.message_type,
             replayMode: doc.replay_mode as WaRetryOutboundMessageRecord['replayMode'],
             replayPayload: fromBinary(doc.replay_payload),
             state: doc.state as WaRetryOutboundState,
-            createdAtMs: doc.created_at_ms,
             updatedAtMs: doc.updated_at_ms,
             expiresAtMs: doc.expires_at.getTime()
         }

--- a/packages/store-mysql/package.json
+++ b/packages/store-mysql/package.json
@@ -27,13 +27,8 @@
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
     },
     "peerDependencies": {
-        "zapo-js": ">=0.1.0",
+        "zapo-js": "^0.3.0",
         "mysql2": ">=3.0.0"
-    },
-    "peerDependenciesMeta": {
-        "zapo-js": {
-            "optional": true
-        }
     },
     "devDependencies": {
         "mysql2": "^3.14.0",

--- a/packages/store-mysql/src/__tests__/integration.test.ts
+++ b/packages/store-mysql/src/__tests__/integration.test.ts
@@ -182,11 +182,9 @@ describe('store-mysql integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([1, 2, 3]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs: now + 60_000,
             eligibleRequesterDeviceJids: ['dev1@s.whatsapp.net'],
@@ -379,11 +377,9 @@ describe('store-mysql integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-status-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([1, 2, 3]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs,
             eligibleRequesterDeviceJids: ['dev1@s.whatsapp.net', 'dev2@s.whatsapp.net'],
@@ -673,11 +669,9 @@ describe('store-mysql integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-update-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([31, 32]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs
         })
@@ -904,8 +898,6 @@ describe('store-mysql integration', { timeout: 60_000 }, () => {
             participantJid: 'alice:1@s.whatsapp.net',
             fromMe: false,
             timestampMs: 4_321,
-            encType: 'msg',
-            plaintext: new Uint8Array([1, 2, 3]),
             messageBytes: new Uint8Array([4, 5, 6, 7])
         })
 
@@ -913,8 +905,6 @@ describe('store-mysql integration', { timeout: 60_000 }, () => {
         assert.ok(loaded)
         assert.equal(loaded.senderJid, 'alice@s.whatsapp.net')
         assert.equal(loaded.participantJid, 'alice:1@s.whatsapp.net')
-        assert.equal(loaded.encType, 'msg')
-        assert.deepEqual(Array.from(loaded.plaintext ?? []), [1, 2, 3])
         assert.deepEqual(Array.from(loaded.messageBytes ?? []), [4, 5, 6, 7])
 
         const listed = await messages.listByThread('thread-bin@s.whatsapp.net')
@@ -971,11 +961,9 @@ describe('store-mysql integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-no-eligible-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([1]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs
         })

--- a/packages/store-mysql/src/connection.ts
+++ b/packages/store-mysql/src/connection.ts
@@ -326,6 +326,36 @@ const MIGRATIONS: readonly Migration[] = [
                 ADD COLUMN alt_user_jid VARCHAR(255) NULL,
                 ADD INDEX \`__PREFIX__idx_device_list_alt_user_jid\` (session_id, alt_user_jid)
         `
+    },
+    {
+        name: '0014_mailbox_contacts_phone_number_index',
+        domain: 'mailbox',
+        sql: `
+            ALTER TABLE \`__PREFIX__mailbox_contacts\`
+                ADD INDEX \`__PREFIX__idx_mailbox_contacts_phone_number\` (session_id, phone_number)
+        `
+    },
+    {
+        name: '0015_mailbox_messages_drop_dead_columns',
+        domain: 'mailbox',
+        sql: `
+            ALTER TABLE \`__PREFIX__mailbox_messages\`
+                DROP COLUMN enc_type,
+                DROP COLUMN plaintext
+        `
+    },
+    {
+        name: '0016_retry_drop_dead_columns',
+        domain: 'retry',
+        sql: `
+            ALTER TABLE \`__PREFIX__retry_outbound_messages\`
+                DROP COLUMN participant_jid,
+                DROP COLUMN recipient_jid,
+                DROP COLUMN message_type,
+                DROP COLUMN created_at_ms;
+            ALTER TABLE \`__PREFIX__retry_inbound_counters\`
+                DROP COLUMN updated_at_ms
+        `
     }
 ]
 

--- a/packages/store-mysql/src/connection.ts
+++ b/packages/store-mysql/src/connection.ts
@@ -345,14 +345,20 @@ const MIGRATIONS: readonly Migration[] = [
         `
     },
     {
-        name: '0016_retry_drop_dead_columns',
+        name: '0016_retry_outbound_drop_dead_columns',
         domain: 'retry',
         sql: `
             ALTER TABLE \`__PREFIX__retry_outbound_messages\`
                 DROP COLUMN participant_jid,
                 DROP COLUMN recipient_jid,
                 DROP COLUMN message_type,
-                DROP COLUMN created_at_ms;
+                DROP COLUMN created_at_ms
+        `
+    },
+    {
+        name: '0017_retry_inbound_drop_dead_columns',
+        domain: 'retry',
+        sql: `
             ALTER TABLE \`__PREFIX__retry_inbound_counters\`
                 DROP COLUMN updated_at_ms
         `

--- a/packages/store-mysql/src/contact.store.ts
+++ b/packages/store-mysql/src/contact.store.ts
@@ -1,4 +1,5 @@
 import type { PoolConnection } from 'mysql2/promise'
+import { isUserJid } from 'zapo-js'
 import type { WaContactStore, WaStoredContactRecord } from 'zapo-js/store'
 
 import { BaseMysqlStore } from './BaseMysqlStore'
@@ -94,7 +95,29 @@ export class WaContactMysqlStore extends BaseMysqlStore implements WaContactStor
                 [this.sessionId, jid]
             )
         )
-        if (!row) return null
+        if (row) return this.decodeRow(row)
+        if (isUserJid(jid)) {
+            return this.getByPhoneNumber(jid)
+        }
+        return null
+    }
+
+    public async getByPhoneNumber(pn: string): Promise<WaStoredContactRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.execute(
+                `SELECT jid, display_name, push_name, lid,
+                    phone_number, last_updated_ms
+             FROM ${this.t('mailbox_contacts')}
+             WHERE session_id = ? AND phone_number = ?
+             LIMIT 1`,
+                [this.sessionId, pn]
+            )
+        )
+        return row ? this.decodeRow(row) : null
+    }
+
+    private decodeRow(row: Record<string, unknown>): WaStoredContactRecord {
         return {
             jid: row.jid as string,
             displayName: (row.display_name as string | null) ?? undefined,

--- a/packages/store-mysql/src/message.store.ts
+++ b/packages/store-mysql/src/message.store.ts
@@ -20,8 +20,6 @@ function rowToRecord(row: MysqlRow): WaStoredMessageRecord {
         participantJid: (row.participant_jid as string | null) ?? undefined,
         fromMe: Number(row.from_me) === 1,
         timestampMs: row.timestamp_ms !== null ? Number(row.timestamp_ms) : undefined,
-        encType: (row.enc_type as string | null) ?? undefined,
-        plaintext: toBytesOrNull(row.plaintext) ?? undefined,
         messageBytes: toBytesOrNull(row.message_bytes) ?? undefined
     }
 }
@@ -36,16 +34,14 @@ export class WaMessageMysqlStore extends BaseMysqlStore implements WaMessageStor
         await this.pool.execute(
             `INSERT INTO ${this.t('mailbox_messages')} (
                 session_id, message_id, thread_jid, sender_jid, participant_jid,
-                from_me, timestamp_ms, enc_type, plaintext, message_bytes
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                from_me, timestamp_ms, message_bytes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ON DUPLICATE KEY UPDATE
                 thread_jid = VALUES(thread_jid),
                 sender_jid = VALUES(sender_jid),
                 participant_jid = VALUES(participant_jid),
                 from_me = VALUES(from_me),
                 timestamp_ms = VALUES(timestamp_ms),
-                enc_type = VALUES(enc_type),
-                plaintext = VALUES(plaintext),
                 message_bytes = VALUES(message_bytes)`,
             [
                 this.sessionId,
@@ -55,8 +51,6 @@ export class WaMessageMysqlStore extends BaseMysqlStore implements WaMessageStor
                 record.participantJid ?? null,
                 record.fromMe ? 1 : 0,
                 record.timestampMs ?? null,
-                record.encType ?? null,
-                record.plaintext ?? null,
                 record.messageBytes ?? null
             ]
         )
@@ -68,7 +62,7 @@ export class WaMessageMysqlStore extends BaseMysqlStore implements WaMessageStor
             executor: { execute: PoolConnection['execute'] },
             chunk: readonly WaStoredMessageRecord[]
         ): Promise<void> => {
-            const placeholders = chunk.map(() => '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)').join(', ')
+            const placeholders = chunk.map(() => '(?, ?, ?, ?, ?, ?, ?, ?)').join(', ')
             const params: MysqlParam[] = []
             for (const record of chunk) {
                 params.push(
@@ -79,15 +73,13 @@ export class WaMessageMysqlStore extends BaseMysqlStore implements WaMessageStor
                     record.participantJid ?? null,
                     record.fromMe ? 1 : 0,
                     record.timestampMs ?? null,
-                    record.encType ?? null,
-                    record.plaintext ?? null,
                     record.messageBytes ?? null
                 )
             }
             await executor.execute(
                 `INSERT INTO ${this.t('mailbox_messages')} (
                     session_id, message_id, thread_jid, sender_jid, participant_jid,
-                    from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                    from_me, timestamp_ms, message_bytes
                 ) VALUES ${placeholders}
                 ON DUPLICATE KEY UPDATE
                     thread_jid = VALUES(thread_jid),
@@ -95,8 +87,6 @@ export class WaMessageMysqlStore extends BaseMysqlStore implements WaMessageStor
                     participant_jid = VALUES(participant_jid),
                     from_me = VALUES(from_me),
                     timestamp_ms = VALUES(timestamp_ms),
-                    enc_type = VALUES(enc_type),
-                    plaintext = VALUES(plaintext),
                     message_bytes = VALUES(message_bytes)`,
                 params
             )
@@ -121,7 +111,7 @@ export class WaMessageMysqlStore extends BaseMysqlStore implements WaMessageStor
         const row = queryFirst(
             await this.pool.execute(
                 `SELECT message_id, thread_jid, sender_jid, participant_jid,
-                    from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                    from_me, timestamp_ms, message_bytes
              FROM ${this.t('mailbox_messages')}
              WHERE session_id = ? AND message_id = ?`,
                 [this.sessionId, id]
@@ -143,7 +133,7 @@ export class WaMessageMysqlStore extends BaseMysqlStore implements WaMessageStor
             return queryRows(
                 await this.pool.execute(
                     `SELECT message_id, thread_jid, sender_jid, participant_jid,
-                        from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                        from_me, timestamp_ms, message_bytes
                  FROM ${this.t('mailbox_messages')}
                  WHERE session_id = ? AND thread_jid = ? AND timestamp_ms < ?
                  ORDER BY timestamp_ms DESC, message_id DESC
@@ -156,7 +146,7 @@ export class WaMessageMysqlStore extends BaseMysqlStore implements WaMessageStor
         return queryRows(
             await this.pool.execute(
                 `SELECT message_id, thread_jid, sender_jid, participant_jid,
-                    from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                    from_me, timestamp_ms, message_bytes
              FROM ${this.t('mailbox_messages')}
              WHERE session_id = ? AND thread_jid = ?
              ORDER BY timestamp_ms DESC, message_id DESC

--- a/packages/store-mysql/src/retry.store.ts
+++ b/packages/store-mysql/src/retry.store.ts
@@ -110,41 +110,29 @@ export class WaRetryMysqlStore extends BaseMysqlStore implements WaRetryStore {
                 session_id,
                 message_id,
                 to_jid,
-                participant_jid,
-                recipient_jid,
-                message_type,
                 replay_mode,
                 replay_payload,
                 requesters_json,
                 state,
-                created_at_ms,
                 updated_at_ms,
                 expires_at_ms
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON DUPLICATE KEY UPDATE
                 to_jid = VALUES(to_jid),
-                participant_jid = VALUES(participant_jid),
-                recipient_jid = VALUES(recipient_jid),
-                message_type = VALUES(message_type),
                 replay_mode = VALUES(replay_mode),
                 replay_payload = VALUES(replay_payload),
                 requesters_json = VALUES(requesters_json),
                 state = VALUES(state),
-                created_at_ms = VALUES(created_at_ms),
                 updated_at_ms = VALUES(updated_at_ms),
                 expires_at_ms = VALUES(expires_at_ms)`,
             [
                 this.sessionId,
                 record.messageId,
                 record.toJid,
-                record.participantJid ?? null,
-                record.recipientJid ?? null,
-                record.messageType,
                 record.replayMode,
                 replayPayload,
                 requestersJson,
                 record.state,
-                record.createdAtMs,
                 record.updatedAtMs,
                 record.expiresAtMs
             ]
@@ -171,14 +159,10 @@ export class WaRetryMysqlStore extends BaseMysqlStore implements WaRetryStore {
                 `SELECT
                 message_id,
                 to_jid,
-                participant_jid,
-                recipient_jid,
-                message_type,
                 replay_mode,
                 replay_payload,
                 requesters_json,
                 state,
-                created_at_ms,
                 updated_at_ms,
                 expires_at_ms
             FROM ${this.t('retry_outbound_messages')}
@@ -204,17 +188,13 @@ export class WaRetryMysqlStore extends BaseMysqlStore implements WaRetryStore {
         return {
             messageId: String(row.message_id),
             toJid: String(row.to_jid),
-            participantJid: row.participant_jid !== null ? String(row.participant_jid) : undefined,
-            recipientJid: row.recipient_jid !== null ? String(row.recipient_jid) : undefined,
             eligibleRequesterDeviceJids:
                 requesters.eligible.length > 0 ? requesters.eligible : undefined,
             deliveredRequesterDeviceJids:
                 requesters.delivered.length > 0 ? requesters.delivered : undefined,
-            messageType: String(row.message_type),
             replayMode: String(row.replay_mode) as WaRetryOutboundMessageRecord['replayMode'],
             replayPayload: toBytes(row.replay_payload),
             state: String(row.state) as WaRetryOutboundState,
-            createdAtMs: Number(row.created_at_ms),
             updatedAtMs: Number(row.updated_at_ms),
             expiresAtMs: Number(row.expires_at_ms)
         }
@@ -295,19 +275,18 @@ export class WaRetryMysqlStore extends BaseMysqlStore implements WaRetryStore {
     public async incrementInboundCounter(
         messageId: string,
         requesterJid: string,
-        updatedAtMs: number,
+        _updatedAtMs: number,
         expiresAtMs: number
     ): Promise<number> {
         return this.withTransaction(async (conn) => {
             await conn.execute(
                 `INSERT INTO ${this.t('retry_inbound_counters')} (
-                    session_id, message_id, requester_jid, retry_count, updated_at_ms, expires_at_ms
-                ) VALUES (?, ?, ?, LAST_INSERT_ID(1), ?, ?)
+                    session_id, message_id, requester_jid, retry_count, expires_at_ms
+                ) VALUES (?, ?, ?, LAST_INSERT_ID(1), ?)
                 ON DUPLICATE KEY UPDATE
                     retry_count = LAST_INSERT_ID(retry_count + 1),
-                    updated_at_ms = VALUES(updated_at_ms),
                     expires_at_ms = VALUES(expires_at_ms)`,
-                [this.sessionId, messageId, requesterJid, updatedAtMs, expiresAtMs]
+                [this.sessionId, messageId, requesterJid, expiresAtMs]
             )
             const row = queryFirst(await conn.execute('SELECT LAST_INSERT_ID() AS retry_count', []))
             return row ? Number(row.retry_count) : 1

--- a/packages/store-postgres/package.json
+++ b/packages/store-postgres/package.json
@@ -27,13 +27,8 @@
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
     },
     "peerDependencies": {
-        "zapo-js": ">=0.1.0",
+        "zapo-js": "^0.3.0",
         "pg": ">=8.0.0"
-    },
-    "peerDependenciesMeta": {
-        "zapo-js": {
-            "optional": true
-        }
     },
     "devDependencies": {
         "@types/pg": "^8.11.0",

--- a/packages/store-postgres/src/__tests__/integration.test.ts
+++ b/packages/store-postgres/src/__tests__/integration.test.ts
@@ -182,11 +182,9 @@ describe('store-postgres integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([1, 2, 3]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs: now + 60_000,
             eligibleRequesterDeviceJids: ['dev1@s.whatsapp.net'],
@@ -365,11 +363,9 @@ describe('store-postgres integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-status-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([1, 2, 3]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs,
             eligibleRequesterDeviceJids: ['dev1@s.whatsapp.net', 'dev2@s.whatsapp.net'],
@@ -659,11 +655,9 @@ describe('store-postgres integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-update-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([31, 32]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs
         })
@@ -890,8 +884,6 @@ describe('store-postgres integration', { timeout: 60_000 }, () => {
             participantJid: 'alice:1@s.whatsapp.net',
             fromMe: false,
             timestampMs: 4_321,
-            encType: 'msg',
-            plaintext: new Uint8Array([1, 2, 3]),
             messageBytes: new Uint8Array([4, 5, 6, 7])
         })
 
@@ -899,8 +891,6 @@ describe('store-postgres integration', { timeout: 60_000 }, () => {
         assert.ok(loaded)
         assert.equal(loaded.senderJid, 'alice@s.whatsapp.net')
         assert.equal(loaded.participantJid, 'alice:1@s.whatsapp.net')
-        assert.equal(loaded.encType, 'msg')
-        assert.deepEqual(Array.from(loaded.plaintext ?? []), [1, 2, 3])
         assert.deepEqual(Array.from(loaded.messageBytes ?? []), [4, 5, 6, 7])
 
         const listed = await messages.listByThread('thread-bin@s.whatsapp.net')
@@ -957,11 +947,9 @@ describe('store-postgres integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-no-eligible-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([1]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs
         })

--- a/packages/store-postgres/src/connection.ts
+++ b/packages/store-postgres/src/connection.ts
@@ -341,6 +341,34 @@ const MIGRATIONS: readonly Migration[] = [
             CREATE INDEX IF NOT EXISTS "__PREFIX__idx_device_list_alt_user_jid"
                 ON "__PREFIX__device_list_cache" (session_id, alt_user_jid)
         `
+    },
+    {
+        name: '0014_mailbox_contacts_phone_number_index',
+        domain: 'mailbox',
+        sql: `
+            CREATE INDEX IF NOT EXISTS "__PREFIX__idx_mailbox_contacts_phone_number"
+                ON "__PREFIX__mailbox_contacts" (session_id, phone_number)
+                WHERE phone_number IS NOT NULL
+        `
+    },
+    {
+        name: '0015_mailbox_messages_drop_dead_columns',
+        domain: 'mailbox',
+        sql: `
+            ALTER TABLE "__PREFIX__mailbox_messages" DROP COLUMN IF EXISTS enc_type;
+            ALTER TABLE "__PREFIX__mailbox_messages" DROP COLUMN IF EXISTS plaintext
+        `
+    },
+    {
+        name: '0016_retry_drop_dead_columns',
+        domain: 'retry',
+        sql: `
+            ALTER TABLE "__PREFIX__retry_outbound_messages" DROP COLUMN IF EXISTS participant_jid;
+            ALTER TABLE "__PREFIX__retry_outbound_messages" DROP COLUMN IF EXISTS recipient_jid;
+            ALTER TABLE "__PREFIX__retry_outbound_messages" DROP COLUMN IF EXISTS message_type;
+            ALTER TABLE "__PREFIX__retry_outbound_messages" DROP COLUMN IF EXISTS created_at_ms;
+            ALTER TABLE "__PREFIX__retry_inbound_counters" DROP COLUMN IF EXISTS updated_at_ms
+        `
     }
 ]
 

--- a/packages/store-postgres/src/contact.store.ts
+++ b/packages/store-postgres/src/contact.store.ts
@@ -1,4 +1,5 @@
 import type { PoolClient } from 'pg'
+import { isUserJid } from 'zapo-js'
 import type { WaContactStore, WaStoredContactRecord } from 'zapo-js/store'
 
 import { BasePgStore } from './BasePgStore'
@@ -101,7 +102,30 @@ export class WaContactPgStore extends BasePgStore implements WaContactStore {
                 values: [this.sessionId, jid]
             })
         )
-        if (!row) return null
+        if (row) return this.decodeRow(row)
+        if (isUserJid(jid)) {
+            return this.getByPhoneNumber(jid)
+        }
+        return null
+    }
+
+    public async getByPhoneNumber(pn: string): Promise<WaStoredContactRecord | null> {
+        await this.ensureReady()
+        const row = queryFirst(
+            await this.pool.query({
+                name: this.stmtName('contact_get_by_phone_number'),
+                text: `SELECT jid, display_name, push_name, lid,
+                    phone_number, last_updated_ms
+             FROM ${this.t('mailbox_contacts')}
+             WHERE session_id = $1 AND phone_number = $2
+             LIMIT 1`,
+                values: [this.sessionId, pn]
+            })
+        )
+        return row ? this.decodeRow(row) : null
+    }
+
+    private decodeRow(row: Record<string, unknown>): WaStoredContactRecord {
         return {
             jid: row.jid as string,
             displayName: (row.display_name as string | null) ?? undefined,

--- a/packages/store-postgres/src/message.store.ts
+++ b/packages/store-postgres/src/message.store.ts
@@ -20,8 +20,6 @@ function rowToRecord(row: PgRow): WaStoredMessageRecord {
         participantJid: (row.participant_jid as string | null) ?? undefined,
         fromMe: Boolean(row.from_me),
         timestampMs: row.timestamp_ms !== null ? Number(row.timestamp_ms) : undefined,
-        encType: (row.enc_type as string | null) ?? undefined,
-        plaintext: toBytesOrNull(row.plaintext) ?? undefined,
         messageBytes: toBytesOrNull(row.message_bytes) ?? undefined
     }
 }
@@ -34,7 +32,7 @@ export class WaMessagePgStore extends BasePgStore implements WaMessageStore {
     private upsertQuery(values: unknown[]) {
         return {
             name: this.stmtName('msg_upsert'),
-            text: `INSERT INTO ${this.t('mailbox_messages')} (session_id, message_id, thread_jid, sender_jid, participant_jid, from_me, timestamp_ms, enc_type, plaintext, message_bytes) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) ON CONFLICT (session_id, message_id) DO UPDATE SET thread_jid = EXCLUDED.thread_jid, sender_jid = EXCLUDED.sender_jid, participant_jid = EXCLUDED.participant_jid, from_me = EXCLUDED.from_me, timestamp_ms = EXCLUDED.timestamp_ms, enc_type = EXCLUDED.enc_type, plaintext = EXCLUDED.plaintext, message_bytes = EXCLUDED.message_bytes`,
+            text: `INSERT INTO ${this.t('mailbox_messages')} (session_id, message_id, thread_jid, sender_jid, participant_jid, from_me, timestamp_ms, message_bytes) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT (session_id, message_id) DO UPDATE SET thread_jid = EXCLUDED.thread_jid, sender_jid = EXCLUDED.sender_jid, participant_jid = EXCLUDED.participant_jid, from_me = EXCLUDED.from_me, timestamp_ms = EXCLUDED.timestamp_ms, message_bytes = EXCLUDED.message_bytes`,
             values
         }
     }
@@ -50,8 +48,6 @@ export class WaMessagePgStore extends BasePgStore implements WaMessageStore {
                 record.participantJid ?? null,
                 record.fromMe,
                 record.timestampMs ?? null,
-                record.encType ?? null,
-                record.plaintext ?? null,
                 record.messageBytes ?? null
             ])
         )
@@ -66,8 +62,8 @@ export class WaMessagePgStore extends BasePgStore implements WaMessageStore {
             let paramIdx = 1
             const placeholders = chunk
                 .map(() => {
-                    const p = `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}, $${paramIdx + 5}, $${paramIdx + 6}, $${paramIdx + 7}, $${paramIdx + 8}, $${paramIdx + 9})`
-                    paramIdx += 10
+                    const p = `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}, $${paramIdx + 5}, $${paramIdx + 6}, $${paramIdx + 7})`
+                    paramIdx += 8
                     return p
                 })
                 .join(', ')
@@ -81,8 +77,6 @@ export class WaMessagePgStore extends BasePgStore implements WaMessageStore {
                     record.participantJid ?? null,
                     record.fromMe,
                     record.timestampMs ?? null,
-                    record.encType ?? null,
-                    record.plaintext ?? null,
                     record.messageBytes ?? null
                 )
             }
@@ -90,7 +84,7 @@ export class WaMessagePgStore extends BasePgStore implements WaMessageStore {
                 name: this.stmtName(`msg_upsert_batch_${chunk.length}`),
                 text: `INSERT INTO ${this.t('mailbox_messages')} (
                     session_id, message_id, thread_jid, sender_jid, participant_jid,
-                    from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                    from_me, timestamp_ms, message_bytes
                 ) VALUES ${placeholders}
                 ON CONFLICT (session_id, message_id) DO UPDATE SET
                     thread_jid = EXCLUDED.thread_jid,
@@ -98,8 +92,6 @@ export class WaMessagePgStore extends BasePgStore implements WaMessageStore {
                     participant_jid = EXCLUDED.participant_jid,
                     from_me = EXCLUDED.from_me,
                     timestamp_ms = EXCLUDED.timestamp_ms,
-                    enc_type = EXCLUDED.enc_type,
-                    plaintext = EXCLUDED.plaintext,
                     message_bytes = EXCLUDED.message_bytes`,
                 values: params
             })
@@ -125,7 +117,7 @@ export class WaMessagePgStore extends BasePgStore implements WaMessageStore {
             await this.pool.query({
                 name: this.stmtName('msg_get_by_id'),
                 text: `SELECT message_id, thread_jid, sender_jid, participant_jid,
-                    from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                    from_me, timestamp_ms, message_bytes
              FROM ${this.t('mailbox_messages')}
              WHERE session_id = $1 AND message_id = $2`,
                 values: [this.sessionId, id]
@@ -148,7 +140,7 @@ export class WaMessagePgStore extends BasePgStore implements WaMessageStore {
                 await this.pool.query({
                     name: this.stmtName('msg_list_thread_before'),
                     text: `SELECT message_id, thread_jid, sender_jid, participant_jid,
-                        from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                        from_me, timestamp_ms, message_bytes
                  FROM ${this.t('mailbox_messages')}
                  WHERE session_id = $1 AND thread_jid = $2 AND timestamp_ms < $3
                  ORDER BY timestamp_ms DESC, message_id DESC
@@ -162,7 +154,7 @@ export class WaMessagePgStore extends BasePgStore implements WaMessageStore {
             await this.pool.query({
                 name: this.stmtName('msg_list_thread'),
                 text: `SELECT message_id, thread_jid, sender_jid, participant_jid,
-                    from_me, timestamp_ms, enc_type, plaintext, message_bytes
+                    from_me, timestamp_ms, message_bytes
              FROM ${this.t('mailbox_messages')}
              WHERE session_id = $1 AND thread_jid = $2
              ORDER BY timestamp_ms DESC, message_id DESC

--- a/packages/store-postgres/src/retry.store.ts
+++ b/packages/store-postgres/src/retry.store.ts
@@ -107,41 +107,29 @@ export class WaRetryPgStore extends BasePgStore implements WaRetryStore {
                 session_id,
                 message_id,
                 to_jid,
-                participant_jid,
-                recipient_jid,
-                message_type,
                 replay_mode,
                 replay_payload,
                 requesters_json,
                 state,
-                created_at_ms,
                 updated_at_ms,
                 expires_at_ms
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             ON CONFLICT (session_id, message_id) DO UPDATE SET
                 to_jid = EXCLUDED.to_jid,
-                participant_jid = EXCLUDED.participant_jid,
-                recipient_jid = EXCLUDED.recipient_jid,
-                message_type = EXCLUDED.message_type,
                 replay_mode = EXCLUDED.replay_mode,
                 replay_payload = EXCLUDED.replay_payload,
                 requesters_json = EXCLUDED.requesters_json,
                 state = EXCLUDED.state,
-                created_at_ms = EXCLUDED.created_at_ms,
                 updated_at_ms = EXCLUDED.updated_at_ms,
                 expires_at_ms = EXCLUDED.expires_at_ms`,
             values: [
                 this.sessionId,
                 record.messageId,
                 record.toJid,
-                record.participantJid ?? null,
-                record.recipientJid ?? null,
-                record.messageType,
                 record.replayMode,
                 replayPayload,
                 requestersJson,
                 record.state,
-                record.createdAtMs,
                 record.updatedAtMs,
                 record.expiresAtMs
             ]
@@ -170,14 +158,10 @@ export class WaRetryPgStore extends BasePgStore implements WaRetryStore {
                 text: `SELECT
                     message_id,
                     to_jid,
-                    participant_jid,
-                    recipient_jid,
-                    message_type,
                     replay_mode,
                     replay_payload,
                     requesters_json,
                     state,
-                    created_at_ms,
                     updated_at_ms,
                     expires_at_ms
                 FROM ${this.t('retry_outbound_messages')}
@@ -198,17 +182,13 @@ export class WaRetryPgStore extends BasePgStore implements WaRetryStore {
         return {
             messageId: String(row.message_id),
             toJid: String(row.to_jid),
-            participantJid: row.participant_jid !== null ? String(row.participant_jid) : undefined,
-            recipientJid: row.recipient_jid !== null ? String(row.recipient_jid) : undefined,
             eligibleRequesterDeviceJids:
                 requesters.eligible.length > 0 ? requesters.eligible : undefined,
             deliveredRequesterDeviceJids:
                 requesters.delivered.length > 0 ? requesters.delivered : undefined,
-            messageType: String(row.message_type),
             replayMode: String(row.replay_mode) as WaRetryOutboundMessageRecord['replayMode'],
             replayPayload: toBytes(row.replay_payload),
             state: String(row.state) as WaRetryOutboundState,
-            createdAtMs: Number(row.created_at_ms),
             updatedAtMs: Number(row.updated_at_ms),
             expiresAtMs: Number(row.expires_at_ms)
         }
@@ -287,7 +267,7 @@ export class WaRetryPgStore extends BasePgStore implements WaRetryStore {
     public async incrementInboundCounter(
         messageId: string,
         requesterJid: string,
-        updatedAtMs: number,
+        _updatedAtMs: number,
         expiresAtMs: number
     ): Promise<number> {
         await this.ensureReady()
@@ -295,14 +275,13 @@ export class WaRetryPgStore extends BasePgStore implements WaRetryStore {
         const result = await this.pool.query({
             name: this.stmtName('retry_inc_inbound'),
             text: `INSERT INTO ${tbl} (
-                session_id, message_id, requester_jid, retry_count, updated_at_ms, expires_at_ms
-            ) VALUES ($1, $2, $3, 1, $4, $5)
+                session_id, message_id, requester_jid, retry_count, expires_at_ms
+            ) VALUES ($1, $2, $3, 1, $4)
             ON CONFLICT (session_id, message_id, requester_jid) DO UPDATE SET
                 retry_count = ${tbl}.retry_count + 1,
-                updated_at_ms = EXCLUDED.updated_at_ms,
                 expires_at_ms = EXCLUDED.expires_at_ms
             RETURNING retry_count`,
-            values: [this.sessionId, messageId, requesterJid, updatedAtMs, expiresAtMs]
+            values: [this.sessionId, messageId, requesterJid, expiresAtMs]
         })
         const row = queryFirst(result)
         return row ? Number(row.retry_count) : 1

--- a/packages/store-redis/package.json
+++ b/packages/store-redis/package.json
@@ -27,13 +27,8 @@
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
     },
     "peerDependencies": {
-        "zapo-js": ">=0.1.0",
+        "zapo-js": "^0.3.0",
         "ioredis": ">=5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "zapo-js": {
-            "optional": true
-        }
     },
     "devDependencies": {
         "ioredis": "^5.6.1",

--- a/packages/store-redis/src/__tests__/integration.test.ts
+++ b/packages/store-redis/src/__tests__/integration.test.ts
@@ -162,11 +162,9 @@ describe('store-redis integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([1, 2, 3]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs: now + 60_000,
             eligibleRequesterDeviceJids: ['dev1@s.whatsapp.net'],
@@ -345,11 +343,9 @@ describe('store-redis integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-status-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([1, 2, 3]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs,
             eligibleRequesterDeviceJids: ['dev1@s.whatsapp.net', 'dev2@s.whatsapp.net'],
@@ -639,11 +635,9 @@ describe('store-redis integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-update-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([31, 32]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs
         })
@@ -870,8 +864,6 @@ describe('store-redis integration', { timeout: 60_000 }, () => {
             participantJid: 'alice:1@s.whatsapp.net',
             fromMe: false,
             timestampMs: 4_321,
-            encType: 'msg',
-            plaintext: new Uint8Array([1, 2, 3]),
             messageBytes: new Uint8Array([4, 5, 6, 7])
         })
 
@@ -879,8 +871,6 @@ describe('store-redis integration', { timeout: 60_000 }, () => {
         assert.ok(loaded)
         assert.equal(loaded.senderJid, 'alice@s.whatsapp.net')
         assert.equal(loaded.participantJid, 'alice:1@s.whatsapp.net')
-        assert.equal(loaded.encType, 'msg')
-        assert.deepEqual(Array.from(loaded.plaintext ?? []), [1, 2, 3])
         assert.deepEqual(Array.from(loaded.messageBytes ?? []), [4, 5, 6, 7])
 
         const listed = await messages.listByThread('thread-bin@s.whatsapp.net')
@@ -937,11 +927,9 @@ describe('store-redis integration', { timeout: 60_000 }, () => {
         await retry.upsertOutboundMessage({
             messageId: 'retry-no-eligible-1',
             toJid: 'to@s.whatsapp.net',
-            messageType: 'text',
             replayMode: 'plaintext',
             replayPayload: new Uint8Array([1]),
             state: 'pending',
-            createdAtMs: now,
             updatedAtMs: now,
             expiresAtMs
         })

--- a/packages/store-redis/src/contact.store.ts
+++ b/packages/store-redis/src/contact.store.ts
@@ -1,3 +1,4 @@
+import { isUserJid } from 'zapo-js'
 import type { WaContactStore, WaStoredContactRecord } from 'zapo-js/store'
 
 import { BaseRedisStore } from './BaseRedisStore'
@@ -46,19 +47,30 @@ export class WaContactRedisStore extends BaseRedisStore implements WaContactStor
         return this.k('contact', this.sessionId, jid)
     }
 
+    private phoneLookupKey(pn: string): string {
+        return this.k('contact_pn', this.sessionId, pn)
+    }
+
     public async upsert(record: WaStoredContactRecord): Promise<void> {
         const key = this.contactKey(record.jid)
         const existing = await this.redis.hgetall(key)
         const newFields = recordToHash(record)
 
+        let mergedRecord: WaStoredContactRecord
         if (existing && Object.keys(existing).length > 0) {
             const merged: Record<string, string> = { ...existing }
             for (const [field, value] of Object.entries(newFields)) {
                 merged[field] = value
             }
             await this.redis.hset(key, merged)
+            mergedRecord = hashToRecord(merged)
         } else {
             await this.redis.hset(key, newFields)
+            mergedRecord = hashToRecord(newFields)
+        }
+
+        if (mergedRecord.phoneNumber) {
+            await this.redis.set(this.phoneLookupKey(mergedRecord.phoneNumber), mergedRecord.jid)
         }
     }
 
@@ -72,20 +84,44 @@ export class WaContactRedisStore extends BaseRedisStore implements WaContactStor
 
     public async getByJid(jid: string): Promise<WaStoredContactRecord | null> {
         const data = await this.redis.hgetall(this.contactKey(jid))
+        if (data && Object.keys(data).length > 0) {
+            return hashToRecord(data)
+        }
+        if (isUserJid(jid)) {
+            return this.getByPhoneNumber(jid)
+        }
+        return null
+    }
+
+    public async getByPhoneNumber(pn: string): Promise<WaStoredContactRecord | null> {
+        const targetJid = await this.redis.get(this.phoneLookupKey(pn))
+        if (!targetJid) return null
+        const data = await this.redis.hgetall(this.contactKey(targetJid))
         if (!data || Object.keys(data).length === 0) return null
         return hashToRecord(data)
     }
 
     public async deleteByJid(jid: string): Promise<number> {
-        return this.redis.del(this.contactKey(jid))
+        const existing = await this.redis.hgetall(this.contactKey(jid))
+        const deleted = await this.redis.del(this.contactKey(jid))
+        if (existing && existing.phone_number) {
+            const lookupKey = this.phoneLookupKey(existing.phone_number)
+            const owner = await this.redis.get(lookupKey)
+            if (owner === jid) {
+                await this.redis.del(lookupKey)
+            }
+        }
+        return deleted
     }
 
     public async clear(): Promise<void> {
-        const keys = await scanKeys(this.redis, this.k('contact', this.sessionId, '*'))
-        if (keys.length === 0) return
+        const contactKeys = await scanKeys(this.redis, this.k('contact', this.sessionId, '*'))
+        const phoneKeys = await scanKeys(this.redis, this.k('contact_pn', this.sessionId, '*'))
+        const all = [...contactKeys, ...phoneKeys]
+        if (all.length === 0) return
 
         const pipeline = this.redis.pipeline()
-        for (const key of keys) {
+        for (const key of all) {
             pipeline.del(key)
         }
         await pipeline.exec()

--- a/packages/store-redis/src/contact.store.ts
+++ b/packages/store-redis/src/contact.store.ts
@@ -57,6 +57,10 @@ export class WaContactRedisStore extends BaseRedisStore implements WaContactStor
         const newFields = recordToHash(record)
 
         let mergedRecord: WaStoredContactRecord
+        const previousPhone =
+            existing && Object.keys(existing).length > 0
+                ? (toStringOrNull(existing.phone_number) ?? undefined)
+                : undefined
         if (existing && Object.keys(existing).length > 0) {
             const merged: Record<string, string> = { ...existing }
             for (const [field, value] of Object.entries(newFields)) {
@@ -69,6 +73,13 @@ export class WaContactRedisStore extends BaseRedisStore implements WaContactStor
             mergedRecord = hashToRecord(newFields)
         }
 
+        if (previousPhone && previousPhone !== mergedRecord.phoneNumber) {
+            const staleKey = this.phoneLookupKey(previousPhone)
+            const owner = await this.redis.get(staleKey)
+            if (owner === mergedRecord.jid) {
+                await this.redis.del(staleKey)
+            }
+        }
         if (mergedRecord.phoneNumber) {
             await this.redis.set(this.phoneLookupKey(mergedRecord.phoneNumber), mergedRecord.jid)
         }

--- a/packages/store-redis/src/message.store.ts
+++ b/packages/store-redis/src/message.store.ts
@@ -4,7 +4,7 @@ import { BaseRedisStore } from './BaseRedisStore'
 import { safeLimit, scanKeys, toBytesOrNull, toRedisBuffer, toStringOrNull } from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
-const BINARY_FIELDS = ['plaintext', 'message_bytes'] as const
+const BINARY_FIELDS = ['message_bytes'] as const
 
 export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStore {
     public constructor(options: WaRedisStorageOptions) {
@@ -34,9 +34,6 @@ export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStor
         pipeline.hset(key, recordToHash(record))
         pipeline.zadd(idxKey, String(score), record.id)
 
-        if (record.plaintext !== undefined) {
-            pipeline.set(`${key}:plaintext`, toRedisBuffer(record.plaintext))
-        }
         if (record.messageBytes !== undefined) {
             pipeline.set(`${key}:message_bytes`, toRedisBuffer(record.messageBytes))
         }
@@ -72,9 +69,6 @@ export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStor
             pipeline.hset(key, recordToHash(record))
             pipeline.zadd(idxKey, String(score), record.id)
 
-            if (record.plaintext !== undefined) {
-                pipeline.set(`${key}:plaintext`, toRedisBuffer(record.plaintext))
-            }
             if (record.messageBytes !== undefined) {
                 pipeline.set(`${key}:message_bytes`, toRedisBuffer(record.messageBytes))
             }
@@ -96,7 +90,7 @@ export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStor
         const data = results[0][1] as Record<string, string>
         if (!data || Object.keys(data).length === 0) return null
 
-        return hashToRecord(data, toBytesOrNull(results[1][1]), toBytesOrNull(results[2][1]))
+        return hashToRecord(data, toBytesOrNull(results[1][1]))
     }
 
     public async listByThread(
@@ -148,13 +142,7 @@ export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStor
                 if (err) continue
                 const hash = data as Record<string, string>
                 if (hash && Object.keys(hash).length > 0) {
-                    records.push(
-                        hashToRecord(
-                            hash,
-                            toBytesOrNull(results[i + 1][1]),
-                            toBytesOrNull(results[i + 2][1])
-                        )
-                    )
+                    records.push(hashToRecord(hash, toBytesOrNull(results[i + 1][1])))
                 }
             }
         }
@@ -207,16 +195,12 @@ function recordToHash(record: WaStoredMessageRecord): Record<string, string> {
     if (record.timestampMs !== undefined) {
         fields.timestamp_ms = String(record.timestampMs)
     }
-    if (record.encType !== undefined) {
-        fields.enc_type = record.encType
-    }
 
     return fields
 }
 
 function hashToRecord(
     data: Record<string, string>,
-    plaintext: Uint8Array | null,
     messageBytes: Uint8Array | null
 ): WaStoredMessageRecord {
     return {
@@ -227,8 +211,6 @@ function hashToRecord(
         fromMe: data.from_me === '1',
         timestampMs:
             toStringOrNull(data.timestamp_ms) !== null ? Number(data.timestamp_ms) : undefined,
-        encType: toStringOrNull(data.enc_type) ?? undefined,
-        plaintext: plaintext ?? undefined,
         messageBytes: messageBytes ?? undefined
     }
 }

--- a/packages/store-redis/src/message.store.ts
+++ b/packages/store-redis/src/message.store.ts
@@ -5,6 +5,9 @@ import { safeLimit, scanKeys, toBytesOrNull, toRedisBuffer, toStringOrNull } fro
 import type { WaRedisStorageOptions } from './types'
 
 const BINARY_FIELDS = ['message_bytes'] as const
+// Legacy binary suffixes that older builds wrote alongside message_bytes; kept
+// for cleanup so deleteById/clear purge them on existing data.
+const LEGACY_BINARY_FIELDS = ['plaintext'] as const
 
 export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStore {
     public constructor(options: WaRedisStorageOptions) {
@@ -36,6 +39,9 @@ export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStor
 
         if (record.messageBytes !== undefined) {
             pipeline.set(`${key}:message_bytes`, toRedisBuffer(record.messageBytes))
+        }
+        for (const field of LEGACY_BINARY_FIELDS) {
+            pipeline.del(`${key}:${field}`)
         }
 
         await pipeline.exec()
@@ -71,6 +77,9 @@ export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStor
 
             if (record.messageBytes !== undefined) {
                 pipeline.set(`${key}:message_bytes`, toRedisBuffer(record.messageBytes))
+            }
+            for (const field of LEGACY_BINARY_FIELDS) {
+                pipeline.del(`${key}:${field}`)
             }
         }
         await pipeline.exec()
@@ -158,6 +167,9 @@ export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStor
         const pipeline = this.redis.pipeline()
         pipeline.del(key)
         for (const field of BINARY_FIELDS) {
+            pipeline.del(`${key}:${field}`)
+        }
+        for (const field of LEGACY_BINARY_FIELDS) {
             pipeline.del(`${key}:${field}`)
         }
         pipeline.zrem(this.idxKey(threadJid), id)

--- a/packages/store-redis/src/retry.store.ts
+++ b/packages/store-redis/src/retry.store.ts
@@ -21,8 +21,7 @@ const DEFAULT_RETRY_TTL_MS = 60 * 1000
 const LUA_INCREMENT_INBOUND = `
 local key = KEYS[1]
 local count = redis.call('HINCRBY', key, 'retry_count', 1)
-redis.call('HSET', key, 'updated_at_ms', ARGV[1])
-redis.call('PEXPIREAT', key, tonumber(ARGV[2]))
+redis.call('PEXPIREAT', key, tonumber(ARGV[1]))
 return count
 `
 
@@ -133,18 +132,10 @@ export class WaRetryRedisStore extends BaseRedisStore implements WaRetryStore {
         const fields: Record<string, string> = {
             message_id: record.messageId,
             to_jid: record.toJid,
-            message_type: record.messageType,
             replay_mode: record.replayMode,
             state: record.state,
-            created_at_ms: String(record.createdAtMs),
             updated_at_ms: String(record.updatedAtMs),
             expires_at_ms: String(record.expiresAtMs)
-        }
-        if (record.participantJid !== undefined) {
-            fields.participant_jid = record.participantJid
-        }
-        if (record.recipientJid !== undefined) {
-            fields.recipient_jid = record.recipientJid
         }
         if (requestersJson !== null) {
             fields.requesters_json = requestersJson
@@ -202,17 +193,13 @@ export class WaRetryRedisStore extends BaseRedisStore implements WaRetryStore {
         return {
             messageId: data.message_id,
             toJid: data.to_jid,
-            participantJid: toStringOrNull(data.participant_jid) ?? undefined,
-            recipientJid: toStringOrNull(data.recipient_jid) ?? undefined,
             eligibleRequesterDeviceJids:
                 requesters.eligible.length > 0 ? requesters.eligible : undefined,
             deliveredRequesterDeviceJids:
                 requesters.delivered.length > 0 ? requesters.delivered : undefined,
-            messageType: data.message_type,
             replayMode: data.replay_mode as WaRetryOutboundMessageRecord['replayMode'],
             replayPayload,
             state: data.state as WaRetryOutboundState,
-            createdAtMs: Number(data.created_at_ms),
             updatedAtMs: Number(data.updated_at_ms),
             expiresAtMs: Number(data.expires_at_ms)
         }
@@ -264,17 +251,11 @@ export class WaRetryRedisStore extends BaseRedisStore implements WaRetryStore {
     public async incrementInboundCounter(
         messageId: string,
         requesterJid: string,
-        updatedAtMs: number,
+        _updatedAtMs: number,
         expiresAtMs: number
     ): Promise<number> {
         const key = this.k('retry:in', this.sessionId, messageId, requesterJid)
-        const count = await this.redis.eval(
-            LUA_INCREMENT_INBOUND,
-            1,
-            key,
-            String(updatedAtMs),
-            String(expiresAtMs)
-        )
+        const count = await this.redis.eval(LUA_INCREMENT_INBOUND, 1, key, String(expiresAtMs))
         return Number(count)
     }
 

--- a/packages/store-sqlite/package.json
+++ b/packages/store-sqlite/package.json
@@ -27,13 +27,8 @@
         "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
     },
     "peerDependencies": {
-        "zapo-js": ">=0.1.0",
+        "zapo-js": "^0.3.0",
         "better-sqlite3": ">=11.0.0"
-    },
-    "peerDependenciesMeta": {
-        "zapo-js": {
-            "optional": true
-        }
     },
     "devDependencies": {
         "better-sqlite3": "^12.6.2",

--- a/packages/store-sqlite/src/__tests__/sqlite-runtime.test.ts
+++ b/packages/store-sqlite/src/__tests__/sqlite-runtime.test.ts
@@ -319,14 +319,10 @@ test('sqlite retry store tracks outbound state, inbound counters and expiration'
         const outbound: WaRetryOutboundMessageRecord = {
             messageId: 'm1',
             toJid: '5511@s.whatsapp.net',
-            participantJid: '5512@s.whatsapp.net',
-            recipientJid: '5513@s.whatsapp.net',
             eligibleRequesterDeviceJids: ['5511@s.whatsapp.net', '5511:1@s.whatsapp.net'],
-            messageType: 'text',
             replayMode: 'encrypted',
             replayPayload: makeBytes(12, 1),
             state: 'pending',
-            createdAtMs: 1000,
             updatedAtMs: 1000,
             expiresAtMs: 1500
         }

--- a/packages/store-sqlite/src/contact.store.ts
+++ b/packages/store-sqlite/src/contact.store.ts
@@ -1,3 +1,4 @@
+import { isUserJid } from 'zapo-js'
 import type { WaContactStore as Contract, WaStoredContactRecord } from 'zapo-js/store'
 import { asNumber, asOptionalString, asString } from 'zapo-js/util'
 
@@ -53,6 +54,22 @@ export class WaContactSqliteStore extends BaseSqliteStore implements Contract {
              FROM mailbox_contacts
              WHERE session_id = ? AND jid = ?`,
             [this.options.sessionId, jid]
+        )
+        if (row) return decodeContactRow(row)
+        if (isUserJid(jid)) {
+            return this.getByPhoneNumber(jid)
+        }
+        return null
+    }
+
+    public async getByPhoneNumber(pn: string): Promise<WaStoredContactRecord | null> {
+        const db = await this.getConnection()
+        const row = db.get<ContactRow>(
+            `SELECT jid, display_name, push_name, lid, phone_number, last_updated_ms
+             FROM mailbox_contacts
+             WHERE session_id = ? AND phone_number = ?
+             LIMIT 1`,
+            [this.options.sessionId, pn]
         )
         return row ? decodeContactRow(row) : null
     }

--- a/packages/store-sqlite/src/message.store.ts
+++ b/packages/store-sqlite/src/message.store.ts
@@ -18,8 +18,6 @@ interface MessageRow extends Record<string, unknown> {
     readonly participant_jid: unknown
     readonly from_me: unknown
     readonly timestamp_ms: unknown
-    readonly enc_type: unknown
-    readonly plaintext: unknown
     readonly message_bytes: unknown
 }
 
@@ -31,8 +29,6 @@ function decodeMessageRow(row: MessageRow): WaStoredMessageRecord {
         participantJid: asOptionalString(row.participant_jid, 'mailbox_messages.participant_jid'),
         fromMe: Number(row.from_me) === 1,
         timestampMs: asOptionalNumber(row.timestamp_ms, 'mailbox_messages.timestamp_ms'),
-        encType: asOptionalString(row.enc_type, 'mailbox_messages.enc_type'),
-        plaintext: asOptionalBytes(row.plaintext, 'mailbox_messages.plaintext'),
         messageBytes: asOptionalBytes(row.message_bytes, 'mailbox_messages.message_bytes')
     }
 }
@@ -68,8 +64,6 @@ export class WaMessageSqliteStore extends BaseSqliteStore implements Contract {
                 participant_jid,
                 from_me,
                 timestamp_ms,
-                enc_type,
-                plaintext,
                 message_bytes
              FROM mailbox_messages
              WHERE session_id = ? AND message_id = ?`,
@@ -95,8 +89,6 @@ export class WaMessageSqliteStore extends BaseSqliteStore implements Contract {
                           participant_jid,
                           from_me,
                           timestamp_ms,
-                          enc_type,
-                          plaintext,
                           message_bytes
                        FROM mailbox_messages
                        WHERE session_id = ? AND thread_jid = ?
@@ -112,8 +104,6 @@ export class WaMessageSqliteStore extends BaseSqliteStore implements Contract {
                           participant_jid,
                           from_me,
                           timestamp_ms,
-                          enc_type,
-                          plaintext,
                           message_bytes
                        FROM mailbox_messages
                        WHERE session_id = ?
@@ -157,18 +147,14 @@ export class WaMessageSqliteStore extends BaseSqliteStore implements Contract {
                 participant_jid,
                 from_me,
                 timestamp_ms,
-                enc_type,
-                plaintext,
                 message_bytes
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(session_id, message_id) DO UPDATE SET
                 thread_jid=excluded.thread_jid,
                 sender_jid=excluded.sender_jid,
                 participant_jid=excluded.participant_jid,
                 from_me=excluded.from_me,
                 timestamp_ms=excluded.timestamp_ms,
-                enc_type=excluded.enc_type,
-                plaintext=excluded.plaintext,
                 message_bytes=excluded.message_bytes`,
             [
                 this.options.sessionId,
@@ -178,8 +164,6 @@ export class WaMessageSqliteStore extends BaseSqliteStore implements Contract {
                 record.participantJid ?? null,
                 record.fromMe ? 1 : 0,
                 record.timestampMs ?? null,
-                record.encType ?? null,
-                record.plaintext ?? null,
                 record.messageBytes ?? null
             ]
         )

--- a/packages/store-sqlite/src/migrations.ts
+++ b/packages/store-sqlite/src/migrations.ts
@@ -380,6 +380,48 @@ const SQLITE_MIGRATIONS: readonly WaSqliteMigration[] = [
                     ON device_list_cache (session_id, alt_user_jid);
             `)
         }
+    },
+    {
+        id: '0014_mailbox_contacts_phone_number_index',
+        domain: 'mailbox',
+        up: (db) => {
+            db.exec(`
+                CREATE INDEX IF NOT EXISTS mailbox_contacts_by_phone_number
+                    ON mailbox_contacts (session_id, phone_number)
+                    WHERE phone_number IS NOT NULL;
+            `)
+        }
+    },
+    {
+        id: '0015_mailbox_messages_drop_dead_columns',
+        domain: 'mailbox',
+        up: (db) => {
+            // enc_type and plaintext were write-only - nothing in the runtime
+            // ever read them back. Drop to reclaim space and stop persisting
+            // sensitive plaintext bytes that have no consumer.
+            db.exec(`
+                ALTER TABLE mailbox_messages DROP COLUMN enc_type;
+                ALTER TABLE mailbox_messages DROP COLUMN plaintext;
+            `)
+        }
+    },
+    {
+        id: '0016_retry_drop_dead_columns',
+        domain: 'retry',
+        up: (db) => {
+            // participant_jid, recipient_jid, message_type and created_at_ms on
+            // outbound were write-only: replay reconstructs the destination
+            // from requesterJid and reads type out of the encoded replay
+            // payload. updated_at_ms on inbound was equally write-only and
+            // never even tracked in the in-memory provider.
+            db.exec(`
+                ALTER TABLE retry_outbound_messages DROP COLUMN participant_jid;
+                ALTER TABLE retry_outbound_messages DROP COLUMN recipient_jid;
+                ALTER TABLE retry_outbound_messages DROP COLUMN message_type;
+                ALTER TABLE retry_outbound_messages DROP COLUMN created_at_ms;
+                ALTER TABLE retry_inbound_counters DROP COLUMN updated_at_ms;
+            `)
+        }
     }
 ]
 

--- a/packages/store-sqlite/src/retry.store.ts
+++ b/packages/store-sqlite/src/retry.store.ts
@@ -8,14 +8,10 @@ import type { WaSqliteStorageOptions } from './types'
 interface RetryOutboundRow extends Record<string, unknown> {
     readonly message_id: unknown
     readonly to_jid: unknown
-    readonly participant_jid: unknown
-    readonly recipient_jid: unknown
-    readonly message_type: unknown
     readonly replay_mode: unknown
     readonly replay_payload: unknown
     readonly requesters_json: unknown
     readonly state: unknown
-    readonly created_at_ms: unknown
     readonly updated_at_ms: unknown
     readonly expires_at_ms: unknown
 }
@@ -121,41 +117,29 @@ export class WaRetrySqliteStore extends BaseSqliteStore implements WaRetryStore 
                 session_id,
                 message_id,
                 to_jid,
-                participant_jid,
-                recipient_jid,
-                message_type,
                 replay_mode,
                 replay_payload,
                 requesters_json,
                 state,
-                created_at_ms,
                 updated_at_ms,
                 expires_at_ms
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(session_id, message_id) DO UPDATE SET
                 to_jid=excluded.to_jid,
-                participant_jid=excluded.participant_jid,
-                recipient_jid=excluded.recipient_jid,
-                message_type=excluded.message_type,
                 replay_mode=excluded.replay_mode,
                 replay_payload=excluded.replay_payload,
                 requesters_json=excluded.requesters_json,
                 state=excluded.state,
-                created_at_ms=excluded.created_at_ms,
                 updated_at_ms=excluded.updated_at_ms,
                 expires_at_ms=excluded.expires_at_ms`,
             [
                 this.options.sessionId,
                 record.messageId,
                 record.toJid,
-                record.participantJid ?? null,
-                record.recipientJid ?? null,
-                record.messageType,
                 record.replayMode,
                 replayPayload,
                 requestersJson,
                 record.state,
-                record.createdAtMs,
                 record.updatedAtMs,
                 record.expiresAtMs
             ]
@@ -181,14 +165,10 @@ export class WaRetrySqliteStore extends BaseSqliteStore implements WaRetryStore 
             `SELECT
                 message_id,
                 to_jid,
-                participant_jid,
-                recipient_jid,
-                message_type,
                 replay_mode,
                 replay_payload,
                 requesters_json,
                 state,
-                created_at_ms,
                 updated_at_ms,
                 expires_at_ms
             FROM retry_outbound_messages
@@ -211,26 +191,16 @@ export class WaRetrySqliteStore extends BaseSqliteStore implements WaRetryStore 
         return {
             messageId: asString(row.message_id, 'retry_outbound_messages.message_id'),
             toJid: asString(row.to_jid, 'retry_outbound_messages.to_jid'),
-            participantJid: asOptionalString(
-                row.participant_jid,
-                'retry_outbound_messages.participant_jid'
-            ),
-            recipientJid: asOptionalString(
-                row.recipient_jid,
-                'retry_outbound_messages.recipient_jid'
-            ),
             eligibleRequesterDeviceJids:
                 requesters.eligible.length > 0 ? requesters.eligible : undefined,
             deliveredRequesterDeviceJids:
                 requesters.delivered.length > 0 ? requesters.delivered : undefined,
-            messageType: asString(row.message_type, 'retry_outbound_messages.message_type'),
             replayMode: asString(
                 row.replay_mode,
                 'retry_outbound_messages.replay_mode'
             ) as WaRetryOutboundMessageRecord['replayMode'],
             replayPayload: asBytes(row.replay_payload, 'retry_outbound_messages.replay_payload'),
             state: asString(row.state, 'retry_outbound_messages.state') as WaRetryOutboundState,
-            createdAtMs: asNumber(row.created_at_ms, 'retry_outbound_messages.created_at_ms'),
             updatedAtMs: asNumber(row.updated_at_ms, 'retry_outbound_messages.updated_at_ms'),
             expiresAtMs: asNumber(row.expires_at_ms, 'retry_outbound_messages.expires_at_ms')
         }
@@ -307,7 +277,7 @@ export class WaRetrySqliteStore extends BaseSqliteStore implements WaRetryStore 
     public async incrementInboundCounter(
         messageId: string,
         requesterJid: string,
-        updatedAtMs: number,
+        _updatedAtMs: number,
         expiresAtMs: number
     ): Promise<number> {
         const db = await this.getConnection()
@@ -317,15 +287,13 @@ export class WaRetrySqliteStore extends BaseSqliteStore implements WaRetryStore 
                 message_id,
                 requester_jid,
                 retry_count,
-                updated_at_ms,
                 expires_at_ms
-            ) VALUES (?, ?, ?, 1, ?, ?)
+            ) VALUES (?, ?, ?, 1, ?)
             ON CONFLICT(session_id, message_id, requester_jid) DO UPDATE SET
                 retry_count=retry_inbound_counters.retry_count + 1,
-                updated_at_ms=excluded.updated_at_ms,
                 expires_at_ms=excluded.expires_at_ms
             RETURNING retry_count`,
-            [this.options.sessionId, messageId, requesterJid, updatedAtMs, expiresAtMs]
+            [this.options.sessionId, messageId, requesterJid, expiresAtMs]
         )
         if (!row) {
             return 1

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -35,7 +35,7 @@ import { ConsoleLogger } from '@infra/log/ConsoleLogger'
 import type { Logger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import { proto, type Proto } from '@proto'
-import { WA_DEFAULTS } from '@protocol/constants'
+import { WA_DEFAULTS, WA_MESSAGE_TYPES } from '@protocol/constants'
 import { normalizeDeviceJid } from '@protocol/jid'
 import { WA_DISCONNECT_REASONS, WA_LOGOUT_REASONS, type WaLogoutReason } from '@protocol/stream'
 import { NOOP_MESSAGE_SECRET_STORE } from '@store/noop.store'
@@ -351,6 +351,8 @@ export class WaClient extends EventEmitter {
                     this.options.history?.enabled !== false &&
                     protocolMessage.historySyncNotification
                 ) {
+                    const peerRemoteJid = event.key.remoteJid
+                    const peerStanzaId = event.key.id
                     await runHistorySyncNotification(
                         {
                             logger: this.logger,
@@ -362,7 +364,27 @@ export class WaClient extends EventEmitter {
                             onPrivacyTokens: (conversations) =>
                                 this.deps.trustedContactToken.hydrateFromHistorySync(conversations),
                             onNctSalt: (salt) =>
-                                this.deps.trustedContactToken.hydrateNctSaltFromHistorySync(salt)
+                                this.deps.trustedContactToken.hydrateNctSaltFromHistorySync(salt),
+                            onProcessed:
+                                peerRemoteJid && peerStanzaId
+                                    ? async () => {
+                                          try {
+                                              await this.message.sendReceipt(
+                                                  peerRemoteJid,
+                                                  peerStanzaId,
+                                                  {
+                                                      type: WA_MESSAGE_TYPES.RECEIPT_TYPE_HISTORY_SYNC
+                                                  }
+                                              )
+                                          } catch (err) {
+                                              this.logger.warn('failed to send hist_sync receipt', {
+                                                  id: peerStanzaId,
+                                                  to: peerRemoteJid,
+                                                  message: toError(err).message
+                                              })
+                                          }
+                                      }
+                                    : undefined
                         },
                         protocolMessage.historySyncNotification
                     )

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -495,6 +495,7 @@ export function buildWaClientDependencies(input: {
             mediaConnCacheFallback = mediaConn
             connectionManager?.setMediaConnCache(mediaConn)
         },
+        serverClock,
         media: options.media,
         linkPreviewResolver: (content) =>
             resolveLinkPreview(content.text, content.linkPreview, {
@@ -502,7 +503,8 @@ export function buildWaClientDependencies(input: {
                 mediaTransfer,
                 getMediaConn: () => getClientMediaConn(mediaMessageBuildOptions),
                 fetcher: linkPreviewFetcher,
-                options: linkPreviewOptions
+                options: linkPreviewOptions,
+                serverClock
             })
     }
 
@@ -748,7 +750,8 @@ export function buildWaClientDependencies(input: {
                 additionalAttributes: sendOptions.additionalAttributes
             }),
         getIcdcHashLength: () => abPropsCoordinator.getConfigValue('md_icdc_hash_length'),
-        mobileMessageIdFormat: options.mobileTransport !== undefined
+        mobileMessageIdFormat: options.mobileTransport !== undefined,
+        serverClock
     })
 
     const presenceCoordinator = createPresenceCoordinator({

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -293,6 +293,327 @@ test('history sync processor forwards privacy token payloads and nct salt hooks'
     assert.deepEqual(nctSalts, [new Uint8Array([9, 9, 9])])
 })
 
+test('history sync processor skips stub messages (system events)', async () => {
+    const historySyncBytes = proto.HistorySync.encode({
+        conversations: [
+            {
+                id: '120363000000000000@g.us',
+                messages: [
+                    {
+                        message: {
+                            key: { id: 'real-msg', fromMe: false },
+                            messageTimestamp: 100,
+                            message: { conversation: 'hello' }
+                        }
+                    },
+                    {
+                        message: {
+                            key: { id: '3672884721', fromMe: true },
+                            messageTimestamp: 101,
+                            messageStubType: proto.WebMessageInfo.StubType.GROUP_PARTICIPANT_LEAVE,
+                            messageStubParameters: ['someone@lid']
+                        }
+                    },
+                    {
+                        message: {
+                            key: { id: 'real-msg-2', fromMe: false },
+                            messageTimestamp: 102,
+                            message: { conversation: 'world' }
+                        }
+                    }
+                ]
+            }
+        ]
+    }).finish()
+    const zipped = gzipSync(historySyncBytes)
+
+    const persistedIds: string[] = []
+    const emitted: { type: string; payload: unknown }[] = []
+    await processHistorySyncNotification(
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: {
+                downloadAndDecrypt: async () => {
+                    throw new Error('should not be called for inline payload')
+                }
+            } as never,
+            writeBehind: {
+                persistMessageAsync: async (record: { id: string }) => {
+                    persistedIds.push(record.id)
+                },
+                persistThreadAsync: async () => undefined,
+                persistContactAsync: async () => undefined
+            } as never,
+            emitEvent: (type, payload) => {
+                emitted.push({ type, payload })
+            }
+        },
+        {
+            syncType: proto.Message.HistorySyncType.RECENT,
+            initialHistBootstrapInlinePayload: zipped
+        }
+    )
+
+    assert.deepEqual(persistedIds, ['real-msg', 'real-msg-2'])
+    assert.equal(emitted.length, 1)
+    assert.equal((emitted[0].payload as { messagesCount: number }).messagesCount, 2)
+})
+
+test('history sync processor persists phoneNumberToLidMappings as a single LID-canonical row per pair', async () => {
+    const historySyncBytes = proto.HistorySync.encode({
+        phoneNumberToLidMappings: [
+            { pnJid: '5511999999999@s.whatsapp.net', lidJid: '111111111111111@lid' },
+            { pnJid: '5511888888888@s.whatsapp.net', lidJid: '222222222222222@lid' },
+            // invalid entries should be skipped
+            { pnJid: '', lidJid: '333333333333333@lid' },
+            { pnJid: '5511777777777@s.whatsapp.net', lidJid: '' }
+        ]
+    }).finish()
+    const zipped = gzipSync(historySyncBytes)
+
+    const contactWrites: Array<{ jid: string; lid?: string; phoneNumber?: string }> = []
+    await processHistorySyncNotification(
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: {
+                downloadAndDecrypt: async () => {
+                    throw new Error('should not be called for inline payload')
+                }
+            } as never,
+            writeBehind: {
+                persistMessageAsync: async () => undefined,
+                persistThreadAsync: async () => undefined,
+                persistContactAsync: async (record: {
+                    jid: string
+                    lid?: string
+                    phoneNumber?: string
+                }) => {
+                    contactWrites.push(record)
+                }
+            } as never,
+            emitEvent: () => undefined
+        },
+        {
+            syncType: proto.Message.HistorySyncType.NON_BLOCKING_DATA,
+            initialHistBootstrapInlinePayload: zipped
+        }
+    )
+
+    const mapped = contactWrites.map((w) => ({
+        jid: w.jid,
+        lid: w.lid,
+        phoneNumber: w.phoneNumber
+    }))
+    assert.deepEqual(mapped, [
+        { jid: '111111111111111@lid', lid: undefined, phoneNumber: '5511999999999@s.whatsapp.net' },
+        { jid: '222222222222222@lid', lid: undefined, phoneNumber: '5511888888888@s.whatsapp.net' }
+    ])
+})
+
+test('history sync processor coalesces pushname onto the LID-canonical row when a mapping is in the same chunk', async () => {
+    const historySyncBytes = proto.HistorySync.encode({
+        phoneNumberToLidMappings: [
+            { pnJid: '5511999999999@s.whatsapp.net', lidJid: '111111111111111@lid' }
+        ],
+        pushnames: [
+            { id: '5511999999999@s.whatsapp.net', pushname: 'Vinicius' },
+            // pushname without matching mapping: keeps PN-form jid
+            { id: '5511888888888@s.whatsapp.net', pushname: 'Other' }
+        ]
+    }).finish()
+    const zipped = gzipSync(historySyncBytes)
+
+    const contactWrites: Array<{
+        jid: string
+        pushName?: string
+        phoneNumber?: string
+        lid?: string
+    }> = []
+    await processHistorySyncNotification(
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: {
+                downloadAndDecrypt: async () => {
+                    throw new Error('should not be called for inline payload')
+                }
+            } as never,
+            writeBehind: {
+                persistMessageAsync: async () => undefined,
+                persistThreadAsync: async () => undefined,
+                persistContactAsync: async (record: {
+                    jid: string
+                    pushName?: string
+                    phoneNumber?: string
+                    lid?: string
+                }) => {
+                    contactWrites.push(record)
+                }
+            } as never,
+            emitEvent: () => undefined
+        },
+        {
+            syncType: proto.Message.HistorySyncType.PUSH_NAME,
+            initialHistBootstrapInlinePayload: zipped
+        }
+    )
+
+    const mappedPushname = contactWrites.find(
+        (w) => w.jid === '111111111111111@lid' && w.pushName === 'Vinicius'
+    )
+    assert.ok(mappedPushname, 'pushname for the mapped PN should land on the LID-canonical row')
+    assert.equal(mappedPushname.phoneNumber, '5511999999999@s.whatsapp.net')
+
+    const unmappedPushname = contactWrites.find(
+        (w) => w.jid === '5511888888888@s.whatsapp.net' && w.pushName === 'Other'
+    )
+    assert.ok(unmappedPushname, 'pushname without a mapping should fall back to the PN-form jid')
+    assert.equal(unmappedPushname.phoneNumber, undefined)
+
+    // No PN-form row is written for the mapped pair (would create the duplicate we are fixing).
+    const pnFormDuplicate = contactWrites.find((w) => w.jid === '5511999999999@s.whatsapp.net')
+    assert.equal(pnFormDuplicate, undefined)
+})
+
+test('history sync processor invokes onProcessed after handled chunk (for hist_sync receipt)', async () => {
+    const historySyncBytes = proto.HistorySync.encode({
+        conversations: [{ id: 'thread@s.whatsapp.net' }]
+    }).finish()
+    const zipped = gzipSync(historySyncBytes)
+
+    const ackedSyncTypes: number[] = []
+    await processHistorySyncNotification(
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: {
+                downloadAndDecrypt: async () => {
+                    throw new Error('should not be called for inline payload')
+                }
+            } as never,
+            writeBehind: {
+                persistMessageAsync: async () => undefined,
+                persistThreadAsync: async () => undefined,
+                persistContactAsync: async () => undefined
+            } as never,
+            emitEvent: () => undefined,
+            onProcessed: async (syncType) => {
+                ackedSyncTypes.push(syncType)
+            }
+        },
+        {
+            syncType: proto.Message.HistorySyncType.RECENT,
+            initialHistBootstrapInlinePayload: zipped
+        }
+    )
+
+    assert.deepEqual(ackedSyncTypes, [proto.Message.HistorySyncType.RECENT])
+})
+
+test('history sync processor invokes onProcessed for INITIAL_STATUS_V3 (recognized but unhandled)', async () => {
+    const ackedSyncTypes: number[] = []
+    await processHistorySyncNotification(
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: {
+                downloadAndDecrypt: async () => {
+                    throw new Error('should not be called - status_v3 is skipped before download')
+                }
+            } as never,
+            writeBehind: {
+                persistMessageAsync: async () => undefined,
+                persistThreadAsync: async () => undefined,
+                persistContactAsync: async () => undefined
+            } as never,
+            emitEvent: () => undefined,
+            onProcessed: async (syncType) => {
+                ackedSyncTypes.push(syncType)
+            }
+        },
+        {
+            syncType: proto.Message.HistorySyncType.INITIAL_STATUS_V3
+        }
+    )
+
+    assert.deepEqual(ackedSyncTypes, [proto.Message.HistorySyncType.INITIAL_STATUS_V3])
+})
+
+test('history sync processor does NOT invoke onProcessed when syncType is null', async () => {
+    const ackedSyncTypes: number[] = []
+    await processHistorySyncNotification(
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: { downloadAndDecrypt: async () => new Uint8Array() } as never,
+            writeBehind: {
+                persistMessageAsync: async () => undefined,
+                persistThreadAsync: async () => undefined,
+                persistContactAsync: async () => undefined
+            } as never,
+            emitEvent: () => undefined,
+            onProcessed: async (syncType) => {
+                ackedSyncTypes.push(syncType)
+            }
+        },
+        {} as never
+    )
+    assert.deepEqual(ackedSyncTypes, [])
+})
+
+test('history sync processor handles NON_BLOCKING_DATA syncType (previously skipped)', async () => {
+    const historySyncBytes = proto.HistorySync.encode({
+        conversations: [
+            {
+                id: '120363000000000000@g.us',
+                name: 'Past Group'
+            }
+        ],
+        phoneNumberToLidMappings: [
+            { pnJid: '5511999999999@s.whatsapp.net', lidJid: '111111111111111@lid' }
+        ]
+    }).finish()
+    const zipped = gzipSync(historySyncBytes)
+
+    const threadWrites: Array<{ jid: string }> = []
+    const contactWrites: Array<{ jid: string }> = []
+    const emitted: { type: string; payload: unknown }[] = []
+    await processHistorySyncNotification(
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: {
+                downloadAndDecrypt: async () => {
+                    throw new Error('should not be called for inline payload')
+                }
+            } as never,
+            writeBehind: {
+                persistMessageAsync: async () => undefined,
+                persistThreadAsync: async (record: { jid: string }) => {
+                    threadWrites.push(record)
+                },
+                persistContactAsync: async (record: { jid: string }) => {
+                    contactWrites.push(record)
+                }
+            } as never,
+            emitEvent: (type, payload) => {
+                emitted.push({ type, payload })
+            }
+        },
+        {
+            syncType: proto.Message.HistorySyncType.NON_BLOCKING_DATA,
+            initialHistBootstrapInlinePayload: zipped
+        }
+    )
+
+    assert.equal(threadWrites.length, 1)
+    assert.equal(threadWrites[0].jid, '120363000000000000@g.us')
+    // One canonical (LID-form) contact row per mapping, not the legacy pair of mirror rows.
+    assert.equal(contactWrites.length, 1)
+    assert.equal(contactWrites[0].jid, '111111111111111@lid')
+    assert.equal(emitted.length, 1)
+    assert.equal(emitted[0].type, 'history_sync_chunk')
+    assert.equal(
+        (emitted[0].payload as { syncType: number }).syncType,
+        proto.Message.HistorySyncType.NON_BLOCKING_DATA
+    )
+})
+
 test('resolveWaClientBase rejects invalid proxy transport shapes', () => {
     const minimalStore = {
         session: () => ({})

--- a/src/client/__tests__/link-preview.test.ts
+++ b/src/client/__tests__/link-preview.test.ts
@@ -12,11 +12,17 @@ import type {
 } from '@message/addons/link-preview/types'
 import { proto } from '@proto'
 import { TEXT_ENCODER } from '@util/bytes'
+import type { ServerClock } from '@util/clock'
 
 const fakeMediaConn: WaMediaConn = {
     auth: 'auth-token',
     expiresAtMs: Date.now() + 60_000,
     hosts: [{ hostname: 'mmg.whatsapp.net', isFallback: false }]
+}
+
+const localServerClock: ServerClock = {
+    nowMs: () => Date.now(),
+    nowSeconds: () => Math.floor(Date.now() / 1000)
 }
 
 function noopFetcher(result: WaLinkPreviewResolved | null = null): WaLinkPreviewFetcher {
@@ -76,6 +82,7 @@ test('resolveLinkPreview returns null when perMessage=false', async () => {
         logger: createNoopLogger(),
         mediaTransfer: uploadStubMediaTransfer('').transfer,
         getMediaConn: () => Promise.resolve(fakeMediaConn),
+        serverClock: localServerClock,
         fetcher: noopFetcher({
             matchedText: 'https://example.com',
             title: 'x',
@@ -91,6 +98,7 @@ test('resolveLinkPreview returns null when text has no url', async () => {
         logger: createNoopLogger(),
         mediaTransfer: uploadStubMediaTransfer('').transfer,
         getMediaConn: () => Promise.resolve(fakeMediaConn),
+        serverClock: localServerClock,
         fetcher: noopFetcher(),
         options: {}
     })
@@ -102,6 +110,7 @@ test('resolveLinkPreview returns null when global disabled and perMessage undefi
         logger: createNoopLogger(),
         mediaTransfer: uploadStubMediaTransfer('').transfer,
         getMediaConn: () => Promise.resolve(fakeMediaConn),
+        serverClock: localServerClock,
         fetcher: noopFetcher({
             matchedText: 'https://example.com',
             title: 'x',
@@ -118,6 +127,7 @@ test('resolveLinkPreview allows opt-in when global disabled', async () => {
         logger: createNoopLogger(),
         mediaTransfer: uploadStubMediaTransfer('').transfer,
         getMediaConn: () => Promise.resolve(fakeMediaConn),
+        serverClock: localServerClock,
         fetcher,
         options: { enabled: false }
     })
@@ -139,6 +149,7 @@ test('resolveLinkPreview uses override without invoking fetcher', async () => {
             logger: createNoopLogger(),
             mediaTransfer: uploadStubMediaTransfer('').transfer,
             getMediaConn: () => Promise.resolve(fakeMediaConn),
+            serverClock: localServerClock,
             fetcher,
             options: {}
         }
@@ -159,6 +170,7 @@ test('resolveLinkPreview inlines thumbnails ≤ 64KB', async () => {
             logger: createNoopLogger(),
             mediaTransfer: uploadStubMediaTransfer('').transfer,
             getMediaConn: () => Promise.resolve(fakeMediaConn),
+            serverClock: localServerClock,
             fetcher: noopFetcher(),
             options: {}
         }
@@ -176,6 +188,7 @@ test('resolveLinkPreview drops oversized thumbnail when uploadHqThumbnail=false'
             logger: createNoopLogger(),
             mediaTransfer: uploadStubMediaTransfer('').transfer,
             getMediaConn: () => Promise.resolve(fakeMediaConn),
+            serverClock: localServerClock,
             fetcher: noopFetcher(),
             options: { uploadHqThumbnail: false }
         }
@@ -194,6 +207,7 @@ test('resolveLinkPreview uploads HQ thumbnail when oversize and upload enabled',
             logger: createNoopLogger(),
             mediaTransfer: stub.transfer,
             getMediaConn: () => Promise.resolve(fakeMediaConn),
+            serverClock: localServerClock,
             fetcher: noopFetcher(),
             options: { uploadHqThumbnail: true }
         }
@@ -224,6 +238,7 @@ test('resolveLinkPreview drops thumbnail on upload failure', async () => {
             logger: createNoopLogger(),
             mediaTransfer: failingTransfer,
             getMediaConn: () => Promise.resolve(fakeMediaConn),
+            serverClock: localServerClock,
             fetcher: noopFetcher(),
             options: { uploadHqThumbnail: true }
         }
@@ -242,6 +257,7 @@ function makeBuildOptions(
         queryWithContext: async () => ({ tag: 'noop', attrs: {} }),
         getMediaConnCache: () => null,
         setMediaConnCache: () => {},
+        serverClock: localServerClock,
         linkPreviewResolver: resolver
     }
 }

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -22,6 +22,7 @@ import {
     resolvePollOptionNames,
     shouldUseAddonAdditionalData
 } from '@message/crypto/addon-crypto'
+import { unwrapMessage } from '@message/encode/content'
 import { resolveMediaPayload } from '@message/encode/media-payload'
 import type { PeerDataOperationRequester } from '@message/primitives/peer-data-operation'
 import type {
@@ -440,10 +441,15 @@ export class WaMessageCoordinator {
      *
      * Called automatically by the client unless `options.addons.autoDecrypt`
      * is explicitly `false` - you rarely need to invoke it directly. The
-     * parent secret
-     * is looked up in the in-memory `messageSecret` cache first, then in
-     * the `messages` store; if both are `'none'`/missing, decryption fails
-     * silently (and the event never fires).
+     * parent secret is looked up in the in-memory `messageSecret` cache
+     * first, then in the `messages` store. If both are `'none'`/missing,
+     * decryption fails and the event never fires; failures are logged at
+     * `warn` for `secretEncryptedMessage` addons (whose parent can be
+     * any message type, so the secret is only available when the
+     * `messages` mailbox is active) and at `debug` for the dedicated
+     * addon types (reactions, poll votes, event responses, comments)
+     * whose parent always carries a persisted secret or is itself
+     * short-lived.
      */
     public async tryDecryptAddon(event: WaIncomingMessageEvent): Promise<void> {
         const message = event.message
@@ -461,10 +467,19 @@ export class WaMessageCoordinator {
             this.messageStore
         )
         if (!parentEntry) {
-            this.logger.debug('addon parent message secret not found', {
+            const logCtx = {
                 id: event.key.id,
-                targetId: targetMessageId
-            })
+                targetId: targetMessageId,
+                kind: addon.kind
+            }
+            if (unwrapMessage(message).secretEncryptedMessage) {
+                this.logger.warn(
+                    'addon parent message secret not found - enable the `messages` mailbox to support decryption of secretEncryptedMessage addons on arbitrary parents',
+                    logCtx
+                )
+            } else {
+                this.logger.debug('addon parent message secret not found', logCtx)
+            }
             return
         }
 

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -81,6 +81,7 @@ import {
 } from '@transport/node/builders/message'
 import type { BinaryNode } from '@transport/types'
 import { bytesToHex, TEXT_ENCODER } from '@util/bytes'
+import type { ServerClock } from '@util/clock'
 import { toError } from '@util/primitives'
 
 interface WaMessageDispatchCoordinatorOptions {
@@ -118,6 +119,7 @@ interface WaMessageDispatchCoordinatorOptions {
     ) => Promise<WaMessagePublishResult>
     readonly getIcdcHashLength?: () => number
     readonly mobileMessageIdFormat?: boolean
+    readonly serverClock: ServerClock
 }
 
 type GroupAddressingMode = 'pn' | 'lid'
@@ -142,6 +144,7 @@ interface WaOutboundEnvelope {
 export class WaMessageDispatchCoordinator {
     private readonly deps: WaMessageDispatchCoordinatorOptions
     private readonly mobileMessageIdFormat: boolean
+    private readonly serverClock: ServerClock
     private readonly icdcDedup = new PromiseDedup()
     private readonly privacyTokenDedup = new PromiseDedup()
     private readonly distributionDedup = new PromiseDedup()
@@ -149,6 +152,7 @@ export class WaMessageDispatchCoordinator {
     public constructor(options: WaMessageDispatchCoordinatorOptions) {
         this.deps = options
         this.mobileMessageIdFormat = options.mobileMessageIdFormat ?? false
+        this.serverClock = options.serverClock
     }
 
     public async publishMessageNode(
@@ -160,7 +164,6 @@ export class WaMessageDispatchCoordinator {
             type: node.attrs.type,
             to: node.attrs.to
         })
-        const messageType = node.attrs.type ?? 'text'
         const replayPayload: WaRetryReplayPayload = {
             mode: 'opaque_node',
             node: encodeBinaryNode(node)
@@ -169,10 +172,7 @@ export class WaMessageDispatchCoordinator {
             {
                 messageIdHint: node.attrs.id,
                 toJid: node.attrs.to,
-                type: messageType,
-                replayPayload,
-                participantJid: node.attrs.participant,
-                recipientJid: node.attrs.recipient
+                replayPayload
             },
             async () => this.deps.messageClient.publishNode(node, options)
         )
@@ -199,9 +199,7 @@ export class WaMessageDispatchCoordinator {
             {
                 messageIdHint: input.id,
                 toJid: input.to,
-                type: input.type ?? 'text',
                 replayPayload,
-                participantJid: input.participant,
                 eligibleRequesterDeviceJids: [input.to]
             },
             async () => this.deps.messageClient.publishEncrypted(input, options)
@@ -243,9 +241,7 @@ export class WaMessageDispatchCoordinator {
             {
                 messageIdHint: input.id,
                 toJid: input.to,
-                type: messageType,
                 replayPayload,
-                participantJid: input.participant,
                 eligibleRequesterDeviceJids: [input.to]
             },
             async () =>
@@ -361,7 +357,7 @@ export class WaMessageDispatchCoordinator {
                           ...(editParticipant ? { participant: editParticipant } : {})
                       },
                       editedMessage: withViewOnce,
-                      timestampMs: editTimestamp ?? Date.now()
+                      timestampMs: editTimestamp ?? this.serverClock.nowMs()
                   }
               }
             : withViewOnce
@@ -730,7 +726,6 @@ export class WaMessageDispatchCoordinator {
             {
                 messageIdHint: messageNode.attrs.id ?? sendOptions.id,
                 toJid: input.groupJid,
-                type: messageNode.attrs.type,
                 replayPayload,
                 eligibleRequesterDeviceJids: undefined
             },
@@ -909,7 +904,6 @@ export class WaMessageDispatchCoordinator {
             {
                 messageIdHint: messageNode.attrs.id ?? sendOptions.id,
                 toJid: groupJid,
-                type,
                 replayPayload,
                 eligibleRequesterDeviceJids: undefined
             },
@@ -1107,7 +1101,6 @@ export class WaMessageDispatchCoordinator {
             {
                 messageIdHint: messageNode.attrs.id ?? sendOptions.id,
                 toJid: groupJid,
-                type,
                 replayPayload,
                 eligibleRequesterDeviceJids: undefined
             },
@@ -1584,7 +1577,6 @@ export class WaMessageDispatchCoordinator {
             {
                 messageIdHint: messageNode.attrs.id ?? sendOptions.id,
                 toJid: recipientJid,
-                type,
                 replayPayload,
                 eligibleRequesterDeviceJids: deviceJids
             },

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -142,7 +142,8 @@ function createMessageDispatchCoordinator(
             overrides?.meJid ? ({ meJid: overrides.meJid } as never) : null,
         resolvePrivacyTokenNode: async () => null,
         onDirectMessageSent: () => undefined,
-        mobileMessageIdFormat: overrides?.mobileMessageIdFormat
+        mobileMessageIdFormat: overrides?.mobileMessageIdFormat,
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) }
     })
 }
 

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -25,6 +25,7 @@ import {
 import { WaGroupMetadataMemoryStore } from '@store/memory/group-metadata.store'
 import { WaMessageMemoryStore } from '@store/memory/message.store'
 import type { BinaryNode } from '@transport/types'
+import type { ServerClock } from '@util/clock'
 
 function fakeSyncImpl(impl: (options?: WaAppStateSyncOptions) => Promise<WaAppStateSyncResult>) {
     return {
@@ -111,6 +112,7 @@ function createMessageDispatchCoordinator(
     overrides?: {
         readonly meJid?: string
         readonly mobileMessageIdFormat?: boolean
+        readonly serverClock?: ServerClock
     }
 ): WaMessageDispatchCoordinator {
     const groupMetadataCache = createGroupMetadataCache({
@@ -143,7 +145,10 @@ function createMessageDispatchCoordinator(
         resolvePrivacyTokenNode: async () => null,
         onDirectMessageSent: () => undefined,
         mobileMessageIdFormat: overrides?.mobileMessageIdFormat,
-        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) }
+        serverClock: overrides?.serverClock ?? {
+            nowMs: () => Date.now(),
+            nowSeconds: () => Math.floor(Date.now() / 1000)
+        }
     })
 }
 

--- a/src/client/coordinators/__tests__/retry-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/retry-coordinator.test.ts
@@ -337,7 +337,6 @@ test('placeholder resend: decodes WebMessageInfo and re-emits as incoming messag
     const event = harness.emitted[0]
     assert.equal(event.key.id, 'recover-1')
     assert.equal(event.key.remoteJid, '551122223333@s.whatsapp.net')
-    assert.equal(event.encryptionType, 'placeholder_recovery')
     assert.equal(event.message?.conversation, 'recovered')
 })
 
@@ -368,7 +367,6 @@ test('retry coordinator serializes outbound receipt tracking per message id', as
     const retryStore = new ControlledRetryStore({
         messageId: 'msg-1',
         toJid: '551100000000@s.whatsapp.net',
-        messageType: 'text',
         replayMode: 'plaintext',
         replayPayload: {
             mode: 'plaintext',
@@ -377,7 +375,6 @@ test('retry coordinator serializes outbound receipt tracking per message id', as
             plaintext: new Uint8Array([1, 2, 3])
         },
         state: 'pending',
-        createdAtMs: nowMs,
         updatedAtMs: nowMs,
         expiresAtMs: nowMs + 60_000
     })

--- a/src/client/messaging/__tests__/messaging.test.ts
+++ b/src/client/messaging/__tests__/messaging.test.ts
@@ -9,9 +9,16 @@ import type { WaGroupEvent, WaGroupEventAction } from '@client/types'
 import { createNoopLogger } from '@infra/log/types'
 import { proto } from '@proto'
 import { WaGroupMetadataMemoryStore } from '@store/memory/group-metadata.store'
+import type { ServerClock } from '@util/clock'
+
+const localServerClock: ServerClock = {
+    nowMs: () => Date.now(),
+    nowSeconds: () => Math.floor(Date.now() / 1000)
+}
 
 const BUILD_OPTIONS = {
-    logger: createNoopLogger()
+    logger: createNoopLogger(),
+    serverClock: localServerClock
 } as unknown as WaMediaMessageOptions
 
 function createGroupEvent(input: {
@@ -631,4 +638,43 @@ test('buildMediaMessageContent encrypts event-response with addon-crypto and cho
     assert.ok(resp?.encPayload instanceof Uint8Array)
     assert.ok(resp?.encIv instanceof Uint8Array)
     assert.equal(resp?.encIv?.byteLength, 12)
+})
+
+test('buildMediaMessageContent applies server-clock skew when caller omits timestamps', async () => {
+    const fixedMs = 1_700_000_000_000
+    const fixedSeconds = Math.floor(fixedMs / 1000)
+    const skewedClock = {
+        logger: createNoopLogger(),
+        serverClock: {
+            nowMs: () => fixedMs,
+            nowSeconds: () => fixedSeconds
+        }
+    } as unknown as WaMediaMessageOptions
+
+    const chatJid = '551122222222@s.whatsapp.net'
+
+    const reaction = await buildMediaMessageContent(
+        skewedClock,
+        {
+            type: 'reaction',
+            emoji: '🔥',
+            target: { remoteJid: chatJid, id: 'STANZA_R', fromMe: true }
+        },
+        { to: chatJid }
+    )
+    assert.equal(reaction.message.reactionMessage?.senderTimestampMs, fixedMs)
+
+    const pin = await buildMediaMessageContent(
+        skewedClock,
+        { type: 'pin', target: { remoteJid: chatJid, id: 'STANZA_P', fromMe: true } },
+        { to: chatJid }
+    )
+    assert.equal(pin.message.pinInChatMessage?.senderTimestampMs, fixedMs)
+
+    const keep = await buildMediaMessageContent(
+        skewedClock,
+        { type: 'keep', target: { remoteJid: chatJid, id: 'STANZA_K', fromMe: true } },
+        { to: chatJid }
+    )
+    assert.equal(keep.message.keepInChatMessage?.timestampMs, fixedMs)
 })

--- a/src/client/messaging/link-preview.ts
+++ b/src/client/messaging/link-preview.ts
@@ -23,6 +23,7 @@ import type {
     WaLinkPreviewThumbnailStream
 } from '@message/addons/link-preview/types'
 import { proto } from '@proto'
+import type { ServerClock } from '@util/clock'
 import { toError } from '@util/primitives'
 
 const INLINE_THUMBNAIL_MAX_BYTES = 64 * 1024
@@ -33,6 +34,7 @@ export interface ResolveLinkPreviewDeps {
     readonly getMediaConn: () => Promise<WaMediaConn>
     readonly fetcher: WaLinkPreviewFetcher
     readonly options: WaLinkPreviewOptions
+    readonly serverClock: ServerClock
 }
 
 export interface ResolvedLinkPreviewResult {
@@ -163,7 +165,7 @@ async function uploadHqFromBytes(
         thumbnailSha256: encrypted.fileSha256,
         thumbnailEncSha256: encrypted.fileEncSha256,
         mediaKey,
-        mediaKeyTimestamp: Math.floor(Date.now() / 1000),
+        mediaKeyTimestamp: deps.serverClock.nowSeconds(),
         ...(thumbnail.width !== undefined ? { thumbnailWidth: thumbnail.width } : {}),
         ...(thumbnail.height !== undefined ? { thumbnailHeight: thumbnail.height } : {})
     }
@@ -194,7 +196,7 @@ async function uploadHqFromStream(
             thumbnailSha256: encrypted.fileSha256,
             thumbnailEncSha256: encrypted.fileEncSha256,
             mediaKey,
-            mediaKeyTimestamp: Math.floor(Date.now() / 1000),
+            mediaKeyTimestamp: deps.serverClock.nowSeconds(),
             ...(thumbnail.width !== undefined ? { thumbnailWidth: thumbnail.width } : {}),
             ...(thumbnail.height !== undefined ? { thumbnailHeight: thumbnail.height } : {})
         }

--- a/src/client/messaging/messages.ts
+++ b/src/client/messaging/messages.ts
@@ -76,6 +76,7 @@ import { isBroadcastJid, isGroupJid, toUserJid } from '@protocol/jid'
 import { buildMediaConnIq } from '@transport/node/builders/media'
 import type { BinaryNode } from '@transport/types'
 import { bytesToBase64, TEXT_ENCODER, toBytesView } from '@util/bytes'
+import type { ServerClock } from '@util/clock'
 import { toError } from '@util/primitives'
 
 const VOICE_NOTE_MIMETYPE = 'audio/ogg; codecs=opus'
@@ -92,6 +93,7 @@ export interface WaMediaMessageOptions {
     ) => Promise<BinaryNode>
     readonly getMediaConnCache: () => WaMediaConn | null
     readonly setMediaConnCache: (mediaConn: WaMediaConn | null) => void
+    readonly serverClock: ServerClock
     readonly media?: WaMediaOptions
     readonly linkPreviewResolver?: (
         content: WaSendTextMessage
@@ -143,6 +145,7 @@ function targetMessageKey(remoteJid: string, key: WaMessageKey): Proto.IMessageK
 
 function buildReactionMessage(
     content: WaSendReactionMessage,
+    serverClock: ServerClock,
     ctx?: WaBuildMessageContext
 ): Proto.IMessage {
     requireCtxField(ctx, 'to', 'reaction')
@@ -150,7 +153,7 @@ function buildReactionMessage(
         reactionMessage: {
             key: targetMessageKey(ctx!.to, resolveMessageTarget(content.target)),
             text: content.emoji,
-            senderTimestampMs: content.senderTimestampMs ?? Date.now()
+            senderTimestampMs: content.senderTimestampMs ?? serverClock.nowMs()
         }
     }
 }
@@ -168,7 +171,11 @@ function buildRevokeMessage(
     }
 }
 
-function buildPinMessage(content: WaSendPinMessage, ctx?: WaBuildMessageContext): Proto.IMessage {
+function buildPinMessage(
+    content: WaSendPinMessage,
+    serverClock: ServerClock,
+    ctx?: WaBuildMessageContext
+): Proto.IMessage {
     requireCtxField(ctx, 'to', content.type)
     return {
         pinInChatMessage: {
@@ -177,12 +184,16 @@ function buildPinMessage(content: WaSendPinMessage, ctx?: WaBuildMessageContext)
                 content.type === 'pin'
                     ? proto.Message.PinInChatMessage.Type.PIN_FOR_ALL
                     : proto.Message.PinInChatMessage.Type.UNPIN_FOR_ALL,
-            senderTimestampMs: content.senderTimestampMs ?? Date.now()
+            senderTimestampMs: content.senderTimestampMs ?? serverClock.nowMs()
         }
     }
 }
 
-function buildKeepMessage(content: WaSendKeepMessage, ctx?: WaBuildMessageContext): Proto.IMessage {
+function buildKeepMessage(
+    content: WaSendKeepMessage,
+    serverClock: ServerClock,
+    ctx?: WaBuildMessageContext
+): Proto.IMessage {
     requireCtxField(ctx, 'to', content.type)
     return {
         keepInChatMessage: {
@@ -191,7 +202,7 @@ function buildKeepMessage(content: WaSendKeepMessage, ctx?: WaBuildMessageContex
                 content.type === 'keep'
                     ? proto.KeepType.KEEP_FOR_ALL
                     : proto.KeepType.UNDO_KEEP_FOR_ALL,
-            timestampMs: content.timestampMs ?? Date.now()
+            timestampMs: content.timestampMs ?? serverClock.nowMs()
         }
     }
 }
@@ -277,6 +288,7 @@ async function encryptAddonForOutgoing(input: {
 
 async function buildPollVoteMessage(
     content: WaSendPollVoteMessage,
+    serverClock: ServerClock,
     ctx?: WaBuildMessageContext
 ): Promise<Proto.IMessage> {
     requireCtxField(ctx, 'outgoingStanzaId', 'poll-vote')
@@ -305,20 +317,21 @@ async function buildPollVoteMessage(
                 content.poll.participant
             ),
             vote: { encPayload, encIv },
-            senderTimestampMs: content.senderTimestampMs ?? Date.now()
+            senderTimestampMs: content.senderTimestampMs ?? serverClock.nowMs()
         }
     }
 }
 
 async function buildEventResponseMessage(
     content: WaSendEventResponseMessage,
+    serverClock: ServerClock,
     ctx?: WaBuildMessageContext
 ): Promise<Proto.IMessage> {
     requireCtxField(ctx, 'outgoingStanzaId', 'event-response')
     requireCtxField(ctx, 'meJid', 'event-response')
     const responseProto: Proto.Message.IEventResponseMessage = {
         response: EVENT_RESPONSE_ENUM[content.response],
-        timestampMs: content.timestampMs ?? Date.now()
+        timestampMs: content.timestampMs ?? serverClock.nowMs()
     }
     if (content.extraGuestCount !== undefined) {
         responseProto.extraGuestCount = content.extraGuestCount
@@ -375,17 +388,23 @@ export async function buildMediaMessageContent(
         }
         return { message: { extendedTextMessage: { text: content.text } } }
     }
-    if (isSendReactionMessage(content)) return { message: buildReactionMessage(content, ctx) }
+    if (isSendReactionMessage(content)) {
+        return { message: buildReactionMessage(content, options.serverClock, ctx) }
+    }
     if (isSendRevokeMessage(content)) return { message: buildRevokeMessage(content, ctx) }
-    if (isSendPinMessage(content)) return { message: buildPinMessage(content, ctx) }
-    if (isSendKeepMessage(content)) return { message: buildKeepMessage(content, ctx) }
+    if (isSendPinMessage(content)) {
+        return { message: buildPinMessage(content, options.serverClock, ctx) }
+    }
+    if (isSendKeepMessage(content)) {
+        return { message: buildKeepMessage(content, options.serverClock, ctx) }
+    }
     if (isSendPollMessage(content)) return { message: buildPollCreationMessage(content) }
     if (isSendEventMessage(content)) return { message: buildEventMessage(content) }
     if (isSendPollVoteMessage(content)) {
-        return { message: await buildPollVoteMessage(content, ctx) }
+        return { message: await buildPollVoteMessage(content, options.serverClock, ctx) }
     }
     if (isSendEventResponseMessage(content)) {
-        return { message: await buildEventResponseMessage(content, ctx) }
+        return { message: await buildEventResponseMessage(content, options.serverClock, ctx) }
     }
     if (isSendMediaMessage(content)) {
         return buildMediaMessage(options, content)
@@ -512,7 +531,7 @@ async function buildMediaMessage(
         if (processResult.status === 'rejected') throw processResult.reason
         const uploaded = uploadResult.value
         const processed = processResult.value
-        const mediaKeyTimestamp = Math.floor(Date.now() / 1000)
+        const mediaKeyTimestamp = options.serverClock.nowSeconds()
         const uploadedFields = {
             url: uploaded.url,
             fileSha256: uploaded.fileSha256,
@@ -634,7 +653,7 @@ async function buildMediaMessage(
                             firstFrameLength: content.firstFrameLength ?? uploaded.firstFrameLength,
                             firstFrameSidecar:
                                 content.firstFrameSidecar ?? uploaded.firstFrameSidecar,
-                            stickerSentTs: content.stickerSentTs ?? Date.now()
+                            stickerSentTs: content.stickerSentTs ?? options.serverClock.nowMs()
                         }
                     }
                 }
@@ -890,7 +909,7 @@ async function buildStickerPackMediaMessage(
                 fileSha256: bundle.fileSha256,
                 fileEncSha256: bundle.fileEncSha256,
                 mediaKey,
-                mediaKeyTimestamp: Math.floor(Date.now() / 1000),
+                mediaKeyTimestamp: options.serverClock.nowSeconds(),
                 directPath: bundle.directPath,
                 thumbnailDirectPath: cover.directPath,
                 thumbnailSha256: cover.fileSha256,

--- a/src/client/persistence/__tests__/mailbox.test.ts
+++ b/src/client/persistence/__tests__/mailbox.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { persistIncomingMailboxEntities } from '@client/persistence/mailbox'
+import type { WaIncomingMessageEvent } from '@client/types'
+import { createNoopLogger } from '@infra/log/types'
+import type { WaStoredContactRecord } from '@store/contracts/contact.store'
+
+interface Captured {
+    readonly messages: { readonly id: string; readonly threadJid: string }[]
+    readonly contacts: WaStoredContactRecord[]
+}
+
+function captureWriteBehind(): {
+    readonly captured: Captured
+    readonly writeBehind: unknown
+} {
+    const captured: Captured = { messages: [], contacts: [] }
+    const writeBehind = {
+        persistMessage: (record: { id: string; threadJid: string }) => {
+            captured.messages.push({ id: record.id, threadJid: record.threadJid })
+        },
+        persistContact: (record: WaStoredContactRecord) => {
+            captured.contacts.push(record)
+        }
+    }
+    return { captured, writeBehind }
+}
+
+function baseEvent(
+    overrides: Partial<WaIncomingMessageEvent> & {
+        readonly keyOverrides?: Partial<WaIncomingMessageEvent['key']>
+    }
+): WaIncomingMessageEvent {
+    const { keyOverrides, ...rest } = overrides
+    return {
+        key: {
+            remoteJid: '120363000000000000@g.us',
+            id: 'msg-1',
+            fromMe: false,
+            isGroup: true,
+            isBroadcast: false,
+            isNewsletter: false,
+            senderDevice: 0,
+            ...keyOverrides
+        },
+        rawNode: {
+            tag: 'message',
+            attrs: {}
+        },
+        ...rest
+    } as unknown as WaIncomingMessageEvent
+}
+
+test('mailbox persist writes ONE LID-canonical row when participant+participantAlt form a LID/PN pair', () => {
+    const { captured, writeBehind } = captureWriteBehind()
+    persistIncomingMailboxEntities({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        messageSecretStore: { set: async () => undefined } as never,
+        event: baseEvent({
+            keyOverrides: {
+                remoteJid: '120363000000000000@g.us',
+                participant: '111111111111111@lid',
+                participantAlt: '5511999999999@s.whatsapp.net'
+            }
+        })
+    })
+
+    assert.equal(captured.contacts.length, 1)
+    assert.equal(captured.contacts[0].jid, '111111111111111@lid')
+    assert.equal(captured.contacts[0].phoneNumber, '5511999999999@s.whatsapp.net')
+    assert.equal(captured.contacts[0].lid, undefined)
+})
+
+test('mailbox persist writes ONE canonical row for 1:1 chat with remoteJid+remoteJidAlt pair', () => {
+    const { captured, writeBehind } = captureWriteBehind()
+    persistIncomingMailboxEntities({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        messageSecretStore: { set: async () => undefined } as never,
+        event: baseEvent({
+            keyOverrides: {
+                remoteJid: '5511999999999@s.whatsapp.net',
+                remoteJidAlt: '111111111111111@lid',
+                isGroup: false
+            }
+        })
+    })
+
+    assert.equal(captured.contacts.length, 1)
+    assert.equal(captured.contacts[0].jid, '111111111111111@lid')
+    assert.equal(captured.contacts[0].phoneNumber, '5511999999999@s.whatsapp.net')
+})
+
+test('mailbox persist falls back to bare jid when no LID/PN pair available', () => {
+    const { captured, writeBehind } = captureWriteBehind()
+    persistIncomingMailboxEntities({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        messageSecretStore: { set: async () => undefined } as never,
+        event: baseEvent({
+            keyOverrides: {
+                participant: '111111111111111@lid',
+                // both LIDs - no pairing possible
+                participantAlt: '222222222222222@lid'
+            }
+        })
+    })
+    assert.equal(captured.contacts.length, 1)
+    assert.equal(captured.contacts[0].jid, '111111111111111@lid')
+    assert.equal(captured.contacts[0].phoneNumber, undefined)
+    assert.equal(captured.contacts[0].lid, undefined)
+})
+
+test('mailbox persist does NOT treat remoteJid pair as user pair for groups', () => {
+    const { captured, writeBehind } = captureWriteBehind()
+    persistIncomingMailboxEntities({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        messageSecretStore: { set: async () => undefined } as never,
+        event: baseEvent({
+            keyOverrides: {
+                remoteJid: '120363000000000000@g.us',
+                remoteJidAlt: '120363999999999999@lid',
+                participant: '111111111111111@lid',
+                participantAlt: '5511999999999@s.whatsapp.net',
+                isGroup: true
+            }
+        })
+    })
+    // Only the participant pair should produce a cross-ref row;
+    // remoteJid is a group jid and is not a contact at all.
+    const crossRefRows = captured.contacts.filter((c) => c.phoneNumber || c.lid)
+    assert.equal(crossRefRows.length, 1)
+    assert.equal(crossRefRows[0].jid, '111111111111111@lid')
+})

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -16,7 +16,8 @@ const HANDLED_SYNC_TYPES = new Set([
     proto.Message.HistorySyncType.RECENT,
     proto.Message.HistorySyncType.FULL,
     proto.Message.HistorySyncType.PUSH_NAME,
-    proto.Message.HistorySyncType.ON_DEMAND
+    proto.Message.HistorySyncType.ON_DEMAND,
+    proto.Message.HistorySyncType.NON_BLOCKING_DATA
 ])
 const HISTORY_SYNC_MAX_PENDING_WRITES = 1_024
 
@@ -37,6 +38,14 @@ interface WaHistorySyncDeps {
         }[]
     ) => Promise<void>
     readonly onNctSalt?: (salt: Uint8Array) => Promise<void>
+    /**
+     * Invoked once per recognized chunk after it has been fully processed (or
+     * after the early-return for `INITIAL_STATUS_V3` and other recognized-but-
+     * unhandled types). The WaClient wires this to the `hist_sync` receipt
+     * stanza required by wa-web so the primary device does not keep resending
+     * the same chunk.
+     */
+    readonly onProcessed?: (syncType: Proto.Message.HistorySyncType) => Promise<void>
 }
 
 export async function runHistorySyncNotification(
@@ -59,8 +68,17 @@ export async function processHistorySyncNotification(
     notification: Proto.Message.IHistorySyncNotification
 ): Promise<void> {
     const syncType = notification.syncType
-    if (syncType === null || syncType === undefined || !HANDLED_SYNC_TYPES.has(syncType)) {
+    if (syncType === null || syncType === undefined) {
+        deps.logger.debug('skipping history sync notification without syncType')
+        return
+    }
+    if (!HANDLED_SYNC_TYPES.has(syncType)) {
         deps.logger.debug('skipping unhandled history sync type', { syncType })
+        // INITIAL_STATUS_V3 is the only recognized syncType we do not process today;
+        // still ack it so the primary device does not keep resending the same chunk.
+        if (syncType === proto.Message.HistorySyncType.INITIAL_STATUS_V3 && deps.onProcessed) {
+            await deps.onProcessed(syncType)
+        }
         return
     }
 
@@ -78,15 +96,36 @@ export async function processHistorySyncNotification(
 
     const nowMs = Date.now()
     const pendingWrites: Promise<void>[] = []
+
+    // Build PN -> LID lookup from this chunk's mappings so pushnames and
+    // mappings land on a single canonical (LID-form) contact row instead of
+    // two mirror rows (one keyed by PN, one keyed by LID).
+    const pnToLid = new Map<string, string>()
+    for (const map of historySync.phoneNumberToLidMappings ?? []) {
+        if (map.pnJid && map.lidJid) {
+            pnToLid.set(map.pnJid, map.lidJid)
+        }
+    }
+
     for (const pn of historySync.pushnames) {
         if (!pn.id) {
             continue
         }
-        pendingWrites[pendingWrites.length] = deps.writeBehind.persistContactAsync({
-            jid: pn.id,
-            pushName: pn.pushname ?? undefined,
-            lastUpdatedMs: nowMs
-        })
+        const lidJid = pnToLid.get(pn.id)
+        pendingWrites[pendingWrites.length] = deps.writeBehind.persistContactAsync(
+            lidJid
+                ? {
+                      jid: lidJid,
+                      pushName: pn.pushname ?? undefined,
+                      phoneNumber: pn.id,
+                      lastUpdatedMs: nowMs
+                  }
+                : {
+                      jid: pn.id,
+                      pushName: pn.pushname ?? undefined,
+                      lastUpdatedMs: nowMs
+                  }
+        )
         if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
             await flushPendingWrites(pendingWrites)
         }
@@ -115,7 +154,11 @@ export async function processHistorySyncNotification(
         }
         for (const histMsg of conversation.messages ?? []) {
             const webMsg = histMsg.message
-            if (!webMsg?.key?.id) {
+            if (!webMsg?.key?.id || !webMsg.message) {
+                // Stubs (group system events: add/remove/promote, revokes, ephemeral toggles)
+                // arrive as WebMessageInfo with a key + messageStubType but no `.message`. They
+                // duplicate live `notification` stanzas that the client already processes, and
+                // storing them as content-less rows produces "ghost" entries — skip them here.
                 continue
             }
             const timestampMs = longToNumber(webMsg.messageTimestamp) * 1000
@@ -125,14 +168,26 @@ export async function processHistorySyncNotification(
                 senderJid: webMsg.key.participant ?? undefined,
                 fromMe: webMsg.key.fromMe === true,
                 timestampMs: timestampMs || undefined,
-                messageBytes: webMsg.message
-                    ? proto.Message.encode(webMsg.message).finish()
-                    : undefined
+                messageBytes: proto.Message.encode(webMsg.message).finish()
             })
             if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
                 await flushPendingWrites(pendingWrites)
             }
             messagesCount += 1
+        }
+    }
+
+    // Persist LID<->PN mappings as a single LID-canonical row per contact.
+    // Lookups by PN form fall through to `getByPhoneNumber` via the secondary
+    // index, so the mirror PN row is no longer needed.
+    for (const [pnJid, lidJid] of pnToLid) {
+        pendingWrites[pendingWrites.length] = deps.writeBehind.persistContactAsync({
+            jid: lidJid,
+            phoneNumber: pnJid,
+            lastUpdatedMs: nowMs
+        })
+        if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
+            await flushPendingWrites(pendingWrites)
         }
     }
 
@@ -177,6 +232,9 @@ export async function processHistorySyncNotification(
     }
     await flushPendingWrites(pendingWrites)
     deps.emitEvent('history_sync_chunk', event)
+    if (deps.onProcessed) {
+        await deps.onProcessed(syncType)
+    }
 }
 
 async function flushPendingWrites(pendingWrites: Promise<void>[]): Promise<void> {

--- a/src/client/persistence/mailbox.ts
+++ b/src/client/persistence/mailbox.ts
@@ -64,6 +64,9 @@ function persistContacts(
         const record = canonicalContact(senderPrimary, alt, nowMs)
         writeBehind.persistContact(record)
         written.add(record.jid)
+        if (record.phoneNumber) {
+            written.add(record.phoneNumber)
+        }
     }
     if (participantJid && !written.has(participantJid)) {
         writeBehind.persistContact({ jid: participantJid, lastUpdatedMs: nowMs })

--- a/src/client/persistence/mailbox.ts
+++ b/src/client/persistence/mailbox.ts
@@ -3,7 +3,7 @@ import type { WaIncomingMessageEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import { needsSecretPersistence } from '@message/encode/content'
 import { proto } from '@proto'
-import { toUserJid } from '@protocol/jid'
+import { isLidJid, isUserJid, toUserJid } from '@protocol/jid'
 import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
 import { toError } from '@util/primitives'
 
@@ -14,22 +14,58 @@ interface WaPersistIncomingMailboxOptions {
     readonly event: WaIncomingMessageEvent
 }
 
+function pairLidPn(a: string | undefined, b: string | undefined): readonly [string, string] | null {
+    if (!a || !b) return null
+    if (isLidJid(a) && isUserJid(b)) return [a, b]
+    if (isLidJid(b) && isUserJid(a)) return [b, a]
+    return null
+}
+
+/**
+ * Returns the LID-canonical contact record for a primary jid and (optionally)
+ * its alternate addressing. When both forms are known, the row carries
+ * `jid=<lid>, phoneNumber=<pn>` so lookups by either form converge on a
+ * single row via the contact store's PN-fallback path. When only one form is
+ * known, the row falls back to that jid as canonical.
+ */
+function canonicalContact(
+    primary: string,
+    alt: string | undefined,
+    nowMs: number
+): { readonly jid: string; readonly phoneNumber?: string; readonly lastUpdatedMs: number } {
+    const pair = pairLidPn(primary, alt)
+    if (pair) {
+        const [lid, pn] = pair
+        return { jid: lid, phoneNumber: pn, lastUpdatedMs: nowMs }
+    }
+    return { jid: primary, lastUpdatedMs: nowMs }
+}
+
 function persistContacts(
     writeBehind: WriteBehindPersistence,
     event: WaIncomingMessageEvent,
     nowMs: number
 ): void {
-    const senderJid =
-        event.key.participant ?? event.rawNode.attrs.participant ?? event.key.remoteJid
     const rawParticipant = event.rawNode.attrs.participant
     const participantJid = rawParticipant ? toUserJid(rawParticipant) : undefined
-    if (!senderJid && !participantJid) {
+    const senderPrimary = event.key.participant ?? rawParticipant ?? event.key.remoteJid
+    if (!senderPrimary && !participantJid) {
         return
     }
-    if (senderJid) {
-        writeBehind.persistContact({ jid: senderJid, lastUpdatedMs: nowMs })
+
+    const written = new Set<string>()
+    if (senderPrimary) {
+        // For 1:1 chats the sender is the same person as remoteJid, so its
+        // cross-ref pair info lives in remoteJidAlt rather than participantAlt.
+        let alt = event.key.participantAlt
+        if (!alt && !event.key.isGroup && senderPrimary === event.key.remoteJid) {
+            alt = event.key.remoteJidAlt
+        }
+        const record = canonicalContact(senderPrimary, alt, nowMs)
+        writeBehind.persistContact(record)
+        written.add(record.jid)
     }
-    if (participantJid && participantJid !== senderJid) {
+    if (participantJid && !written.has(participantJid)) {
         writeBehind.persistContact({ jid: participantJid, lastUpdatedMs: nowMs })
     }
 }
@@ -56,8 +92,6 @@ export function persistIncomingMailboxEntities(options: WaPersistIncomingMailbox
             fromMe: false,
             timestampMs:
                 event.timestampSeconds === undefined ? undefined : event.timestampSeconds * 1_000,
-            encType: event.encryptionType,
-            plaintext: event.plaintext,
             messageBytes
         })
         persistContacts(writeBehind, event, nowMs)

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -252,7 +252,10 @@ export interface WaAddonOptions {
      * decrypt yourself via `client.message.tryDecryptAddon(event)`. The
      * parent message secret is looked up in the `messageSecret` cache
      * first, then in the `messages` store; setting both to `'none'`
-     * defeats addon decryption silently.
+     * defeats addon decryption. Failures are logged at `warn` for
+     * `secretEncryptedMessage` addons (whose parent can be any message
+     * type) and at `debug` for the dedicated addon types (reactions,
+     * poll votes, event responses, comments).
      */
     readonly autoDecrypt?: boolean
 }
@@ -507,15 +510,6 @@ export interface WaIncomingMessageEvent extends Omit<WaIncomingBaseEvent, 'chatJ
     readonly expirationSeconds?: number
     /** Sender's display name from the stanza's `notify` attr. */
     readonly pushName?: string
-    /**
-     * Signal envelope used to decrypt this message: `'pkmsg'` (PreKeySignalMessage),
-     * `'msg'` (1:1 SignalMessage), `'skmsg'` (group sender-key), `'msmsg'`
-     * (Meta-AI streaming), `'placeholder_recovery'` (retry-recovered placeholder),
-     * or `'plaintext'` (newsletter, no Signal layer).
-     */
-    readonly encryptionType?: string
-    /** Decrypted bytes before protobuf parsing. Kept so consumers can re-derive addon decryption material. */
-    readonly plaintext?: Uint8Array
     readonly message?: Proto.IMessage
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -277,6 +277,7 @@ export {
     isLidJid,
     isNewsletterJid,
     isStatusBroadcastJid,
+    isUserJid,
     normalizeDeviceJid,
     normalizeRecipientJid,
     parseJidFull,

--- a/src/media/__tests__/media.test.ts
+++ b/src/media/__tests__/media.test.ts
@@ -21,6 +21,12 @@ import { WaMediaCrypto } from '@media/crypto/WaMediaCrypto'
 import { parseMediaConnResponse } from '@media/transfer/conn'
 import { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import type { BinaryNode } from '@transport/types'
+import type { ServerClock } from '@util/clock'
+
+const localServerClock: ServerClock = {
+    nowMs: () => Date.now(),
+    nowSeconds: () => Math.floor(Date.now() / 1000)
+}
 
 function buildMediaConnNode(auth = 'token', ttl = '120'): BinaryNode {
     return {
@@ -440,7 +446,8 @@ test('media message builder supports text passthrough and conn caching', async (
             getMediaConnCache: () => cache,
             setMediaConnCache: (value) => {
                 cache = value
-            }
+            },
+            serverClock: localServerClock
         },
         'hello'
     )
@@ -467,7 +474,8 @@ test('media message builder supports text passthrough and conn caching', async (
             getMediaConnCache: () => cache,
             setMediaConnCache: (value) => {
                 cache = value
-            }
+            },
+            serverClock: localServerClock
         },
         false
     )
@@ -484,7 +492,8 @@ test('media message builder supports text passthrough and conn caching', async (
             getMediaConnCache: () => cache,
             setMediaConnCache: (value) => {
                 cache = value
-            }
+            },
+            serverClock: localServerClock
         },
         false
     )
@@ -525,7 +534,8 @@ test('media message builder uploads ptv bytes and maps upload response fields', 
             } as never,
             queryWithContext: async () => buildMediaConnNode('auth-token', '120'),
             getMediaConnCache: () => null,
-            setMediaConnCache: () => undefined
+            setMediaConnCache: () => undefined,
+            serverClock: localServerClock
         },
         {
             type: 'ptv',
@@ -572,6 +582,7 @@ test('media message builder continues probe extraction when thumbnail generation
             queryWithContext: async () => buildMediaConnNode('auth-token', '120'),
             getMediaConnCache: () => null,
             setMediaConnCache: () => undefined,
+            serverClock: localServerClock,
             media: {
                 processor: {
                     generateVideoThumbnail: async () => {
@@ -619,6 +630,7 @@ test('media message builder fills only missing probe fields', async () => {
             queryWithContext: async () => buildMediaConnNode('auth-token', '120'),
             getMediaConnCache: () => null,
             setMediaConnCache: () => undefined,
+            serverClock: localServerClock,
             media: {
                 processor: {
                     probeMedia: async () => ({
@@ -663,6 +675,7 @@ test('media message builder reuses streamed media across processor steps', async
             queryWithContext: async () => buildMediaConnNode('auth-token', '120'),
             getMediaConnCache: () => null,
             setMediaConnCache: () => undefined,
+            serverClock: localServerClock,
             media: {
                 processor: {
                     probeMedia: async (input) => {
@@ -726,6 +739,7 @@ test('media message builder supports file path input for upload and processing',
                 queryWithContext: async () => buildMediaConnNode('auth-token', '120'),
                 getMediaConnCache: () => null,
                 setMediaConnCache: () => undefined,
+                serverClock: localServerClock,
                 media: {
                     processor: {
                         generateVideoThumbnail: async (input) => {
@@ -783,7 +797,8 @@ test('media message builder propagates upload response errors for byte uploads',
                     } as never,
                     queryWithContext: async () => buildMediaConnNode(),
                     getMediaConnCache: () => null,
-                    setMediaConnCache: () => undefined
+                    setMediaConnCache: () => undefined,
+                    serverClock: localServerClock
                 },
                 content
             ),
@@ -801,7 +816,8 @@ test('media message builder propagates upload response errors for byte uploads',
                     } as never,
                     queryWithContext: async () => buildMediaConnNode(),
                     getMediaConnCache: () => null,
-                    setMediaConnCache: () => undefined
+                    setMediaConnCache: () => undefined,
+                    serverClock: localServerClock
                 },
                 content
             ),
@@ -820,7 +836,8 @@ test('media message builder propagates upload response errors for byte uploads',
                     } as never,
                     queryWithContext: async () => buildMediaConnNode(),
                     getMediaConnCache: () => null,
-                    setMediaConnCache: () => undefined
+                    setMediaConnCache: () => undefined,
+                    serverClock: localServerClock
                 },
                 content
             ),
@@ -856,7 +873,8 @@ test('media message builder cleans encrypted temp file when stream upload fails'
                         } as never,
                         queryWithContext: async () => buildMediaConnNode(),
                         getMediaConnCache: () => null,
-                        setMediaConnCache: () => undefined
+                        setMediaConnCache: () => undefined,
+                        serverClock: localServerClock
                     },
                     {
                         type: 'audio',

--- a/src/message/__tests__/message.test.ts
+++ b/src/message/__tests__/message.test.ts
@@ -794,7 +794,6 @@ test('processIncomingNewsletterMessage decodes plaintext message and emits event
     const event = emitted as unknown as WaIncomingMessageEvent
     assert.equal(event.key.remoteJid, '120363025343298869@newsletter')
     assert.equal(event.key.participant, undefined)
-    assert.equal(event.encryptionType, 'plaintext')
     assert.equal(event.key.isNewsletter, true)
     assert.equal(event.key.isGroup, false)
     assert.equal(event.key.isBroadcast, false)

--- a/src/message/kinds/newsletter.ts
+++ b/src/message/kinds/newsletter.ts
@@ -154,8 +154,6 @@ export function processIncomingNewsletterMessage(
         offline: node.attrs.offline !== undefined,
         timestampSeconds: parseOptionalInt(node.attrs.t),
         ...(expirationSeconds !== undefined ? { expirationSeconds } : {}),
-        encryptionType: 'plaintext',
-        plaintext: decoded.plaintext,
         message: decoded.message
     })
 }

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -157,7 +157,6 @@ export function buildRecoveredIncomingEvent(
             senderDevice: senderDevice ?? 0
         },
         timestampSeconds,
-        encryptionType: 'placeholder_recovery',
         ...(expirationSeconds !== undefined ? { expirationSeconds } : {}),
         message
     }
@@ -342,8 +341,6 @@ function processMsmsgEncNode(
             offline: node.attrs.offline !== undefined,
             timestampSeconds: parseOptionalInt(node.attrs.t),
             pushName,
-            encryptionType: 'msmsg',
-            plaintext: payload,
             message
         })
         return { success: true, encType: 'msmsg' }
@@ -431,8 +428,6 @@ async function decryptAndProcessEncNode(
                 timestampSeconds: parseOptionalInt(node.attrs.t),
                 ...(expirationSeconds !== undefined ? { expirationSeconds } : {}),
                 pushName,
-                encryptionType: encType,
-                plaintext: unpaddedPlaintext,
                 message
             })
         }

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -15,6 +15,7 @@ export {
     isLidJid,
     isNewsletterJid,
     isStatusBroadcastJid,
+    isUserJid,
     normalizeDeviceJid,
     normalizeRecipientJid,
     parseJidFull,

--- a/src/protocol/jid.ts
+++ b/src/protocol/jid.ts
@@ -85,6 +85,11 @@ export function isLidJid(jid: string): boolean {
     return isJidType(jid, WA_DEFAULTS.LID_SERVER)
 }
 
+/** Returns `true` for JIDs in the `@s.whatsapp.net` server (phone-number user JIDs). */
+export function isUserJid(jid: string): boolean {
+    return isJidType(jid, WA_DEFAULTS.HOST_DOMAIN)
+}
+
 /** Returns `true` for JIDs in the `@bot` server. */
 export function isBotJid(jid: string): boolean {
     return isJidType(jid, WA_DEFAULTS.BOT_SERVER)

--- a/src/protocol/message.ts
+++ b/src/protocol/message.ts
@@ -33,6 +33,7 @@ export type WaOutboundReceiptType =
     | typeof WA_MESSAGE_TYPES.RECEIPT_TYPE_PLAYED
     | typeof WA_MESSAGE_TYPES.RECEIPT_TYPE_PLAYED_SELF
     | typeof WA_MESSAGE_TYPES.RECEIPT_TYPE_INACTIVE
+    | typeof WA_MESSAGE_TYPES.RECEIPT_TYPE_HISTORY_SYNC
 
 export const WA_RETRYABLE_ACK_CODES = Object.freeze(['408', '429', '500', '503'] as const)
 

--- a/src/retry/__tests__/retry.test.ts
+++ b/src/retry/__tests__/retry.test.ts
@@ -24,11 +24,9 @@ function buildOutboundRecord(
     return {
         messageId,
         toJid: 'target@s.whatsapp.net',
-        messageType: 'text',
         replayMode: replayPayload.mode,
         replayPayload: encodeRetryReplayPayload(replayPayload),
         state: 'pending',
-        createdAtMs: now,
         updatedAtMs: now,
         expiresAtMs: now + 60_000
     }
@@ -251,7 +249,6 @@ test('retry replay service accepts raw replay payloads from memory store', async
     const outbound: WaRetryOutboundMessageRecord = {
         messageId: 'm-plain-raw',
         toJid: '5511999999999@s.whatsapp.net',
-        messageType: 'text',
         replayMode: 'plaintext',
         replayPayload: {
             mode: 'plaintext',
@@ -260,7 +257,6 @@ test('retry replay service accepts raw replay payloads from memory store', async
             plaintext: new Uint8Array([1, 2, 3])
         },
         state: 'pending',
-        createdAtMs: now,
         updatedAtMs: now,
         expiresAtMs: now + 60_000
     }
@@ -384,7 +380,6 @@ test('retry replay service emits status@broadcast retry with meta and no address
     const outbound: WaRetryOutboundMessageRecord = {
         messageId: 'm-status-1',
         toJid: 'status@broadcast',
-        messageType: 'text',
         replayMode: 'plaintext',
         replayPayload: {
             mode: 'plaintext',
@@ -394,7 +389,6 @@ test('retry replay service emits status@broadcast retry with meta and no address
             statusSetting: 'denylist'
         },
         state: 'pending',
-        createdAtMs: now,
         updatedAtMs: now,
         expiresAtMs: now + 60_000
     }

--- a/src/retry/__tests__/tracker.test.ts
+++ b/src/retry/__tests__/tracker.test.ts
@@ -37,7 +37,6 @@ test('outbound retry tracker persists once when hinted id matches publish result
         {
             messageIdHint: 'hinted-id',
             toJid: '551100000000@s.whatsapp.net',
-            type: 'text',
             replayPayload: {
                 mode: 'plaintext',
                 to: '551100000000@s.whatsapp.net',
@@ -90,7 +89,6 @@ test('outbound retry tracker skips codec when store supports raw replay payloads
     await tracker.track(
         {
             toJid: replayPayload.to,
-            type: replayPayload.type,
             replayPayload
         },
         async () => ({
@@ -135,7 +133,6 @@ test('outbound retry tracker persists publish result when id hint is not provide
     await tracker.track(
         {
             toJid: '551100000000@s.whatsapp.net',
-            type: 'text',
             replayPayload: {
                 mode: 'plaintext',
                 to: '551100000000@s.whatsapp.net',
@@ -181,7 +178,6 @@ test('outbound retry tracker persists only publish result when server rewrites i
         {
             messageIdHint: 'hinted-id',
             toJid: '551100000000@s.whatsapp.net',
-            type: 'text',
             replayPayload: {
                 mode: 'plaintext',
                 to: '551100000000@s.whatsapp.net',
@@ -226,7 +222,6 @@ test('outbound retry tracker does not default eligible requester list for group 
     await tracker.track(
         {
             toJid: '123456@g.us',
-            type: 'text',
             replayPayload: {
                 mode: 'plaintext',
                 to: '123456@g.us',

--- a/src/retry/tracker.ts
+++ b/src/retry/tracker.ts
@@ -10,10 +10,7 @@ import { toError } from '@util/primitives'
 export type OutboundRetryTrackHint = {
     readonly messageIdHint?: string
     readonly toJid?: string
-    readonly type: string
     readonly replayPayload: WaRetryReplayPayload
-    readonly participantJid?: string
-    readonly recipientJid?: string
     readonly eligibleRequesterDeviceJids?: readonly string[]
 }
 
@@ -86,7 +83,6 @@ export function createOutboundRetryTracker(options: {
 
     return {
         track: async (hint, publish) => {
-            const nowMs = Date.now()
             const replayMode = hint.replayPayload.mode
             const resolvedToJid =
                 hint.toJid ?? (replayMode === 'opaque_node' ? '' : hint.replayPayload.to)
@@ -115,15 +111,11 @@ export function createOutboundRetryTracker(options: {
             ): WaRetryOutboundMessageRecord => ({
                 messageId,
                 toJid: resolvedToJid,
-                participantJid: hint.participantJid,
-                recipientJid: hint.recipientJid,
                 eligibleRequesterDeviceJids,
                 deliveredRequesterDeviceJids: [],
-                messageType: hint.type,
                 replayMode,
                 replayPayload,
                 state: 'pending',
-                createdAtMs: nowMs,
                 updatedAtMs,
                 expiresAtMs
             })

--- a/src/retry/types.ts
+++ b/src/retry/types.ts
@@ -79,15 +79,11 @@ export type WaRetryStoredReplayPayload = Uint8Array | WaRetryReplayPayload
 export interface WaRetryOutboundMessageRecord {
     readonly messageId: string
     readonly toJid: string
-    readonly participantJid?: string
-    readonly recipientJid?: string
     readonly eligibleRequesterDeviceJids?: readonly string[]
     readonly deliveredRequesterDeviceJids?: readonly string[]
-    readonly messageType: string
     readonly replayMode: WaRetryOutboundMode
     readonly replayPayload: WaRetryStoredReplayPayload
     readonly state: WaRetryOutboundState
-    readonly createdAtMs: number
     readonly updatedAtMs: number
     readonly expiresAtMs: number
 }

--- a/src/store/contracts/contact.store.ts
+++ b/src/store/contracts/contact.store.ts
@@ -10,7 +10,21 @@ export interface WaStoredContactRecord {
 export interface WaContactStore {
     upsert(record: WaStoredContactRecord): Promise<void>
     upsertBatch(records: readonly WaStoredContactRecord[]): Promise<void>
+    /**
+     * Lookup by jid. Contacts are persisted in LID-canonical form when both
+     * LID and PN are known (one row, `jid=<lid>` + `phoneNumber=<pn>`), so
+     * passing the PN form falls through to {@link getByPhoneNumber} when no
+     * row matches the PN jid directly. Callers do not need to know which
+     * form was used to write the row.
+     */
     getByJid(jid: string): Promise<WaStoredContactRecord | null>
+    /**
+     * Lookup the contact whose `phoneNumber` field equals `pn`. Returns the
+     * LID-canonical row when the cross-reference is known, `null` otherwise.
+     * Used by {@link getByJid} for the PN-fallback path and exposed publicly
+     * for callers that already know the PN form.
+     */
+    getByPhoneNumber(pn: string): Promise<WaStoredContactRecord | null>
     deleteByJid(jid: string): Promise<number>
     clear(): Promise<void>
 }

--- a/src/store/contracts/message.store.ts
+++ b/src/store/contracts/message.store.ts
@@ -5,8 +5,6 @@ export interface WaStoredMessageRecord {
     readonly participantJid?: string
     readonly fromMe: boolean
     readonly timestampMs?: number
-    readonly encType?: string
-    readonly plaintext?: Uint8Array
     readonly messageBytes?: Uint8Array
 }
 

--- a/src/store/locks/contact.lock.ts
+++ b/src/store/locks/contact.lock.ts
@@ -20,6 +20,7 @@ export function withContactLock(store: WaContactStore): WithDestroyLifecycle<WaC
                 )
             ),
         getByJid: (jid) => gate.runShared(() => store.getByJid(jid)),
+        getByPhoneNumber: (pn) => gate.runShared(() => store.getByPhoneNumber(pn)),
         deleteByJid: (jid) =>
             gate.runShared(() => lock.run(`contact:${jid}`, () => store.deleteByJid(jid))),
         clear: () => gate.runExclusive(() => lock.run(WA_CONTACT_CLEAR_KEY, () => store.clear())),

--- a/src/store/memory/__tests__/memory-providers.test.ts
+++ b/src/store/memory/__tests__/memory-providers.test.ts
@@ -72,11 +72,9 @@ test('memory retry/device-list stores expire entries and support cleanup', async
         messageId: 'id-1',
         toJid: 'to',
         eligibleRequesterDeviceJids: ['5511@s.whatsapp.net'],
-        messageType: 'text',
         replayMode: 'plaintext',
         replayPayload,
         state: 'pending',
-        createdAtMs: 1,
         updatedAtMs: 1,
         expiresAtMs: 5
     })

--- a/src/store/memory/contact.store.ts
+++ b/src/store/memory/contact.store.ts
@@ -44,8 +44,16 @@ export class WaContactMemoryStore implements Contract {
     }
 
     private writeRecord(record: WaStoredContactRecord): void {
-        const merged = mergeContactRecords(this.contacts.get(record.jid), record)
+        const previous = this.contacts.get(record.jid)
+        const merged = mergeContactRecords(previous, record)
         setBoundedMapEntry(this.contacts, merged.jid, merged, this.maxContacts)
+        if (
+            previous?.phoneNumber &&
+            previous.phoneNumber !== merged.phoneNumber &&
+            this.phoneIndex.get(previous.phoneNumber) === merged.jid
+        ) {
+            this.phoneIndex.delete(previous.phoneNumber)
+        }
         if (merged.phoneNumber) {
             this.phoneIndex.set(merged.phoneNumber, merged.jid)
         }

--- a/src/store/memory/contact.store.ts
+++ b/src/store/memory/contact.store.ts
@@ -1,3 +1,4 @@
+import { isUserJid } from '@protocol/jid'
 import type {
     WaContactStore as Contract,
     WaStoredContactRecord
@@ -13,8 +14,25 @@ export interface WaContactMemoryStoreOptions {
     readonly maxContacts?: number
 }
 
+function mergeContactRecords(
+    previous: WaStoredContactRecord | undefined,
+    incoming: WaStoredContactRecord
+): WaStoredContactRecord {
+    if (!previous) return incoming
+    return {
+        jid: incoming.jid,
+        displayName: incoming.displayName ?? previous.displayName,
+        pushName: incoming.pushName ?? previous.pushName,
+        lid: incoming.lid ?? previous.lid,
+        phoneNumber: incoming.phoneNumber ?? previous.phoneNumber,
+        lastUpdatedMs: Math.max(previous.lastUpdatedMs, incoming.lastUpdatedMs)
+    }
+}
+
 export class WaContactMemoryStore implements Contract {
     private readonly contacts = new Map<string, WaStoredContactRecord>()
+    /** Secondary index: phone_number -> primary jid (typically the LID form). */
+    private readonly phoneIndex = new Map<string, string>()
     private readonly maxContacts: number
 
     public constructor(options: WaContactMemoryStoreOptions = {}) {
@@ -25,25 +43,55 @@ export class WaContactMemoryStore implements Contract {
         )
     }
 
+    private writeRecord(record: WaStoredContactRecord): void {
+        const merged = mergeContactRecords(this.contacts.get(record.jid), record)
+        setBoundedMapEntry(this.contacts, merged.jid, merged, this.maxContacts)
+        if (merged.phoneNumber) {
+            this.phoneIndex.set(merged.phoneNumber, merged.jid)
+        }
+    }
+
     public async upsert(record: WaStoredContactRecord): Promise<void> {
-        setBoundedMapEntry(this.contacts, record.jid, record, this.maxContacts)
+        this.writeRecord(record)
     }
 
     public async upsertBatch(records: readonly WaStoredContactRecord[]): Promise<void> {
         for (const record of records) {
-            setBoundedMapEntry(this.contacts, record.jid, record, this.maxContacts)
+            this.writeRecord(record)
         }
     }
 
     public async getByJid(jid: string): Promise<WaStoredContactRecord | null> {
+        const direct = this.contacts.get(jid)
+        if (direct) return direct
+        if (isUserJid(jid)) {
+            return this.getByPhoneNumberSync(jid)
+        }
+        return null
+    }
+
+    public async getByPhoneNumber(pn: string): Promise<WaStoredContactRecord | null> {
+        return this.getByPhoneNumberSync(pn)
+    }
+
+    private getByPhoneNumberSync(pn: string): WaStoredContactRecord | null {
+        const jid = this.phoneIndex.get(pn)
+        if (!jid) return null
         return this.contacts.get(jid) ?? null
     }
 
     public async deleteByJid(jid: string): Promise<number> {
-        return this.contacts.delete(jid) ? 1 : 0
+        const existing = this.contacts.get(jid)
+        if (!existing) return 0
+        this.contacts.delete(jid)
+        if (existing.phoneNumber && this.phoneIndex.get(existing.phoneNumber) === jid) {
+            this.phoneIndex.delete(existing.phoneNumber)
+        }
+        return 1
     }
 
     public async clear(): Promise<void> {
         this.contacts.clear()
+        this.phoneIndex.clear()
     }
 }

--- a/src/store/noop.store.ts
+++ b/src/store/noop.store.ts
@@ -60,6 +60,7 @@ export const NOOP_CONTACT_STORE: WaContactStore = Object.freeze({
     upsert: async (_record: WaStoredContactRecord): Promise<void> => {},
     upsertBatch: async (_records: readonly WaStoredContactRecord[]): Promise<void> => {},
     getByJid: async (_jid: string): Promise<WaStoredContactRecord | null> => null,
+    getByPhoneNumber: async (_pn: string): Promise<WaStoredContactRecord | null> => null,
     deleteByJid: async (_jid: string): Promise<number> => 0,
     clear: async (): Promise<void> => {}
 })


### PR DESCRIPTION
Bundle of three independent improvements:

1. LID-canonical contacts + history sync improvements
   - `WaContactStore.getByPhoneNumber` added (contract + memory/sqlite/postgres/mysql/redis/mongo/noop impls).
   - sqlite migration 0014 adds a partial index on `mailbox_contacts.phone_number`.
   - History sync now coalesces PN/LID mappings onto a single LID-canonical contact row (one row, `jid=<lid>` + `phoneNumber=<pn>`) instead of two mirror rows.
   - `HANDLED_SYNC_TYPES` now includes `NON_BLOCKING_DATA`.
   - Stub messages (group system events: add/remove/promote, revokes, ephemeral toggles) are skipped instead of persisted as content-less ghost rows.
   - History sync exposes `onProcessed(syncType)`; `WaClient` wires it to the `hist_sync` receipt so the primary device stops resending the same chunk.

2. Server clock plumbing through message builders
   - `WaMediaMessageOptions` and `WaMessageDispatchCoordinator` accept a `ServerClock`.
   - Outgoing reactions / pins / keeps / link-preview HQ thumbnail timestamps and the edit-timestamp fallback now use server time instead of `Date.now()`, so messages stay consistent with WA's server clock under skew.

3. Drop dead write-only columns from message + retry stores
   - sqlite migrations 0015 + 0016 drop `mailbox_messages.{enc_type,plaintext}` and `retry_outbound_messages.{participant_jid,recipient_jid,message_type,created_at_ms}` + `retry_inbound_counters.updated_at_ms`. None of these were read back; `plaintext` in particular was persisting sensitive bytes with no consumer.
   - Contracts (`WaStoredMessageRecord`, `WaRetryOutboundEntry`), the outbound retry tracker, and every store provider (sqlite/postgres/mysql/redis/mongo/memory) stop writing the removed fields. Newsletter + incoming emitters drop the no-op `encryptionType`/`plaintext` event fields.

BREAKING CHANGE: drops `WaStoredMessageRecord.encType` and `WaStoredMessageRecord.plaintext`; drops `WaRetryOutboundEntry.{type,participantJid,recipientJid,messageType,createdAtMs}`. sqlite users will have the columns auto-dropped by migrations 0015/0016; users on other providers should run equivalent ALTER TABLE drops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phone-number fallback lookup for user JIDs.
  * History-sync processing: broader sync types handled, per-chunk processed callback, and history-sync receipt attempts.

* **Bug Fixes**
  * Skip persisting stub/system messages during history sync.
  * Incoming events no longer expose raw plaintext/encryptionType fields; contact persistence is canonicalized.

* **Chores**
  * Tightened dependency version constraints and simplified stored message/retry payload shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->