### PR TITLE
feat(client,appstate): sync address-book contacts via app-state Contact mutations

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -173,7 +173,8 @@ export class WaClient extends EventEmitter {
                     return () => {
                         this.off('message_protocol', handler)
                     }
-                }
+                },
+                persistContact: (record) => this.writeBehind.persistContact(record)
             }
         })
         this.deps = dependencies
@@ -469,6 +470,8 @@ export class WaClient extends EventEmitter {
             this.logger.trace('wa client connect already in-flight')
             return this.connectPromise
         }
+
+        this.writeBehind.restart()
 
         this.acceptingIncomingEvents = true
         this.connectPromise = this.deps.connectionManager

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -113,6 +113,7 @@ import { SignalSessionSyncApi } from '@signal/api/SignalSessionSyncApi'
 import { SenderKeyManager } from '@signal/group/SenderKeyManager'
 import { createSignalSessionResolver } from '@signal/session/resolver'
 import { SignalProtocol } from '@signal/session/SignalProtocol'
+import type { WaStoredContactRecord } from '@store/contracts/contact.store'
 import { WaKeepAlive } from '@transport/keepalive/WaKeepAlive'
 import { buildAckNode } from '@transport/node/builders/global'
 import { buildPresenceNode } from '@transport/node/builders/presence'
