### PR TITLE
feat(client): accept a predicate in `ignoreKey` alongside the descriptor

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -23,6 +23,7 @@ import type {
     WaClientEventMap,
     WaClientOptions,
     WaIgnoreKey,
+    WaIgnoreKeyPredicate,
     WaIncomingMessageEvent,
     WaIncomingProtocolMessageEvent
 } from '@client/types'
@@ -521,19 +522,26 @@ export class WaClient extends EventEmitter {
     /**
      * Drops matching inbound stanzas before any handler runs. Server still
      * gets the ack so it stops re-delivering. Returns an `unregister` function.
-     * Throws when the descriptor has no match field or empty arrays.
+     *
+     * Accepts either a declarative descriptor or a predicate. The descriptor
+     * matches by `remoteJid`/`fromMe`/`id`/`participant` (PN ↔ LID alt-attrs
+     * resolved automatically) and throws when no match field is given or
+     * arrays are empty. The predicate receives a parsed
+     * {@link WaIgnoreKeyContext} and returns `true` to drop the stanza.
      *
      * @example
      * ```ts
-     * const off = client.ignoreKey({ remoteJid: spammerJid })
-     * client.ignoreKey({ remoteJid: spammerJid, only: ['message'] })
+     * client.ignoreKey({ remoteJid: spammerJid })
      * client.ignoreKey({ fromMe: true, only: ['message'] })
+     * client.ignoreKey((m) => m.kind === 'message' && isGroupJid(m.remoteJid ?? ''))
      * ```
      */
-    public ignoreKey(descriptor: WaIgnoreKey): () => void {
-        validateIgnoreKey(descriptor)
+    public ignoreKey(input: WaIgnoreKey | WaIgnoreKeyPredicate): () => void {
+        if (typeof input !== 'function') {
+            validateIgnoreKey(input)
+        }
         const filter = createIgnoreKeyFilter(
-            descriptor,
+            input,
             () => this.deps.authClient.getCurrentCredentials()?.meJid
         )
         return this.deps.incomingNode.registerIncomingStanzaFilter(filter)

--- a/src/client/messaging/__tests__/ignore-key.test.ts
+++ b/src/client/messaging/__tests__/ignore-key.test.ts
@@ -192,6 +192,16 @@ test('createIgnoreKeyFilter with predicate routes the parsed context, drops non-
     assert.equal(filter({ tag: 'iq', attrs: { from: PN, id: 'DROP' } }), false)
 })
 
+test('createIgnoreKeyFilter forwards non-message addressable kinds to the predicate', () => {
+    const filter = createIgnoreKeyFilter(
+        (m) => m.kind === 'receipt' && m.id === 'DROP',
+        () => ME_JID
+    )
+    assert.equal(filter(receipt({ from: PN, id: 'DROP' })), true)
+    assert.equal(filter(receipt({ from: PN, id: 'KEEP' })), false)
+    assert.equal(filter(message({ from: PN, id: 'DROP' })), false)
+})
+
 test('createIgnoreKeyFilter with descriptor delegates to matchesIgnoreKey', () => {
     const filter = createIgnoreKeyFilter({ remoteJid: PN, only: ['message'] }, () => ME_JID)
     assert.equal(filter(message({ from: PN, id: 'X' })), true)

--- a/src/client/messaging/__tests__/ignore-key.test.ts
+++ b/src/client/messaging/__tests__/ignore-key.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { matchesIgnoreKey, validateIgnoreKey } from '@client/messaging/ignore-key'
+import {
+    createIgnoreKeyFilter,
+    extractIgnoreKeyContext,
+    matchesIgnoreKey,
+    validateIgnoreKey
+} from '@client/messaging/ignore-key'
 import type { WaIgnoreKey } from '@client/types'
 import type { BinaryNode } from '@transport/types'
 
@@ -152,4 +157,43 @@ test('validate accepts valid combinations', () => {
     validateIgnoreKey({ fromMe: true, only: ['message'] })
     validateIgnoreKey({ participant: PN, only: ['message', 'notification'] })
     validateIgnoreKey({ id: 'X', only: ['message'] })
+})
+
+test('extractIgnoreKeyContext returns parsed context with kind/from/fromMe/id/participant', () => {
+    const node = message({ from: 'group@g.us', participant: LID, id: 'X' })
+    const ctx = extractIgnoreKeyContext(node, ME_JID)
+    assert.deepEqual(ctx, {
+        kind: 'message',
+        remoteJid: 'group@g.us',
+        fromMe: false,
+        id: 'X',
+        participant: LID
+    })
+})
+
+test('extractIgnoreKeyContext fromMe resolves against sender_pn alt attr', () => {
+    const ownEcho = message({ from: LID, sender_pn: ME_JID, id: 'X' })
+    assert.equal(extractIgnoreKeyContext(ownEcho, ME_JID)?.fromMe, true)
+})
+
+test('extractIgnoreKeyContext returns null for non-addressable tags', () => {
+    const iq: BinaryNode = { tag: 'iq', attrs: { from: PN } }
+    assert.equal(extractIgnoreKeyContext(iq, ME_JID), null)
+})
+
+test('createIgnoreKeyFilter with predicate routes the parsed context, drops non-addressable', () => {
+    const filter = createIgnoreKeyFilter(
+        (m) => m.kind === 'message' && m.id === 'DROP',
+        () => ME_JID
+    )
+    assert.equal(filter(message({ from: PN, id: 'DROP' })), true)
+    assert.equal(filter(message({ from: PN, id: 'KEEP' })), false)
+    assert.equal(filter(receipt({ from: PN, id: 'DROP' })), false)
+    assert.equal(filter({ tag: 'iq', attrs: { from: PN, id: 'DROP' } }), false)
+})
+
+test('createIgnoreKeyFilter with descriptor delegates to matchesIgnoreKey', () => {
+    const filter = createIgnoreKeyFilter({ remoteJid: PN, only: ['message'] }, () => ME_JID)
+    assert.equal(filter(message({ from: PN, id: 'X' })), true)
+    assert.equal(filter(receipt({ from: PN, id: 'X' })), false)
 })

--- a/src/client/messaging/ignore-key.ts
+++ b/src/client/messaging/ignore-key.ts
@@ -1,4 +1,10 @@
-import type { WaIgnoreKey, WaIgnoreStanzaKind, WaIncomingStanzaFilter } from '@client/types'
+import type {
+    WaIgnoreKey,
+    WaIgnoreKeyContext,
+    WaIgnoreKeyPredicate,
+    WaIgnoreStanzaKind,
+    WaIncomingStanzaFilter
+} from '@client/types'
 import { parseJidFull } from '@protocol/jid'
 import { WA_MESSAGE_TAGS } from '@protocol/message'
 import { WA_NODE_TAGS } from '@protocol/nodes'
@@ -48,25 +54,67 @@ function matchesAnyJid(actual: string | undefined, candidates: readonly string[]
     return false
 }
 
+function collectFromCandidates(kind: WaIgnoreStanzaKind, attrs: BinaryNode['attrs']): string[] {
+    const list: string[] = []
+    if (attrs.from) list.push(attrs.from)
+    if (kind === 'message') {
+        if (attrs.sender_pn) list.push(attrs.sender_pn)
+        if (attrs.sender_lid) list.push(attrs.sender_lid)
+    } else if (kind === 'call' && attrs.sender_lid) {
+        list.push(attrs.sender_lid)
+    }
+    return list
+}
+
+function collectParticipantCandidates(
+    kind: WaIgnoreStanzaKind,
+    attrs: BinaryNode['attrs']
+): string[] {
+    const list: string[] = []
+    if (attrs.participant) list.push(attrs.participant)
+    if (kind === 'message') {
+        if (attrs.participant_pn) list.push(attrs.participant_pn)
+        if (attrs.participant_lid) list.push(attrs.participant_lid)
+    }
+    return list
+}
+
+/**
+ * Builds the parsed context handed to a {@link WaIgnoreKeyPredicate}. Returns
+ * `null` when the node's tag is not one of the addressable kinds (`<iq>`, etc.).
+ */
+export function extractIgnoreKeyContext(
+    node: BinaryNode,
+    meJid: string | null | undefined
+): WaIgnoreKeyContext | null {
+    const kind = TAG_TO_KIND[node.tag]
+    if (kind === undefined) return null
+    const a = node.attrs
+    const me = tryParseJid(meJid)
+    const fromCandidates = collectFromCandidates(kind, a)
+    const fromMe =
+        me !== null && fromCandidates.some((f) => tryParseJid(f)?.address.user === me.address.user)
+    return {
+        kind,
+        remoteJid: a.from ?? null,
+        fromMe,
+        id: a.id,
+        participant: a.participant ?? null
+    }
+}
+
 /** Pure matcher. Exported for direct testing without a coordinator. */
 export function matchesIgnoreKey(
     node: BinaryNode,
     d: WaIgnoreKey,
     meJid: string | null | undefined
 ): boolean {
-    const kind = TAG_TO_KIND[node.tag]
-    if (kind === undefined) return false
-    if (d.only !== undefined && !d.only.includes(kind)) return false
+    const ctx = extractIgnoreKeyContext(node, meJid)
+    if (ctx === null) return false
+    if (d.only !== undefined && !d.only.includes(ctx.kind)) return false
 
     const a = node.attrs
-    const fromCandidates: string[] = []
-    if (a.from) fromCandidates.push(a.from)
-    if (kind === 'message') {
-        if (a.sender_pn) fromCandidates.push(a.sender_pn)
-        if (a.sender_lid) fromCandidates.push(a.sender_lid)
-    } else if (kind === 'call' && a.sender_lid) {
-        fromCandidates.push(a.sender_lid)
-    }
+    const fromCandidates = collectFromCandidates(ctx.kind, a)
 
     if (d.remoteJid !== undefined) {
         const candidates = Array.isArray(d.remoteJid) ? d.remoteJid : [d.remoteJid]
@@ -74,31 +122,26 @@ export function matchesIgnoreKey(
     }
 
     if (d.participant !== undefined) {
-        const pCandidates: string[] = []
-        if (a.participant) pCandidates.push(a.participant)
-        if (kind === 'message') {
-            if (a.participant_pn) pCandidates.push(a.participant_pn)
-            if (a.participant_lid) pCandidates.push(a.participant_lid)
-        }
+        const pCandidates = collectParticipantCandidates(ctx.kind, a)
         if (!pCandidates.some((p) => matchesAnyJid(p, [d.participant!]))) return false
     }
 
-    if (d.id !== undefined && a.id !== d.id) return false
+    if (d.id !== undefined && ctx.id !== d.id) return false
 
-    if (d.fromMe !== undefined) {
-        const me = tryParseJid(meJid)
-        const isFromMe =
-            me !== null &&
-            fromCandidates.some((f) => tryParseJid(f)?.address.user === me.address.user)
-        if (d.fromMe !== isFromMe) return false
-    }
+    if (d.fromMe !== undefined && d.fromMe !== ctx.fromMe) return false
 
     return true
 }
 
 export function createIgnoreKeyFilter(
-    descriptor: WaIgnoreKey,
+    input: WaIgnoreKey | WaIgnoreKeyPredicate,
     getMeJid: () => string | null | undefined
 ): WaIncomingStanzaFilter {
-    return (node) => matchesIgnoreKey(node, descriptor, getMeJid())
+    if (typeof input === 'function') {
+        return (node) => {
+            const ctx = extractIgnoreKeyContext(node, getMeJid())
+            return ctx !== null && input(ctx)
+        }
+    }
+    return (node) => matchesIgnoreKey(node, input, getMeJid())
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -455,6 +455,28 @@ export interface WaIgnoreKey {
     readonly only?: readonly WaIgnoreStanzaKind[]
 }
 
+/**
+ * Parsed view of an inbound stanza passed to {@link WaIgnoreKeyPredicate}.
+ * Lib does the wire-format parsing (kind detection, PN↔LID alt-attr lookup,
+ * `fromMe` resolution against `meJid`); the predicate only decides.
+ */
+export interface WaIgnoreKeyContext {
+    readonly kind: WaIgnoreStanzaKind
+    /** Raw `from` attr (group JID for groups, PN or LID device JID for 1:1). */
+    readonly remoteJid: string | null
+    readonly fromMe: boolean
+    readonly id: string | undefined
+    /** Raw `participant` attr; `null` for non-group stanzas. */
+    readonly participant: string | null
+}
+
+/**
+ * Predicate form of {@link WaClient.ignoreKey}. Return `true` to drop the
+ * stanza, `false` to let it through. Receives the same fields the descriptor
+ * matches against, already parsed from the wire-format node.
+ */
+export type WaIgnoreKeyPredicate = (ctx: WaIgnoreKeyContext) => boolean
+
 export interface WaIncomingBaseEvent {
     /** The raw decoded stanza, kept for forward-compat parsing of fields the typed event does not expose. */
     readonly rawNode: BinaryNode

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -457,8 +457,15 @@ export interface WaIgnoreKey {
 
 /**
  * Parsed view of an inbound stanza passed to {@link WaIgnoreKeyPredicate}.
- * Lib does the wire-format parsing (kind detection, PN↔LID alt-attr lookup,
- * `fromMe` resolution against `meJid`); the predicate only decides.
+ * Lib derives `kind` from the stanza tag and resolves `fromMe` by comparing
+ * every from-candidate (`from`, `sender_pn`, `sender_lid`) against `meJid`.
+ *
+ * `remoteJid` and `participant` expose the **raw** `from` / `participant`
+ * attrs verbatim and do NOT include the descriptor-style alt-attr lookups
+ * (`sender_pn` / `sender_lid` / `participant_pn` / `participant_lid`) or
+ * PN↔LID normalization. If the predicate needs to match by user identity
+ * regardless of addressing mode, run the raw JID through `parseJidFull` and
+ * compare on `userJid`, or use the descriptor form which handles it.
  */
 export interface WaIgnoreKeyContext {
     readonly kind: WaIgnoreStanzaKind
@@ -472,8 +479,9 @@ export interface WaIgnoreKeyContext {
 
 /**
  * Predicate form of {@link WaClient.ignoreKey}. Return `true` to drop the
- * stanza, `false` to let it through. Receives the same fields the descriptor
- * matches against, already parsed from the wire-format node.
+ * stanza, `false` to let it through. Receives a {@link WaIgnoreKeyContext}
+ * with the raw `from`/`participant` attrs (see the context's JSDoc for the
+ * PN↔LID caveat) plus lib-resolved `kind` and `fromMe`.
  */
 export type WaIgnoreKeyPredicate = (ctx: WaIgnoreKeyContext) => boolean
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ export type {
     WaGroupEventParticipant,
     WaGroupEventSubgroupSuggestion,
     WaIgnoreKey,
+    WaIgnoreKeyContext,
+    WaIgnoreKeyPredicate,
     WaIgnoreStanzaKind,
     WaIncomingAddonEvent,
     WaIncomingBaseEvent,


### PR DESCRIPTION
`ignoreKey` only accepted a static descriptor (`remoteJid` / `fromMe` / `id` / `participant` / `only`), which forces callers to enumerate matches and cannot express open-ended filters like "drop everything from any group".

Add a predicate form that receives a parsed `WaIgnoreKeyContext` (`kind`, `remoteJid`, `fromMe`, `id`, `participant`) and returns `true` to drop. Lib still owns the wire-format parsing (tag → kind, PN ↔ LID alt-attr lookup for `fromMe`); the predicate just decides. Combine it with the existing `parseJidFull`, `isGroupJid`, etc. exports for common cases.

```ts
client.ignoreKey((m) => m.kind === 'message' && isGroupJid(m.remoteJid ?? ''))
```

The descriptor path is unchanged and still validated at register time. The predicate path skips validation since there is no shape to check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ignore-key registration now accepts custom filtering functions, enabling more sophisticated rules for controlling which inbound stanzas are processed.

* **Tests**
  * Expanded test coverage for ignore-key context extraction and custom filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->