### PR TITLE
fix(client,transport): peer-message wire format parity with wa-web

### DIFF
--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -231,6 +231,8 @@ export class WaMessageDispatchCoordinator {
             input.expectedIdentity
         )
         const messageType = input.type ?? 'text'
+        const deviceIdentity =
+            encrypted.type === 'pkmsg' ? this.getEncodedSignedDeviceIdentity() : undefined
         const replayPayload: WaRetryReplayPayload = {
             mode: 'plaintext',
             to: input.to,
@@ -255,7 +257,9 @@ export class WaMessageDispatchCoordinator {
                         category: input.category,
                         pushPriority: input.pushPriority,
                         participant: input.participant,
-                        deviceFanout: input.deviceFanout
+                        deviceFanout: input.deviceFanout,
+                        deviceIdentity,
+                        metaNode: input.metaNode
                     },
                     options
                 )
@@ -503,13 +507,28 @@ export class WaMessageDispatchCoordinator {
         protocolMessage: Proto.Message.IProtocolMessage,
         options?: { readonly id?: string; readonly pushPriority?: 'high' | 'high_force' }
     ): Promise<WaMessagePublishResult> {
+        const meJid = this.deps.getCurrentCredentials()?.meJid
+        const meParsed = meJid ? parseJidFull(meJid) : undefined
+        const meUserJid = meParsed?.userJid
+        let senderIcdc: IcdcMeta | null = null
+        if (meUserJid) {
+            const regInfo = await this.deps.signalStore.getRegistrationInfo()
+            const localPubKey = regInfo?.identityKeyPair.pubKey
+            const localIdentity =
+                meParsed && localPubKey
+                    ? { address: meParsed.address, pubKey: localPubKey }
+                    : undefined
+            senderIcdc = await this.resolveUserIcdc(meUserJid, localIdentity)
+        }
+        const message = injectDeviceListMetadata({ protocolMessage }, senderIcdc, null)
         return this.publishSignalMessage({
             to: deviceJid,
-            plaintext: proto.Message.encode({ protocolMessage }).finish(),
+            plaintext: proto.Message.encode(message).finish(),
             id: options?.id,
             type: 'text',
             category: 'peer',
-            pushPriority: options?.pushPriority ?? 'high'
+            pushPriority: options?.pushPriority ?? 'high',
+            metaNode: buildMetaNode({ appdata: 'default' })
         })
     }
 

--- a/src/client/coordinators/WaPassiveTasksCoordinator.ts
+++ b/src/client/coordinators/WaPassiveTasksCoordinator.ts
@@ -16,6 +16,7 @@ import type { SignalRotateKeyApi } from '@signal/api/SignalRotateKeyApi'
 import { generatePreKeyPair } from '@signal/registration/keygen'
 import type { WaPreKeyStore } from '@store/contracts/pre-key.store'
 import type { WaSignalStore } from '@store/contracts/signal.store'
+import { buildPassiveModeIqNode } from '@transport/node/builders/passive'
 import type { BinaryNode } from '@transport/types'
 import { toError } from '@util/primitives'
 
@@ -149,6 +150,21 @@ export class WaPassiveTasksCoordinator {
         await this.validateDigestAndRecoverPreKeys(prefetchedLocalKeyBundle)
         await this.rotateSignedPreKeyIfDue(signedPreKeyRotationTs)
         await this.flushDanglingReceipts()
+        await this.sendActiveModeIq()
+    }
+
+    private async sendActiveModeIq(): Promise<void> {
+        try {
+            await this.runtime.queryWithContext(
+                'passive.active',
+                buildPassiveModeIqNode('active'),
+                WA_DEFAULTS.IQ_TIMEOUT_MS
+            )
+        } catch (error) {
+            this.logger.warn('passive active iq failed', {
+                message: toError(error).message
+            })
+        }
     }
 
     private async validateDigestAndRecoverPreKeys(

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -297,6 +297,7 @@ export interface WaSignalMessagePublishInput {
     readonly pushPriority?: string
     readonly participant?: string
     readonly deviceFanout?: string
+    readonly metaNode?: BinaryNode
 }
 
 export interface WaSendMessageOptions extends WaMessagePublishOptions {

--- a/src/protocol/nodes.ts
+++ b/src/protocol/nodes.ts
@@ -108,5 +108,6 @@ export const WA_XMLNS = Object.freeze({
     ABPROPS: 'abt',
     MEX: 'w:mex',
     BOT: 'bot',
-    DISAPPEARING_MODE: 'disappearing_mode'
+    DISAPPEARING_MODE: 'disappearing_mode',
+    PASSIVE: 'passive'
 } as const)

--- a/src/transport/node/builders/passive.ts
+++ b/src/transport/node/builders/passive.ts
@@ -1,0 +1,11 @@
+import { WA_DEFAULTS, WA_IQ_TYPES, WA_XMLNS } from '@protocol/constants'
+import { buildIqNode } from '@transport/node/query'
+import type { BinaryNode } from '@transport/types'
+
+export type WaPassiveMode = 'active' | 'passive'
+
+export function buildPassiveModeIqNode(mode: WaPassiveMode): BinaryNode {
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.PASSIVE, [
+        { tag: mode, attrs: {} }
+    ])
+}


### PR DESCRIPTION
Three gaps caused `<stream:error><conflict type='device_removed'/>` to hit fresh pairings (either ~3s after the first peer message or at the ~60s server-side bootstrap timeout):

- post-pair bootstrap never sent `<iq xmlns='passive'><active/></iq>`, so the server kept the device in bootstrap mode until its 60s inactivity timeout fired
- `publishProtocolMessageToDevice` skipped the `messageContextInfo.deviceListMetadata` (sender ICDC) and the `<meta appdata='default'/>` sibling that wa-web emits on every peer message
- `publishSignalMessage` did not attach `<device-identity>` next to `<enc type='pkmsg'>`, so the primary could not validate the new device's ADV-signed identity and the server dropped the session

Adds `WA_XMLNS.PASSIVE` and a `buildPassiveModeIqNode(mode)` builder on top of `buildIqNode`; threads `metaNode` through `WaSignalMessagePublishInput` so peer sends can attach the meta node alongside the ciphertext.

Validated end-to-end against the primary device via MCP: passive active iq returns `<active/>` result; peer messages (both pkmsg and msg) round-trip with `appStateSyncKeyShare` and a
`peerDataOperationRequestResponseMessage` for a placeholder resend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved message encryption and delivery with enhanced device metadata handling.
  * Strengthened connection state management after digest validation.

* **Chores**
  * Updated protocol support for passive mode operations.
  * Extended messaging infrastructure to support additional metadata configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->