### PR TITLE
fix(client): order group-event cache mutation before emit and store canonical participant

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -363,7 +363,8 @@ function createIncomingNodeRuntime(input: {
         emitRegistrationCode: (event) => emitEvent('mobile_registration_code', event),
         emitAccountTakeoverNotice: (event) => emitEvent('mobile_account_takeover_notice', event),
         emitGroupEvent: (event) => {
-            emitEvent('group', event)
+            // Register the cache mutation before emitting so a handler that
+            // sends synchronously sees the fresh participants, not the stale ones.
             void messageDispatch.mutateGroupMetadataCacheFromGroupEvent(event).catch((error) => {
                 logger.warn('failed to mutate group metadata cache from group event', {
                     action: event.action,
@@ -372,6 +373,7 @@ function createIncomingNodeRuntime(input: {
                     message: toError(error).message
                 })
             })
+            emitEvent('group', event)
         },
         emitBusinessEvent: (event) => emitEvent('business', event),
         emitPictureEvent: (event) => emitEvent('picture', event),

--- a/src/client/messaging/__tests__/messaging.test.ts
+++ b/src/client/messaging/__tests__/messaging.test.ts
@@ -178,6 +178,76 @@ test('group metadata cache mutates membership from events', async () => {
     }
 })
 
+test('group metadata cache add stores only the canonical (lid) participant form', async () => {
+    const groupMetadataStore = new WaGroupMetadataMemoryStore(60_000)
+    try {
+        const cache = createGroupMetadataCache({
+            groupMetadataStore,
+            queryGroupMetadata: async () => ({ participants: [] }),
+            logger: createNoopLogger()
+        })
+
+        await cache.mutateFromGroupEvent(
+            createGroupEvent({
+                action: 'create',
+                groupJid: '120@g.us',
+                participants: ['108869518913624@lid']
+            })
+        )
+
+        await cache.mutateFromGroupEvent({
+            rawNode: { tag: 'notification', attrs: {} },
+            rawActionNode: { tag: 'add', attrs: {} },
+            action: 'add',
+            groupJid: '120@g.us',
+            participants: [
+                {
+                    jid: '75935072161893@lid',
+                    phoneJid: '554796129545@s.whatsapp.net'
+                }
+            ]
+        })
+
+        const cached = await groupMetadataStore.getGroupMetadata('120@g.us')
+        assert.deepEqual(cached?.participants, ['108869518913624@lid', '75935072161893@lid'])
+    } finally {
+        await groupMetadataStore.destroy()
+    }
+})
+
+test('group metadata cache resolve awaits an in-flight membership mutation', async () => {
+    const groupMetadataStore = new WaGroupMetadataMemoryStore(60_000)
+    try {
+        const cache = createGroupMetadataCache({
+            groupMetadataStore,
+            queryGroupMetadata: async () => ({ participants: [] }),
+            logger: createNoopLogger()
+        })
+
+        await cache.mutateFromGroupEvent(
+            createGroupEvent({
+                action: 'create',
+                groupJid: '120@g.us',
+                participants: ['551100000000@s.whatsapp.net']
+            })
+        )
+
+        const joinMutation = cache.mutateFromGroupEvent(
+            createGroupEvent({
+                action: 'add',
+                groupJid: '120@g.us',
+                participants: ['552200000000@s.whatsapp.net']
+            })
+        )
+        const resolved = await cache.resolveParticipantUsers('120@g.us')
+        await joinMutation
+
+        assert.deepEqual(resolved, ['551100000000@s.whatsapp.net', '552200000000@s.whatsapp.net'])
+    } finally {
+        await groupMetadataStore.destroy()
+    }
+})
+
 test('group metadata cache stores and updates ephemeral from events', async () => {
     const groupMetadataStore = new WaGroupMetadataMemoryStore(60_000)
     try {

--- a/src/client/messaging/group-metadata.ts
+++ b/src/client/messaging/group-metadata.ts
@@ -28,6 +28,7 @@ export function createGroupMetadataCache(options: {
 }): GroupMetadataCache {
     const { groupMetadataStore, queryGroupMetadata, logger } = options
     const dedup = new PromiseDedup()
+    const pendingMutations = new Map<string, Promise<void>>()
 
     const sanitizeParticipantUsers = (participants: readonly string[]): readonly string[] => {
         const deduped = new Set<string>()
@@ -170,14 +171,9 @@ export function createGroupMetadataCache(options: {
     const extractParticipantUsersFromGroupEvent = (event: WaGroupEvent): readonly string[] => {
         const candidates: string[] = []
         for (const participant of event.participants ?? []) {
-            if (participant.jid) {
-                candidates.push(participant.jid)
-            }
-            if (participant.lidJid) {
-                candidates.push(participant.lidJid)
-            }
-            if (participant.phoneJid) {
-                candidates.push(participant.phoneJid)
+            const canonical = participant.jid ?? participant.lidJid ?? participant.phoneJid
+            if (canonical) {
+                candidates.push(canonical)
             }
         }
         return sanitizeParticipantUsers(candidates)
@@ -198,6 +194,7 @@ export function createGroupMetadataCache(options: {
 
     const resolveParticipantUsers = (groupJid: string): Promise<readonly string[]> =>
         dedup.run(`resolve:${groupJid}`, async () => {
+            await pendingMutations.get(groupJid)?.catch(() => undefined)
             const cached = await groupMetadataStore.getGroupMetadata(groupJid)
             if (cached && cached.participants.length > 0) {
                 return sanitizeParticipantUsers(cached.participants)
@@ -220,7 +217,7 @@ export function createGroupMetadataCache(options: {
         return refreshed?.ephemeral ?? null
     }
 
-    const mutateFromGroupEvent = async (event: WaGroupEvent): Promise<void> => {
+    const applyGroupEvent = async (event: WaGroupEvent): Promise<void> => {
         const groupJid = resolveGroupJidForGroupCacheEvent(event)
         if (!groupJid) {
             return
@@ -304,6 +301,24 @@ export function createGroupMetadataCache(options: {
                 participantUsers
             )
         }
+    }
+
+    const mutateFromGroupEvent = (event: WaGroupEvent): Promise<void> => {
+        const groupJid = resolveGroupJidForGroupCacheEvent(event)
+        if (!groupJid) {
+            return applyGroupEvent(event)
+        }
+        const prev = pendingMutations.get(groupJid) ?? Promise.resolve()
+        const next = prev.then(
+            () => applyGroupEvent(event),
+            () => applyGroupEvent(event)
+        )
+        pendingMutations.set(groupJid, next)
+        return next.finally(() => {
+            if (pendingMutations.get(groupJid) === next) {
+                pendingMutations.delete(groupJid)
+            }
+        })
     }
 
     return {


### PR DESCRIPTION
Register the group-metadata cache mutation before emitting the group event so a synchronous handler observes fresh participants. Serialize per-group mutations and have resolve await an in-flight mutation. Store only the canonical (lid) participant form instead of all three jids.