### PR TITLE
fix(client): use 100px max edge for image and video thumbnails

### DIFF
--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -102,8 +102,8 @@ export function parseWebpAnimation(data: Uint8Array): WebpAnimInfo | null {
     return null
 }
 
-const IMAGE_THUMB_MAX_EDGE = 320
-const VIDEO_THUMB_MAX_EDGE = 48
+const IMAGE_THUMB_MAX_EDGE = 100
+const VIDEO_THUMB_MAX_EDGE = 100
 const STICKER_THUMB_MAX_EDGE = 100
 const EMPTY_PROCESSED: ProcessedMediaFields = {}
 type MediaProcessorStep = 'thumbnail' | 'probe' | 'waveform' | 'stickerThumbnail'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted thumbnail sizing for image and video media display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->