### PR TITLE
fix(client): keep credentials on forced-login stream error

### DIFF
--- a/src/client/coordinators/WaStreamControlCoordinator.ts
+++ b/src/client/coordinators/WaStreamControlCoordinator.ts
@@ -94,11 +94,10 @@ export function createStreamControlHandler(
         const reason = WA_DISCONNECT_REASONS.STREAM_ERROR_FORCE_LOGIN
         stopCommsImmediately()
         await runStreamControlLifecycle(reason, async () => {
-            logger.warn('received forced login stream error; starting login lifecycle', {
+            logger.warn('received forced login stream error; reconnecting, keeping credentials', {
                 code
             })
-            await disconnect(reason, true, code)
-            await clearStoredCredentials()
+            await disconnect(reason, false, code)
             await restartBackendAfterStreamControl(reason)
         })
     }

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -511,11 +511,11 @@ test('stream control handler runs force-login and resume flows', async () => {
         code: WA_STREAM_SIGNALING.FORCE_LOGIN_CODE
     })
 
-    assert.deepEqual(calls, ['stopComms', 'disconnect', 'clear_credentials', 'connect'])
+    assert.deepEqual(calls, ['stopComms', 'disconnect', 'connect'])
     assert.deepEqual(disconnectCalls, [
         {
             reason: WA_DISCONNECT_REASONS.STREAM_ERROR_FORCE_LOGIN,
-            isLogout: true,
+            isLogout: false,
             code: WA_STREAM_SIGNALING.FORCE_LOGIN_CODE
         }
     ])


### PR DESCRIPTION
Reconnect on a forced-login stream error instead of clearing stored credentials, so the session resumes without re-pairing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Improved error recovery: When a stream connection error triggers a forced login, the app now reconnects while preserving your stored credentials instead of clearing them and requiring re-authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->