### PR TITLE
fix(transport,auth): support hosted devices

### DIFF
--- a/src/auth/pairing/WaPairingFlow.ts
+++ b/src/auth/pairing/WaPairingFlow.ts
@@ -311,7 +311,7 @@ export class WaPairingFlow {
         }
 
         const { signedIdentity, keyIndex, responseIdentityBytes } =
-            await this.buildPairSuccessResponseIdentity(credentials, wrappedDetails, isHosted)
+            await this.buildPairSuccessResponseIdentity(credentials, wrappedDetails)
         const nextCredentials: WaAuthCredentials = {
             ...credentials,
             signedIdentity,
@@ -355,8 +355,7 @@ export class WaPairingFlow {
 
     private async buildPairSuccessResponseIdentity(
         credentials: WaAuthCredentials,
-        wrappedDetails: Uint8Array,
-        isHosted: boolean
+        wrappedDetails: Uint8Array
     ): Promise<{
         readonly signedIdentity: ReturnType<typeof proto.ADVSignedDeviceIdentity.decode>
         readonly keyIndex: number
@@ -373,13 +372,15 @@ export class WaPairingFlow {
             'ADVSignedDeviceIdentity.accountSignatureKey'
         )
         const localIdentity = credentials.registrationInfo.identityKeyPair
+        const advDeviceIdentity = proto.ADVDeviceIdentity.decode(details)
+        const isDeviceHosted = advDeviceIdentity.deviceType === proto.ADVEncryptionType.HOSTED
         if (this.opts.dangerous?.disableAdvSignatureVerification !== true) {
             const validAccountSignature = await verifyDeviceIdentityAccountSignature(
                 details,
                 accountSignature,
                 localIdentity.pubKey,
                 accountSignatureKey,
-                isHosted
+                isDeviceHosted
             )
             if (!validAccountSignature) {
                 this.opts.logger.error('pair-success account signature invalid')
@@ -391,9 +392,8 @@ export class WaPairingFlow {
             details,
             localIdentity,
             accountSignatureKey,
-            isHosted
+            false
         )
-        const advDeviceIdentity = proto.ADVDeviceIdentity.decode(details)
         const responseIdentityBytes = proto.ADVSignedDeviceIdentity.encode({
             details: signedIdentity.details,
             accountSignature: signedIdentity.accountSignature,

--- a/src/transport/binary/constants.ts
+++ b/src/transport/binary/constants.ts
@@ -16,6 +16,13 @@ export const BINARY_20 = 253
 export const BINARY_32 = 254
 export const NIBBLE_8 = 255
 
+export const JID_U_DOMAIN_TYPE_PN = 0x00
+export const JID_U_DOMAIN_TYPE_LID = 0x01
+export const JID_U_DOMAIN_TYPE_HOSTED = 0x80
+export const JID_U_DOMAIN_TYPE_HOSTED_LID = 0x81
+export const JID_U_DOMAIN_TYPE_HOSTED_MASK = 0x80
+export const JID_U_DOMAIN_TYPE_LID_MASK = 0x01
+
 export const NIBBLE_ALPHABET = Object.freeze([
     '0',
     '1',

--- a/src/transport/binary/decoder.ts
+++ b/src/transport/binary/decoder.ts
@@ -14,6 +14,10 @@ import {
     JID_INTEROP,
     JID_PAIR,
     JID_U,
+    JID_U_DOMAIN_TYPE_HOSTED_LID,
+    JID_U_DOMAIN_TYPE_HOSTED_MASK,
+    JID_U_DOMAIN_TYPE_LID,
+    JID_U_DOMAIN_TYPE_LID_MASK,
     LIST_16,
     LIST_8,
     LIST_EMPTY,
@@ -27,10 +31,6 @@ import { TEXT_DECODER, TEXT_ENCODER, toBytesView } from '@util/bytes'
 
 const unzipAsync = promisify(unzip)
 const inflateRawAsync = promisify(inflateRaw)
-const JID_U_DOMAIN_TYPE_LID = 0x01
-const JID_U_DOMAIN_TYPE_HOSTED_LID = 0x81
-const JID_U_DOMAIN_TYPE_HOSTED_MASK = 0x80
-const JID_U_DOMAIN_TYPE_LID_MASK = 0x01
 
 class ByteReader {
     private readonly data: Uint8Array

--- a/src/transport/binary/encoder.ts
+++ b/src/transport/binary/encoder.ts
@@ -1,3 +1,4 @@
+import { WA_DEFAULTS } from '@protocol/constants'
 import {
     BINARY_20,
     BINARY_32,
@@ -5,8 +6,15 @@ import {
     DICTIONARY_0,
     DICTIONARY_TOKEN_MAPS,
     HEX_8,
+    JID_PAIR,
+    JID_U,
+    JID_U_DOMAIN_TYPE_HOSTED,
+    JID_U_DOMAIN_TYPE_HOSTED_LID,
+    JID_U_DOMAIN_TYPE_LID,
+    JID_U_DOMAIN_TYPE_PN,
     LIST_16,
     LIST_8,
+    LIST_EMPTY,
     NIBBLE_8,
     SINGLE_BYTE_TOKEN_MAP
 } from '@transport/binary/constants'
@@ -192,6 +200,65 @@ function writeString(value: string, writer: ByteWriter): void {
     writer.writeBytes(encoded)
 }
 
+function tryWriteJid(value: string, writer: ByteWriter): boolean {
+    const atIndex = value.indexOf('@')
+    if (atIndex <= 0 || atIndex === value.length - 1) {
+        return false
+    }
+    if (value.indexOf('@', atIndex + 1) !== -1) {
+        return false
+    }
+
+    let userEnd = atIndex
+    let device = 0
+    const colonIndex = value.indexOf(':')
+    if (colonIndex !== -1 && colonIndex < atIndex) {
+        if (colonIndex === atIndex - 1) {
+            return false
+        }
+        for (let i = colonIndex + 1; i < atIndex; i += 1) {
+            const digit = value.charCodeAt(i) - 48
+            if (digit < 0 || digit > 9) {
+                return false
+            }
+            device = device * 10 + digit
+            if (device > 255) {
+                return false
+            }
+        }
+        userEnd = colonIndex
+    }
+
+    const server = value.slice(atIndex + 1)
+    let domainType = -1
+    if (server === WA_DEFAULTS.LID_SERVER) {
+        domainType = JID_U_DOMAIN_TYPE_LID
+    } else if (server === WA_DEFAULTS.HOSTED_LID_SERVER) {
+        domainType = JID_U_DOMAIN_TYPE_HOSTED_LID
+    } else if (server === WA_DEFAULTS.HOST_DOMAIN) {
+        domainType = JID_U_DOMAIN_TYPE_PN
+    } else if (server === WA_DEFAULTS.HOSTED_SERVER) {
+        domainType = JID_U_DOMAIN_TYPE_HOSTED
+    }
+
+    if (domainType !== -1 && device !== 0 && userEnd > 0) {
+        writer.writeUint8(JID_U)
+        writer.writeUint8(domainType)
+        writer.writeUint8(device)
+        writeString(value.slice(0, userEnd), writer)
+        return true
+    }
+
+    writer.writeUint8(JID_PAIR)
+    if (userEnd === 0) {
+        writer.writeUint8(LIST_EMPTY)
+    } else {
+        writeString(value.slice(0, userEnd), writer)
+    }
+    writeString(server, writer)
+    return true
+}
+
 function writeListSize(size: number, writer: ByteWriter): void {
     if (!Number.isSafeInteger(size) || size < 0) {
         throw new Error(`invalid list size ${size}`)
@@ -220,7 +287,10 @@ function writeNodeInternal(node: BinaryNode, writer: ByteWriter): void {
     for (let i = 0; i < keys.length; i += 1) {
         const key = keys[i]
         writeString(key, writer)
-        writeString(node.attrs[key], writer)
+        const value = node.attrs[key]
+        if (!tryWriteJid(value, writer)) {
+            writeString(value, writer)
+        }
     }
 
     if (!hasContent) {


### PR DESCRIPTION
Encoder previously serialized every attribute value as a packed string, which the server silently dropped for hosted JIDs (`:99@hosted.lid`): prekey IQs and message participants addressed to hosted devices never reached them. Detect JID-shaped attrs and emit JID_U / JID_PAIR packed tokens matching the wa-web wire format. JID_U domain-type constants are shared between encoder and decoder via constants.ts.

Pair-success derived isHosted from the HMAC envelope's accountType, which is E2EE for the common coex pairing flow even when the device itself is hosted. The server signs the account signature using the prefix dictated by the inner ADVDeviceIdentity deviceType, so the verification was using the wrong prefix and rejecting valid hosted / coex pair-success stanzas. Decode the inner identity first and derive isHosted from deviceType.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized binary encoding and decoding of user identifiers for improved efficiency.
  * Restructured authentication credential derivation during device pairing to consolidate logic and enhance maintainability.
  * Centralized identifier domain type constants for consistency across binary transport operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vinikjkkj/zapo/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->