@@ -162,6 +163,13 @@ interface WaClientBuildRuntime {
     readonly subscribeProtocolMessage: (
         handler: (event: WaIncomingProtocolMessageEvent) => void
     ) => () => void
+    /**
+     * Sink for address-book contact rows synced over app-state. Wired by
+     * `WaClient` to {@link WriteBehindPersistence.persistContact} so Contact
+     * mutations land in the contact store at pair-time (snapshot) and on
+     * every incremental sync.
+     */
+    readonly persistContact: (record: WaStoredContactRecord) => void
 }
 
 export interface WaClientDependencies {
@@ -854,7 +862,8 @@ export function buildWaClientDependencies(input: {
         serverClock,
         emitSnapshotMutations: options.chatEvents?.emitSnapshotMutations === true,
         emitMutation: (event) => runtime.emitEvent('mutation', event),
-        nctSaltSink: (salt) => trustedContactToken.handleNctSaltSync(salt)
+        nctSaltSink: (salt) => trustedContactToken.handleNctSaltSync(salt),
+        contactSink: runtime.persistContact
     })
 
     const profileCoordinator = createProfileCoordinator({

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -724,7 +724,8 @@ test('buildWaClientDependencies wires privacy coordinator', () => {
         handleIncomingFrame: async (_frame: Uint8Array) => undefined,
         clearStoredState: async () => undefined,
         resumeIncomingEvents: () => undefined,
-        subscribeProtocolMessage: () => () => undefined
+        subscribeProtocolMessage: () => () => undefined,
+        persistContact: () => undefined
     }
 
     const dependencies = buildWaClientDependencies({ base, runtime })
@@ -767,7 +768,8 @@ test('buildWaClientDependencies wires trusted contact token AB prop overrides', 
         handleIncomingFrame: async (_frame: Uint8Array) => undefined,
         clearStoredState: async () => undefined,
         resumeIncomingEvents: () => undefined,
-        subscribeProtocolMessage: () => () => undefined
+        subscribeProtocolMessage: () => () => undefined,
+        persistContact: () => undefined
     }
 
     const dependencies = buildWaClientDependencies({ base, runtime })

--- a/src/client/coordinators/WaAppStateMutationCoordinator.ts
+++ b/src/client/coordinators/WaAppStateMutationCoordinator.ts
@@ -1,6 +1,7 @@
 import type { WaAppStateSyncClient } from '@appstate/sync/WaAppStateSyncClient'
 import type {
     AppStateCollectionName,
+    WaAppStateMutation,
     WaAppStateMutationInput,
     WaAppStateSyncOptions,
     WaAppStateSyncResult
@@ -31,10 +32,13 @@ import { WA_APP_STATE_COLLECTION_STATES } from '@protocol/constants'
 import {
     isGroupJid,
     isGroupOrBroadcastJid,
+    isLidJid,
+    isUserJid,
     normalizeDeviceJid,
     normalizeRecipientJid,
     toUserJid
 } from '@protocol/jid'
+import type { WaStoredContactRecord } from '@store/contracts/contact.store'
 import type { WaMessageStore, WaStoredMessageRecord } from '@store/contracts/message.store'
 import type { ServerClock } from '@util/clock'
 import { resolvePositive } from '@util/coercion'
@@ -282,6 +286,13 @@ interface WaAppStateMutationCoordinatorOptions {
     readonly emitMutation?: (event: WaAppStateMutationEvent) => void
     readonly emitSnapshotMutations?: boolean
     readonly nctSaltSink?: (salt: Uint8Array | null) => Promise<void>
+    /**
+     * Persistence sink for `Contact` collection mutations (the locally-saved
+     * address-book name the primary device synced over app-state). Invoked on
+     * every winning mutation including snapshot ones, so the contact store is
+     * bootstrapped at pair-time regardless of `emitSnapshotMutations`.
+     */
+    readonly contactSink?: (record: WaStoredContactRecord) => void
 }
 
 export interface WaSetStatusPrivacyInput {
@@ -319,6 +330,7 @@ export class WaAppStateMutationCoordinator {
     private readonly emitMutation?: (event: WaAppStateMutationEvent) => void
     private readonly emitSnapshotMutations: boolean
     private readonly nctSaltSink?: (salt: Uint8Array | null) => Promise<void>
+    private readonly contactSink?: (record: WaStoredContactRecord) => void
     private readonly pendingMutations: Map<string, WaAppStateMutationInput>
     private flushPromise: Promise<void> | null
 
@@ -337,6 +349,7 @@ export class WaAppStateMutationCoordinator {
         this.emitMutation = options.emitMutation
         this.emitSnapshotMutations = options.emitSnapshotMutations === true
         this.nctSaltSink = options.nctSaltSink
+        this.contactSink = options.contactSink
         this.pendingMutations = new Map()
         this.flushPromise = null
     }
@@ -388,6 +401,34 @@ export class WaAppStateMutationCoordinator {
     public emitEventsFromSyncResult(syncResult: WaAppStateSyncResult): void {
         for (const collectionResult of syncResult.collections) {
             const mutations = collectionResult.mutations ?? []
+
+            // Persistence sinks (contact store, ...): run on the last-wins
+            // mutation per key INCLUDING snapshot sources, so pair-time
+            // bootstrap of the address book always lands in the store even
+            // when public events are suppressed for snapshot mutations.
+            if (this.contactSink) {
+                const sinkLastIndex = new Map<string, number>()
+                for (let i = 0; i < mutations.length; i += 1) {
+                    const m = mutations[i]
+                    sinkLastIndex.set(`${m.collection}\u0001${m.index}`, i)
+                }
+                for (let i = 0; i < mutations.length; i += 1) {
+                    const m = mutations[i]
+                    if (sinkLastIndex.get(`${m.collection}\u0001${m.index}`) !== i) {
+                        continue
+                    }
+                    try {
+                        this.handleContactMutation(m)
+                    } catch (error) {
+                        this.logger.debug('contact sink failed', {
+                            collection: m.collection,
+                            index: m.index,
+                            message: toError(error).message
+                        })
+                    }
+                }
+            }
+
             const lastMutationIndexByKey = new Map<string, number>()
             for (let mutationIndex = 0; mutationIndex < mutations.length; mutationIndex += 1) {
                 const mutation = mutations[mutationIndex]
@@ -452,6 +493,51 @@ export class WaAppStateMutationCoordinator {
                 })
             )
         }
+    }
+
+    private handleContactMutation(mutation: WaAppStateMutation): void {
+        if (!this.contactSink) return
+        // Cheap reject before JSON.parse — Contact mutations always carry
+        // the literal "contact" as their first index segment.
+        if (!mutation.index.includes('"contact"')) return
+        let parts: unknown
+        try {
+            parts = JSON.parse(mutation.index)
+        } catch {
+            return
+        }
+        if (!Array.isArray(parts) || parts[0] !== 'contact' || typeof parts[1] !== 'string') {
+            return
+        }
+        const indexJid = parts[1]
+        const lastUpdatedMs = mutation.timestamp > 0 ? mutation.timestamp : Date.now()
+        if (mutation.operation === 'remove') {
+            // Contact left the primary address book. Keep the row (chat may
+            // still be open); only invalidate the synced display name.
+            this.contactSink({ jid: indexJid, lastUpdatedMs })
+            return
+        }
+        const action = mutation.value?.contactAction
+        if (!action) return
+        // Resolve canonical (LID-preferred) jid + cross-reference: the index
+        // typically carries the PN form, and `contactAction.lidJid` carries
+        // the LID counterpart. Store one row keyed by LID when both are known
+        // (mirrors what the contact store does for history-sync writes), with
+        // `phoneNumber` populated so PN-form lookups still resolve.
+        const lid = action.lidJid && isLidJid(action.lidJid) ? action.lidJid : undefined
+        const indexIsPn = isUserJid(indexJid)
+        const indexIsLid = isLidJid(indexJid)
+        const jid = lid ?? indexJid
+        const phoneNumber = indexIsPn ? indexJid : undefined
+        const lidField = lid ?? (indexIsLid ? indexJid : undefined)
+        const displayName = action.fullName || action.firstName || undefined
+        this.contactSink({
+            jid,
+            displayName,
+            lid: lidField,
+            phoneNumber,
+            lastUpdatedMs
+        })
     }
 
     /**

--- a/src/client/coordinators/WaAppStateMutationCoordinator.ts
+++ b/src/client/coordinators/WaAppStateMutationCoordinator.ts
@@ -497,7 +497,7 @@ export class WaAppStateMutationCoordinator {
 
     private handleContactMutation(mutation: WaAppStateMutation): void {
         if (!this.contactSink) return
-        // Cheap reject before JSON.parse — Contact mutations always carry
+        // Cheap reject before JSON.parse: Contact mutations always carry
         // the literal "contact" as their first index segment.
         if (!mutation.index.includes('"contact"')) return
         let parts: unknown
@@ -511,12 +511,11 @@ export class WaAppStateMutationCoordinator {
         }
         const indexJid = parts[1]
         const lastUpdatedMs = mutation.timestamp > 0 ? mutation.timestamp : Date.now()
-        if (mutation.operation === 'remove') {
-            // Contact left the primary address book. Keep the row (chat may
-            // still be open); only invalidate the synced display name.
-            this.contactSink({ jid: indexJid, lastUpdatedMs })
-            return
-        }
+        // Remove operations are a no-op for the contact store: `mergeContact`
+        // preserves prior displayName when incoming.displayName is undefined,
+        // and the row should stay around (the chat may still be open). The
+        // public mutation event still fires below so consumers can react.
+        if (mutation.operation === 'remove') return
         const action = mutation.value?.contactAction
         if (!action) return
         // Resolve canonical (LID-preferred) jid + cross-reference: the index

--- a/src/client/persistence/WriteBehindPersistence.ts
+++ b/src/client/persistence/WriteBehindPersistence.ts
@@ -52,12 +52,15 @@ function mergeContact(
 
 export class WriteBehindPersistence {
     private readonly logger: Logger
-    private readonly queues: {
+    private readonly stores: WriteBehindStores
+    private readonly options: WaWriteBehindOptions
+    private queues: {
         readonly messages: BackgroundQueue<string, WaStoredMessageRecord>
         readonly threads: BackgroundQueue<string, WaStoredThreadRecord>
         readonly contacts: BackgroundQueue<string, WaStoredContactRecord>
     }
     private readonly flushTimeoutMs: number
+    private destroyed: boolean
 
     public constructor(
         stores: WriteBehindStores,
@@ -65,7 +68,16 @@ export class WriteBehindPersistence {
         options: WaWriteBehindOptions = {}
     ) {
         this.logger = logger
+        this.stores = stores
+        this.options = options
         this.flushTimeoutMs = options.flushTimeoutMs ?? 5_000
+        this.queues = this.buildQueues()
+        this.destroyed = false
+    }
+
+    private buildQueues(): typeof this.queues {
+        const stores = this.stores
+        const options = this.options
         const queueOptions = (domain: string) => ({
             maxPendingKeys: options.maxPendingKeys ?? 4_096,
             maxWriteConcurrency: options.maxWriteConcurrency ?? 4,
@@ -91,7 +103,7 @@ export class WriteBehindPersistence {
                 })
             }
         })
-        this.queues = {
+        return {
             messages: new BackgroundQueue((_key, value) => stores.messageStore.upsert(value), {
                 ...queueOptions('messages'),
                 batchWriter: (entries) =>
@@ -110,6 +122,20 @@ export class WriteBehindPersistence {
                     stores.contactStore.upsertBatch(entries.map((e) => e.value))
             })
         }
+    }
+
+    /**
+     * Re-arm the queues after a previous {@link destroy} call. Idempotent —
+     * a no-op when the persistence is already live. Used by `WaClient.connect`
+     * to recover from a logout/clear-stored-state cycle without leaking the
+     * old destroyed queues into the next session.
+     */
+    public restart(): void {
+        if (!this.destroyed) {
+            return
+        }
+        this.queues = this.buildQueues()
+        this.destroyed = false
     }
 
     public persistMessage(record: WaStoredMessageRecord): void {
@@ -159,6 +185,7 @@ export class WriteBehindPersistence {
             this.queues.threads.destroy(timeoutMs),
             this.queues.contacts.destroy(timeoutMs)
         ])
+        this.destroyed = true
         const result = this.toDrainResult(messages, threads, contacts)
         if (result.remaining > 0) {
             this.logger.warn('write-behind destroy finished with pending writes', {

--- a/src/client/persistence/__tests__/WriteBehindPersistence.test.ts
+++ b/src/client/persistence/__tests__/WriteBehindPersistence.test.ts
@@ -167,3 +167,61 @@ test('write-behind flush and destroy expose remaining pending entries', async ()
     const finalFlush = await writeBehind.flush(2_000)
     assert.equal(finalFlush.remaining, 0)
 })
+
+test('write-behind restart re-arms queues after destroy so new sessions enqueue', async () => {
+    const writes: WaStoredContactRecord[] = []
+    const writeBehind = new WriteBehindPersistence(
+        {
+            messageStore: {
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
+            } as never,
+            threadStore: {
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
+            } as never,
+            contactStore: {
+                upsert: async (record: WaStoredContactRecord) => {
+                    writes.push(record)
+                },
+                upsertBatch: async (records: readonly WaStoredContactRecord[]) => {
+                    for (const r of records) writes.push(r)
+                }
+            } as never
+        },
+        createNoopLogger()
+    )
+
+    await writeBehind.destroy(10)
+    // Without restart, the next enqueue would throw "background queue is destroyed".
+    writeBehind.restart()
+    writeBehind.persistContact({ jid: 'after-restart@s.whatsapp.net', lastUpdatedMs: 1 })
+    await writeBehind.flush(2_000)
+
+    assert.equal(writes.length, 1)
+    assert.equal(writes[0].jid, 'after-restart@s.whatsapp.net')
+})
+
+test('write-behind restart is a no-op when queues are live', () => {
+    const writeBehind = new WriteBehindPersistence(
+        {
+            messageStore: {
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
+            } as never,
+            threadStore: {
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
+            } as never,
+            contactStore: {
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
+            } as never
+        },
+        createNoopLogger()
+    )
+
+    // Calling restart twice on a live instance must not throw or rebuild queues.
+    writeBehind.restart()
+    writeBehind.restart()
+})

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -6,6 +6,7 @@ import type { WaClientEventMap, WaHistorySyncChunkEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import { proto, type Proto } from '@proto'
+import { isGroupJid } from '@protocol/jid'
 import { decodeProtoBytes, toBytesView } from '@util/bytes'
 import { longToNumber, toError } from '@util/primitives'
 
@@ -91,19 +92,26 @@ export async function processHistorySyncNotification(
         chunkOrder: historySync.chunkOrder,
         progress: historySync.progress,
         conversations: historySync.conversations.length,
-        pushnames: historySync.pushnames.length
+        pushnames: historySync.pushnames.length,
+        inlineContacts: historySync.inlineContacts?.length ?? 0
     })
 
     const nowMs = Date.now()
     const pendingWrites: Promise<void>[] = []
 
-    // Build PN -> LID lookup from this chunk's mappings so pushnames and
-    // mappings land on a single canonical (LID-form) contact row instead of
-    // two mirror rows (one keyed by PN, one keyed by LID).
+    // Build PN -> LID lookup from this chunk's mappings (and inline contacts,
+    // which carry the same pair) so pushnames and mappings land on a single
+    // canonical (LID-form) contact row instead of two mirror rows (one keyed
+    // by PN, one keyed by LID).
     const pnToLid = new Map<string, string>()
     for (const map of historySync.phoneNumberToLidMappings ?? []) {
         if (map.pnJid && map.lidJid) {
             pnToLid.set(map.pnJid, map.lidJid)
+        }
+    }
+    for (const c of historySync.inlineContacts ?? []) {
+        if (c.pnJid && c.lidJid) {
+            pnToLid.set(c.pnJid, c.lidJid)
         }
     }
 
@@ -131,6 +139,26 @@ export async function processHistorySyncNotification(
         }
     }
 
+    for (const c of historySync.inlineContacts ?? []) {
+        const jid = c.lidJid ?? c.pnJid
+        if (!jid) {
+            continue
+        }
+        const displayName = c.fullName || c.firstName || undefined
+        if (!displayName && !c.pnJid) {
+            continue
+        }
+        pendingWrites[pendingWrites.length] = deps.writeBehind.persistContactAsync({
+            jid,
+            displayName,
+            phoneNumber: c.pnJid ?? undefined,
+            lastUpdatedMs: nowMs
+        })
+        if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
+            await flushPendingWrites(pendingWrites)
+        }
+    }
+
     let messagesCount = 0
     for (const conversation of historySync.conversations) {
         const threadJid = conversation.id
@@ -151,6 +179,27 @@ export async function processHistorySyncNotification(
         })
         if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
             await flushPendingWrites(pendingWrites)
+        }
+
+        if (!isGroupJid(threadJid)) {
+            const contactDisplay = conversation.displayName || conversation.username || undefined
+            const contactPn = conversation.pnJid ?? undefined
+            const contactLid = conversation.lidJid ?? conversation.accountLid ?? undefined
+            if (contactDisplay || contactPn || contactLid) {
+                const contactJid = contactLid ?? threadJid
+                pendingWrites[pendingWrites.length] = deps.writeBehind.persistContactAsync({
+                    jid: contactJid,
+                    displayName: contactDisplay,
+                    phoneNumber: contactPn,
+                    lastUpdatedMs: nowMs
+                })
+                if (contactPn && contactLid) {
+                    pnToLid.set(contactPn, contactLid)
+                }
+                if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
+                    await flushPendingWrites(pendingWrites)
+                }
+            }
         }
         for (const histMsg of conversation.messages ?? []) {
             const webMsg = histMsg.message
@@ -227,6 +276,7 @@ export async function processHistorySyncNotification(
         messagesCount,
         conversationsCount: historySync.conversations.length,
         pushnamesCount: historySync.pushnames.length,
+        inlineContactsCount: historySync.inlineContacts?.length ?? 0,
         chunkOrder: historySync.chunkOrder ?? undefined,
         progress: historySync.progress ?? undefined
     }

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -6,7 +6,7 @@ import type { WaClientEventMap, WaHistorySyncChunkEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import { proto, type Proto } from '@proto'
-import { isGroupJid } from '@protocol/jid'
+import { isUserJid } from '@protocol/jid'
 import { decodeProtoBytes, toBytesView } from '@util/bytes'
 import { longToNumber, toError } from '@util/primitives'
 
@@ -99,10 +99,10 @@ export async function processHistorySyncNotification(
     const nowMs = Date.now()
     const pendingWrites: Promise<void>[] = []
 
-    // Build PN -> LID lookup from this chunk's mappings (and inline contacts,
-    // which carry the same pair) so pushnames and mappings land on a single
-    // canonical (LID-form) contact row instead of two mirror rows (one keyed
-    // by PN, one keyed by LID).
+    // Build PN -> LID lookup from this chunk's mappings (and inline contacts
+    // and conversation-level pn/lid pairs, which carry the same pair) so
+    // pushnames and mappings land on a single canonical (LID-form) contact
+    // row instead of two mirror rows (one keyed by PN, one keyed by LID).
     const pnToLid = new Map<string, string>()
     for (const map of historySync.phoneNumberToLidMappings ?? []) {
         if (map.pnJid && map.lidJid) {
@@ -112,6 +112,13 @@ export async function processHistorySyncNotification(
     for (const c of historySync.inlineContacts ?? []) {
         if (c.pnJid && c.lidJid) {
             pnToLid.set(c.pnJid, c.lidJid)
+        }
+    }
+    for (const conversation of historySync.conversations) {
+        const pnJid = conversation.pnJid
+        const lidJid = conversation.lidJid ?? conversation.accountLid
+        if (pnJid && lidJid) {
+            pnToLid.set(pnJid, lidJid)
         }
     }
 
@@ -181,7 +188,7 @@ export async function processHistorySyncNotification(
             await flushPendingWrites(pendingWrites)
         }
 
-        if (!isGroupJid(threadJid)) {
+        if (isUserJid(threadJid) || (conversation.lidJid ?? conversation.accountLid)) {
             const contactDisplay = conversation.displayName || conversation.username || undefined
             const contactPn = conversation.pnJid ?? undefined
             const contactLid = conversation.lidJid ?? conversation.accountLid ?? undefined
@@ -193,9 +200,6 @@ export async function processHistorySyncNotification(
                     phoneNumber: contactPn,
                     lastUpdatedMs: nowMs
                 })
-                if (contactPn && contactLid) {
-                    pnToLid.set(contactPn, contactLid)
-                }
                 if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
                     await flushPendingWrites(pendingWrites)
                 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1137,6 +1137,7 @@ export interface WaHistorySyncChunkEvent {
     readonly messagesCount: number
     readonly conversationsCount: number
     readonly pushnamesCount: number
+    readonly inlineContactsCount: number
     readonly chunkOrder?: number
     /** Server-reported progress, 0–100. */
     readonly progress?: number

--- a/src/transport/noise/WaClientPayload.ts
+++ b/src/transport/noise/WaClientPayload.ts
@@ -138,7 +138,8 @@ function defaultDeviceProps(
             supportHostedGroupMsg: true,
             supportBizHostedMsg: true,
             supportFbidBotChatHistory: true,
-            supportMessageAssociation: true
+            supportMessageAssociation: true,
+            supportInlineContacts: true
         }
     }).finish()
 }


### PR DESCRIPTION
Add a `contactSink` to `WaAppStateMutationCoordinator` that runs on every winning Contact mutation (including snapshot-source ones) so the contact store is bootstrapped at pair-time alongside incremental sync, independent of the public `emitSnapshotMutations` toggle. The sink resolves the LID-canonical jid from `contactAction.lidJid`, mirrors the PN form into `phoneNumber`, and writes `fullName ?? firstName` as `displayName`.

Also persist `inlineContacts` + `conversation.displayName/username` from history-sync when the primary device forwards them, and advertise `supportInlineContacts` in the pair payload.

WaClient now wires the sink to `WriteBehindPersistence.persistContact` and re-arms the queues on `connect` so a logout/clear-stored-state cycle no longer leaves the persistence in a destroyed state for the next pair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist contacts during app-state sync and history-sync (including inline contacts)
  * Expose inlineContactsCount metric in history-sync events
  * Client now restarts persistence automatically when starting a connection

* **Refactor**
  * Centralized write-behind queue management with restart support

* **Tests**
  * Added tests for persistence restart behavior and updated dependency wiring in client tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->