### PR TITLE
fix(signal): send E.164-prefixed contact in device sync usync

### DIFF
--- a/src/signal/api/SignalDeviceSyncApi.ts
+++ b/src/signal/api/SignalDeviceSyncApi.ts
@@ -314,7 +314,9 @@ export class SignalDeviceSyncApi {
                     {
                         tag: WA_NODE_TAGS.CONTACT,
                         attrs: {},
-                        content: splitJid(jid).user
+                        // E.164 '+': without it the server normalizes under the
+                        // account's country and resolves the wrong contact.
+                        content: `+${splitJid(jid).user}`
                     }
                 ]
             }


### PR DESCRIPTION
Prefix the contact number with '+' so the server does not normalize it under the account country and resolve the wrong contact.