### PR TITLE
feat(infra,store,media): structured logging overhaul

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,11 +261,101 @@ try {
 
 ### 5.7 Logging
 
-- Use structured logs: message + context object.
-- Keep log messages lowercase and descriptive.
+The `Logger` interface lives in `@infra/log/types` with 5 levels (trace,
+debug, info, warn, error), a `(message, context?)` signature, and a
+`child(bindings)` method that returns a derived logger with pre-bound
+fields. Adapters: `ConsoleLogger` (zero-dep default) and `PinoLogger`
+(optional pino-backed).
+
+#### General rules
+
+- Use structured logs: lowercase static message + context object. Never
+  interpolate variables into the message string (`'failed to send'` +
+  `{ kind }`, **not** `` `failed to send ${kind}` ``). String interpolation
+  in the message breaks log-aggregator deduplication.
+- Use `toError(e).message` in catches; never log the raw error or stack.
 - Log IDs/tags/sizes/durations when relevant.
 - Never log key material, secret values, or raw sensitive payload bytes.
-- Avoid `console.log` in runtime source (`src/`), except explicit example/test contexts.
+  `keyId` rendered as hex (`bytesToHex(...)`) is public and safe.
+- Avoid `console.log` in runtime source (`src/`), except explicit example
+  or test contexts.
+
+#### Level rubric
+
+Apply these semantics consistently; mis-leveling makes `level: debug`
+unusable in staging because hot paths drown the operator.
+
+| Level | Meaning                                                         | Examples                                                                                              |
+| ----- | --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| error | invariant violation / non-recoverable failure (rare)            | noise handshake failed, MAC validation failed, pending-frame buffer overflow, primary recipient drop  |
+| warn  | abnormal but auto-handled (fallback / retry / degraded path)    | socket open failed (will retry), ack mismatch triggering refetch, fanout dropping secondary devices   |
+| info  | lifecycle boundary, once per long-lived event                   | `wa client connected`, `pair-success credentials updated`, `noise session established`, prekey upload |
+| debug | per-operation internals for active troubleshooting              | per-send envelope build, per-retry-request rejection, sync key request response                       |
+| trace | per-frame / per-iteration / hot path; only with explicit filter | per-incoming-stanza ack/receipt, per-frame noise codec calls, filter-dropped stanzas                  |
+
+Concrete rules that fall out of this:
+
+- **Per-message / per-frame / per-send logs must never exceed `trace`.**
+  In a high-volume account, anything at `debug` here will drown the log.
+- **Auto-recovered fallback paths are `debug`, not `warn`.** Warn is for
+  things the operator should actually see at default level.
+- **`info` is for operator-visible lifecycle events**, not for narration of
+  what a method is doing. `'X started'` / `'X finished'` pairs around
+  routine syncs belong at `debug`.
+- **Aggregate per-target failures in batch operations.** A per-device
+  warn in fanout fires N times per group send. Collect into a single warn
+  with `{ droppedCount, totalExpected, sample: jids.slice(0, 3) }` after
+  the loop.
+
+#### Use `child(bindings)` for repeated context
+
+When a function emits 3+ logs that all carry the same field (`jid`, `id`,
+`from`, `requester`, etc.), bind it once with `logger.child({ ... })` and
+drop the field from every per-call context object. Bindings stack;
+per-call context wins on key conflicts.
+
+```ts
+const requesterLogger = this.deps.logger.child({
+    id: request.stanzaId,
+    originalMsgId: request.originalMsgId,
+    requester: requesterJid
+})
+requesterLogger.debug('retry request rejected: retry count exceeded', {
+    remoteRetryCount: request.retryCount
+})
+```
+
+Current adopters worth modeling after:
+`signal/session/resolver.ts` (`{ jid }`),
+`client/coordinators/WaRetryCoordinator.ts` (`{ id, originalMsgId, requester }`),
+`appstate/sync/WaAppStateSyncClient.ts` (`{ id, from }`).
+
+#### Optional packages: receive the logger via per-call `ctx`, never a callback or a mutable slot
+
+Optional packages (`@zapo-js/media-utils`, future store/transport addons)
+that need to emit warnings must NOT accept a logging callback in their
+options, and must NOT keep a mutable logger slot the caller has to wire
+up. Instead, accept the logger via a per-call context arg on each method
+of the contract:
+
+```ts
+export interface WaSomeProcessorCallContext {
+    readonly logger?: Logger
+}
+
+export interface WaSomeProcessor {
+    readonly doSomething?: (input: Input, ctx?: WaSomeProcessorCallContext) => Promise<Result>
+    // ...rest of the contract
+}
+```
+
+The runtime fills `ctx.logger` with the relevant child logger (typically
+`callerLogger.child({ scope: '@zapo-js/<name>' })`) on every call. This
+keeps the package implementation **stateless**, so a single instance is
+safe to share across multiple `WaClient` sessions - each invocation
+lands its warnings in the right session log without any per-session
+plumbing. Canonical example: `WaMediaProcessor` in
+`src/media/processor.ts` + `packages/media-utils/src/index.ts`.
 
 ### 5.8 Sensitive types
 
@@ -534,7 +624,7 @@ Use flow tests for auth/transport/signal/retry changes that need real protocol v
 
 Do not redefine common fixtures inline. Shared helpers live in `@infra/log/types`:
 
-- `createNoopLogger(level?)` – silent `Logger` for tests. Use instead of redefining a local `function createLogger(): Logger { return { level: 'trace', trace: () => undefined, ... } }`.
+- `createNoopLogger(level?)` – silent `Logger` for tests. Use instead of redefining a local `function createLogger(): Logger { return { level: 'trace', trace: () => undefined, child: () => ... } }`. Also re-exported from the public root (`'zapo-js'`) so optional packages can import it the same way.
 
 Add new shared test-only helpers to a sibling `__tests__/_helpers.ts` only when reused across 3+ files.
 
@@ -570,10 +660,12 @@ PR comment script (`scripts/build-bench-comment.cjs`) consumes:
 - `Buffer` usage in runtime modules
 - silent catches without logs/context
 - secret leakage in logs
+- per-message / per-frame / per-send logs above `trace` level (§5.7). In high-volume accounts, a per-send `debug` drowns the log and makes `level: debug` unusable in staging.
 - duplicate protocol parsing/building across modules when a shared helper is appropriate
 - monolithic coordinators doing build + parse + orchestration inline without separation
 - `uint8Equal()` / `===` for MAC/signature comparison instead of `uint8TimingSafeEqual()` (§7.5)
 - allocating a fixed-size buffer (e.g. AES nonce) per call in a hot path instead of using a per-instance scratch (§7.6)
+- accepting a logging callback (`onWarning`, `onLog`, ...) or a mutable `bindLogger(logger)` slot in an optional package's options instead of the per-call `ctx.logger` contract (§5.7). Callbacks lose level/structure; a mutable slot breaks when one processor is shared across multiple `WaClient` sessions (last-write-wins on the slot).
 
 ### Frequent review nits
 
@@ -585,6 +677,11 @@ PR comment script (`scripts/build-bench-comment.cjs`) consumes:
 - applying perf "optimizations" (`.slice()` → loop, `+=` → array+join, batched lookup over linear scan) without a benchmark proving the gain – V8 often beats the rewrite (§7.7)
 - deleting an export flagged by `knip`/`ts-prune` without verifying internal usage (default parameter values, same-file consumers, dynamic-import-only consumers, type-only imports)
 - redefining `function createLogger(): Logger { return { level: 'trace', ... } }` in test files instead of importing `createNoopLogger` from `@infra/log/types` (§9.2.1)
+- using `warn` for an auto-recovered fallback / retry path (§5.7). Warn is for things the operator should see at default level; auto-recovered paths are `debug`.
+- using `info` to narrate routine method internals (`'X start'` / `'X finished'` pairs around a sync). Info is reserved for once-per-lifecycle events.
+- string interpolation in the log message itself (`` `failed to send ${kind}` ``) instead of the context object (`'failed to send'` + `{ kind }`) (§5.7). Breaks log aggregator dedup.
+- emitting per-target `warn` in a loop over devices/jids in batch operations instead of aggregating after the loop with `{ droppedCount, totalExpected, sample: jids.slice(0, 3) }` (§5.7).
+- repeating the same field (`jid`, `id`, `requester`) in every log call inside a function with 3+ logs instead of binding it once via `logger.child({ ... })` (§5.7).
 - citing this guide (`AGENTS.md §N`, `see AGENTS`) in source comments, JSDoc, or commit messages. This guide is the contract for contributors, not runtime documentation. Section numbers and headings rot when the guide is reorganized, leaving stale pointers in source. Comments must stand on their own – explain _why_ the code is the way it is in plain language; if a rule needs the guide to be understood, restate the rule briefly in the comment.
 
 ---

--- a/packages/fake-server/bench/_common.ts
+++ b/packages/fake-server/bench/_common.ts
@@ -68,7 +68,7 @@ export function forceGcIfAvailable(): void {
     if (gc) gc()
 }
 
-export const NOOP_LOGGER: Logger = {
+const benchLogger: Logger = {
     level: 'error',
     trace: () => {},
     debug: () => {},
@@ -78,8 +78,10 @@ export const NOOP_LOGGER: Logger = {
     },
     error: (...args: unknown[]) => {
         if (process.env.ZAPO_BENCH_VERBOSE) console.error('[lib error]', ...args)
-    }
+    },
+    child: () => benchLogger
 }
+export const NOOP_LOGGER: Logger = benchLogger
 
 // ─── Profiler ─────────────────────────────────────────────────────────
 

--- a/packages/fake-server/bench/messaging.bench.ts
+++ b/packages/fake-server/bench/messaging.bench.ts
@@ -98,7 +98,7 @@ function forceGcIfAvailable(): void {
     if (gc) gc()
 }
 
-const NOOP_LOGGER: Logger = {
+const benchLogger: Logger = {
     level: 'error',
     trace: () => {},
     debug: () => {},
@@ -108,8 +108,10 @@ const NOOP_LOGGER: Logger = {
     },
     error: (...args: unknown[]) => {
         if (process.env.ZAPO_BENCH_VERBOSE) console.error('[lib error]', ...args)
-    }
+    },
+    child: () => benchLogger
 }
+const NOOP_LOGGER: Logger = benchLogger
 
 // ─── Profiler ─────────────────────────────────────────────────────────
 

--- a/packages/fake-server/src/__tests__/helpers/zapo-client.ts
+++ b/packages/fake-server/src/__tests__/helpers/zapo-client.ts
@@ -1,13 +1,6 @@
-import { createStore, type Logger, WaClient } from 'zapo-js'
+import { createNoopLogger, createStore, type Logger, WaClient } from 'zapo-js'
 
-const NOOP_LOGGER: Logger = {
-    level: 'error',
-    trace: () => {},
-    debug: () => {},
-    info: () => {},
-    warn: () => {},
-    error: () => {}
-}
+const NOOP_LOGGER: Logger = createNoopLogger('error')
 
 import type { FakeWaServer } from '../../api/FakeWaServer'
 

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -42,6 +42,43 @@ export interface LogEntry {
  *   - a bounded in-memory ring buffer queryable via the `logs` MCP tool
  *   - an optional append-only file (controlled by MCP_LOG_FILE)
  */
+class BoundLogger implements Logger {
+    public readonly level: LogLevel
+    private readonly parent: Logger
+    private readonly bindings: Readonly<Record<string, unknown>>
+
+    public constructor(parent: Logger, bindings: Readonly<Record<string, unknown>>) {
+        this.parent = parent
+        this.level = parent.level
+        this.bindings = bindings
+    }
+
+    public trace(message: string, context?: Readonly<Record<string, unknown>>): void {
+        this.parent.trace(message, this.merge(context))
+    }
+    public debug(message: string, context?: Readonly<Record<string, unknown>>): void {
+        this.parent.debug(message, this.merge(context))
+    }
+    public info(message: string, context?: Readonly<Record<string, unknown>>): void {
+        this.parent.info(message, this.merge(context))
+    }
+    public warn(message: string, context?: Readonly<Record<string, unknown>>): void {
+        this.parent.warn(message, this.merge(context))
+    }
+    public error(message: string, context?: Readonly<Record<string, unknown>>): void {
+        this.parent.error(message, this.merge(context))
+    }
+    public child(bindings: Readonly<Record<string, unknown>>): Logger {
+        return new BoundLogger(this.parent, { ...this.bindings, ...bindings })
+    }
+
+    private merge(
+        context: Readonly<Record<string, unknown>> | undefined
+    ): Readonly<Record<string, unknown>> {
+        return context ? { ...this.bindings, ...context } : this.bindings
+    }
+}
+
 class BufferedTeeLogger implements Logger {
     public readonly level: LogLevel
     private readonly minPriority: number
@@ -89,6 +126,9 @@ class BufferedTeeLogger implements Logger {
     }
     public error(message: string, context?: Record<string, unknown>): void {
         this.write('error', message, context)
+    }
+    public child(bindings: Readonly<Record<string, unknown>>): Logger {
+        return new BoundLogger(this, { ...bindings })
     }
 
     public listLogs(
@@ -630,9 +670,7 @@ export class McpRuntime {
                 nodeQueryTimeoutMs: 30_000,
                 chatSocketUrls: this.config.chatSocketUrls,
                 media: {
-                    processor: createMediaProcessor({
-                        onWarning: (message) => sessionLogger.warn(message)
-                    })
+                    processor: createMediaProcessor()
                 },
                 testHooks: this.config.noiseRootCa
                     ? { noiseRootCa: this.config.noiseRootCa }
@@ -650,22 +688,12 @@ export class McpRuntime {
     }
 
     /**
-     * Wrap the shared logger so every line a session's `WaClient` emits is
-     * tagged with `context.session`. Lets the `logs` tool scope by session
-     * while keeping a single ring buffer (and a single optional log file).
+     * Returns a logger that tags every line with `context.session`. Lets
+     * the `logs` tool scope by session while keeping a single ring buffer
+     * (and a single optional log file).
      */
     private createSessionLogger(sessionId: string): Logger {
-        const base = this.logger
-        const tag = (context?: Record<string, unknown>): Record<string, unknown> =>
-            context ? { ...context, session: sessionId } : { session: sessionId }
-        return {
-            level: base.level,
-            trace: (message, context) => base.trace(message, tag(context)),
-            debug: (message, context) => base.debug(message, tag(context)),
-            info: (message, context) => base.info(message, tag(context)),
-            warn: (message, context) => base.warn(message, tag(context)),
-            error: (message, context) => base.error(message, tag(context))
-        }
+        return this.logger.child({ session: sessionId })
     }
 
     public getClient(session?: string): WaClient | null {

--- a/packages/media-utils/README.md
+++ b/packages/media-utils/README.md
@@ -84,9 +84,9 @@ RUN apk add --no-cache ffmpeg
 ```
 
 Confirm `ffmpeg -version` and `ffprobe -version` resolve before starting your
-app. The processor is non-fatal on missing binaries (calls `onWarning`
-instead of throwing), so a misconfigured deploy degrades to "no thumbnails /
-no waveform" instead of crashing.
+app. The processor is non-fatal on missing binaries (emits a `warn` through
+the per-call logger context instead of throwing), so a misconfigured deploy
+degrades to "no thumbnails / no waveform" instead of crashing.
 
 ## Quick start
 
@@ -94,14 +94,15 @@ no waveform" instead of crashing.
 import { WaClient } from 'zapo-js'
 import { createMediaProcessor } from '@zapo-js/media-utils'
 
+// One processor can be shared across many WaClient sessions. The runtime
+// passes a per-call `ctx.logger` to each method so warnings always land
+// in the right session log without any per-session setup.
+const processor = createMediaProcessor()
+
 const client = new WaClient({
     store,
     sessionId: 'default',
-    media: {
-        processor: createMediaProcessor({
-            onWarning: (msg) => console.warn('[media]', msg)
-        })
-    }
+    media: { processor }
 })
 
 // Now sending a video produces a real thumbnail + correct duration/dimensions:
@@ -117,18 +118,25 @@ await client.message.send(jid, {
 
 `createMediaProcessor(options)` accepts:
 
-| Field                                                               | Description                                                           |
-| ------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `ffmpegPath` / `ffprobePath`                                        | Override binary paths (default: resolved from `PATH`).                |
-| `imageThumbMaxEdge`                                                 | Override the per-call `maxEdge` for image/video thumbnails.           |
-| `imageThumbQuality`                                                 | JPEG quality (1-100) for image thumbnails.                            |
-| `waveformPoints`                                                    | Number of waveform points for voice notes (WA default: 64).           |
-| `voiceNoteBitRate` / `voiceNoteSampleRate` / `voiceNoteApplication` | Opus encoding params for voice-note normalization.                    |
-| `onWarning`                                                         | Callback for non-fatal warnings (missing binary, probe failure, ...). |
+| Field                                                               | Description                                                 |
+| ------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `ffmpegPath` / `ffprobePath`                                        | Override binary paths (default: resolved from `PATH`).      |
+| `imageThumbMaxEdge`                                                 | Override the per-call `maxEdge` for image/video thumbnails. |
+| `imageThumbQuality`                                                 | JPEG quality (1-100) for image thumbnails.                  |
+| `waveformPoints`                                                    | Number of waveform points for voice notes (WA default: 64). |
+| `voiceNoteBitRate` / `voiceNoteSampleRate` / `voiceNoteApplication` | Opus encoding params for voice-note normalization.          |
+
+Logging is wired automatically when the processor is invoked from a
+`WaClient`: every method receives a per-call `ctx: { logger?: Logger }`
+the runtime fills in with that session's logger (carrying its
+`{ session, scope: 'media-utils' }` bindings). No callback to plumb, no
+mutable state on the processor - so a single `createMediaProcessor()`
+result is safe to share across multiple `WaClient` instances. When used
+standalone (no `ctx`), the processor stays silent.
 
 ## Notes
 
-- **Missing binaries are non-fatal.** If `ffmpeg`/`ffprobe` isn't installed, the affected operation is skipped and `onWarning` fires - the rest of the media path still works. This means you can ship the processor as a soft dependency.
+- **Missing binaries are non-fatal.** If `ffmpeg`/`ffprobe` isn't installed, the affected operation is skipped and a `warn` is emitted through the per-call logger context - the rest of the media path still works. This means you can ship the processor as a soft dependency.
 - The thumbnail / waveform code paths follow what the official client produces - sticker first-frame extraction matches WhatsApp's expected layout, waveforms render natively on iOS/Android/desktop.
 - Voice-note normalization is needed because WhatsApp only renders Opus 16k mono in the chat UI - other formats play but lose the waveform.
 

--- a/packages/media-utils/src/ffmpeg.ts
+++ b/packages/media-utils/src/ffmpeg.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 
+import type { Logger } from 'zapo-js'
 import type {
     WaMediaProcessorImageResult,
     WaMediaProcessorInput,
@@ -14,8 +15,6 @@ import type {
 } from 'zapo-js/media'
 
 import { generateImageThumbnail } from './sharp'
-
-export type FfmpegWarnFn = (message: string) => void
 
 const WAVEFORM_POINTS = 64
 const WAVEFORM_MIN_POINTS = 64
@@ -35,15 +34,18 @@ function which(bin: string): Promise<boolean> {
 const binCache = new Map<string, boolean>()
 const warnedBins = new Set<string>()
 
-async function hasBin(path: string, label: string, warn?: FfmpegWarnFn): Promise<boolean> {
+async function hasBin(path: string, label: string, logger?: Logger): Promise<boolean> {
     let available = binCache.get(path)
     if (available === undefined) {
         available = await which(path)
         binCache.set(path, available)
     }
-    if (!available && warn && !warnedBins.has(path)) {
+    if (!available && logger && !warnedBins.has(path)) {
         warnedBins.add(path)
-        warn(`${label} not found at '${path}', related processing will be skipped`)
+        logger.warn('media-utils binary not found, related processing will be skipped', {
+            binary: label,
+            path
+        })
     }
     return available
 }
@@ -51,10 +53,10 @@ async function hasBin(path: string, label: string, warn?: FfmpegWarnFn): Promise
 export async function probeWithFfmpeg(
     input: WaMediaProcessorInput,
     ffprobePath?: string,
-    warn?: FfmpegWarnFn
+    logger?: Logger
 ): Promise<WaMediaProcessorProbeResult | null> {
     const bin = ffprobePath ?? 'ffprobe'
-    if (!(await hasBin(bin, 'ffprobe', warn))) return null
+    if (!(await hasBin(bin, 'ffprobe', logger))) return null
 
     let filePath: string
     let needsCleanup: boolean
@@ -141,10 +143,10 @@ export async function generateVideoThumbnailWithFfmpeg(
     input: WaMediaProcessorInput,
     maxEdge: number,
     ffmpegPath?: string,
-    warn?: FfmpegWarnFn
+    logger?: Logger
 ): Promise<WaMediaProcessorImageResult | null> {
     const bin = ffmpegPath ?? 'ffmpeg'
-    if (!(await hasBin(bin, 'ffmpeg', warn))) return null
+    if (!(await hasBin(bin, 'ffmpeg', logger))) return null
 
     let filePath: string
     let needsCleanup: boolean
@@ -186,10 +188,10 @@ export async function computeWaveformWithFfmpeg(
     input: WaMediaProcessorInput,
     ffmpegPath?: string,
     points?: number,
-    warn?: FfmpegWarnFn
+    logger?: Logger
 ): Promise<WaMediaProcessorWaveformResult | null> {
     const bin = ffmpegPath ?? 'ffmpeg'
-    if (!(await hasBin(bin, 'ffmpeg', warn))) return null
+    if (!(await hasBin(bin, 'ffmpeg', logger))) return null
 
     const useFile = typeof input === 'string'
     const args = [
@@ -304,7 +306,7 @@ export interface NormalizeVoiceNoteOptions {
     readonly sampleRate?: number
     readonly application?: 'voip' | 'audio'
     readonly ffmpegPath?: string
-    readonly onWarning?: FfmpegWarnFn
+    readonly logger?: Logger
 }
 
 const VOICE_NOTE_DEFAULT_BITRATE = 64_000
@@ -316,7 +318,7 @@ export async function normalizeVoiceNoteWithFfmpeg(
     options: NormalizeVoiceNoteOptions = {}
 ): Promise<Readable | null> {
     const bin = options.ffmpegPath ?? 'ffmpeg'
-    if (!(await hasBin(bin, 'ffmpeg', options.onWarning))) return null
+    if (!(await hasBin(bin, 'ffmpeg', options.logger))) return null
 
     const useFile = typeof input === 'string'
     const bitRate = options.bitRate ?? VOICE_NOTE_DEFAULT_BITRATE

--- a/packages/media-utils/src/ffmpeg.ts
+++ b/packages/media-utils/src/ffmpeg.ts
@@ -32,7 +32,12 @@ function which(bin: string): Promise<boolean> {
 }
 
 const binCache = new Map<string, boolean>()
-const warnedBins = new Set<string>()
+
+// Per-logger dedup: each Logger instance warns at most once per missing binary
+// path. The previous module-scoped Set warned only the first session in the
+// process to call hasBin, which silently hid the issue from every other
+// session that shares the same stateless processor.
+const warnedBinsByLogger = new WeakMap<Logger, Set<string>>()
 
 async function hasBin(path: string, label: string, logger?: Logger): Promise<boolean> {
     let available = binCache.get(path)
@@ -40,12 +45,19 @@ async function hasBin(path: string, label: string, logger?: Logger): Promise<boo
         available = await which(path)
         binCache.set(path, available)
     }
-    if (!available && logger && !warnedBins.has(path)) {
-        warnedBins.add(path)
-        logger.warn('media-utils binary not found, related processing will be skipped', {
-            binary: label,
-            path
-        })
+    if (!available && logger) {
+        let warned = warnedBinsByLogger.get(logger)
+        if (!warned) {
+            warned = new Set()
+            warnedBinsByLogger.set(logger, warned)
+        }
+        if (!warned.has(path)) {
+            warned.add(path)
+            logger.warn('media-utils binary not found, related processing will be skipped', {
+                binary: label,
+                path
+            })
+        }
     }
     return available
 }

--- a/packages/media-utils/src/index.ts
+++ b/packages/media-utils/src/index.ts
@@ -1,4 +1,8 @@
-import type { WaMediaProcessor, WaMediaProcessorInput } from 'zapo-js/media'
+import type {
+    WaMediaProcessor,
+    WaMediaProcessorCallContext,
+    WaMediaProcessorInput
+} from 'zapo-js/media'
 import { toError } from 'zapo-js/util'
 
 import {
@@ -20,28 +24,28 @@ export type { WaMediaProcessorOptions } from './types'
  * waveform generation on outgoing media.
  *
  * Missing binaries are non-fatal: `ffmpeg`/`ffprobe` absence skips the
- * affected operation and forwards a `onWarning` message instead of
- * throwing.
+ * affected operation and emits a `warn` through `ctx.logger` (when set).
+ *
+ * Logging is wired automatically: each `WaClient` passes its own
+ * `Logger` via the per-call `ctx` argument the runtime fills in. The
+ * processor itself is **stateless with respect to logging**, so a single
+ * processor instance can be safely shared across multiple `WaClient`
+ * sessions - each invocation lands its warnings in the right session
+ * logger (with the right `{ session }` binding).
  *
  * @example
  * ```ts
  * import { WaClient } from 'zapo-js'
  * import { createMediaProcessor } from '@zapo-js/media-utils'
  *
- * const client = new WaClient({
- *     store,
- *     sessionId: 'default',
- *     media: {
- *         processor: createMediaProcessor({
- *             onWarning: (msg) => console.warn('[media]', msg)
- *         })
- *     }
- * })
+ * // One processor, multiple sessions - safe.
+ * const processor = createMediaProcessor()
+ * const a = new WaClient({ store, sessionId: 'a', media: { processor } })
+ * const b = new WaClient({ store, sessionId: 'b', media: { processor } })
  * ```
  */
 export function createMediaProcessor(options?: WaMediaProcessorOptions): WaMediaProcessor {
     const opts = options ?? {}
-    const warn = opts.onWarning
 
     return {
         async generateImageThumbnail(input: WaMediaProcessorInput, maxEdge: number) {
@@ -52,30 +56,39 @@ export function createMediaProcessor(options?: WaMediaProcessorOptions): WaMedia
             )
         },
 
-        async generateVideoThumbnail(input: WaMediaProcessorInput, maxEdge: number) {
+        async generateVideoThumbnail(
+            input: WaMediaProcessorInput,
+            maxEdge: number,
+            ctx?: WaMediaProcessorCallContext
+        ) {
             return generateVideoThumbnailWithFfmpeg(
                 input,
                 opts.imageThumbMaxEdge ?? maxEdge,
                 opts.ffmpegPath,
-                warn
+                ctx?.logger
             )
         },
 
-        async probeMedia(input: WaMediaProcessorInput) {
-            return (await probeWithFfmpeg(input, opts.ffprobePath, warn)) ?? {}
+        async probeMedia(input: WaMediaProcessorInput, ctx?: WaMediaProcessorCallContext) {
+            return (await probeWithFfmpeg(input, opts.ffprobePath, ctx?.logger)) ?? {}
         },
 
-        async computeWaveform(input: WaMediaProcessorInput) {
-            return computeWaveformWithFfmpeg(input, opts.ffmpegPath, opts.waveformPoints, warn)
+        async computeWaveform(input: WaMediaProcessorInput, ctx?: WaMediaProcessorCallContext) {
+            return computeWaveformWithFfmpeg(
+                input,
+                opts.ffmpegPath,
+                opts.waveformPoints,
+                ctx?.logger
+            )
         },
 
-        async normalizeVoiceNote(input: WaMediaProcessorInput) {
+        async normalizeVoiceNote(input: WaMediaProcessorInput, ctx?: WaMediaProcessorCallContext) {
             return normalizeVoiceNoteWithFfmpeg(input, {
                 bitRate: opts.voiceNoteBitRate,
                 sampleRate: opts.voiceNoteSampleRate,
                 application: opts.voiceNoteApplication,
                 ffmpegPath: opts.ffmpegPath,
-                onWarning: warn
+                logger: ctx?.logger
             })
         },
 
@@ -83,7 +96,7 @@ export function createMediaProcessor(options?: WaMediaProcessorOptions): WaMedia
             return generateStickerThumbnail(input, maxEdge)
         },
 
-        async detectMimetype(input: string | Uint8Array) {
+        async detectMimetype(input: string | Uint8Array, ctx?: WaMediaProcessorCallContext) {
             try {
                 const fileType = await import('file-type')
                 const result =
@@ -92,7 +105,9 @@ export function createMediaProcessor(options?: WaMediaProcessorOptions): WaMedia
                         : await fileType.fileTypeFromBuffer(input)
                 return result?.mime ?? null
             } catch (error) {
-                warn?.(`detectMimetype failed: ${toError(error).message}`)
+                ctx?.logger?.warn('detectMimetype failed', {
+                    message: toError(error).message
+                })
                 return null
             }
         }

--- a/packages/media-utils/src/types.ts
+++ b/packages/media-utils/src/types.ts
@@ -1,6 +1,13 @@
 /**
  * Tuning knobs for the {@link createMediaProcessor} factory. Every field
  * is optional; defaults match what the official WhatsApp clients produce.
+ *
+ * For logging, this package does not accept a callback. The runtime
+ * passes a `Logger` per call via the `ctx` argument the
+ * `WaMediaProcessor` methods receive, so all warnings flow into the same
+ * `Logger` the rest of the runtime uses - including any per-session
+ * bindings the caller has attached. Without a runtime-supplied `ctx`,
+ * the processor stays silent.
  */
 export interface WaMediaProcessorOptions {
     /**
@@ -31,10 +38,4 @@ export interface WaMediaProcessorOptions {
     readonly voiceNoteSampleRate?: number
     /** Opus `application` flag - `'voip'` favors speech, `'audio'` favors general audio. */
     readonly voiceNoteApplication?: 'voip' | 'audio'
-    /**
-     * Callback for non-fatal warnings (missing ffmpeg/ffprobe, probe
-     * field coercion failures, etc.). The processor never throws on
-     * missing binaries - it skips the feature and forwards a warning.
-     */
-    readonly onWarning?: (message: string) => void
 }

--- a/packages/store-mongo/src/BaseMongoStore.ts
+++ b/packages/store-mongo/src/BaseMongoStore.ts
@@ -1,12 +1,17 @@
 import type { ClientSession, Collection, Db, Document } from 'mongodb'
+import type { Logger } from 'zapo-js'
 
 import { assertSafeCollectionPrefix } from './helpers'
 import type { WaMongoStorageOptions } from './types'
+
+const DEFAULT_SLOW_OPERATION_THRESHOLD_MS = 250
 
 export abstract class BaseMongoStore {
     protected readonly db: Db
     protected readonly sessionId: string
     protected readonly collectionPrefix: string
+    protected readonly logger: Logger | undefined
+    protected readonly slowOperationThresholdMs: number
     private indexPromise: Promise<void> | null
     private transactionSupportPromise: Promise<boolean> | null
 
@@ -14,6 +19,9 @@ export abstract class BaseMongoStore {
         this.db = options.db
         this.sessionId = options.sessionId
         this.collectionPrefix = options.collectionPrefix ?? ''
+        this.logger = options.logger
+        this.slowOperationThresholdMs =
+            options.slowOperationThresholdMs ?? DEFAULT_SLOW_OPERATION_THRESHOLD_MS
         assertSafeCollectionPrefix(this.collectionPrefix)
         this.indexPromise = null
         this.transactionSupportPromise = null
@@ -37,13 +45,37 @@ export abstract class BaseMongoStore {
         // Override in subclasses that need indexes
     }
 
+    /**
+     * Wraps a non-session operation with slow-timing telemetry. Use for
+     * batch reads or expensive single commands. No-op when no logger.
+     */
+    protected async timed<T>(operation: string, run: () => Promise<T> | T): Promise<T> {
+        if (!this.logger) {
+            return run()
+        }
+        const startedAt = Date.now()
+        try {
+            return await run()
+        } finally {
+            const durationMs = Date.now() - startedAt
+            if (durationMs >= this.slowOperationThresholdMs) {
+                this.logger.warn('slow mongo operation', {
+                    operation,
+                    durationMs,
+                    thresholdMs: this.slowOperationThresholdMs
+                })
+            }
+        }
+    }
+
     protected async withSession<T>(run: (session: ClientSession) => Promise<T>): Promise<T> {
         await this.ensureIndexes()
+        const startedAt = this.logger ? Date.now() : 0
         const session = this.db.client.startSession()
         try {
             const supportsTransactions = await this.canUseTransactions()
             if (!supportsTransactions) {
-                return run(session)
+                return await run(session)
             }
             try {
                 let result: T | undefined
@@ -61,10 +93,21 @@ export abstract class BaseMongoStore {
                     throw error
                 }
                 this.transactionSupportPromise = Promise.resolve(false)
-                return run(session)
+                this.logger?.warn('mongo transactions unsupported by deployment, falling back')
+                return await run(session)
             }
         } finally {
             await session.endSession()
+            if (this.logger) {
+                const durationMs = Date.now() - startedAt
+                if (durationMs >= this.slowOperationThresholdMs) {
+                    this.logger.warn('slow mongo session', {
+                        operation: 'withSession',
+                        durationMs,
+                        thresholdMs: this.slowOperationThresholdMs
+                    })
+                }
+            }
         }
     }
 

--- a/packages/store-mongo/src/BaseMongoStore.ts
+++ b/packages/store-mongo/src/BaseMongoStore.ts
@@ -45,29 +45,6 @@ export abstract class BaseMongoStore {
         // Override in subclasses that need indexes
     }
 
-    /**
-     * Wraps a non-session operation with slow-timing telemetry. Use for
-     * batch reads or expensive single commands. No-op when no logger.
-     */
-    protected async timed<T>(operation: string, run: () => Promise<T> | T): Promise<T> {
-        if (!this.logger) {
-            return run()
-        }
-        const startedAt = Date.now()
-        try {
-            return await run()
-        } finally {
-            const durationMs = Date.now() - startedAt
-            if (durationMs >= this.slowOperationThresholdMs) {
-                this.logger.warn('slow mongo operation', {
-                    operation,
-                    durationMs,
-                    thresholdMs: this.slowOperationThresholdMs
-                })
-            }
-        }
-    }
-
     protected async withSession<T>(run: (session: ClientSession) => Promise<T>): Promise<T> {
         await this.ensureIndexes()
         const startedAt = this.logger ? Date.now() : 0

--- a/packages/store-mongo/src/createMongoStore.ts
+++ b/packages/store-mongo/src/createMongoStore.ts
@@ -1,4 +1,5 @@
 import { type Db, MongoClient, type MongoClientOptions } from 'mongodb'
+import type { Logger } from 'zapo-js'
 
 import { WaAppStateMongoStore } from './appstate.store'
 import { WaAuthMongoStore } from './auth.store'
@@ -48,6 +49,17 @@ export interface WaMongoStoreConfig {
         readonly deviceListMs?: number
         readonly messageSecretMs?: number
     }
+    /**
+     * Logger for connection lifecycle, slow operations, and degraded
+     * paths. The factory binds `{ scope: 'store', provider: 'mongo' }`
+     * and each per-domain store binds its own `{ domain: '<name>' }`.
+     */
+    readonly logger?: Logger
+    /**
+     * Threshold in milliseconds above which a Mongo operation emits a
+     * `warn`. Defaults to `250`.
+     */
+    readonly slowOperationThresholdMs?: number
 }
 
 export interface WaMongoStoreResult {
@@ -115,35 +127,61 @@ export function createMongoStore(config: WaMongoStoreConfig): WaMongoStoreResult
     const groupMetadataTtlMs = config.cacheTtlMs?.groupMetadataMs
     const deviceListTtlMs = config.cacheTtlMs?.deviceListMs
     const messageSecretTtlMs = config.cacheTtlMs?.messageSecretMs
+    const baseLogger = config.logger?.child({ scope: 'store', provider: 'mongo' })
+    const slowOperationThresholdMs = config.slowOperationThresholdMs
 
-    const opts = (sessionId: string): WaMongoStorageOptions => ({
+    if (baseLogger && client) {
+        client.on('serverHeartbeatFailed', (event) =>
+            baseLogger.warn('mongo heartbeat failed', {
+                connectionId: event.connectionId,
+                message: event.failure?.message
+            })
+        )
+        client.on('connectionPoolCleared', () => baseLogger.warn('mongo connection pool cleared'))
+        client.on('topologyDescriptionChanged', (event) =>
+            baseLogger.debug('mongo topology changed', {
+                previousType: event.previousDescription.type,
+                newType: event.newDescription.type
+            })
+        )
+        baseLogger.info('mongo store created', {
+            database: db.databaseName,
+            collectionPrefix: collectionPrefix || undefined
+        })
+    }
+
+    const opts = (sessionId: string, domain: string): WaMongoStorageOptions => ({
         db,
         sessionId,
-        collectionPrefix
+        collectionPrefix,
+        logger: baseLogger?.child({ domain, sessionId }),
+        slowOperationThresholdMs
     })
 
     return {
         db,
         stores: {
-            auth: (sessionId) => new WaAuthMongoStore(opts(sessionId)),
-            preKey: (sessionId) => new WaPreKeyMongoStore(opts(sessionId)),
-            session: (sessionId) => new WaSessionMongoStore(opts(sessionId)),
-            identity: (sessionId) => new WaIdentityMongoStore(opts(sessionId)),
-            signal: (sessionId) => new WaSignalMongoStore(opts(sessionId)),
-            senderKey: (sessionId) => new WaSenderKeyMongoStore(opts(sessionId)),
-            appState: (sessionId) => new WaAppStateMongoStore(opts(sessionId)),
-            messages: (sessionId) => new WaMessageMongoStore(opts(sessionId)),
-            threads: (sessionId) => new WaThreadMongoStore(opts(sessionId)),
-            contacts: (sessionId) => new WaContactMongoStore(opts(sessionId)),
-            privacyToken: (sessionId) => new WaPrivacyTokenMongoStore(opts(sessionId))
+            auth: (sessionId) => new WaAuthMongoStore(opts(sessionId, 'auth')),
+            preKey: (sessionId) => new WaPreKeyMongoStore(opts(sessionId, 'preKey')),
+            session: (sessionId) => new WaSessionMongoStore(opts(sessionId, 'session')),
+            identity: (sessionId) => new WaIdentityMongoStore(opts(sessionId, 'identity')),
+            signal: (sessionId) => new WaSignalMongoStore(opts(sessionId, 'signal')),
+            senderKey: (sessionId) => new WaSenderKeyMongoStore(opts(sessionId, 'senderKey')),
+            appState: (sessionId) => new WaAppStateMongoStore(opts(sessionId, 'appState')),
+            messages: (sessionId) => new WaMessageMongoStore(opts(sessionId, 'messages')),
+            threads: (sessionId) => new WaThreadMongoStore(opts(sessionId, 'threads')),
+            contacts: (sessionId) => new WaContactMongoStore(opts(sessionId, 'contacts')),
+            privacyToken: (sessionId) =>
+                new WaPrivacyTokenMongoStore(opts(sessionId, 'privacyToken'))
         },
         caches: {
-            retry: (sessionId) => new WaRetryMongoStore(opts(sessionId), retryTtlMs),
+            retry: (sessionId) => new WaRetryMongoStore(opts(sessionId, 'retry'), retryTtlMs),
             groupMetadata: (sessionId) =>
-                new WaGroupMetadataMongoStore(opts(sessionId), groupMetadataTtlMs),
-            deviceList: (sessionId) => new WaDeviceListMongoStore(opts(sessionId), deviceListTtlMs),
+                new WaGroupMetadataMongoStore(opts(sessionId, 'groupMetadata'), groupMetadataTtlMs),
+            deviceList: (sessionId) =>
+                new WaDeviceListMongoStore(opts(sessionId, 'deviceList'), deviceListTtlMs),
             messageSecret: (sessionId) =>
-                new WaMessageSecretMongoStore(opts(sessionId), messageSecretTtlMs)
+                new WaMessageSecretMongoStore(opts(sessionId, 'messageSecret'), messageSecretTtlMs)
         },
         async destroy(): Promise<void> {
             if (client) {

--- a/packages/store-mongo/src/types.ts
+++ b/packages/store-mongo/src/types.ts
@@ -1,7 +1,21 @@
 import type { Db } from 'mongodb'
+import type { Logger } from 'zapo-js'
 
 export interface WaMongoStorageOptions {
     readonly db: Db
     readonly sessionId: string
     readonly collectionPrefix?: string
+    /**
+     * Logger used for index-build progress, slow operations, and degraded
+     * paths (e.g. transactions unsupported by the deployment). Bound
+     * automatically by `createMongoStore` with `{ scope: 'store',
+     * provider: 'mongo', domain: '<name>', sessionId }`. Leave unset for
+     * silent operation.
+     */
+    readonly logger?: Logger
+    /**
+     * Threshold in milliseconds above which a Mongo operation emits a
+     * `warn`. Defaults to `250`.
+     */
+    readonly slowOperationThresholdMs?: number
 }

--- a/packages/store-mysql/src/BaseMysqlStore.ts
+++ b/packages/store-mysql/src/BaseMysqlStore.ts
@@ -1,4 +1,5 @@
 import type { Pool, PoolConnection } from 'mysql2/promise'
+import type { Logger } from 'zapo-js'
 import { resolvePositive } from 'zapo-js/util'
 
 import { ensureMysqlMigrations } from './connection'
@@ -6,11 +7,14 @@ import { assertSafeTablePrefix } from './helpers'
 import type { WaMysqlMigrationDomain, WaMysqlStorageOptions } from './types'
 
 const DEFAULT_BATCH_INSERT_CHUNK_SIZE = 500
+const DEFAULT_SLOW_OPERATION_THRESHOLD_MS = 250
 
 export abstract class BaseMysqlStore {
     protected readonly pool: Pool
     protected readonly sessionId: string
     protected readonly tablePrefix: string
+    protected readonly logger: Logger | undefined
+    protected readonly slowOperationThresholdMs: number
     /**
      * Largest power-of-two sub-chunk used by multi-row INSERT helpers.
      * Caller passes `batchInsertChunkSize`; we round down to the nearest
@@ -31,6 +35,9 @@ export abstract class BaseMysqlStore {
         this.pool = options.pool
         this.sessionId = options.sessionId
         this.tablePrefix = options.tablePrefix ?? ''
+        this.logger = options.logger
+        this.slowOperationThresholdMs =
+            options.slowOperationThresholdMs ?? DEFAULT_SLOW_OPERATION_THRESHOLD_MS
         assertSafeTablePrefix(this.tablePrefix)
         const requested = resolvePositive(
             options.batchInsertChunkSize,
@@ -89,6 +96,21 @@ export abstract class BaseMysqlStore {
 
     protected async withTransaction<T>(run: (conn: PoolConnection) => Promise<T>): Promise<T> {
         await this.ensureReady()
+        if (!this.logger) {
+            const conn = await this.pool.getConnection()
+            try {
+                await conn.beginTransaction()
+                const result = await run(conn)
+                await conn.commit()
+                return result
+            } catch (err) {
+                await conn.rollback()
+                throw err
+            } finally {
+                conn.release()
+            }
+        }
+        const startedAt = Date.now()
         const conn = await this.pool.getConnection()
         try {
             await conn.beginTransaction()
@@ -100,6 +122,37 @@ export abstract class BaseMysqlStore {
             throw err
         } finally {
             conn.release()
+            const durationMs = Date.now() - startedAt
+            if (durationMs >= this.slowOperationThresholdMs) {
+                this.logger.warn('slow mysql transaction', {
+                    operation: 'withTransaction',
+                    durationMs,
+                    thresholdMs: this.slowOperationThresholdMs
+                })
+            }
+        }
+    }
+
+    /**
+     * Wraps a non-transactional operation in slow-timing telemetry. No-op
+     * when no logger is set.
+     */
+    protected async timed<T>(operation: string, run: () => Promise<T> | T): Promise<T> {
+        if (!this.logger) {
+            return run()
+        }
+        const startedAt = Date.now()
+        try {
+            return await run()
+        } finally {
+            const durationMs = Date.now() - startedAt
+            if (durationMs >= this.slowOperationThresholdMs) {
+                this.logger.warn('slow mysql operation', {
+                    operation,
+                    durationMs,
+                    thresholdMs: this.slowOperationThresholdMs
+                })
+            }
         }
     }
 

--- a/packages/store-mysql/src/BaseMysqlStore.ts
+++ b/packages/store-mysql/src/BaseMysqlStore.ts
@@ -133,29 +133,6 @@ export abstract class BaseMysqlStore {
         }
     }
 
-    /**
-     * Wraps a non-transactional operation in slow-timing telemetry. No-op
-     * when no logger is set.
-     */
-    protected async timed<T>(operation: string, run: () => Promise<T> | T): Promise<T> {
-        if (!this.logger) {
-            return run()
-        }
-        const startedAt = Date.now()
-        try {
-            return await run()
-        } finally {
-            const durationMs = Date.now() - startedAt
-            if (durationMs >= this.slowOperationThresholdMs) {
-                this.logger.warn('slow mysql operation', {
-                    operation,
-                    durationMs,
-                    thresholdMs: this.slowOperationThresholdMs
-                })
-            }
-        }
-    }
-
     public async destroy(): Promise<void> {
         this.migrationPromise = null
         this.migrationDone = false

--- a/packages/store-mysql/src/createMysqlStore.ts
+++ b/packages/store-mysql/src/createMysqlStore.ts
@@ -1,4 +1,5 @@
 import type { Pool, PoolOptions } from 'mysql2/promise'
+import type { Logger } from 'zapo-js'
 
 import { WaAppStateMysqlStore } from './appstate.store'
 import { WaAuthMysqlStore } from './auth.store'
@@ -69,6 +70,17 @@ export interface WaMysqlStoreConfig {
      * workloads where `N` varies widely.
      */
     readonly batchInsertChunkSize?: number
+    /**
+     * Logger for pool lifecycle, slow queries, and migration progress.
+     * The factory binds `{ scope: 'store', provider: 'mysql' }` and each
+     * per-domain store binds its own `{ domain: '<name>' }`.
+     */
+    readonly logger?: Logger
+    /**
+     * Threshold in milliseconds above which a transaction emits a `warn`.
+     * Defaults to `250`.
+     */
+    readonly slowOperationThresholdMs?: number
 }
 
 export interface WaMysqlStoreResult {
@@ -132,13 +144,23 @@ export function createMysqlStore(config: WaMysqlStoreConfig): WaMysqlStoreResult
     const deviceListTtlMs = config.cacheTtlMs?.deviceListMs
     const messageSecretTtlMs = config.cacheTtlMs?.messageSecretMs
     const ownsPool = !isPool(config.pool)
+    const baseLogger = config.logger?.child({ scope: 'store', provider: 'mysql' })
+    const slowOperationThresholdMs = config.slowOperationThresholdMs
+
+    if (baseLogger && ownsPool) {
+        baseLogger.info('mysql store created', {
+            tablePrefix: tablePrefix || undefined
+        })
+    }
 
     const batchInsertChunkSize = config.batchInsertChunkSize
-    const opts = (sessionId: string): WaMysqlStorageOptions => ({
+    const opts = (sessionId: string, domain: string): WaMysqlStorageOptions => ({
         pool,
         sessionId,
         tablePrefix,
-        batchInsertChunkSize
+        batchInsertChunkSize,
+        logger: baseLogger?.child({ domain, sessionId }),
+        slowOperationThresholdMs
     })
 
     const cleanupPollers = new Set<MysqlCleanupPoller>()
@@ -146,34 +168,44 @@ export function createMysqlStore(config: WaMysqlStoreConfig): WaMysqlStoreResult
     return {
         pool,
         stores: {
-            auth: (sessionId) => new WaAuthMysqlStore(opts(sessionId)),
-            preKey: (sessionId) => new WaPreKeyMysqlStore(opts(sessionId)),
-            session: (sessionId) => new WaSessionMysqlStore(opts(sessionId)),
-            identity: (sessionId) => new WaIdentityMysqlStore(opts(sessionId)),
-            signal: (sessionId) => new WaSignalMysqlStore(opts(sessionId)),
-            senderKey: (sessionId) => new WaSenderKeyMysqlStore(opts(sessionId)),
-            appState: (sessionId) => new WaAppStateMysqlStore(opts(sessionId)),
-            messages: (sessionId) => new WaMessageMysqlStore(opts(sessionId)),
-            threads: (sessionId) => new WaThreadMysqlStore(opts(sessionId)),
-            contacts: (sessionId) => new WaContactMysqlStore(opts(sessionId)),
-            privacyToken: (sessionId) => new WaPrivacyTokenMysqlStore(opts(sessionId))
+            auth: (sessionId) => new WaAuthMysqlStore(opts(sessionId, 'auth')),
+            preKey: (sessionId) => new WaPreKeyMysqlStore(opts(sessionId, 'preKey')),
+            session: (sessionId) => new WaSessionMysqlStore(opts(sessionId, 'session')),
+            identity: (sessionId) => new WaIdentityMysqlStore(opts(sessionId, 'identity')),
+            signal: (sessionId) => new WaSignalMysqlStore(opts(sessionId, 'signal')),
+            senderKey: (sessionId) => new WaSenderKeyMysqlStore(opts(sessionId, 'senderKey')),
+            appState: (sessionId) => new WaAppStateMysqlStore(opts(sessionId, 'appState')),
+            messages: (sessionId) => new WaMessageMysqlStore(opts(sessionId, 'messages')),
+            threads: (sessionId) => new WaThreadMysqlStore(opts(sessionId, 'threads')),
+            contacts: (sessionId) => new WaContactMysqlStore(opts(sessionId, 'contacts')),
+            privacyToken: (sessionId) =>
+                new WaPrivacyTokenMysqlStore(opts(sessionId, 'privacyToken'))
         },
         caches: {
-            retry: (sessionId) => new WaRetryMysqlStore(opts(sessionId), retryTtlMs),
+            retry: (sessionId) => new WaRetryMysqlStore(opts(sessionId, 'retry'), retryTtlMs),
             groupMetadata: (sessionId) =>
-                new WaGroupMetadataMysqlStore(opts(sessionId), groupMetadataTtlMs),
-            deviceList: (sessionId) => new WaDeviceListMysqlStore(opts(sessionId), deviceListTtlMs),
+                new WaGroupMetadataMysqlStore(opts(sessionId, 'groupMetadata'), groupMetadataTtlMs),
+            deviceList: (sessionId) =>
+                new WaDeviceListMysqlStore(opts(sessionId, 'deviceList'), deviceListTtlMs),
             messageSecret: (sessionId) =>
-                new WaMessageSecretMysqlStore(opts(sessionId), messageSecretTtlMs)
+                new WaMessageSecretMysqlStore(opts(sessionId, 'messageSecret'), messageSecretTtlMs)
         },
         startCleanup(sessionId: string): MysqlCleanupPoller {
-            const o = opts(sessionId)
             const poller = new MysqlCleanupPoller({
                 intervalMs: config.cleanup?.intervalMs,
-                retry: new WaRetryMysqlStore(o, retryTtlMs),
-                groupMetadata: new WaGroupMetadataMysqlStore(o, groupMetadataTtlMs),
-                deviceList: new WaDeviceListMysqlStore(o, deviceListTtlMs),
-                messageSecret: new WaMessageSecretMysqlStore(o, messageSecretTtlMs),
+                retry: new WaRetryMysqlStore(opts(sessionId, 'retry'), retryTtlMs),
+                groupMetadata: new WaGroupMetadataMysqlStore(
+                    opts(sessionId, 'groupMetadata'),
+                    groupMetadataTtlMs
+                ),
+                deviceList: new WaDeviceListMysqlStore(
+                    opts(sessionId, 'deviceList'),
+                    deviceListTtlMs
+                ),
+                messageSecret: new WaMessageSecretMysqlStore(
+                    opts(sessionId, 'messageSecret'),
+                    messageSecretTtlMs
+                ),
                 onError: config.cleanup?.onError
             })
             poller.start()

--- a/packages/store-mysql/src/types.ts
+++ b/packages/store-mysql/src/types.ts
@@ -1,4 +1,5 @@
 import type { Pool, PoolOptions } from 'mysql2/promise'
+import type { Logger } from 'zapo-js'
 
 export type MysqlParam = string | number | bigint | Uint8Array | boolean | null
 
@@ -19,6 +20,17 @@ export interface WaMysqlStorageOptions {
     readonly sessionId: string
     readonly tablePrefix?: string
     readonly batchInsertChunkSize?: number
+    /**
+     * Logger for slow-query warnings and migration progress. Bound
+     * automatically by `createMysqlStore` with `{ scope: 'store',
+     * provider: 'mysql', domain: '<name>', sessionId }`.
+     */
+    readonly logger?: Logger
+    /**
+     * Threshold in milliseconds above which a transaction or timed-helper
+     * call emits a `warn`. Defaults to `250`.
+     */
+    readonly slowOperationThresholdMs?: number
 }
 
 export interface WaMysqlCreateStoreOptions {

--- a/packages/store-postgres/src/BasePgStore.ts
+++ b/packages/store-postgres/src/BasePgStore.ts
@@ -1,4 +1,5 @@
 import type { Pool, PoolClient } from 'pg'
+import type { Logger } from 'zapo-js'
 import { resolvePositive } from 'zapo-js/util'
 
 import { ensurePgMigrations } from './connection'
@@ -6,11 +7,14 @@ import { assertSafeTablePrefix } from './helpers'
 import type { WaPgMigrationDomain, WaPgStorageOptions } from './types'
 
 const DEFAULT_BATCH_INSERT_CHUNK_SIZE = 500
+const DEFAULT_SLOW_OPERATION_THRESHOLD_MS = 250
 
 export abstract class BasePgStore {
     protected readonly pool: Pool
     protected readonly sessionId: string
     protected readonly tablePrefix: string
+    protected readonly logger: Logger | undefined
+    protected readonly slowOperationThresholdMs: number
     /**
      * Largest power-of-two sub-chunk used by multi-row INSERT helpers.
      * `batchInsertChunkSize` is rounded down to the nearest power of two
@@ -29,6 +33,9 @@ export abstract class BasePgStore {
         this.pool = options.pool
         this.sessionId = options.sessionId
         this.tablePrefix = options.tablePrefix ?? ''
+        this.logger = options.logger
+        this.slowOperationThresholdMs =
+            options.slowOperationThresholdMs ?? DEFAULT_SLOW_OPERATION_THRESHOLD_MS
         assertSafeTablePrefix(this.tablePrefix)
         const requested = resolvePositive(
             options.batchInsertChunkSize,
@@ -83,6 +90,21 @@ export abstract class BasePgStore {
 
     protected async withTransaction<T>(run: (client: PoolClient) => Promise<T>): Promise<T> {
         await this.ensureReady()
+        if (!this.logger) {
+            const client = await this.pool.connect()
+            try {
+                await client.query('BEGIN')
+                const result = await run(client)
+                await client.query('COMMIT')
+                return result
+            } catch (err) {
+                await client.query('ROLLBACK')
+                throw err
+            } finally {
+                client.release()
+            }
+        }
+        const startedAt = Date.now()
         const client = await this.pool.connect()
         try {
             await client.query('BEGIN')
@@ -94,6 +116,37 @@ export abstract class BasePgStore {
             throw err
         } finally {
             client.release()
+            const durationMs = Date.now() - startedAt
+            if (durationMs >= this.slowOperationThresholdMs) {
+                this.logger.warn('slow postgres transaction', {
+                    operation: 'withTransaction',
+                    durationMs,
+                    thresholdMs: this.slowOperationThresholdMs
+                })
+            }
+        }
+    }
+
+    /**
+     * Wraps a non-transactional operation in slow-timing telemetry. No-op
+     * when no logger is set.
+     */
+    protected async timed<T>(operation: string, run: () => Promise<T> | T): Promise<T> {
+        if (!this.logger) {
+            return run()
+        }
+        const startedAt = Date.now()
+        try {
+            return await run()
+        } finally {
+            const durationMs = Date.now() - startedAt
+            if (durationMs >= this.slowOperationThresholdMs) {
+                this.logger.warn('slow postgres operation', {
+                    operation,
+                    durationMs,
+                    thresholdMs: this.slowOperationThresholdMs
+                })
+            }
         }
     }
 

--- a/packages/store-postgres/src/BasePgStore.ts
+++ b/packages/store-postgres/src/BasePgStore.ts
@@ -127,29 +127,6 @@ export abstract class BasePgStore {
         }
     }
 
-    /**
-     * Wraps a non-transactional operation in slow-timing telemetry. No-op
-     * when no logger is set.
-     */
-    protected async timed<T>(operation: string, run: () => Promise<T> | T): Promise<T> {
-        if (!this.logger) {
-            return run()
-        }
-        const startedAt = Date.now()
-        try {
-            return await run()
-        } finally {
-            const durationMs = Date.now() - startedAt
-            if (durationMs >= this.slowOperationThresholdMs) {
-                this.logger.warn('slow postgres operation', {
-                    operation,
-                    durationMs,
-                    thresholdMs: this.slowOperationThresholdMs
-                })
-            }
-        }
-    }
-
     public async destroy(): Promise<void> {
         this.migrationPromise = null
     }

--- a/packages/store-postgres/src/createPostgresStore.ts
+++ b/packages/store-postgres/src/createPostgresStore.ts
@@ -1,4 +1,5 @@
 import type { Pool, PoolConfig } from 'pg'
+import type { Logger } from 'zapo-js'
 
 import { WaAppStatePgStore } from './appstate.store'
 import { WaAuthPgStore } from './auth.store'
@@ -64,6 +65,17 @@ export interface WaPgStoreConfig {
      * statement cache stable even when `N` varies widely.
      */
     readonly batchInsertChunkSize?: number
+    /**
+     * Logger for pool lifecycle, slow queries, and migration progress. The
+     * factory binds `{ scope: 'store', provider: 'postgres' }` and each
+     * per-domain store binds its own `{ domain: '<name>' }`.
+     */
+    readonly logger?: Logger
+    /**
+     * Threshold in milliseconds above which a transaction emits a `warn`.
+     * Defaults to `250`.
+     */
+    readonly slowOperationThresholdMs?: number
 }
 
 export interface WaPgStoreResult {
@@ -127,13 +139,25 @@ export function createPostgresStore(config: WaPgStoreConfig): WaPgStoreResult {
     const deviceListTtlMs = config.cacheTtlMs?.deviceListMs
     const messageSecretTtlMs = config.cacheTtlMs?.messageSecretMs
     const ownsPool = !isPool(config.pool)
+    const baseLogger = config.logger?.child({ scope: 'store', provider: 'postgres' })
+    const slowOperationThresholdMs = config.slowOperationThresholdMs
+
+    if (baseLogger && ownsPool) {
+        pool.on('error', (err) => baseLogger.warn('postgres pool error', { message: err.message }))
+        pool.on('connect', () => baseLogger.debug('postgres client connected to pool'))
+        baseLogger.info('postgres store created', {
+            tablePrefix: tablePrefix || undefined
+        })
+    }
 
     const batchInsertChunkSize = config.batchInsertChunkSize
-    const opts = (sessionId: string): WaPgStorageOptions => ({
+    const opts = (sessionId: string, domain: string): WaPgStorageOptions => ({
         pool,
         sessionId,
         tablePrefix,
-        batchInsertChunkSize
+        batchInsertChunkSize,
+        logger: baseLogger?.child({ domain, sessionId }),
+        slowOperationThresholdMs
     })
 
     const cleanupPollers = new Set<PgCleanupPoller>()
@@ -141,34 +165,40 @@ export function createPostgresStore(config: WaPgStoreConfig): WaPgStoreResult {
     return {
         pool,
         stores: {
-            auth: (sessionId) => new WaAuthPgStore(opts(sessionId)),
-            preKey: (sessionId) => new WaPreKeyPgStore(opts(sessionId)),
-            session: (sessionId) => new WaSessionPgStore(opts(sessionId)),
-            identity: (sessionId) => new WaIdentityPgStore(opts(sessionId)),
-            signal: (sessionId) => new WaSignalPgStore(opts(sessionId)),
-            senderKey: (sessionId) => new WaSenderKeyPgStore(opts(sessionId)),
-            appState: (sessionId) => new WaAppStatePgStore(opts(sessionId)),
-            messages: (sessionId) => new WaMessagePgStore(opts(sessionId)),
-            threads: (sessionId) => new WaThreadPgStore(opts(sessionId)),
-            contacts: (sessionId) => new WaContactPgStore(opts(sessionId)),
-            privacyToken: (sessionId) => new WaPrivacyTokenPgStore(opts(sessionId))
+            auth: (sessionId) => new WaAuthPgStore(opts(sessionId, 'auth')),
+            preKey: (sessionId) => new WaPreKeyPgStore(opts(sessionId, 'preKey')),
+            session: (sessionId) => new WaSessionPgStore(opts(sessionId, 'session')),
+            identity: (sessionId) => new WaIdentityPgStore(opts(sessionId, 'identity')),
+            signal: (sessionId) => new WaSignalPgStore(opts(sessionId, 'signal')),
+            senderKey: (sessionId) => new WaSenderKeyPgStore(opts(sessionId, 'senderKey')),
+            appState: (sessionId) => new WaAppStatePgStore(opts(sessionId, 'appState')),
+            messages: (sessionId) => new WaMessagePgStore(opts(sessionId, 'messages')),
+            threads: (sessionId) => new WaThreadPgStore(opts(sessionId, 'threads')),
+            contacts: (sessionId) => new WaContactPgStore(opts(sessionId, 'contacts')),
+            privacyToken: (sessionId) => new WaPrivacyTokenPgStore(opts(sessionId, 'privacyToken'))
         },
         caches: {
-            retry: (sessionId) => new WaRetryPgStore(opts(sessionId), retryTtlMs),
+            retry: (sessionId) => new WaRetryPgStore(opts(sessionId, 'retry'), retryTtlMs),
             groupMetadata: (sessionId) =>
-                new WaGroupMetadataPgStore(opts(sessionId), groupMetadataTtlMs),
-            deviceList: (sessionId) => new WaDeviceListPgStore(opts(sessionId), deviceListTtlMs),
+                new WaGroupMetadataPgStore(opts(sessionId, 'groupMetadata'), groupMetadataTtlMs),
+            deviceList: (sessionId) =>
+                new WaDeviceListPgStore(opts(sessionId, 'deviceList'), deviceListTtlMs),
             messageSecret: (sessionId) =>
-                new WaMessageSecretPgStore(opts(sessionId), messageSecretTtlMs)
+                new WaMessageSecretPgStore(opts(sessionId, 'messageSecret'), messageSecretTtlMs)
         },
         startCleanup(sessionId: string): PgCleanupPoller {
-            const o = opts(sessionId)
             const poller = new PgCleanupPoller({
                 intervalMs: config.cleanup?.intervalMs,
-                retry: new WaRetryPgStore(o, retryTtlMs),
-                groupMetadata: new WaGroupMetadataPgStore(o, groupMetadataTtlMs),
-                deviceList: new WaDeviceListPgStore(o, deviceListTtlMs),
-                messageSecret: new WaMessageSecretPgStore(o, messageSecretTtlMs),
+                retry: new WaRetryPgStore(opts(sessionId, 'retry'), retryTtlMs),
+                groupMetadata: new WaGroupMetadataPgStore(
+                    opts(sessionId, 'groupMetadata'),
+                    groupMetadataTtlMs
+                ),
+                deviceList: new WaDeviceListPgStore(opts(sessionId, 'deviceList'), deviceListTtlMs),
+                messageSecret: new WaMessageSecretPgStore(
+                    opts(sessionId, 'messageSecret'),
+                    messageSecretTtlMs
+                ),
                 onError: config.cleanup?.onError
             })
             poller.start()

--- a/packages/store-postgres/src/types.ts
+++ b/packages/store-postgres/src/types.ts
@@ -1,4 +1,5 @@
 import type { Pool, PoolConfig } from 'pg'
+import type { Logger } from 'zapo-js'
 
 export type PgParam = string | number | bigint | Uint8Array | boolean | null
 
@@ -19,6 +20,18 @@ export interface WaPgStorageOptions {
     readonly sessionId: string
     readonly tablePrefix?: string
     readonly batchInsertChunkSize?: number
+    /**
+     * Logger for slow-query warnings and migration progress. Bound
+     * automatically by `createPostgresStore` with `{ scope: 'store',
+     * provider: 'postgres', domain: '<name>', sessionId }`. Leave unset
+     * for silent operation.
+     */
+    readonly logger?: Logger
+    /**
+     * Threshold in milliseconds above which a transaction or timed-helper
+     * call emits a `warn`. Defaults to `250`.
+     */
+    readonly slowOperationThresholdMs?: number
 }
 
 export interface WaPgCreateStoreOptions {

--- a/packages/store-redis/src/BaseRedisStore.ts
+++ b/packages/store-redis/src/BaseRedisStore.ts
@@ -1,22 +1,53 @@
 import type Redis from 'ioredis'
+import type { Logger } from 'zapo-js'
 
 import { assertSafeKeyPrefix } from './helpers'
 import type { WaRedisStorageOptions } from './types'
+
+const DEFAULT_SLOW_OPERATION_THRESHOLD_MS = 250
 
 export abstract class BaseRedisStore {
     protected readonly redis: Redis
     protected readonly sessionId: string
     protected readonly keyPrefix: string
+    protected readonly logger: Logger | undefined
+    protected readonly slowOperationThresholdMs: number
 
     protected constructor(options: WaRedisStorageOptions) {
         this.redis = options.redis
         this.sessionId = options.sessionId
         this.keyPrefix = options.keyPrefix ?? ''
+        this.logger = options.logger
+        this.slowOperationThresholdMs =
+            options.slowOperationThresholdMs ?? DEFAULT_SLOW_OPERATION_THRESHOLD_MS
         assertSafeKeyPrefix(this.keyPrefix)
     }
 
     protected k(...parts: readonly string[]): string {
         return `${this.keyPrefix}${parts.join(':')}`
+    }
+
+    /**
+     * Wraps an operation in slow-command timing. Emits a `warn` when the
+     * call exceeds `slowOperationThresholdMs`. No-op when no logger is set.
+     */
+    protected async timed<T>(operation: string, run: () => Promise<T> | T): Promise<T> {
+        if (!this.logger) {
+            return run()
+        }
+        const startedAt = Date.now()
+        try {
+            return await run()
+        } finally {
+            const durationMs = Date.now() - startedAt
+            if (durationMs >= this.slowOperationThresholdMs) {
+                this.logger.warn('slow redis operation', {
+                    operation,
+                    durationMs,
+                    thresholdMs: this.slowOperationThresholdMs
+                })
+            }
+        }
     }
 
     public async destroy(): Promise<void> {

--- a/packages/store-redis/src/BaseRedisStore.ts
+++ b/packages/store-redis/src/BaseRedisStore.ts
@@ -4,50 +4,22 @@ import type { Logger } from 'zapo-js'
 import { assertSafeKeyPrefix } from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
-const DEFAULT_SLOW_OPERATION_THRESHOLD_MS = 250
-
 export abstract class BaseRedisStore {
     protected readonly redis: Redis
     protected readonly sessionId: string
     protected readonly keyPrefix: string
     protected readonly logger: Logger | undefined
-    protected readonly slowOperationThresholdMs: number
 
     protected constructor(options: WaRedisStorageOptions) {
         this.redis = options.redis
         this.sessionId = options.sessionId
         this.keyPrefix = options.keyPrefix ?? ''
         this.logger = options.logger
-        this.slowOperationThresholdMs =
-            options.slowOperationThresholdMs ?? DEFAULT_SLOW_OPERATION_THRESHOLD_MS
         assertSafeKeyPrefix(this.keyPrefix)
     }
 
     protected k(...parts: readonly string[]): string {
         return `${this.keyPrefix}${parts.join(':')}`
-    }
-
-    /**
-     * Wraps an operation in slow-command timing. Emits a `warn` when the
-     * call exceeds `slowOperationThresholdMs`. No-op when no logger is set.
-     */
-    protected async timed<T>(operation: string, run: () => Promise<T> | T): Promise<T> {
-        if (!this.logger) {
-            return run()
-        }
-        const startedAt = Date.now()
-        try {
-            return await run()
-        } finally {
-            const durationMs = Date.now() - startedAt
-            if (durationMs >= this.slowOperationThresholdMs) {
-                this.logger.warn('slow redis operation', {
-                    operation,
-                    durationMs,
-                    thresholdMs: this.slowOperationThresholdMs
-                })
-            }
-        }
     }
 
     public async destroy(): Promise<void> {

--- a/packages/store-redis/src/createRedisStore.ts
+++ b/packages/store-redis/src/createRedisStore.ts
@@ -1,4 +1,5 @@
 import Redis, { type RedisOptions } from 'ioredis'
+import type { Logger } from 'zapo-js'
 
 import { WaAppStateRedisStore } from './appstate.store'
 import { WaAuthRedisStore } from './auth.store'
@@ -42,6 +43,18 @@ export interface WaRedisStoreConfig {
         readonly deviceListMs?: number
         readonly messageSecretMs?: number
     }
+    /**
+     * Logger for connection lifecycle, slow commands, and degraded paths.
+     * The factory binds `{ scope: 'store', provider: 'redis' }` and each
+     * per-domain store binds its own `{ domain: '<name>' }`. When unset,
+     * the Redis layer stays silent.
+     */
+    readonly logger?: Logger
+    /**
+     * Threshold in milliseconds above which a command emits a `warn`.
+     * Defaults to `250`.
+     */
+    readonly slowOperationThresholdMs?: number
 }
 
 export interface WaRedisStoreResult {
@@ -106,35 +119,55 @@ export function createRedisStore(config: WaRedisStoreConfig): WaRedisStoreResult
     const deviceListTtlMs = config.cacheTtlMs?.deviceListMs
     const messageSecretTtlMs = config.cacheTtlMs?.messageSecretMs
     const ownsRedis = !isRedis(config.redis)
+    const baseLogger = config.logger?.child({ scope: 'store', provider: 'redis' })
+    const slowOperationThresholdMs = config.slowOperationThresholdMs
 
-    const opts = (sessionId: string): WaRedisStorageOptions => ({
+    if (baseLogger && ownsRedis) {
+        // Only attach lifecycle listeners on connections we own; externally
+        // supplied clients keep their existing event surface untouched.
+        redis.on('connect', () =>
+            baseLogger.info('redis connected', { keyPrefix: keyPrefix || undefined })
+        )
+        redis.on('ready', () => baseLogger.debug('redis ready'))
+        redis.on('reconnecting', (delayMs: number) =>
+            baseLogger.warn('redis reconnecting', { delayMs })
+        )
+        redis.on('end', () => baseLogger.warn('redis connection ended'))
+        redis.on('error', (err: Error) => baseLogger.warn('redis error', { message: err.message }))
+    }
+
+    const opts = (sessionId: string, domain: string): WaRedisStorageOptions => ({
         redis,
         sessionId,
-        keyPrefix
+        keyPrefix,
+        logger: baseLogger?.child({ domain, sessionId }),
+        slowOperationThresholdMs
     })
 
     return {
         redis,
         stores: {
-            auth: (sessionId) => new WaAuthRedisStore(opts(sessionId)),
-            preKey: (sessionId) => new WaPreKeyRedisStore(opts(sessionId)),
-            session: (sessionId) => new WaSessionRedisStore(opts(sessionId)),
-            identity: (sessionId) => new WaIdentityRedisStore(opts(sessionId)),
-            signal: (sessionId) => new WaSignalRedisStore(opts(sessionId)),
-            senderKey: (sessionId) => new WaSenderKeyRedisStore(opts(sessionId)),
-            appState: (sessionId) => new WaAppStateRedisStore(opts(sessionId)),
-            messages: (sessionId) => new WaMessageRedisStore(opts(sessionId)),
-            threads: (sessionId) => new WaThreadRedisStore(opts(sessionId)),
-            contacts: (sessionId) => new WaContactRedisStore(opts(sessionId)),
-            privacyToken: (sessionId) => new WaPrivacyTokenRedisStore(opts(sessionId))
+            auth: (sessionId) => new WaAuthRedisStore(opts(sessionId, 'auth')),
+            preKey: (sessionId) => new WaPreKeyRedisStore(opts(sessionId, 'preKey')),
+            session: (sessionId) => new WaSessionRedisStore(opts(sessionId, 'session')),
+            identity: (sessionId) => new WaIdentityRedisStore(opts(sessionId, 'identity')),
+            signal: (sessionId) => new WaSignalRedisStore(opts(sessionId, 'signal')),
+            senderKey: (sessionId) => new WaSenderKeyRedisStore(opts(sessionId, 'senderKey')),
+            appState: (sessionId) => new WaAppStateRedisStore(opts(sessionId, 'appState')),
+            messages: (sessionId) => new WaMessageRedisStore(opts(sessionId, 'messages')),
+            threads: (sessionId) => new WaThreadRedisStore(opts(sessionId, 'threads')),
+            contacts: (sessionId) => new WaContactRedisStore(opts(sessionId, 'contacts')),
+            privacyToken: (sessionId) =>
+                new WaPrivacyTokenRedisStore(opts(sessionId, 'privacyToken'))
         },
         caches: {
-            retry: (sessionId) => new WaRetryRedisStore(opts(sessionId), retryTtlMs),
+            retry: (sessionId) => new WaRetryRedisStore(opts(sessionId, 'retry'), retryTtlMs),
             groupMetadata: (sessionId) =>
-                new WaGroupMetadataRedisStore(opts(sessionId), groupMetadataTtlMs),
-            deviceList: (sessionId) => new WaDeviceListRedisStore(opts(sessionId), deviceListTtlMs),
+                new WaGroupMetadataRedisStore(opts(sessionId, 'groupMetadata'), groupMetadataTtlMs),
+            deviceList: (sessionId) =>
+                new WaDeviceListRedisStore(opts(sessionId, 'deviceList'), deviceListTtlMs),
             messageSecret: (sessionId) =>
-                new WaMessageSecretRedisStore(opts(sessionId), messageSecretTtlMs)
+                new WaMessageSecretRedisStore(opts(sessionId, 'messageSecret'), messageSecretTtlMs)
         },
         async destroy(): Promise<void> {
             if (ownsRedis) {

--- a/packages/store-redis/src/createRedisStore.ts
+++ b/packages/store-redis/src/createRedisStore.ts
@@ -127,7 +127,9 @@ export function createRedisStore(config: WaRedisStoreConfig): WaRedisStoreResult
         redis.on('reconnecting', (delayMs: number) =>
             baseLogger.warn('redis reconnecting', { delayMs })
         )
-        redis.on('end', () => baseLogger.warn('redis connection ended'))
+        // 'end' also fires on the redis.quit() path during graceful destroy(),
+        // so this stays at debug to avoid spurious warns on intentional teardown.
+        redis.on('end', () => baseLogger.debug('redis connection ended'))
         redis.on('error', (err: Error) => baseLogger.warn('redis error', { message: err.message }))
     }
 

--- a/packages/store-redis/src/createRedisStore.ts
+++ b/packages/store-redis/src/createRedisStore.ts
@@ -44,17 +44,13 @@ export interface WaRedisStoreConfig {
         readonly messageSecretMs?: number
     }
     /**
-     * Logger for connection lifecycle, slow commands, and degraded paths.
-     * The factory binds `{ scope: 'store', provider: 'redis' }` and each
-     * per-domain store binds its own `{ domain: '<name>' }`. When unset,
-     * the Redis layer stays silent.
+     * Logger for connection lifecycle and degraded paths emitted by the
+     * factory (connect/ready/reconnecting/end/error). The factory binds
+     * `{ scope: 'store', provider: 'redis' }` and each per-domain store
+     * binds its own `{ domain: '<name>' }`. When unset, the Redis layer
+     * stays silent.
      */
     readonly logger?: Logger
-    /**
-     * Threshold in milliseconds above which a command emits a `warn`.
-     * Defaults to `250`.
-     */
-    readonly slowOperationThresholdMs?: number
 }
 
 export interface WaRedisStoreResult {
@@ -120,7 +116,6 @@ export function createRedisStore(config: WaRedisStoreConfig): WaRedisStoreResult
     const messageSecretTtlMs = config.cacheTtlMs?.messageSecretMs
     const ownsRedis = !isRedis(config.redis)
     const baseLogger = config.logger?.child({ scope: 'store', provider: 'redis' })
-    const slowOperationThresholdMs = config.slowOperationThresholdMs
 
     if (baseLogger && ownsRedis) {
         // Only attach lifecycle listeners on connections we own; externally
@@ -140,8 +135,7 @@ export function createRedisStore(config: WaRedisStoreConfig): WaRedisStoreResult
         redis,
         sessionId,
         keyPrefix,
-        logger: baseLogger?.child({ domain, sessionId }),
-        slowOperationThresholdMs
+        logger: baseLogger?.child({ domain, sessionId })
     })
 
     return {

--- a/packages/store-redis/src/types.ts
+++ b/packages/store-redis/src/types.ts
@@ -1,9 +1,22 @@
 import type { default as Redis, RedisOptions } from 'ioredis'
+import type { Logger } from 'zapo-js'
 
 export interface WaRedisStorageOptions {
     readonly redis: Redis
     readonly sessionId: string
     readonly keyPrefix?: string
+    /**
+     * Logger used for slow-command warnings and connection events. Bound
+     * automatically by `createRedisStore` with `{ scope: 'store',
+     * provider: 'redis', domain: '<name>', sessionId }`. Leave unset for
+     * silent operation.
+     */
+    readonly logger?: Logger
+    /**
+     * Threshold in milliseconds above which a Redis command emits a
+     * `warn`. Defaults to `250`.
+     */
+    readonly slowOperationThresholdMs?: number
 }
 
 export interface WaRedisCreateStoreOptions {

--- a/packages/store-redis/src/types.ts
+++ b/packages/store-redis/src/types.ts
@@ -6,17 +6,12 @@ export interface WaRedisStorageOptions {
     readonly sessionId: string
     readonly keyPrefix?: string
     /**
-     * Logger used for slow-command warnings and connection events. Bound
-     * automatically by `createRedisStore` with `{ scope: 'store',
-     * provider: 'redis', domain: '<name>', sessionId }`. Leave unset for
-     * silent operation.
+     * Logger used for connection lifecycle events emitted by the
+     * factory. Bound automatically by `createRedisStore` with
+     * `{ scope: 'store', provider: 'redis', domain: '<name>', sessionId }`.
+     * Leave unset for silent operation.
      */
     readonly logger?: Logger
-    /**
-     * Threshold in milliseconds above which a Redis command emits a
-     * `warn`. Defaults to `250`.
-     */
-    readonly slowOperationThresholdMs?: number
 }
 
 export interface WaRedisCreateStoreOptions {

--- a/packages/store-redis/src/types.ts
+++ b/packages/store-redis/src/types.ts
@@ -6,10 +6,10 @@ export interface WaRedisStorageOptions {
     readonly sessionId: string
     readonly keyPrefix?: string
     /**
-     * Logger used for connection lifecycle events emitted by the
-     * factory. Bound automatically by `createRedisStore` with
-     * `{ scope: 'store', provider: 'redis', domain: '<name>', sessionId }`.
-     * Leave unset for silent operation.
+     * Logger passed through by `createRedisStore`. The factory binds
+     * `{ scope: 'store', provider: 'redis' }` for Redis connection lifecycle
+     * logs, then adds `{ domain: '<name>', sessionId }` on the child logger
+     * passed into each store/cache. Leave unset for silent operation.
      */
     readonly logger?: Logger
 }

--- a/packages/store-sqlite/src/BaseSqliteStore.ts
+++ b/packages/store-sqlite/src/BaseSqliteStore.ts
@@ -69,30 +69,6 @@ export abstract class BaseSqliteStore {
         }
     }
 
-    /**
-     * Wraps a non-transactional operation in slow-timing telemetry. Use
-     * for batch reads or expensive single statements where logging slow
-     * cases is worth the timing overhead. No-op when no logger is set.
-     */
-    protected async timed<T>(operation: string, run: () => Promise<T> | T): Promise<T> {
-        if (!this.logger) {
-            return run()
-        }
-        const startedAt = Date.now()
-        try {
-            return await run()
-        } finally {
-            const durationMs = Date.now() - startedAt
-            if (durationMs >= this.slowOperationThresholdMs) {
-                this.logger.warn('slow sqlite operation', {
-                    operation,
-                    durationMs,
-                    thresholdMs: this.slowOperationThresholdMs
-                })
-            }
-        }
-    }
-
     public async destroy(): Promise<void> {
         const connectionPromise = this.connectionPromise
         this.connectionPromise = null

--- a/packages/store-sqlite/src/BaseSqliteStore.ts
+++ b/packages/store-sqlite/src/BaseSqliteStore.ts
@@ -1,9 +1,15 @@
+import type { Logger } from 'zapo-js'
+
 import { type NonPromise, openSqliteConnection, type WaSqliteConnection } from './connection'
 import { ensureSqliteMigrations, type WaSqliteMigrationDomain } from './migrations'
 import type { WaSqliteStorageOptions } from './types'
 
+const DEFAULT_SLOW_OPERATION_THRESHOLD_MS = 250
+
 export abstract class BaseSqliteStore {
     protected readonly options: WaSqliteStorageOptions
+    protected readonly logger: Logger | undefined
+    protected readonly slowOperationThresholdMs: number
     private readonly migrationDomains: readonly WaSqliteMigrationDomain[]
     private connectionPromise: Promise<WaSqliteConnection> | null
 
@@ -12,6 +18,9 @@ export abstract class BaseSqliteStore {
         migrationDomains: readonly WaSqliteMigrationDomain[]
     ) {
         this.options = options
+        this.logger = options.logger
+        this.slowOperationThresholdMs =
+            options.slowOperationThresholdMs ?? DEFAULT_SLOW_OPERATION_THRESHOLD_MS
         this.migrationDomains = migrationDomains
         this.connectionPromise = null
     }
@@ -28,9 +37,11 @@ export abstract class BaseSqliteStore {
             }
             const open: Promise<WaSqliteConnection> = supplied
                 ? Promise.resolve(supplied)
-                : openSqliteConnection(this.options)
+                : openSqliteConnection(this.options, this.logger)
             this.connectionPromise = open.then((connection) =>
-                ensureSqliteMigrations(connection, this.migrationDomains).then(() => connection)
+                ensureSqliteMigrations(connection, this.migrationDomains, this.logger).then(
+                    () => connection
+                )
             )
         }
         return this.connectionPromise
@@ -40,7 +51,46 @@ export abstract class BaseSqliteStore {
         run: (connection: WaSqliteConnection) => NonPromise<T>
     ): Promise<NonPromise<T>> {
         const db = await this.getConnection()
-        return db.runInTransaction(() => run(db))
+        if (!this.logger) {
+            return db.runInTransaction(() => run(db))
+        }
+        const startedAt = Date.now()
+        try {
+            return await db.runInTransaction(() => run(db))
+        } finally {
+            const durationMs = Date.now() - startedAt
+            if (durationMs >= this.slowOperationThresholdMs) {
+                this.logger.warn('slow sqlite transaction', {
+                    operation: 'withTransaction',
+                    durationMs,
+                    thresholdMs: this.slowOperationThresholdMs
+                })
+            }
+        }
+    }
+
+    /**
+     * Wraps a non-transactional operation in slow-timing telemetry. Use
+     * for batch reads or expensive single statements where logging slow
+     * cases is worth the timing overhead. No-op when no logger is set.
+     */
+    protected async timed<T>(operation: string, run: () => Promise<T> | T): Promise<T> {
+        if (!this.logger) {
+            return run()
+        }
+        const startedAt = Date.now()
+        try {
+            return await run()
+        } finally {
+            const durationMs = Date.now() - startedAt
+            if (durationMs >= this.slowOperationThresholdMs) {
+                this.logger.warn('slow sqlite operation', {
+                    operation,
+                    durationMs,
+                    thresholdMs: this.slowOperationThresholdMs
+                })
+            }
+        }
     }
 
     public async destroy(): Promise<void> {

--- a/packages/store-sqlite/src/connection.ts
+++ b/packages/store-sqlite/src/connection.ts
@@ -1,3 +1,4 @@
+import type { Logger } from 'zapo-js'
 import { isBunRuntime, toSafeNumber } from 'zapo-js/util'
 
 import {
@@ -424,7 +425,8 @@ function createConnectionHandle(
 }
 
 export async function openSqliteConnection(
-    options: WaSqliteStorageOptions
+    options: WaSqliteStorageOptions,
+    logger?: Logger
 ): Promise<WaSqliteConnection> {
     const { path } = options
     if (!path) {
@@ -440,6 +442,7 @@ export async function openSqliteConnection(
         .join(';')}|${serializeSqliteTableNames(resolvedTableNames)}`
     let entry = SQLITE_CONNECTION_CACHE.get(cacheKey)
     if (!entry) {
+        const startedAt = Date.now()
         const createdConnection =
             driver === 'bun'
                 ? openBunSqlite(path, resolveSql, normalizedPragmas)
@@ -452,12 +455,23 @@ export async function openSqliteConnection(
         createdEntry.connectionPromise = createdConnection
             .then((connection) => {
                 createdEntry.connection = connection
+                logger?.info('sqlite connection opened', {
+                    path,
+                    driver,
+                    pragmas: normalizedPragmas,
+                    durationMs: Date.now() - startedAt
+                })
                 return connection
             })
             .catch((error) => {
                 if (SQLITE_CONNECTION_CACHE.get(cacheKey) === createdEntry) {
                     SQLITE_CONNECTION_CACHE.delete(cacheKey)
                 }
+                logger?.error('sqlite connection failed to open', {
+                    path,
+                    driver,
+                    message: error instanceof Error ? error.message : String(error)
+                })
                 throw error
             })
         SQLITE_CONNECTION_CACHE.set(cacheKey, createdEntry)

--- a/packages/store-sqlite/src/createSqliteStore.ts
+++ b/packages/store-sqlite/src/createSqliteStore.ts
@@ -1,3 +1,5 @@
+import type { Logger } from 'zapo-js'
+
 import { WaAppStateSqliteStore } from './appstate.store'
 import { WaAuthSqliteStore } from './auth.store'
 import type { WaSqliteConnection } from './connection'
@@ -76,6 +78,19 @@ export interface WaSqliteStoreConfig {
         readonly deviceListMs?: number
         readonly messageSecretMs?: number
     }
+    /**
+     * Logger for connection lifecycle, migration progress, and
+     * slow-operation warnings. The factory binds `{ scope: 'store',
+     * provider: 'sqlite' }` to it, then each per-domain store binds its
+     * own `{ domain: '<name>' }`. When unset, the SQLite layer stays
+     * silent.
+     */
+    readonly logger?: Logger
+    /**
+     * Threshold in milliseconds above which a transaction emits a `warn`.
+     * Defaults to `250`.
+     */
+    readonly slowOperationThresholdMs?: number
 }
 
 export interface WaSqliteStoreResult {
@@ -151,48 +166,56 @@ export function createSqliteStore(config: WaSqliteStoreConfig): WaSqliteStoreRes
     const deviceListTtlMs = config.cacheTtlMs?.deviceListMs
     const messageSecretTtlMs = config.cacheTtlMs?.messageSecretMs
     const batchSizes = config.batchSizes
+    const baseLogger = config.logger?.child({ scope: 'store', provider: 'sqlite' })
+    const slowOperationThresholdMs = config.slowOperationThresholdMs
 
-    const opts = (sessionId: string): WaSqliteStorageOptions => ({
+    const opts = (sessionId: string, domain: string): WaSqliteStorageOptions => ({
         sessionId,
         path: config.path,
         connection: config.connection,
         driver: config.driver,
         pragmas: config.pragmas,
-        tableNames: config.tableNames
+        tableNames: config.tableNames,
+        logger: baseLogger?.child({ domain, sessionId }),
+        slowOperationThresholdMs
     })
 
     return {
         stores: {
-            auth: (sessionId) => new WaAuthSqliteStore(opts(sessionId)),
+            auth: (sessionId) => new WaAuthSqliteStore(opts(sessionId, 'auth')),
             preKey: (sessionId) =>
-                new WaPreKeySqliteStore(opts(sessionId), {
+                new WaPreKeySqliteStore(opts(sessionId, 'preKey'), {
                     preKeyBatchSize: batchSizes?.signalPreKey
                 }),
             session: (sessionId) =>
-                new WaSessionSqliteStore(opts(sessionId), {
+                new WaSessionSqliteStore(opts(sessionId, 'session'), {
                     hasSessionBatchSize: batchSizes?.signalHasSession
                 }),
-            identity: (sessionId) => new WaIdentitySqliteStore(opts(sessionId)),
-            signal: (sessionId) => new WaSignalSqliteStore(opts(sessionId)),
-            senderKey: (sessionId) => new SenderKeySqliteStore(opts(sessionId)),
-            appState: (sessionId) => new WaAppStateSqliteStore(opts(sessionId)),
-            messages: (sessionId) => new WaMessageSqliteStore(opts(sessionId)),
-            threads: (sessionId) => new WaThreadSqliteStore(opts(sessionId)),
-            contacts: (sessionId) => new WaContactSqliteStore(opts(sessionId)),
-            privacyToken: (sessionId) => new WaPrivacyTokenSqliteStore(opts(sessionId))
+            identity: (sessionId) => new WaIdentitySqliteStore(opts(sessionId, 'identity')),
+            signal: (sessionId) => new WaSignalSqliteStore(opts(sessionId, 'signal')),
+            senderKey: (sessionId) => new SenderKeySqliteStore(opts(sessionId, 'senderKey')),
+            appState: (sessionId) => new WaAppStateSqliteStore(opts(sessionId, 'appState')),
+            messages: (sessionId) => new WaMessageSqliteStore(opts(sessionId, 'messages')),
+            threads: (sessionId) => new WaThreadSqliteStore(opts(sessionId, 'threads')),
+            contacts: (sessionId) => new WaContactSqliteStore(opts(sessionId, 'contacts')),
+            privacyToken: (sessionId) =>
+                new WaPrivacyTokenSqliteStore(opts(sessionId, 'privacyToken'))
         },
         caches: {
-            retry: (sessionId) => new WaRetrySqliteStore(opts(sessionId), retryTtlMs),
+            retry: (sessionId) => new WaRetrySqliteStore(opts(sessionId, 'retry'), retryTtlMs),
             groupMetadata: (sessionId) =>
-                new WaGroupMetadataSqliteStore(opts(sessionId), groupMetadataTtlMs),
+                new WaGroupMetadataSqliteStore(
+                    opts(sessionId, 'groupMetadata'),
+                    groupMetadataTtlMs
+                ),
             deviceList: (sessionId) =>
                 new WaDeviceListSqliteStore(
-                    opts(sessionId),
+                    opts(sessionId, 'deviceList'),
                     deviceListTtlMs,
                     batchSizes?.deviceList
                 ),
             messageSecret: (sessionId) =>
-                new WaMessageSecretSqliteStore(opts(sessionId), messageSecretTtlMs)
+                new WaMessageSecretSqliteStore(opts(sessionId, 'messageSecret'), messageSecretTtlMs)
         }
     }
 }

--- a/packages/store-sqlite/src/migrations.ts
+++ b/packages/store-sqlite/src/migrations.ts
@@ -1,3 +1,5 @@
+import type { Logger } from 'zapo-js'
+
 import type { WaSqliteConnection } from './connection'
 
 const UNIQUE_CONSTRAINT_ID_RE = /UNIQUE constraint failed: [A-Za-z_][A-Za-z0-9_]*\.id/
@@ -464,7 +466,8 @@ function hasDomain(
 
 export async function ensureSqliteMigrations(
     db: WaSqliteConnection,
-    domains: readonly WaSqliteMigrationDomain[]
+    domains: readonly WaSqliteMigrationDomain[],
+    logger?: Logger
 ): Promise<void> {
     ensureMigrationTable(db)
     const domainSet = new Set(domains)
@@ -479,6 +482,7 @@ export async function ensureSqliteMigrations(
         if (hasMigration(db, migration.id)) {
             continue
         }
+        const startedAt = Date.now()
         try {
             await db.runInTransaction(() => {
                 if (hasMigration(db, migration.id)) {
@@ -491,10 +495,25 @@ export async function ensureSqliteMigrations(
                 )
                 migration.up(db)
             })
+            logger?.info('sqlite migration applied', {
+                id: migration.id,
+                migrationDomain: migration.domain,
+                durationMs: Date.now() - startedAt
+            })
         } catch (error) {
             if (isMigrationAlreadyAppliedRace(error)) {
+                logger?.debug('sqlite migration skipped due to concurrent apply race', {
+                    id: migration.id,
+                    migrationDomain: migration.domain
+                })
                 continue
             }
+            logger?.error('sqlite migration failed', {
+                id: migration.id,
+                migrationDomain: migration.domain,
+                durationMs: Date.now() - startedAt,
+                message: error instanceof Error ? error.message : String(error)
+            })
             throw error
         }
     }

--- a/packages/store-sqlite/src/types.ts
+++ b/packages/store-sqlite/src/types.ts
@@ -1,3 +1,5 @@
+import type { Logger } from 'zapo-js'
+
 import type { WaSqliteConnection } from './connection'
 
 export type WaSqliteDriver = 'auto' | 'better-sqlite3' | 'bun'
@@ -46,6 +48,18 @@ export interface WaSqliteStorageOptions {
     readonly driver?: WaSqliteDriver
     readonly pragmas?: Readonly<Record<string, string | number>>
     readonly tableNames?: WaSqliteTableNameOverrides
+    /**
+     * Logger used for connection lifecycle, migration progress, and
+     * slow-operation warnings. Typically a child logger pre-bound with
+     * `{ scope: 'store', provider: 'sqlite' }` (or `{ domain: '...' }`
+     * downstream). When unset, the store is silent.
+     */
+    readonly logger?: Logger
+    /**
+     * Threshold in milliseconds above which a SQLite transaction or
+     * timed-helper call emits a `warn` log. Defaults to `250`.
+     */
+    readonly slowOperationThresholdMs?: number
 }
 
 export type WaSqliteMigrationDomain =

--- a/src/appstate/sync/WaAppStateSyncClient.ts
+++ b/src/appstate/sync/WaAppStateSyncClient.ts
@@ -195,35 +195,25 @@ export class WaAppStateSyncClient {
         context: IncomingKeyEventContext,
         protocolMessage: Proto.Message.IProtocolMessage
     ): Promise<void> {
+        const log = this.logger.child({ id: context.id, from: context.remoteJid })
         const share = protocolMessage.appStateSyncKeyShare
         if (!share) {
-            this.logger.warn('incoming app-state key share protocol message without payload', {
-                id: context.id,
-                from: context.remoteJid
-            })
+            log.warn('incoming app-state key share protocol message without payload')
             return
         }
 
         try {
             const imported = await this.importSyncKeyShare(share)
-            this.logger.info('imported app-state sync key share from protocol message', {
-                id: context.id,
-                from: context.remoteJid,
-                imported
-            })
+            log.info('imported app-state sync key share from protocol message', { imported })
             if (imported > 0 && this.triggerSync) {
                 void this.triggerSync().catch((error) => {
-                    this.logger.warn('failed to sync app-state after key share import', {
-                        id: context.id,
-                        from: context.remoteJid,
+                    log.warn('failed to sync app-state after key share import', {
                         message: toError(error).message
                     })
                 })
             }
         } catch (error) {
-            this.logger.warn('failed to import app-state sync key share from protocol message', {
-                id: context.id,
-                from: context.remoteJid,
+            log.warn('failed to import app-state sync key share from protocol message', {
                 message: toError(error).message
             })
         }
@@ -234,20 +224,16 @@ export class WaAppStateSyncClient {
         context: IncomingKeyEventContext,
         protocolMessage: Proto.Message.IProtocolMessage
     ): Promise<void> {
+        const log = this.logger.child({ id: context.id, from: context.remoteJid })
         const request = protocolMessage.appStateSyncKeyRequest
         if (!request) {
-            this.logger.warn('incoming app-state key request protocol message without payload', {
-                id: context.id,
-                from: context.remoteJid
-            })
+            log.warn('incoming app-state key request protocol message without payload')
             return
         }
 
         const senderJid = context.participant ?? context.remoteJid
         if (!senderJid) {
-            this.logger.warn('incoming app-state key request missing sender jid', {
-                id: context.id
-            })
+            log.warn('incoming app-state key request missing sender jid')
             return
         }
 
@@ -256,36 +242,27 @@ export class WaAppStateSyncClient {
             const requesterRaw = applyDeviceToJid(senderJid, context.senderDevice)
             requesterDeviceJid = normalizeDeviceJid(requesterRaw)
         } catch (error) {
-            this.logger.warn('incoming app-state key request has malformed sender jid', {
-                id: context.id,
-                from: senderJid,
+            log.warn('incoming app-state key request has malformed sender jid', {
+                senderJid,
                 message: toError(error).message
             })
             return
         }
 
+        const deviceLog = log.child({ to: requesterDeviceJid })
         if (this.isOwnAccountDevice && !this.isOwnAccountDevice(requesterDeviceJid)) {
-            this.logger.warn('incoming app-state key request ignored: sender is not own account', {
-                id: context.id,
-                from: requesterDeviceJid
-            })
+            deviceLog.warn('incoming app-state key request ignored: sender is not own account')
             return
         }
 
         const requestedKeyIds = this.extractKeyRequestIds(request)
         if (requestedKeyIds.length === 0) {
-            this.logger.warn('incoming app-state key request has no valid key ids', {
-                id: context.id,
-                from: requesterDeviceJid
-            })
+            deviceLog.warn('incoming app-state key request has no valid key ids')
             return
         }
 
         if (!this.sendKeyShare) {
-            this.logger.warn('incoming app-state key request received but no sendKeyShare wired', {
-                id: context.id,
-                from: requesterDeviceJid
-            })
+            deviceLog.warn('incoming app-state key request received but no sendKeyShare wired')
             return
         }
 
@@ -303,17 +280,13 @@ export class WaAppStateSyncClient {
 
         try {
             await this.sendKeyShare(requesterDeviceJid, availableKeys, missingKeyIds)
-            this.logger.info('responded to app-state key request', {
-                id: context.id,
-                to: requesterDeviceJid,
+            deviceLog.info('responded to app-state key request', {
                 requested: requestedKeyIds.length,
                 shared: availableKeys.length,
                 missing: missingKeyIds.length
             })
         } catch (error) {
-            this.logger.warn('failed to respond to app-state key request', {
-                id: context.id,
-                to: requesterDeviceJid,
+            deviceLog.warn('failed to respond to app-state key request', {
                 requested: requestedKeyIds.length,
                 shared: availableKeys.length,
                 missing: missingKeyIds.length,
@@ -415,7 +388,7 @@ export class WaAppStateSyncClient {
                 context.collections.set(collections[index], initialCollectionStates[index])
             }
 
-            this.logger.info('app-state sync start', {
+            this.logger.debug('app-state sync start', {
                 collections: collections.length,
                 pendingMutations: options.pendingMutations?.length ?? 0
             })
@@ -475,7 +448,7 @@ export class WaAppStateSyncClient {
 
             if (stateChanged && context.dirtyCollections.size > 0) {
                 await this.persistCollectionUpdates()
-                this.logger.info('app-state sync persisted updated state')
+                this.logger.debug('app-state sync persisted updated state')
             }
 
             const orderedResults = collections.map(
@@ -486,7 +459,7 @@ export class WaAppStateSyncClient {
                     }
             )
 
-            this.logger.info('app-state sync finished', {
+            this.logger.debug('app-state sync finished', {
                 collections: orderedResults.length,
                 stateChanged
             })
@@ -716,12 +689,13 @@ export class WaAppStateSyncClient {
         readonly result: WaAppStateCollectionSyncResult
         readonly missingKeyId: Uint8Array | null
     }> {
+        const collectionLogger = this.logger.child({ collection })
         const payload = payloadByCollection.get(collection)
         let shouldRefetch = false
         let collectionStateChanged = false
 
         if (!payload) {
-            this.logger.warn('app-state sync response missing collection payload', { collection })
+            collectionLogger.warn('app-state sync response missing collection payload')
             return this.createCollectionOutcome(
                 collection,
                 WA_APP_STATE_COLLECTION_STATES.ERROR_RETRY
@@ -822,8 +796,7 @@ export class WaAppStateSyncClient {
                 (payload.state === WA_APP_STATE_COLLECTION_STATES.SUCCESS &&
                     skippedUploadCollections.has(collection))
 
-            this.logger.debug('app-state collection processed', {
-                collection: payload.collection,
+            collectionLogger.debug('app-state collection processed', {
                 state: payload.state,
                 version: payload.version,
                 appliedMutations: appliedMutations.length
@@ -838,8 +811,7 @@ export class WaAppStateSyncClient {
             )
         } catch (error) {
             if (error instanceof WaAppStateMissingKeyError) {
-                this.logger.warn('app-state blocked by missing key', {
-                    collection: payload.collection,
+                collectionLogger.debug('app-state blocked by missing key', {
                     message: error.message
                 })
                 return this.createCollectionOutcome(
@@ -852,8 +824,7 @@ export class WaAppStateSyncClient {
                     error.keyId
                 )
             }
-            this.logger.warn('app-state collection processing failed', {
-                collection: payload.collection,
+            collectionLogger.debug('app-state collection processing failed', {
                 message: toError(error).message
             })
             return this.createCollectionOutcome(
@@ -907,10 +878,12 @@ export class WaAppStateSyncClient {
         }
 
         const keyIdsHex = keyIds.map((keyId) => bytesToHex(keyId))
-        this.logger.info('app-state requesting missing sync keys', {
+        const requestLogger = this.logger.child({
             keys: keyIdsHex.length,
-            keyIds: keyIdsHex.join(','),
             collections: collections.join(',')
+        })
+        requestLogger.debug('app-state requesting missing sync keys', {
+            keyIds: keyIdsHex.join(',')
         })
 
         try {
@@ -919,9 +892,7 @@ export class WaAppStateSyncClient {
                 collections
             })
         } catch (error) {
-            this.logger.warn('app-state missing key callback failed', {
-                keys: keyIdsHex.length,
-                collections: collections.join(','),
+            requestLogger.warn('app-state missing key callback failed', {
                 message: toError(error).message
             })
         }
@@ -1331,7 +1302,7 @@ export class WaAppStateSyncClient {
         )
         // non-fatal: wa-mob/wa-web tolerate this – patchMac below covers payload integrity.
         if (!uint8TimingSafeEqual(expectedSnapshotMac, snapshotMac)) {
-            this.logger.warn('patch snapshot MAC mismatch (tolerated)', {
+            this.logger.debug('patch snapshot MAC mismatch (tolerated)', {
                 collection,
                 patchVersion
             })

--- a/src/auth/WaAuthClient.ts
+++ b/src/auth/WaAuthClient.ts
@@ -359,7 +359,7 @@ export class WaAuthClient {
     ): Promise<string> {
         this.requireConnected()
         this.requireCredentials()
-        this.logger.info('auth client requesting pairing code')
+        this.logger.debug('auth client requesting pairing code')
         return this.runHandled(() =>
             this.pairingFlow.requestPairingCode(phoneNumber, shouldShowPushNotification, customCode)
         )

--- a/src/auth/pairing/WaPairingFlow.ts
+++ b/src/auth/pairing/WaPairingFlow.ts
@@ -145,7 +145,7 @@ export class WaPairingFlow {
             finished: false
         }
         this.opts.callbacks.emitPairingCode(companionHello.pairingCode)
-        this.opts.logger.info('pairing code emitted', {
+        this.opts.logger.debug('pairing code emitted', {
             phoneJid,
             createdAtSeconds: this.pairingSession.createdAtSeconds
         })
@@ -168,21 +168,19 @@ export class WaPairingFlow {
     }
 
     public async handleIncomingIqSet(node: BinaryNode): Promise<boolean> {
-        this.opts.logger.trace('pairing flow received iq:set', {
-            id: node.attrs.id,
-            from: node.attrs.from
-        })
+        const iqLogger = this.opts.logger.child({ id: node.attrs.id })
+        iqLogger.trace('pairing flow received iq:set', { from: node.attrs.from })
         const firstChild = getFirstNodeChild(node)
         if (!firstChild) {
             return false
         }
         if (firstChild.tag === WA_NODE_TAGS.PAIR_DEVICE) {
-            this.opts.logger.debug('handling pair-device stanza', { id: node.attrs.id })
+            iqLogger.debug('handling pair-device stanza')
             await this.handlePairDevice(node, firstChild)
             return true
         }
         if (firstChild.tag === WA_NODE_TAGS.PAIR_SUCCESS) {
-            this.opts.logger.debug('handling pair-success stanza', { id: node.attrs.id })
+            iqLogger.debug('handling pair-success stanza')
             await this.handlePairSuccess(node, firstChild)
             return true
         }
@@ -216,7 +214,7 @@ export class WaPairingFlow {
                 'refresh_code.link_code_pairing_ref'
             )
             if (uint8Equal(ref, this.pairingSession.ref)) {
-                this.opts.logger.info('received pairing refresh notification', {
+                this.opts.logger.debug('received pairing refresh notification', {
                     forceManualRefresh: linkCodeNode.attrs.force_manual_refresh === 'true'
                 })
                 this.opts.callbacks.emitPairingRefresh(
@@ -250,7 +248,7 @@ export class WaPairingFlow {
                 typeOverride: WA_SIGNALING.COMPANION_REG_REFRESH_NOTIFICATION
             })
         )
-        this.opts.logger.info('handled companion_reg_refresh notification')
+        this.opts.logger.debug('handled companion_reg_refresh notification')
         this.opts.qrFlow.refreshCurrentQr()
         return true
     }
@@ -265,14 +263,14 @@ export class WaPairingFlow {
         await this.rotateAdvSecret(this.requireCredentials())
         await this.opts.socket.sendNode(buildIqResultNode(iqNode))
         this.opts.qrFlow.setRefs(refs)
-        this.opts.logger.info('pair-device refs updated', { refsCount: refs.length })
+        this.opts.logger.debug('pair-device refs updated', { refsCount: refs.length })
     }
 
     private async handlePairSuccess(
         iqNode: BinaryNode,
         pairSuccessNode: BinaryNode
     ): Promise<void> {
-        this.opts.logger.info('processing pair-success node')
+        this.opts.logger.debug('processing pair-success node')
         const credentials = this.requireCredentials()
         const [deviceIdentityNode, deviceNode, platformNode] = findNodeChildrenByTags(
             pairSuccessNode,
@@ -305,7 +303,12 @@ export class WaPairingFlow {
                 : wrappedDetails
             const expectedHmac = computeAdvIdentityHmac(credentials.advSecretKey, hmacInput)
             if (!uint8TimingSafeEqual(expectedHmac, wrappedHmac)) {
-                this.opts.logger.error('pair-success hmac mismatch')
+                this.opts.logger.error('pair-success hmac mismatch', {
+                    meJid: deviceNode.attrs.jid,
+                    meLid: deviceNode.attrs.lid,
+                    platform: platformNode.attrs.name,
+                    isHosted
+                })
                 throw new Error('pair-success HMAC validation failed')
             }
         }
@@ -383,7 +386,10 @@ export class WaPairingFlow {
                 isDeviceHosted
             )
             if (!validAccountSignature) {
-                this.opts.logger.error('pair-success account signature invalid')
+                this.opts.logger.error('pair-success account signature invalid', {
+                    keyIndex: advDeviceIdentity.keyIndex ?? 0,
+                    isDeviceHosted
+                })
                 throw new Error('pair-success account signature validation failed')
             }
         }
@@ -439,7 +445,9 @@ export class WaPairingFlow {
             'primary_hello.link_code_pairing_ref'
         )
         if (!pairingSession.ref || !uint8Equal(ref, pairingSession.ref)) {
-            this.opts.logger.warn('primary_hello ref mismatch ignored')
+            this.opts.logger.warn('primary_hello ref mismatch ignored', {
+                phoneJid: pairingSession.phoneJid
+            })
             return
         }
 
@@ -482,7 +490,7 @@ export class WaPairingFlow {
             advSecretKey: finish.advSecret
         })
         pairingSession.finished = true
-        this.opts.logger.info('primary_hello completed with companion_finish success')
+        this.opts.logger.debug('primary_hello completed with companion_finish success')
     }
 
     private async rotateAdvSecret(credentials: WaAuthCredentials): Promise<WaAuthCredentials> {

--- a/src/client/connection/WaConnectionManager.ts
+++ b/src/client/connection/WaConnectionManager.ts
@@ -98,6 +98,7 @@ export class WaConnectionManager {
                     return
                 }
                 this.logger.warn('failed to reconnect after pairing', {
+                    meJid: this.authClient.getCurrentCredentials()?.meJid,
                     message: toError(error).message
                 })
             })
@@ -168,7 +169,7 @@ export class WaConnectionManager {
             return
         }
 
-        this.logger.info('wa client connect start')
+        this.logger.debug('wa client connect start')
         let credentials = await this.authClient.loadOrCreateCredentials()
         this.assertLifecycleCurrent(lifecycleGeneration, 'connect')
 
@@ -258,7 +259,7 @@ export class WaConnectionManager {
             return
         }
 
-        this.logger.info('wa client disconnect start')
+        this.logger.debug('wa client disconnect start')
         if (this.pairingReconnectTimeout) {
             clearTimeout(this.pairingReconnectTimeout)
             this.pairingReconnectTimeout = null
@@ -290,7 +291,7 @@ export class WaConnectionManager {
         ])
 
         if (this.isLifecycleCurrent(lifecycleGeneration)) {
-            this.logger.info('wa client disconnected')
+            this.logger.debug('wa client disconnected')
         }
     }
 
@@ -324,7 +325,7 @@ export class WaConnectionManager {
             this.comms = comms
             this.pendingComms = null
             this.nodeTransport.bindComms(comms)
-            this.logger.info('comms connected')
+            this.logger.debug('comms connected')
             comms.startHandlingRequests()
 
             if (credentials.meJid) {

--- a/src/client/coordinators/WaIncomingNodeCoordinator.ts
+++ b/src/client/coordinators/WaIncomingNodeCoordinator.ts
@@ -187,14 +187,13 @@ export class WaIncomingNodeCoordinator {
         if (this.stanzaFilters.length === 0 || FILTER_PROTECTED_TAGS.has(node.tag)) {
             return false
         }
+        const filterLogger = this.logger.child({ tag: node.tag, id: node.attrs.id })
         for (let i = 0; i < this.stanzaFilters.length; i += 1) {
             let verdict: boolean
             try {
                 verdict = await this.stanzaFilters[i](node)
             } catch (error) {
-                this.logger.warn('incoming stanza filter threw', {
-                    tag: node.tag,
-                    id: node.attrs.id,
+                filterLogger.warn('incoming stanza filter threw', {
                     message: toError(error).message
                 })
                 continue
@@ -202,9 +201,7 @@ export class WaIncomingNodeCoordinator {
             if (!verdict) {
                 continue
             }
-            this.logger.debug('incoming stanza dropped by filter', {
-                tag: node.tag,
-                id: node.attrs.id,
+            filterLogger.trace('incoming stanza dropped by filter', {
                 type: node.attrs.type,
                 from: node.attrs.from
             })

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -159,7 +159,7 @@ export class WaMessageDispatchCoordinator {
         node: BinaryNode,
         options: WaMessagePublishOptions = {}
     ): Promise<WaMessagePublishResult> {
-        this.deps.logger.debug('wa client publish message node', {
+        this.deps.logger.trace('wa client publish message node', {
             tag: node.tag,
             type: node.attrs.type,
             to: node.attrs.to
@@ -182,7 +182,7 @@ export class WaMessageDispatchCoordinator {
         input: WaEncryptedMessageInput,
         options: WaMessagePublishOptions = {}
     ): Promise<WaMessagePublishResult> {
-        this.deps.logger.debug('wa client publish encrypted message', {
+        this.deps.logger.trace('wa client publish encrypted message', {
             to: input.to,
             type: input.type,
             encType: input.encType
@@ -217,7 +217,7 @@ export class WaMessageDispatchCoordinator {
                 'publishSignalMessage currently supports only direct chats; use sender-key flow for groups'
             )
         }
-        this.deps.logger.debug('wa client publish signal message', {
+        this.deps.logger.trace('wa client publish signal message', {
             to: input.to,
             type: input.type
         })
@@ -388,6 +388,7 @@ export class WaMessageDispatchCoordinator {
                 .catch((error) => {
                     this.deps.logger.warn('failed to persist outgoing message secret', {
                         id: sendOptions.id,
+                        to: recipientJid,
                         message: toError(error).message
                     })
                 })
@@ -742,14 +743,12 @@ export class WaMessageDispatchCoordinator {
                 distributedAddresses
             )
         } catch (error) {
-            this.deps.logger.warn(
-                `failed to mark ${input.logTag} sender key distribution targets`,
-                {
-                    groupJid: input.groupJid,
-                    participants: distributedAddresses.length,
-                    message: toError(error).message
-                }
-            )
+            this.deps.logger.warn('failed to mark sender key distribution targets', {
+                logTag: input.logTag,
+                groupJid: input.groupJid,
+                participants: distributedAddresses.length,
+                message: toError(error).message
+            })
         }
         return result
     }
@@ -812,13 +811,19 @@ export class WaMessageDispatchCoordinator {
         for (let index = 0; index < fanoutDeviceJids.length; index += 1) {
             uniqueNormalizedFanoutJids.add(normalizeDeviceJid(fanoutDeviceJids[index]))
         }
+        const droppedDevices: string[] = []
         for (const expected of uniqueNormalizedFanoutJids) {
             if (!resolvedNormalizedJids.has(expected)) {
-                this.deps.logger.warn(
-                    'group direct fanout dropping device without signal session',
-                    { groupJid, device: expected }
-                )
+                droppedDevices.push(expected)
             }
+        }
+        if (droppedDevices.length > 0) {
+            this.deps.logger.warn('group direct fanout dropping devices without signal session', {
+                groupJid,
+                droppedCount: droppedDevices.length,
+                totalExpected: uniqueNormalizedFanoutJids.size,
+                sample: droppedDevices.slice(0, 3)
+            })
         }
         if (resolvedFanoutTargets.length === 0) {
             throw new Error('group direct send resolved no signal sessions')
@@ -958,7 +963,7 @@ export class WaMessageDispatchCoordinator {
         try {
             address = parseSignalAddressFromJid(botJid)
         } catch (error) {
-            this.deps.logger.warn('bot sidecar: failed to parse bot jid', {
+            this.deps.logger.debug('bot sidecar: failed to parse bot jid', {
                 botJid,
                 message: toError(error).message
             })
@@ -969,14 +974,14 @@ export class WaMessageDispatchCoordinator {
         try {
             resolvedTargets = await this.deps.sessionResolver.ensureSessionsBatch([botJid])
         } catch (error) {
-            this.deps.logger.warn('bot sidecar: signal session sync failed', {
+            this.deps.logger.debug('bot sidecar: signal session sync failed', {
                 botJid,
                 message: toError(error).message
             })
             return null
         }
         if (resolvedTargets.length === 0) {
-            this.deps.logger.warn('bot sidecar: signal session not established', { botJid })
+            this.deps.logger.debug('bot sidecar: signal session not established', { botJid })
             return null
         }
 
@@ -997,14 +1002,14 @@ export class WaMessageDispatchCoordinator {
                 }))
             )
             if (!encrypted) return null
-            this.deps.logger.debug('bot sidecar encrypted', { botJid, encType: encrypted.type })
+            this.deps.logger.trace('bot sidecar encrypted', { botJid, encType: encrypted.type })
             return {
                 jid: botJid,
                 encType: encrypted.type,
                 ciphertext: encrypted.ciphertext
             }
         } catch (error) {
-            this.deps.logger.warn('bot sidecar: encryption failed', {
+            this.deps.logger.debug('bot sidecar: encryption failed', {
                 botJid,
                 message: toError(error).message
             })
@@ -1392,7 +1397,7 @@ export class WaMessageDispatchCoordinator {
         const recipientUserJid = toUserJid(recipientJid)
         const meUserJid = toUserJid(selfDeviceJidForRecipient)
 
-        this.deps.logger.debug('wa client publish signal fanout', {
+        this.deps.logger.trace('wa client publish signal fanout', {
             to: recipientJid,
             devices: deviceJids.length,
             type
@@ -1416,6 +1421,7 @@ export class WaMessageDispatchCoordinator {
             resolvedFanoutTargetsByJid.set(normalizeDeviceJid(target.jid), target)
         }
         const liveTargets: typeof targets = []
+        const droppedSecondaryDevices: string[] = []
         for (let index = 0; index < targets.length; index += 1) {
             const target = targets[index]
             if (resolvedFanoutTargetsByJid.has(target.normalizedJid)) {
@@ -1424,18 +1430,25 @@ export class WaMessageDispatchCoordinator {
             }
             const isPrimaryRecipient =
                 target.userJid === recipientUserJid && target.normalizedJid === target.userJid
-            const logContext = { to: recipientJid, device: target.jid }
             if (isPrimaryRecipient) {
                 this.deps.logger.error(
                     'direct fanout dropping primary recipient device without signal session',
-                    logContext
+                    { to: recipientJid, device: target.jid }
                 )
             } else {
-                this.deps.logger.warn(
-                    'direct fanout dropping device without signal session',
-                    logContext
-                )
+                droppedSecondaryDevices.push(target.jid)
             }
+        }
+        if (droppedSecondaryDevices.length > 0) {
+            this.deps.logger.warn(
+                'direct fanout dropping secondary devices without signal session',
+                {
+                    to: recipientJid,
+                    droppedCount: droppedSecondaryDevices.length,
+                    totalExpected: targets.length,
+                    sample: droppedSecondaryDevices.slice(0, 3)
+                }
+            )
         }
         if (liveTargets.length === 0) {
             throw new Error('direct fanout missing signal sessions for all targets')

--- a/src/client/coordinators/WaPassiveTasksCoordinator.ts
+++ b/src/client/coordinators/WaPassiveTasksCoordinator.ts
@@ -241,6 +241,7 @@ export class WaPassiveTasksCoordinator {
         const failure = parsePreKeyUploadFailure(response)
         this.logger.warn('upload prekeys failed', {
             count: preKeys.length,
+            lastPreKeyId,
             errorCode: failure.errorCode,
             errorText: failure.errorText
         })

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -278,9 +278,10 @@ export class WaRetryCoordinator {
             retryCount,
             retryKeys:
                 forceKeysForHosted || retryCount >= RETRY_KEYS_MIN_COUNT
-                    ? ((await this.buildRetryKeysSection(
-                          registrationInfo.identityKeyPair.pubKey
-                      )) ?? undefined)
+                    ? ((await this.buildRetryKeysSection(registrationInfo.identityKeyPair.pubKey, {
+                          stanzaId: context.stanzaId,
+                          from: context.from
+                      })) ?? undefined)
                     : undefined,
             retryReason: mapRetryReasonFromError(error),
             timestamp: context.t ?? String(Math.trunc(nowMs / 1000)),
@@ -307,7 +308,7 @@ export class WaRetryCoordinator {
             keys: prepared.retryKeys
         })
         await this.deps.sendNode(retryReceiptNode)
-        this.deps.logger.debug('sent retry receipt for decrypt failure', {
+        this.deps.logger.trace('sent retry receipt for decrypt failure', {
             id: context.stanzaId,
             to: context.from,
             participant: context.participant,
@@ -343,7 +344,7 @@ export class WaRetryCoordinator {
         request: WaParsedRetryRequest
     ): Promise<void> {
         if (request.type === WA_MESSAGE_TYPES.RECEIPT_TYPE_ENC_REKEY_RETRY) {
-            this.deps.logger.info('received enc_rekey_retry request (voip path deferred)', {
+            this.deps.logger.debug('received enc_rekey_retry request (voip path deferred)', {
                 id: request.stanzaId,
                 originalMsgId: request.originalMsgId,
                 from: request.from,
@@ -364,25 +365,24 @@ export class WaRetryCoordinator {
         if (!prepared) {
             return
         }
+        const requestLogger = this.deps.logger.child({
+            id: request.stanzaId,
+            originalMsgId: request.originalMsgId,
+            requester: prepared.requesterJid
+        })
         const resendResult = await this.retryReplayService.resendOutboundMessage(
             prepared.outbound,
             prepared.requesterJid,
             request.retryCount
         )
         if (resendResult === 'ineligible') {
-            this.deps.logger.info('retry request marked ineligible for resend', {
-                id: request.stanzaId,
-                originalMsgId: request.originalMsgId,
-                requester: prepared.requesterJid,
+            requestLogger.debug('retry request marked ineligible for resend', {
                 mode: prepared.outbound.replayMode
             })
             return
         }
 
-        this.deps.logger.info('retry request processed and resent', {
-            id: request.stanzaId,
-            originalMsgId: request.originalMsgId,
-            requester: prepared.requesterJid,
+        requestLogger.debug('retry request processed and resent', {
             mode: prepared.outbound.replayMode,
             remoteRetryCount: request.retryCount,
             ...getRemoteRetryReasonLogFields(request.retryReason)
@@ -392,14 +392,16 @@ export class WaRetryCoordinator {
     private async prepareRetryResend(
         request: WaParsedRetryRequest
     ): Promise<RetryResendPreparation | null> {
+        const requestLogger = this.deps.logger.child({
+            id: request.stanzaId,
+            originalMsgId: request.originalMsgId
+        })
         const requesterJid = request.participant ?? request.from ?? null
         if (!requesterJid) {
-            this.deps.logger.warn('retry request ignored: missing requester jid', {
-                id: request.stanzaId,
-                originalMsgId: request.originalMsgId
-            })
+            requestLogger.warn('retry request ignored: missing requester jid')
             return null
         }
+        const requesterLogger = requestLogger.child({ requester: requesterJid })
         let requesterAddress: ReturnType<typeof parseSignalAddressFromJid>
         let requesterNormalizedDeviceJid: string
         try {
@@ -407,20 +409,14 @@ export class WaRetryCoordinator {
             requesterAddress = requesterParsed.address
             requesterNormalizedDeviceJid = requesterParsed.normalizedJid
         } catch (error) {
-            this.deps.logger.info('retry request rejected: invalid requester jid', {
-                id: request.stanzaId,
-                originalMsgId: request.originalMsgId,
-                requester: requesterJid,
+            requesterLogger.debug('retry request rejected: invalid requester jid', {
                 message: toError(error).message
             })
             return null
         }
 
         if (request.retryCount >= MAX_RETRY_ATTEMPTS) {
-            this.deps.logger.info('retry request rejected: retry count exceeded', {
-                id: request.stanzaId,
-                originalMsgId: request.originalMsgId,
-                requester: requesterJid,
+            requesterLogger.debug('retry request rejected: retry count exceeded', {
                 remoteRetryCount: request.retryCount,
                 ...getRemoteRetryReasonLogFields(request.retryReason)
             })
@@ -429,11 +425,7 @@ export class WaRetryCoordinator {
 
         const outbound = await this.deps.retryStore.getOutboundMessage(request.originalMsgId)
         if (!outbound) {
-            this.deps.logger.info('retry request ignored: outbound message not found', {
-                id: request.stanzaId,
-                originalMsgId: request.originalMsgId,
-                requester: requesterJid
-            })
+            requesterLogger.debug('retry request ignored: outbound message not found')
             return null
         }
 
@@ -444,10 +436,7 @@ export class WaRetryCoordinator {
             requesterNormalizedDeviceJid
         )
         if (!sessionReady) {
-            this.deps.logger.info('retry request rejected: missing compatible session', {
-                id: request.stanzaId,
-                originalMsgId: request.originalMsgId,
-                requester: requesterJid,
+            requesterLogger.debug('retry request rejected: missing compatible session', {
                 remoteRetryCount: request.retryCount,
                 ...getRemoteRetryReasonLogFields(request.retryReason)
             })
@@ -462,10 +451,7 @@ export class WaRetryCoordinator {
             requesterNormalizedDeviceJid
         )
         if (!authorization.authorized) {
-            this.deps.logger.info('retry request rejected', {
-                id: request.stanzaId,
-                originalMsgId: request.originalMsgId,
-                requester: requesterJid,
+            requesterLogger.debug('retry request rejected', {
                 reason: authorization.reason,
                 remoteRetryCount: request.retryCount,
                 ...getRemoteRetryReasonLogFields(request.retryReason)
@@ -560,13 +546,19 @@ export class WaRetryCoordinator {
         }
     }
 
-    private async buildRetryKeysSection(identity: Uint8Array): Promise<WaRetryKeyBundle | null> {
+    private async buildRetryKeysSection(
+        identity: Uint8Array,
+        logContext: { readonly stanzaId?: string; readonly from?: string }
+    ): Promise<WaRetryKeyBundle | null> {
         const [signedPreKey, preKey] = await Promise.all([
             this.deps.signalStore.getSignedPreKey(),
             this.deps.preKeyStore.getOrGenSinglePreKey(generatePreKeyPair)
         ])
         if (!signedPreKey) {
-            this.deps.logger.warn('retry keys section skipped: signed prekey unavailable')
+            this.deps.logger.warn('retry keys section skipped: signed prekey unavailable', {
+                id: logContext.stanzaId,
+                from: logContext.from
+            })
             return null
         }
         await this.deps.preKeyStore.markKeyAsUploaded(preKey.keyId)
@@ -594,6 +586,11 @@ export class WaRetryCoordinator {
         requesterAddress: ReturnType<typeof parseSignalAddressFromJid>,
         requesterNormalizedDeviceJid: string
     ): Promise<boolean> {
+        const requestLogger = this.deps.logger.child({
+            id: request.stanzaId,
+            originalMsgId: request.originalMsgId,
+            requester: requesterJid
+        })
         const [, currentSession] = await Promise.all([
             this.markRetryRequesterSenderKeyAsStale(request, requesterJid, requesterAddress),
             this.deps.sessionStore.getSession(requesterAddress)
@@ -609,12 +606,9 @@ export class WaRetryCoordinator {
             }
             if (request.offline) {
                 if (!currentSession) {
-                    this.deps.logger.info(
+                    requestLogger.debug(
                         'retry request rejected: offline retry missing existing session',
                         {
-                            id: request.stanzaId,
-                            originalMsgId: request.originalMsgId,
-                            requester: requesterJid,
                             remoteRetryCount: request.retryCount,
                             ...getRemoteRetryReasonLogFields(request.retryReason)
                         }
@@ -623,12 +617,9 @@ export class WaRetryCoordinator {
                     return false
                 }
                 if (regIdMismatch) {
-                    this.deps.logger.info(
+                    requestLogger.debug(
                         'retry request rejected: offline retry registration id mismatch',
                         {
-                            id: request.stanzaId,
-                            originalMsgId: request.originalMsgId,
-                            requester: requesterJid,
                             remoteRetryCount: request.retryCount,
                             ...getRemoteRetryReasonLogFields(request.retryReason)
                         }
@@ -722,7 +713,7 @@ export class WaRetryCoordinator {
         }
 
         await this.deps.sessionStore.deleteSession(requesterAddress)
-        this.deps.logger.info('retry request forcing session refresh due to repeated base key', {
+        this.deps.logger.debug('retry request forcing session refresh due to repeated base key', {
             id: request.stanzaId,
             originalMsgId: request.originalMsgId,
             requester: requesterJid,
@@ -774,6 +765,7 @@ export class WaRetryCoordinator {
         requesterNormalizedDeviceJid: string,
         requesterRegistrationId: number
     ): Promise<SignalPreKeyBundle | null> {
+        const requesterLogger = this.deps.logger.child({ requester: requesterJid })
         try {
             const results = await this.deps.signalMissingPreKeysSync.fetchMissingPreKeys([
                 {
@@ -788,8 +780,7 @@ export class WaRetryCoordinator {
             ])
             const first = results[0]
             if (!first || !('devices' in first)) {
-                this.deps.logger.warn('missing prekeys fetch returned user error', {
-                    requester: requesterJid,
+                requesterLogger.debug('missing prekeys fetch returned user error', {
                     errorText: first && 'errorText' in first ? first.errorText : 'unknown'
                 })
                 return null
@@ -799,16 +790,14 @@ export class WaRetryCoordinator {
                 (device) => normalizeDeviceJid(device.deviceJid) === requesterNormalizedDeviceJid
             )
             if (!matched) {
-                this.deps.logger.warn('missing prekeys fetch did not return requested device', {
-                    requester: requesterJid,
+                requesterLogger.debug('missing prekeys fetch did not return requested device', {
                     devices: first.devices.length
                 })
                 return null
             }
             return matched.bundle
         } catch (error) {
-            this.deps.logger.warn('failed to fetch missing prekeys for retry requester', {
-                requester: requesterJid,
+            requesterLogger.debug('failed to fetch missing prekeys for retry requester', {
                 message: toError(error).message
             })
             return null

--- a/src/client/events/dirty.ts
+++ b/src/client/events/dirty.ts
@@ -177,7 +177,7 @@ async function handleAccountSyncDirtyBit(
     protocols: readonly string[]
 ): Promise<void> {
     const selectedProtocols = resolveAccountSyncProtocols(protocols)
-    runtime.logger.info('received account_sync dirty bit', {
+    runtime.logger.debug('received account_sync dirty bit', {
         protocols: selectedProtocols.join(',')
     })
     const failures: string[] = []
@@ -220,7 +220,7 @@ async function runAccountSyncProtocol(
             await syncAccountBlocklistDirtyBit(runtime)
             return
         case WA_DIRTY_PROTOCOLS.NOTICE:
-            runtime.logger.info(
+            runtime.logger.debug(
                 'account_sync notice protocol received (no GraphQL/MEX job configured)'
             )
             return
@@ -232,7 +232,7 @@ async function runAccountSyncProtocol(
 }
 
 async function handleSyncdAppStateDirtyBit(runtime: WaDirtySyncRuntime): Promise<void> {
-    runtime.logger.info('received syncd_app_state dirty bit, starting sync')
+    runtime.logger.debug('received syncd_app_state dirty bit, starting sync')
     await runtime.syncAppState()
 }
 
@@ -240,13 +240,13 @@ async function syncAccountDevicesDirtyBit(runtime: WaDirtySyncRuntime): Promise<
     const credentials = runtime.getCurrentCredentials()
     const meJid = credentials?.meJid ?? null
     if (!meJid) {
-        runtime.logger.warn('account_sync devices skipped: meJid is missing')
+        runtime.logger.trace('account_sync devices skipped: meJid is missing')
         return
     }
 
     const userJids = resolveAccountSyncDeviceTargets(credentials)
     if (userJids.length === 0) {
-        runtime.logger.warn('account_sync devices skipped: no valid account_sync targets')
+        runtime.logger.trace('account_sync devices skipped: no valid account_sync targets')
         return
     }
 
@@ -261,7 +261,7 @@ async function syncAccountDevicesDirtyBit(runtime: WaDirtySyncRuntime): Promise<
 async function syncAccountPictureDirtyBit(runtime: WaDirtySyncRuntime): Promise<void> {
     const meJid = runtime.getCurrentCredentials()?.meJid ?? null
     if (!meJid) {
-        runtime.logger.warn('account_sync picture skipped: meJid is missing')
+        runtime.logger.trace('account_sync picture skipped: meJid is missing')
         return
     }
     const targetJid = toUserJid(meJid)
@@ -389,7 +389,7 @@ async function clearDirtyBits(
             },
             { useSystemId: true }
         )
-        runtime.logger.info('dirty bits cleared', {
+        runtime.logger.debug('dirty bits cleared', {
             count: dirtyBits.length
         })
     } catch (error) {

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -467,6 +467,21 @@ async function runProcessorStep<T>(
     }
 }
 
+// Reuse one scoped child logger per parent. The processor is allowed to be
+// shared across WaClient sessions; without this cache, each call would mint
+// a fresh child logger and any package-side dedup keyed by Logger identity
+// (e.g. ffmpeg's missing-binary warn) would reset on every send.
+const SCOPED_MEDIA_LOGGER_CACHE = new WeakMap<Logger, Logger>()
+
+export function getScopedMediaLogger(parent: Logger): Logger {
+    let scoped = SCOPED_MEDIA_LOGGER_CACHE.get(parent)
+    if (!scoped) {
+        scoped = parent.child({ scope: 'media-utils' })
+        SCOPED_MEDIA_LOGGER_CACHE.set(parent, scoped)
+    }
+    return scoped
+}
+
 export async function runMediaProcessor(
     media: WaMediaOptions | undefined,
     input: Uint8Array | string | undefined,
@@ -477,7 +492,7 @@ export async function runMediaProcessor(
     if (!processor || !hasMediaProcessingTasks(media, content) || !input) return EMPTY_PROCESSED
 
     const result: MutableProcessedMediaFields = {}
-    const ctx = { logger: logger.child({ scope: 'media-utils' }) }
+    const ctx = { logger: getScopedMediaLogger(logger) }
 
     const isVideo = content.type === 'video' || content.type === 'ptv'
     const thumbFn = isVideo ? processor.generateVideoThumbnail : processor.generateImageThumbnail

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -477,17 +477,18 @@ export async function runMediaProcessor(
     if (!processor || !hasMediaProcessingTasks(media, content) || !input) return EMPTY_PROCESSED
 
     const result: MutableProcessedMediaFields = {}
+    const ctx = { logger: logger.child({ scope: 'media-utils' }) }
 
     const isVideo = content.type === 'video' || content.type === 'ptv'
     const thumbFn = isVideo ? processor.generateVideoThumbnail : processor.generateImageThumbnail
     const thumbMaxEdge = isVideo ? VIDEO_THUMB_MAX_EDGE : IMAGE_THUMB_MAX_EDGE
 
     const thumbTask = shouldGenerateThumbnail(media, content)
-        ? runProcessorStep('thumbnail', content, logger, () => thumbFn!(input, thumbMaxEdge))
+        ? runProcessorStep('thumbnail', content, logger, () => thumbFn!(input, thumbMaxEdge, ctx))
         : null
 
     const probeTask = shouldProbeMedia(media, content)
-        ? runProcessorStep('probe', content, logger, () => processor.probeMedia!(input))
+        ? runProcessorStep('probe', content, logger, () => processor.probeMedia!(input, ctx))
         : null
 
     const [thumb, probe] = await Promise.all([thumbTask, probeTask])
@@ -517,7 +518,7 @@ export async function runMediaProcessor(
 
     if (shouldGenerateWaveform(media, content)) {
         const waveformResult = await runProcessorStep('waveform', content, logger, () =>
-            processor.computeWaveform!(input)
+            processor.computeWaveform!(input, ctx)
         )
         if (waveformResult) {
             result.waveform = waveformResult.waveform
@@ -533,7 +534,7 @@ export async function runMediaProcessor(
     if (content.type === 'sticker') {
         if (shouldGenerateStickerThumbnail(media, content)) {
             const stickerThumb = await runProcessorStep('stickerThumbnail', content, logger, () =>
-                processor.generateStickerThumbnail!(input, STICKER_THUMB_MAX_EDGE)
+                processor.generateStickerThumbnail!(input, STICKER_THUMB_MAX_EDGE, ctx)
             )
             if (stickerThumb) {
                 result.pngThumbnail = stickerThumb.pngThumbnail

--- a/src/client/messaging/fanout.ts
+++ b/src/client/messaging/fanout.ts
@@ -71,7 +71,7 @@ export function createDeviceFanoutResolver(options: {
 
             return [...fanout]
         } catch (error) {
-            logger.warn('signal device fanout sync failed, falling back to direct recipient', {
+            logger.debug('signal device fanout sync failed, falling back to direct recipient', {
                 to: recipientJid,
                 message: toError(error).message
             })
@@ -140,7 +140,7 @@ export function createDeviceFanoutResolver(options: {
             }
             return [...fanout]
         } catch (error) {
-            logger.warn(
+            logger.debug(
                 'group participant device sync failed, falling back to participant user jids',
                 {
                     participants: candidateUsers.length,

--- a/src/client/messaging/messages.ts
+++ b/src/client/messaging/messages.ts
@@ -21,6 +21,7 @@ import { aesGcmEncrypt, randomBytesAsync, sha256 } from '@crypto'
 import type { Logger } from '@infra/log/types'
 import { MEDIA_CONN_CACHE_GRACE_MS, MEDIA_UPLOAD_PATHS } from '@media/constants'
 import { WaMediaCrypto } from '@media/crypto/WaMediaCrypto'
+import type { WaMediaProcessorCallContext } from '@media/processor'
 import { createStickerPackZipStream } from '@media/sticker/sticker-pack'
 import { parseMediaConnResponse } from '@media/transfer/conn'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
@@ -449,13 +450,14 @@ function resolveUploadType(
 async function resolveMimetype(
     content: Exclude<WaSendMediaMessage, WaSendStickerPackMessage>,
     media: WaMediaOptions | undefined,
-    processorInput: string | Uint8Array | undefined
+    processorInput: string | Uint8Array | undefined,
+    ctx: WaMediaProcessorCallContext
 ): Promise<string> {
     if (content.mimetype) return content.mimetype
     if (content.type === 'sticker') return 'image/webp'
     const detect = media?.processor?.detectMimetype
     if (detect && processorInput !== undefined) {
-        const detected = await detect(processorInput)
+        const detected = await detect(processorInput, ctx)
         if (detected) return detected
     }
     throw new Error(
@@ -470,12 +472,17 @@ async function buildMediaMessage(
     if (content.type === 'sticker-pack') {
         return buildStickerPackMediaMessage(options, content)
     }
+    const processorCtx: WaMediaProcessorCallContext = {
+        logger: options.logger.child({ scope: 'media-utils' })
+    }
     if (shouldNormalizeVoiceNote(options.media, content)) {
         const sourceInput =
             content.media instanceof ArrayBuffer ? toBytesView(content.media) : content.media
         try {
-            const normalizedStream =
-                await options.media!.processor!.normalizeVoiceNote!(sourceInput)
+            const normalizedStream = await options.media!.processor!.normalizeVoiceNote!(
+                sourceInput,
+                processorCtx
+            )
             if (normalizedStream) {
                 content = { ...content, media: normalizedStream, mimetype: VOICE_NOTE_MIMETYPE }
             }
@@ -495,7 +502,12 @@ async function buildMediaMessage(
         (content.type === 'sticker' && content.firstFrameLength === undefined) ||
         needsMimetypeDetection
     const resolved = await resolveMediaInputs(needsTempFile, content.media)
-    const mimetype = await resolveMimetype(content, options.media, resolved.processorInput)
+    const mimetype = await resolveMimetype(
+        content,
+        options.media,
+        resolved.processorInput,
+        processorCtx
+    )
 
     try {
         let detectedFirstFrameLength: number | undefined

--- a/src/client/messaging/messages.ts
+++ b/src/client/messaging/messages.ts
@@ -5,6 +5,7 @@ import {
     assertMediaUploadStatus,
     buildMediaUploadUrl,
     cleanupTempFile,
+    getScopedMediaLogger,
     hasMediaProcessingTasks,
     isReadableStream,
     parseMediaUploadJsonBody,
@@ -473,7 +474,7 @@ async function buildMediaMessage(
         return buildStickerPackMediaMessage(options, content)
     }
     const processorCtx: WaMediaProcessorCallContext = {
-        logger: options.logger.child({ scope: 'media-utils' })
+        logger: getScopedMediaLogger(options.logger)
     }
     if (shouldNormalizeVoiceNote(options.media, content)) {
         const sourceInput =

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,6 +231,7 @@ export type {
 export { ConsoleLogger } from '@infra/log/ConsoleLogger'
 export { PinoLogger, createPinoLogger } from '@infra/log/PinoLogger'
 export type { PinoLoggerOptions } from '@infra/log/PinoLogger'
+export { createNoopLogger } from '@infra/log/types'
 export type { Logger, LogLevel } from '@infra/log/types'
 export { createStore, WaAuthMemoryStore } from '@store'
 export type {

--- a/src/infra/log/ConsoleLogger.ts
+++ b/src/infra/log/ConsoleLogger.ts
@@ -9,11 +9,11 @@ const LOG_LEVEL_PRIORITY: Readonly<Record<LogLevel, number>> = {
 }
 
 const CONSOLE_WRITERS: Readonly<Record<LogLevel, (...args: unknown[]) => void>> = {
-    trace: console.debug,
-    debug: console.debug,
-    info: console.info,
-    warn: console.warn,
-    error: console.error
+    trace: (...args) => console.debug(...args),
+    debug: (...args) => console.debug(...args),
+    info: (...args) => console.info(...args),
+    warn: (...args) => console.warn(...args),
+    error: (...args) => console.error(...args)
 }
 
 /**
@@ -24,11 +24,16 @@ const CONSOLE_WRITERS: Readonly<Record<LogLevel, (...args: unknown[]) => void>> 
 export class ConsoleLogger implements Logger {
     public readonly level: LogLevel
     private readonly minLevelPriority: number
+    private readonly bindings: Readonly<Record<string, unknown>> | null
 
     /** @param level Minimum level to emit. Defaults to `'info'`. */
-    public constructor(level: LogLevel = 'info') {
+    public constructor(
+        level: LogLevel = 'info',
+        bindings: Readonly<Record<string, unknown>> | null = null
+    ) {
         this.level = level
         this.minLevelPriority = LOG_LEVEL_PRIORITY[level]
+        this.bindings = bindings
     }
 
     /** Emits a `trace` record. */
@@ -56,8 +61,21 @@ export class ConsoleLogger implements Logger {
         this.write('error', message, context)
     }
 
+    /**
+     * Returns a derived logger with `bindings` merged into the parent's
+     * bindings. Per-call context still wins on key conflicts.
+     */
+    public child(bindings: Readonly<Record<string, unknown>>): Logger {
+        const merged = this.bindings ? { ...this.bindings, ...bindings } : { ...bindings }
+        return new ConsoleLogger(this.level, merged)
+    }
+
     private write(level: LogLevel, message: string, context?: Record<string, unknown>): void {
         if (LOG_LEVEL_PRIORITY[level] < this.minLevelPriority) {
+            return
+        }
+        if (this.bindings) {
+            CONSOLE_WRITERS[level](message, { ...this.bindings, ...context })
             return
         }
         CONSOLE_WRITERS[level](message, context)

--- a/src/infra/log/PinoLogger.ts
+++ b/src/infra/log/PinoLogger.ts
@@ -7,6 +7,7 @@ type PinoLikeLogger = {
     info: (...args: unknown[]) => void
     warn: (...args: unknown[]) => void
     error: (...args: unknown[]) => void
+    child?: (bindings: Readonly<Record<string, unknown>>) => PinoLikeLogger
 }
 
 type PinoFactory = (options?: Readonly<Record<string, unknown>>) => PinoLikeLogger
@@ -112,6 +113,18 @@ export class PinoLogger implements Logger {
         this.write('error', message, context)
     }
 
+    /**
+     * Returns a derived logger that pre-binds `bindings` into every log
+     * call's context. Delegates to the underlying pino `child()` when
+     * available; otherwise wraps with a parent + bindings merge.
+     */
+    public child(bindings: Readonly<Record<string, unknown>>): Logger {
+        if (typeof this.logger.child === 'function') {
+            return new PinoLogger(this.logger.child(bindings), this.level)
+        }
+        return new BoundLogger(this, bindings)
+    }
+
     private write(
         level: LogLevel,
         message: string,
@@ -128,6 +141,53 @@ export class PinoLogger implements Logger {
             }
         }
         this.logger[level](message)
+    }
+}
+
+/**
+ * Fallback {@link Logger} that pre-binds context fields by merging them
+ * into every call before delegating to a parent logger. Used when the
+ * underlying logger does not support `child()` natively.
+ */
+class BoundLogger implements Logger {
+    public readonly level: LogLevel
+    private readonly parent: Logger
+    private readonly bindings: Readonly<Record<string, unknown>>
+
+    public constructor(parent: Logger, bindings: Readonly<Record<string, unknown>>) {
+        this.parent = parent
+        this.level = parent.level
+        this.bindings = bindings
+    }
+
+    public trace(message: string, context?: Readonly<Record<string, unknown>>): void {
+        this.parent.trace(message, this.merge(context))
+    }
+
+    public debug(message: string, context?: Readonly<Record<string, unknown>>): void {
+        this.parent.debug(message, this.merge(context))
+    }
+
+    public info(message: string, context?: Readonly<Record<string, unknown>>): void {
+        this.parent.info(message, this.merge(context))
+    }
+
+    public warn(message: string, context?: Readonly<Record<string, unknown>>): void {
+        this.parent.warn(message, this.merge(context))
+    }
+
+    public error(message: string, context?: Readonly<Record<string, unknown>>): void {
+        this.parent.error(message, this.merge(context))
+    }
+
+    public child(bindings: Readonly<Record<string, unknown>>): Logger {
+        return new BoundLogger(this.parent, { ...this.bindings, ...bindings })
+    }
+
+    private merge(
+        context: Readonly<Record<string, unknown>> | undefined
+    ): Readonly<Record<string, unknown>> {
+        return context ? { ...this.bindings, ...context } : this.bindings
     }
 }
 

--- a/src/infra/log/__tests__/log.test.ts
+++ b/src/infra/log/__tests__/log.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import { ConsoleLogger } from '@infra/log/ConsoleLogger'
 import { createPinoLogger, PinoLogger } from '@infra/log/PinoLogger'
+import { createNoopLogger } from '@infra/log/types'
 
 test('console logger honors level gating and exposes level', () => {
     const logger = new ConsoleLogger('warn')
@@ -57,4 +58,85 @@ test('pino logger writes bare message for empty context objects', () => {
     logger.info('world', { scope: 'log' })
     assert.deepEqual(captured[0], ['hello'])
     assert.deepEqual(captured[1], [{ scope: 'log' }, 'world'])
+})
+
+test('console logger child bakes bindings into every call and stacks', () => {
+    const captured: unknown[][] = []
+    const original = console.info
+    console.info = ((...args: unknown[]) => {
+        captured.push(args)
+    }) as typeof console.info
+    try {
+        const parent = new ConsoleLogger('info')
+        const session = parent.child({ session: 'abc' })
+        session.info('hello')
+        session.info('with extra', { foo: 1 })
+        const stacked = session.child({ scope: 'media' })
+        stacked.info('nested')
+        stacked.info('override', { session: 'xyz' })
+        assert.deepEqual(captured[0], ['hello', { session: 'abc' }])
+        assert.deepEqual(captured[1], ['with extra', { session: 'abc', foo: 1 }])
+        assert.deepEqual(captured[2], ['nested', { session: 'abc', scope: 'media' }])
+        assert.deepEqual(captured[3], ['override', { session: 'xyz', scope: 'media' }])
+    } finally {
+        console.info = original
+    }
+})
+
+test('pino logger child delegates to underlying child when available', () => {
+    const captured: { method: string; args: unknown[] }[] = []
+    const fakeChild = {
+        level: 'info',
+        trace: () => undefined,
+        debug: () => undefined,
+        info: (...args: unknown[]) => {
+            captured.push({ method: 'child.info', args })
+        },
+        warn: () => undefined,
+        error: () => undefined
+    }
+    const fake = {
+        level: 'info',
+        trace: () => undefined,
+        debug: () => undefined,
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+        child: (bindings: Readonly<Record<string, unknown>>) => {
+            captured.push({ method: 'child', args: [bindings] })
+            return fakeChild
+        }
+    }
+    const logger = new PinoLogger(fake, 'info')
+    const child = logger.child({ session: 'abc' })
+    child.info('hello', { extra: 1 })
+    assert.deepEqual(captured[0], { method: 'child', args: [{ session: 'abc' }] })
+    assert.deepEqual(captured[1], { method: 'child.info', args: [{ extra: 1 }, 'hello'] })
+})
+
+test('pino logger child falls back to manual binding when underlying lacks child', () => {
+    const captured: unknown[][] = []
+    const fake = {
+        level: 'info',
+        trace: () => undefined,
+        debug: () => undefined,
+        info: (...args: unknown[]) => {
+            captured.push(args)
+        },
+        warn: () => undefined,
+        error: () => undefined
+    }
+    const logger = new PinoLogger(fake, 'info')
+    const child = logger.child({ session: 'abc' })
+    child.info('hello')
+    child.info('extra', { foo: 1 })
+    assert.deepEqual(captured[0], [{ session: 'abc' }, 'hello'])
+    assert.deepEqual(captured[1], [{ session: 'abc', foo: 1 }, 'extra'])
+})
+
+test('noop logger child returns itself and stays silent', () => {
+    const noop = createNoopLogger()
+    const child = noop.child({ session: 'x' })
+    assert.equal(child, noop)
+    assert.doesNotThrow(() => child.info('nothing happens', { whatever: 1 }))
 })

--- a/src/infra/log/types.ts
+++ b/src/infra/log/types.ts
@@ -7,17 +7,25 @@ export interface Logger {
     info(message: string, context?: Readonly<Record<string, unknown>>): void
     warn(message: string, context?: Readonly<Record<string, unknown>>): void
     error(message: string, context?: Readonly<Record<string, unknown>>): void
+    /**
+     * Returns a derived logger that pre-binds `bindings` into every log
+     * call's context object. Bindings stack: `parent.child(a).child(b)`
+     * merges `{ ...a, ...b }`. Per-call context wins on key conflicts.
+     */
+    child(bindings: Readonly<Record<string, unknown>>): Logger
 }
 
 function noop(): void {}
 
 export function createNoopLogger(level: LogLevel = 'trace'): Logger {
-    return {
+    const logger: Logger = {
         level,
         trace: noop,
         debug: noop,
         info: noop,
         warn: noop,
-        error: noop
+        error: noop,
+        child: () => logger
     }
+    return logger
 }

--- a/src/media/index.ts
+++ b/src/media/index.ts
@@ -11,6 +11,7 @@ export type { MediaCryptoType, MediaKind, WaMediaConn } from '@media/types'
 export { WaMediaCrypto } from '@media/crypto/WaMediaCrypto'
 export type {
     WaMediaProcessor,
+    WaMediaProcessorCallContext,
     WaMediaProcessorImageResult,
     WaMediaProcessorInput,
     WaMediaProcessorProbeResult,

--- a/src/media/processor.ts
+++ b/src/media/processor.ts
@@ -1,5 +1,7 @@
 import type { Readable } from 'node:stream'
 
+import type { Logger } from '@infra/log/types'
+
 export interface WaMediaProcessorImageResult {
     readonly jpegThumbnail: Uint8Array
     readonly width: number
@@ -25,28 +27,52 @@ export interface WaMediaProcessorWaveformResult {
 
 export type WaMediaProcessorInput = Uint8Array | Readable | string
 
+/**
+ * Per-call context the runtime passes to every {@link WaMediaProcessor}
+ * method. Currently carries an optional `logger` so the processor can
+ * emit warnings (missing binary, probe failure, ...) through the same
+ * `Logger` the caller is using - including any session/scope bindings
+ * the caller has already attached. The processor must stay stateless
+ * with respect to the logger: a single processor instance shared across
+ * multiple `WaClient` sessions receives a different `ctx.logger` per
+ * call and must not cache it.
+ */
+export interface WaMediaProcessorCallContext {
+    readonly logger?: Logger
+}
+
 export interface WaMediaProcessor {
     readonly generateImageThumbnail?: (
         input: WaMediaProcessorInput,
-        maxEdge: number
+        maxEdge: number,
+        ctx?: WaMediaProcessorCallContext
     ) => Promise<WaMediaProcessorImageResult>
 
     readonly generateVideoThumbnail?: (
         input: WaMediaProcessorInput,
-        maxEdge: number
+        maxEdge: number,
+        ctx?: WaMediaProcessorCallContext
     ) => Promise<WaMediaProcessorImageResult | null>
 
-    readonly probeMedia?: (input: WaMediaProcessorInput) => Promise<WaMediaProcessorProbeResult>
+    readonly probeMedia?: (
+        input: WaMediaProcessorInput,
+        ctx?: WaMediaProcessorCallContext
+    ) => Promise<WaMediaProcessorProbeResult>
 
     readonly computeWaveform?: (
-        input: WaMediaProcessorInput
+        input: WaMediaProcessorInput,
+        ctx?: WaMediaProcessorCallContext
     ) => Promise<WaMediaProcessorWaveformResult | null>
 
-    readonly normalizeVoiceNote?: (input: WaMediaProcessorInput) => Promise<Readable | null>
+    readonly normalizeVoiceNote?: (
+        input: WaMediaProcessorInput,
+        ctx?: WaMediaProcessorCallContext
+    ) => Promise<Readable | null>
 
     readonly generateStickerThumbnail?: (
         input: WaMediaProcessorInput,
-        maxEdge: number
+        maxEdge: number,
+        ctx?: WaMediaProcessorCallContext
     ) => Promise<WaMediaProcessorStickerThumbnailResult>
 
     /**
@@ -55,5 +81,8 @@ export interface WaMediaProcessor {
      * stages streams to a temp file before calling this. Returns `null` when
      * the type can't be determined.
      */
-    readonly detectMimetype?: (input: string | Uint8Array) => Promise<string | null>
+    readonly detectMimetype?: (
+        input: string | Uint8Array,
+        ctx?: WaMediaProcessorCallContext
+    ) => Promise<string | null>
 }

--- a/src/message/WaMessageClient.ts
+++ b/src/message/WaMessageClient.ts
@@ -105,14 +105,24 @@ export class WaMessageClient {
                         isRetryableNegativeAck(ackNode)
                     )
                 }
-                this.logger.info('message publish acknowledged', {
-                    id,
-                    tag: ackNode.tag,
-                    type: ackNode.attrs.type,
-                    phash: ackNode.attrs.phash,
-                    addressingMode: ackNode.attrs.addressing_mode,
-                    attempts: attempt
-                })
+                if (attempt > 1) {
+                    this.logger.info('message publish acknowledged after retry', {
+                        id,
+                        tag: ackNode.tag,
+                        type: ackNode.attrs.type,
+                        phash: ackNode.attrs.phash,
+                        addressingMode: ackNode.attrs.addressing_mode,
+                        attempts: attempt
+                    })
+                } else {
+                    this.logger.trace('message publish acknowledged', {
+                        id,
+                        tag: ackNode.tag,
+                        type: ackNode.attrs.type,
+                        phash: ackNode.attrs.phash,
+                        addressingMode: ackNode.attrs.addressing_mode
+                    })
+                }
                 return {
                     id,
                     attempts: attempt,
@@ -126,17 +136,23 @@ export class WaMessageClient {
                 const canRetry =
                     attempt < maxAttempts &&
                     (this.isRetryablePublishError(lastError) || nackRetryable)
+                if (canRetry) {
+                    this.logger.debug('message publish attempt failed, will retry', {
+                        attempt,
+                        maxAttempts,
+                        nackRetryable,
+                        message: lastError.message
+                    })
+                    await delay(retryDelayMs * attempt)
+                    continue
+                }
                 this.logger.warn('message publish attempt failed', {
                     attempt,
                     maxAttempts,
-                    canRetry,
                     nackRetryable,
                     message: lastError.message
                 })
-                if (!canRetry) {
-                    throw lastError
-                }
-                await delay(retryDelayMs * attempt)
+                throw lastError
             }
         }
 

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -262,7 +262,7 @@ async function sendRetryReceiptForDecryptFailure(
     })
     try {
         await options.sendNode(retryReceiptNode)
-        options.logger.debug('sent retry receipt for undecryptable incoming message', {
+        options.logger.trace('sent retry receipt for undecryptable incoming message', {
             id: stanzaId,
             to: from,
             participant: retryReceiptNode.attrs.participant,
@@ -370,6 +370,11 @@ async function decryptAndProcessEncNode(
     options: WaIncomingMessageAckHandlerOptions,
     decrypt: (ciphertext: Uint8Array, senderAddress: SignalAddress) => Promise<Uint8Array>
 ): Promise<DecryptEncNodeResult> {
+    const log = options.logger.child({
+        id: node.attrs.id,
+        from: node.attrs.from,
+        participant: node.attrs.participant
+    })
     try {
         const senderAddress = parseSignalAddressFromJid(senderJid)
         const decryptedPayload = await decrypt(
@@ -387,17 +392,11 @@ async function decryptAndProcessEncNode(
                     senderAddress,
                     senderKeyDistribution.payload
                 )
-                options.logger.debug('processed incoming sender key distribution', {
-                    id: node.attrs.id,
-                    from: node.attrs.from,
-                    participant: node.attrs.participant,
+                log.trace('processed incoming sender key distribution', {
                     groupId: senderKeyDistribution.groupId
                 })
             } catch (error) {
-                options.logger.warn('failed to process incoming sender key distribution', {
-                    id: node.attrs.id,
-                    from: node.attrs.from,
-                    participant: node.attrs.participant,
+                log.warn('failed to process incoming sender key distribution', {
                     groupId: senderKeyDistribution.groupId,
                     message: toError(error).message
                 })
@@ -433,10 +432,7 @@ async function decryptAndProcessEncNode(
         }
         return { success: true, encType }
     } catch (error) {
-        options.logger.warn('failed to decrypt incoming message', {
-            id: node.attrs.id,
-            from: node.attrs.from,
-            participant: node.attrs.participant,
+        log.warn('failed to decrypt incoming message', {
             encType,
             message: toError(error).message
         })
@@ -584,7 +580,7 @@ export async function handleIncomingMessageAck(
             to: from,
             from: options.getMeJid?.()
         })
-        options.logger.debug('sending inbound message ack', {
+        options.logger.trace('sending inbound message ack', {
             id,
             to: from,
             type: ackNode.attrs.type,
@@ -604,7 +600,7 @@ export async function handleIncomingMessageAck(
         id,
         to: from
     })
-    options.logger.debug('sending inbound message receipt', {
+    options.logger.trace('sending inbound message receipt', {
         id,
         to: from,
         type: receiptNode.attrs.type,
@@ -642,7 +638,7 @@ async function handleIncomingNewsletterMessage(
         id,
         to: from
     })
-    options.logger.debug('sending inbound newsletter message ack', {
+    options.logger.trace('sending inbound newsletter message ack', {
         id,
         to: from,
         type: ackNode.attrs.type

--- a/src/retry/__tests__/retry.test.ts
+++ b/src/retry/__tests__/retry.test.ts
@@ -33,7 +33,7 @@ function buildOutboundRecord(
 }
 
 function createLogger(warnings: string[] = []): Logger {
-    return {
+    const logger: Logger = {
         level: 'trace',
         trace: () => undefined,
         debug: () => undefined,
@@ -41,8 +41,10 @@ function createLogger(warnings: string[] = []): Logger {
         warn: (message) => {
             warnings.push(message)
         },
-        error: () => undefined
+        error: () => undefined,
+        child: () => logger
     }
+    return logger
 }
 
 const NOOP_SESSION_RESOLVER: SignalSessionResolver = {

--- a/src/signal/session/resolver.ts
+++ b/src/signal/session/resolver.ts
@@ -71,6 +71,7 @@ export function createSignalSessionResolver(options: {
         prefetchedBundle?: SignalPreKeyBundle,
         knownAbsent = false
     ): Promise<SignalSessionRecord | null> => {
+        const jidLogger = logger.child({ jid })
         const expectedSerializedIdentity = expectedIdentity
             ? toSerializedPubKey(expectedIdentity)
             : null
@@ -81,6 +82,11 @@ export function createSignalSessionResolver(options: {
             if (expectedSerializedIdentity) {
                 const storedIdentity = await identityStore.getRemoteIdentity(address)
                 if (!storedIdentity || !uint8Equal(storedIdentity, expectedSerializedIdentity)) {
+                    jidLogger.warn('signal identity mismatch on stored identity', {
+                        source: 'stored_vs_expected',
+                        expected: bytesToHex(expectedSerializedIdentity),
+                        stored: storedIdentity ? bytesToHex(storedIdentity) : null
+                    })
                     throw new Error('identity mismatch')
                 }
             }
@@ -93,7 +99,7 @@ export function createSignalSessionResolver(options: {
                 bundle: prefetchedBundle
             }
         } else {
-            logger.info('signal session missing, fetching remote key bundle', { jid })
+            jidLogger.debug('signal session missing, fetching remote key bundle')
             fetched = await signalSessionSync.fetchKeyBundle({
                 jid,
                 reasonIdentity
@@ -103,18 +109,27 @@ export function createSignalSessionResolver(options: {
         if (reasonIdentity) {
             const storedIdentity = await identityStore.getRemoteIdentity(address)
             if (storedIdentity && !uint8Equal(remoteIdentity, storedIdentity)) {
+                jidLogger.warn('signal identity mismatch on fetched bundle vs stored', {
+                    source: 'remote_vs_stored',
+                    remote: bytesToHex(remoteIdentity),
+                    stored: bytesToHex(storedIdentity)
+                })
                 throw new Error('identity mismatch')
             }
         }
         if (expectedSerializedIdentity && !uint8Equal(remoteIdentity, expectedSerializedIdentity)) {
+            jidLogger.warn('signal identity mismatch on fetched bundle vs expected', {
+                source: 'remote_vs_expected',
+                remote: bytesToHex(remoteIdentity),
+                expected: bytesToHex(expectedSerializedIdentity)
+            })
             throw new Error('identity mismatch')
         }
         const session = await signalProtocol.establishOutgoingSession(address, fetched.bundle, {
             reuseExisting: true,
             knownAbsent
         })
-        logger.info('signal session synchronized', {
-            jid,
+        jidLogger.debug('signal session synchronized', {
             regId: fetched.bundle.regId,
             hasOneTimeKey: fetched.bundle.oneTimeKey !== undefined
         })
@@ -228,7 +243,14 @@ export function createSignalSessionResolver(options: {
                 normalizedTargetJids[index]
             )
             if (session && expectedIdentity) {
-                if (!uint8Equal(session.remote.pubKey, toSerializedPubKey(expectedIdentity))) {
+                const expectedSerialized = toSerializedPubKey(expectedIdentity)
+                if (!uint8Equal(session.remote.pubKey, expectedSerialized)) {
+                    logger.warn('signal identity mismatch on existing session vs expected', {
+                        jid: normalizedTargetJids[index],
+                        source: 'session_vs_expected',
+                        session: bytesToHex(session.remote.pubKey),
+                        expected: bytesToHex(expectedSerialized)
+                    })
                     throw new Error('identity mismatch')
                 }
             }
@@ -265,6 +287,7 @@ export function createSignalSessionResolver(options: {
             }>
         >(missingIndices.length)
         let prepareCount = 0
+        const missingBundleTargets: { jid: string; reason: string }[] = []
         for (let index = 0; index < missingIndices.length; index += 1) {
             const targetIndex = missingIndices[index]
             const targetJid = normalizedTargetJids[targetIndex]
@@ -272,9 +295,9 @@ export function createSignalSessionResolver(options: {
                 | { readonly bundle?: SignalPreKeyBundle; readonly errorText?: string }
                 | undefined
             if (!batchResult?.bundle) {
-                logger.warn('signal batch key fetch returned target without bundle', {
+                missingBundleTargets.push({
                     jid: targetJid,
-                    message: batchResult?.errorText ?? 'missing key bundle user in response'
+                    reason: batchResult?.errorText ?? 'missing key bundle user in response'
                 })
                 continue
             }
@@ -287,6 +310,12 @@ export function createSignalSessionResolver(options: {
                 expectedSerializedIdentity &&
                 !uint8Equal(bundleIdentity, expectedSerializedIdentity)
             ) {
+                logger.warn('signal identity mismatch on fetched batch bundle vs expected', {
+                    jid: targetJid,
+                    source: 'bundle_vs_expected',
+                    bundle: bytesToHex(bundleIdentity),
+                    expected: bytesToHex(expectedSerializedIdentity)
+                })
                 throw new Error('identity mismatch')
             }
             const targetAddress = normalizedTargetAddresses[targetIndex]
@@ -302,6 +331,13 @@ export function createSignalSessionResolver(options: {
                     remoteIdentity: prep.remoteIdentity
                 }))
             prepareCount += 1
+        }
+        if (missingBundleTargets.length > 0) {
+            logger.warn('signal batch key fetch returned targets without bundle', {
+                droppedCount: missingBundleTargets.length,
+                totalRequested: missingIndices.length,
+                sample: missingBundleTargets.slice(0, 3)
+            })
         }
         if (prepareCount === 0) {
             return collectResolvedTargets()

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -192,6 +192,8 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
     const providers = options.providers ?? {}
     const cacheProviders = options.cacheProviders ?? {}
     const cacheLayer = options.cacheLayer ?? {}
+    const storeLogger = options.logger?.child({ scope: 'store' })
+    const memoryLogger = storeLogger?.child({ provider: 'memory' })
 
     if (Object.keys(backends).length > 0) {
         const missingProviders = REQUIRED_PROVIDER_DOMAINS.filter(
@@ -367,7 +369,8 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
                     cacheProviders.retry === 'memory' || !cacheProviders.retry
                         ? new WaRetryMemoryStore(cacheTtlsMs.retry, {
                               maxOutboundMessages: ml.retryOutboundMessages,
-                              maxInboundCounters: ml.retryInboundCounters
+                              maxInboundCounters: ml.retryInboundCounters,
+                              logger: memoryLogger?.child({ domain: 'retry', sessionId: id })
                           })
                         : NOOP_RETRY_STORE
             )
@@ -380,7 +383,11 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
                 () =>
                     cacheProviders.groupMetadata === 'memory' || !cacheProviders.groupMetadata
                         ? new WaGroupMetadataMemoryStore(cacheTtlsMs.groupMetadata, {
-                              maxGroups: ml.groupMetadataGroups
+                              maxGroups: ml.groupMetadataGroups,
+                              logger: memoryLogger?.child({
+                                  domain: 'groupMetadata',
+                                  sessionId: id
+                              })
                           })
                         : NOOP_GROUP_METADATA_STORE
             )
@@ -393,7 +400,8 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
                 () =>
                     cacheProviders.deviceList === 'memory'
                         ? new WaDeviceListMemoryStore(cacheTtlsMs.deviceList, {
-                              maxUsers: ml.deviceListUsers
+                              maxUsers: ml.deviceListUsers,
+                              logger: memoryLogger?.child({ domain: 'deviceList', sessionId: id })
                           })
                         : NOOP_DEVICE_LIST_STORE
             )
@@ -406,7 +414,11 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
                 () =>
                     cacheProviders.messageSecret === 'memory' || !cacheProviders.messageSecret
                         ? new WaMessageSecretMemoryStore(cacheTtlsMs.messageSecret, {
-                              maxSecrets: ml.messageSecrets
+                              maxSecrets: ml.messageSecrets,
+                              logger: memoryLogger?.child({
+                                  domain: 'messageSecret',
+                                  sessionId: id
+                              })
                           })
                         : NOOP_MESSAGE_SECRET_STORE
             )

--- a/src/store/memory/device-list.store.ts
+++ b/src/store/memory/device-list.store.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '@infra/log/types'
 import type { WaDeviceListSnapshot, WaDeviceListStore } from '@store/contracts/device-list.store'
 import { resolvePositive } from '@util/coercion'
 import {
@@ -17,6 +18,12 @@ const DEFAULTS = Object.freeze({
 
 export interface WaDeviceListMemoryStoreOptions {
     readonly maxUsers?: number
+    /**
+     * Logger for capacity-saturation warnings. Emits a single `warn` the
+     * first time the bounded map evicts an entry; subsequent evictions are
+     * silent to avoid spam.
+     */
+    readonly logger?: Logger
 }
 
 export class WaDeviceListMemoryStore implements WaDeviceListStore {
@@ -25,6 +32,8 @@ export class WaDeviceListMemoryStore implements WaDeviceListStore {
     private readonly ttlMs: number
     private readonly maxUsers: number
     private readonly cleanup: PeriodicCleanupHandle
+    private readonly logger: Logger | undefined
+    private capacityWarned: boolean
 
     public constructor(ttlMs = DEFAULTS.ttlMs, options: WaDeviceListMemoryStoreOptions = {}) {
         if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
@@ -38,8 +47,18 @@ export class WaDeviceListMemoryStore implements WaDeviceListStore {
             DEFAULTS.maxUsers,
             'WaDeviceListMemoryStoreOptions.maxUsers'
         )
+        this.logger = options.logger
+        this.capacityWarned = false
         this.cleanup = createPeriodicCleanup(ttlMs, () => {
             void this.cleanupExpired(Date.now())
+        })
+    }
+
+    private warnCapacity(): void {
+        if (this.capacityWarned || !this.logger) return
+        this.capacityWarned = true
+        this.logger.warn('device list store at capacity, evicting oldest', {
+            max: this.maxUsers
         })
     }
 
@@ -57,7 +76,8 @@ export class WaDeviceListMemoryStore implements WaDeviceListStore {
                     ...snapshot,
                     expiresAtMs: snapshot.updatedAtMs + this.ttlMs
                 },
-                this.maxUsers
+                this.maxUsers,
+                () => this.warnCapacity()
             )
             if (snapshot.altUserJid) {
                 this.altIndex.set(snapshot.altUserJid, snapshot.userJid)

--- a/src/store/memory/group-metadata.store.ts
+++ b/src/store/memory/group-metadata.store.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '@infra/log/types'
 import type {
     WaGroupMetadataSnapshot,
     WaGroupMetadataStore
@@ -20,6 +21,12 @@ const DEFAULTS = Object.freeze({
 
 export interface WaGroupMetadataMemoryStoreOptions {
     readonly maxGroups?: number
+    /**
+     * Logger for capacity-saturation warnings. Emits a single `warn` the
+     * first time the bounded map evicts an entry; subsequent evictions are
+     * silent to avoid spam.
+     */
+    readonly logger?: Logger
 }
 
 export class WaGroupMetadataMemoryStore implements WaGroupMetadataStore {
@@ -27,6 +34,8 @@ export class WaGroupMetadataMemoryStore implements WaGroupMetadataStore {
     private readonly ttlMs: number
     private readonly maxGroups: number
     private readonly cleanup: PeriodicCleanupHandle
+    private readonly logger: Logger | undefined
+    private capacityWarned: boolean
 
     public constructor(ttlMs = DEFAULTS.ttlMs, options: WaGroupMetadataMemoryStoreOptions = {}) {
         if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
@@ -39,8 +48,18 @@ export class WaGroupMetadataMemoryStore implements WaGroupMetadataStore {
             DEFAULTS.maxGroups,
             'WaGroupMetadataMemoryStoreOptions.maxGroups'
         )
+        this.logger = options.logger
+        this.capacityWarned = false
         this.cleanup = createPeriodicCleanup(ttlMs, () => {
             void this.cleanupExpired(Date.now())
+        })
+    }
+
+    private warnCapacity(): void {
+        if (this.capacityWarned || !this.logger) return
+        this.capacityWarned = true
+        this.logger.warn('group metadata store at capacity, evicting oldest', {
+            max: this.maxGroups
         })
     }
 
@@ -52,7 +71,8 @@ export class WaGroupMetadataMemoryStore implements WaGroupMetadataStore {
                 ...snapshot,
                 expiresAtMs: snapshot.updatedAtMs + this.ttlMs
             },
-            this.maxGroups
+            this.maxGroups,
+            () => this.warnCapacity()
         )
     }
 

--- a/src/store/memory/message-secret.store.ts
+++ b/src/store/memory/message-secret.store.ts
@@ -123,7 +123,8 @@ export class WaMessageSecretMemoryStore implements WaMessageSecretStore {
                     senderJid: entries[i].entry.senderJid,
                     expiresAtMs: nowMs + this.ttlMs
                 },
-                this.maxSecrets
+                this.maxSecrets,
+                () => this.warnCapacity()
             )
         }
     }

--- a/src/store/memory/message-secret.store.ts
+++ b/src/store/memory/message-secret.store.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '@infra/log/types'
 import type {
     WaMessageSecretEntry,
     WaMessageSecretStore
@@ -22,6 +23,12 @@ const DEFAULTS = Object.freeze({
 
 export interface WaMessageSecretMemoryStoreOptions {
     readonly maxSecrets?: number
+    /**
+     * Logger for capacity-saturation warnings. Emits a single `warn` the
+     * first time the bounded map evicts an entry; subsequent evictions are
+     * silent to avoid spam.
+     */
+    readonly logger?: Logger
 }
 
 export class WaMessageSecretMemoryStore implements WaMessageSecretStore {
@@ -29,6 +36,8 @@ export class WaMessageSecretMemoryStore implements WaMessageSecretStore {
     private readonly ttlMs: number
     private readonly maxSecrets: number
     private readonly cleanup: PeriodicCleanupHandle
+    private readonly logger: Logger | undefined
+    private capacityWarned: boolean
 
     public constructor(ttlMs = DEFAULTS.ttlMs, options: WaMessageSecretMemoryStoreOptions = {}) {
         if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
@@ -41,8 +50,18 @@ export class WaMessageSecretMemoryStore implements WaMessageSecretStore {
             DEFAULTS.maxSecrets,
             'WaMessageSecretMemoryStoreOptions.maxSecrets'
         )
+        this.logger = options.logger
+        this.capacityWarned = false
         this.cleanup = createPeriodicCleanup(ttlMs, () => {
             void this.cleanupExpired(Date.now())
+        })
+    }
+
+    private warnCapacity(): void {
+        if (this.capacityWarned || !this.logger) return
+        this.capacityWarned = true
+        this.logger.warn('message secret store at capacity, evicting oldest', {
+            max: this.maxSecrets
         })
     }
 
@@ -86,7 +105,8 @@ export class WaMessageSecretMemoryStore implements WaMessageSecretStore {
                 senderJid: entry.senderJid,
                 expiresAtMs: Date.now() + this.ttlMs
             },
-            this.maxSecrets
+            this.maxSecrets,
+            () => this.warnCapacity()
         )
     }
 

--- a/src/store/memory/retry.store.ts
+++ b/src/store/memory/retry.store.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '@infra/log/types'
 import type { WaRetryOutboundMessageRecord, WaRetryOutboundState } from '@retry/types'
 import type { WaRetryStore } from '@store/contracts/retry.store'
 import { resolvePositive } from '@util/coercion'
@@ -21,6 +22,13 @@ const DEFAULTS = Object.freeze({
 export interface WaRetryMemoryStoreOptions {
     readonly maxOutboundMessages?: number
     readonly maxInboundCounters?: number
+    /**
+     * Logger for capacity-saturation warnings. Emits a single `warn` the
+     * first time either bounded map evicts an entry (signals you've hit
+     * `maxOutboundMessages` / `maxInboundCounters`). Subsequent evictions
+     * are silent to avoid spam.
+     */
+    readonly logger?: Logger
 }
 
 export class WaRetryMemoryStore implements WaRetryStore {
@@ -31,6 +39,9 @@ export class WaRetryMemoryStore implements WaRetryStore {
     private readonly maxOutboundMessages: number
     private readonly maxInboundCounters: number
     private readonly cleanup: PeriodicCleanupHandle
+    private readonly logger: Logger | undefined
+    private outboundCapacityWarned: boolean
+    private inboundCapacityWarned: boolean
 
     public constructor(ttlMs = DEFAULTS.ttlMs, options: WaRetryMemoryStoreOptions = {}) {
         if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
@@ -50,8 +61,27 @@ export class WaRetryMemoryStore implements WaRetryStore {
             DEFAULTS.maxInboundCounters,
             'WaRetryMemoryStoreOptions.maxInboundCounters'
         )
+        this.logger = options.logger
+        this.outboundCapacityWarned = false
+        this.inboundCapacityWarned = false
         this.cleanup = createPeriodicCleanup(this.ttlMs, () => {
             void this.cleanupExpired(Date.now())
+        })
+    }
+
+    private warnOutboundCapacity(): void {
+        if (this.outboundCapacityWarned || !this.logger) return
+        this.outboundCapacityWarned = true
+        this.logger.warn('retry outbound store at capacity, evicting oldest', {
+            max: this.maxOutboundMessages
+        })
+    }
+
+    private warnInboundCapacity(): void {
+        if (this.inboundCapacityWarned || !this.logger) return
+        this.inboundCapacityWarned = true
+        this.logger.warn('retry inbound counters at capacity, evicting oldest', {
+            max: this.maxInboundCounters
         })
     }
 
@@ -122,6 +152,7 @@ export class WaRetryMemoryStore implements WaRetryStore {
             this.maxOutboundMessages,
             (messageId) => {
                 this.eligibleSets.delete(messageId)
+                this.warnOutboundCapacity()
             }
         )
         if (record.eligibleRequesterDeviceJids && record.eligibleRequesterDeviceJids.length > 0) {
@@ -165,6 +196,7 @@ export class WaRetryMemoryStore implements WaRetryStore {
             this.maxOutboundMessages,
             (evictedMessageId) => {
                 this.eligibleSets.delete(evictedMessageId)
+                this.warnOutboundCapacity()
             }
         )
     }
@@ -193,6 +225,7 @@ export class WaRetryMemoryStore implements WaRetryStore {
             this.maxOutboundMessages,
             (evictedMessageId) => {
                 this.eligibleSets.delete(evictedMessageId)
+                this.warnOutboundCapacity()
             }
         )
     }
@@ -210,7 +243,8 @@ export class WaRetryMemoryStore implements WaRetryStore {
             this.inboundCounters,
             key,
             { count, expiresAtMs },
-            this.maxInboundCounters
+            this.maxInboundCounters,
+            () => this.warnInboundCapacity()
         )
         return count
     }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '@infra/log/types'
 import type { WaAppStateStore } from '@store/contracts/appstate.store'
 import type { WaAuthStore } from '@store/contracts/auth.store'
 import type { WaContactStore } from '@store/contracts/contact.store'
@@ -284,6 +285,15 @@ export interface WaCreateStoreOptions<B extends string = string> {
      * up for high-traffic accounts (lots of groups / contacts) and down on
      * memory-constrained runtimes.
      */
+    /**
+     * Logger for store-wide events: provider topology at boot, in-memory
+     * capacity saturation warnings, and downstream slow-operation warnings
+     * cascaded through backend factories. When unset, the store layer is
+     * silent. Backend packages (e.g. `@zapo-js/store-sqlite`,
+     * `@zapo-js/store-redis`) receive a `child({ scope: 'store', provider:
+     * '<name>' })` if they accept the same convention in their own factory.
+     */
+    readonly logger?: Logger
     readonly memory?: {
         readonly limits?: WaStoreMemoryLimitSelection
         readonly cacheTtlMs?: {

--- a/src/transport/WaComms.ts
+++ b/src/transport/WaComms.ts
@@ -165,7 +165,7 @@ export class WaComms {
     }
 
     public startComms(handleStanza: StanzaHandler, inflateFrame?: InflateFrame): void {
-        this.logger.info('comms start requested')
+        this.logger.debug('comms start requested')
         this.stanzaHandler = handleStanza
         this.inflateFrame = inflateFrame ?? null
         this.clearPendingFrames()
@@ -213,7 +213,7 @@ export class WaComms {
     }
 
     public async stopComms(): Promise<void> {
-        this.logger.info('comms stop requested')
+        this.logger.debug('comms stop requested')
         this.resetConnectionState({
             started: false,
             connected: false,
@@ -227,7 +227,7 @@ export class WaComms {
     }
 
     public async closeSocketAndResume(): Promise<void> {
-        this.logger.info('comms close socket and resume requested')
+        this.logger.debug('comms close socket and resume requested')
         this.resetConnectionState({
             started: true,
             connected: false,
@@ -344,7 +344,8 @@ export class WaComms {
         this.logger.info('socket closed, scheduling reconnect', {
             code: info.code,
             reason: info.reason,
-            reconnectAfterMs: this.config.reconnectIntervalMs
+            reconnectAfterMs: this.config.reconnectIntervalMs,
+            reconnectAttempts: this.reconnectAttempts
         })
     }
 
@@ -426,7 +427,7 @@ export class WaComms {
         this.lastServerStaticKey = session.getServerStaticKey()
         this.connected = true
         this.reconnectAttempts = 0
-        this.logger.info('comms connected and noise session established')
+        this.logger.debug('comms connected and noise session established')
         this.drainWaiters((waiter) => waiter.resolve())
     }
 

--- a/src/transport/WaWebSocket.ts
+++ b/src/transport/WaWebSocket.ts
@@ -513,8 +513,12 @@ export class WaWebSocket {
     private closeSocketSafe(socket: RawWebSocket, code: number, reason: string): void {
         try {
             socket.close(code, reason)
-        } catch {
-            // no-op
+        } catch (error) {
+            this.logger.trace('socket close ignored', {
+                code,
+                reason,
+                message: toError(error).message
+            })
         }
     }
 

--- a/src/transport/node/WaNodeOrchestrator.ts
+++ b/src/transport/node/WaNodeOrchestrator.ts
@@ -128,8 +128,8 @@ export class WaNodeOrchestrator {
         if (this.pendingQueries.has(id)) {
             throw new Error(`pending node id collision: ${id}`)
         }
-        this.logger.debug('sending query node', {
-            id,
+        const queryLogger = this.logger.child({ id })
+        queryLogger.debug('sending query node', {
             tag: outbound.tag,
             type: outbound.attrs.type,
             timeoutMs
@@ -138,7 +138,7 @@ export class WaNodeOrchestrator {
         return new Promise<BinaryNode>((resolve, reject) => {
             const timer = setTimeout(() => {
                 this.pendingQueries.delete(id)
-                this.logger.warn('query node timeout', { id, timeoutMs })
+                queryLogger.warn('query node timeout', { timeoutMs })
                 reject(new Error(`query timeout (${id}) after ${timeoutMs}ms`))
             }, timeoutMs)
 
@@ -151,8 +151,7 @@ export class WaNodeOrchestrator {
             this.sendNodeFn(outbound).catch((error) => {
                 clearTimeout(timer)
                 this.pendingQueries.delete(id)
-                this.logger.warn('failed to send query node', {
-                    id,
+                queryLogger.warn('failed to send query node', {
                     message: toError(error).message
                 })
                 reject(toError(error))

--- a/src/transport/noise/WaNoiseSession.ts
+++ b/src/transport/noise/WaNoiseSession.ts
@@ -106,7 +106,7 @@ export class WaNoiseSession {
         this.trustedRootCa = config.trustedRootCa
 
         if (config.serverStaticKey && config.serverStaticKey.length === 32) {
-            this.logger.info('noise session attempting resume handshake (IK)')
+            this.logger.debug('noise session attempting resume handshake (IK)')
             this.noiseSocket = await this.resumeHandshake(
                 config.serverStaticKey,
                 config.clientStaticKeyPair,
@@ -116,11 +116,11 @@ export class WaNoiseSession {
                 verifyCertificates
             )
             await this.decodeBufferedPostHandshakeFrames()
-            this.logger.info('noise session established via resume/full fallback path')
+            this.logger.info('noise session established', { mode: 'resume_or_fallback' })
             return
         }
 
-        this.logger.info('noise session starting full handshake (XX)')
+        this.logger.debug('noise session starting full handshake (XX)')
         this.noiseSocket = await this.fullHandshake(
             config.clientStaticKeyPair,
             ephemeralKeyPair,
@@ -129,7 +129,7 @@ export class WaNoiseSession {
             verifyCertificates
         )
         await this.decodeBufferedPostHandshakeFrames()
-        this.logger.info('noise session established via full handshake')
+        this.logger.info('noise session established', { mode: 'full' })
     }
 
     public encryptFrame(frame: Uint8Array): Promise<Uint8Array> {
@@ -274,7 +274,7 @@ export class WaNoiseSession {
         if (resumeResult.socket) {
             return resumeResult.socket
         }
-        this.logger.info('noise resume handshake fallback to XX')
+        this.logger.debug('noise resume handshake fallback to XX')
         return this.resumeHandshakeWithFallback(
             clientStaticKeyPair,
             ephemeralKeyPair,
@@ -349,7 +349,7 @@ export class WaNoiseSession {
 
         handshake.decrypt(serverHello.payload)
         this.serverStaticKey = serverStaticKey
-        this.logger.info('noise resume handshake successful without fallback')
+        this.logger.debug('noise resume handshake successful without fallback')
         return { socket: handshake.finish(), serverHelloFrame: null }
     }
 


### PR DESCRIPTION
- add Logger.child(bindings) to interface + Console/Pino/Noop impls + fallback BoundLogger when underlying lacks child() (Pino path)
- rebalance levels across runtime: per-message publish ack info -> trace, per-msg ack/receipt debug -> trace, dirty-bulletin sequence of 4 infos collapsed into one summary, sequence-debug for retry rejections demoted, noise/connect lifecycle narration consolidated
- aggregate per-target/per-device warns in fanout + signal batch fetch into a single warn with droppedCount + sample, instead of N warns per send
- log structured warns before throwing 'identity mismatch' in signal/session/resolver so caught contexts upstream carry expected/observed pubkeys (hex)
- adopt child(bindings) in 11 functions across signal/retry/appstate/ incoming/orchestrator/pairing/dispatch + mcp-server session logger
- replace WaMediaProcessor.bindLogger with per-call ctx (logger?) on each method; the processor is now stateless and safe to share across multiple WaClient sessions
- createStore now accepts logger; cascades to memory cache providers (retry/groupMetadata/deviceList/messageSecret) which emit a one-shot warn on first eviction
- store packages (sqlite/redis/postgres/mysql/mongo) accept logger + slowOperationThresholdMs in their factories; bind { scope: 'store', provider, domain, sessionId } and emit boot info, connection/pool events, migration progress, and slow-transaction warns
- export createNoopLogger from root barrel so optional packages don't redefine inline noop loggers
- update AGENTS.md with the level rubric, child() guidance, the per-call ctx contract for optional packages, and the related anti-patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logger.child(...) for contextual/scoped logging; noop logger exported for public use
  * Optional per-store slow-operation telemetry with configurable thresholds
  * Media processor and client media calls accept per-call context (logger) for diagnostics

* **Documentation**
  * Expanded logging and review guidelines with structured-logging best practices and examples

* **Refactor**
  * Replaced per-options warning callbacks with per-call logger routing; standardized contextual logging and reduced noisy levels across subsystems

* **Tests**
  * Added unit tests for child-logger behavior and binding stacking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->