### PR TITLE
fix(store): stop getOrGenPreKeys from spinning on colliding key ids

### DIFF
--- a/packages/store-mongo/src/pre-key.store.ts
+++ b/packages/store-mongo/src/pre-key.store.ts
@@ -68,6 +68,10 @@ export class WaPreKeyMongoStore extends BaseMongoStore implements WaPreKeyStore 
             throw new Error(`invalid prekey count: ${count}`)
         }
 
+        // Bail if a round adds no available prekey (a colliding keyId makes the
+        // upsert a no-op); without this the loop would spin forever.
+        let lastAvailableCount = -1
+
         while (true) {
             await this.ensureIndexes()
             const metaCol = this.col<MetaDoc>('signal_meta')
@@ -143,6 +147,13 @@ export class WaPreKeyMongoStore extends BaseMongoStore implements WaPreKeyStore 
             if (finalAvailable.length >= count) {
                 return finalAvailable
             }
+            if (finalAvailable.length <= lastAvailableCount) {
+                throw new Error(
+                    'getOrGenPreKeys made no progress; the generator returned key ids ' +
+                        'that collide with stored prekeys'
+                )
+            }
+            lastAvailableCount = finalAvailable.length
         }
     }
 

--- a/packages/store-mongo/src/pre-key.store.ts
+++ b/packages/store-mongo/src/pre-key.store.ts
@@ -68,10 +68,6 @@ export class WaPreKeyMongoStore extends BaseMongoStore implements WaPreKeyStore 
             throw new Error(`invalid prekey count: ${count}`)
         }
 
-        // Bail if a round adds no available prekey (a colliding keyId makes the
-        // upsert a no-op); without this the loop would spin forever.
-        let lastAvailableCount = -1
-
         while (true) {
             await this.ensureIndexes()
             const metaCol = this.col<MetaDoc>('signal_meta')
@@ -119,6 +115,7 @@ export class WaPreKeyMongoStore extends BaseMongoStore implements WaPreKeyStore 
             }
 
             const prekeys = this.col<PreKeyDoc>('signal_prekeys')
+            let insertedCount = 0
             if (generated.length > 0) {
                 const ops = generated.map((record) => ({
                     updateOne: {
@@ -135,7 +132,8 @@ export class WaPreKeyMongoStore extends BaseMongoStore implements WaPreKeyStore 
                         upsert: true
                     }
                 }))
-                await prekeys.bulkWrite(ops, { ordered: false })
+                const result = await prekeys.bulkWrite(ops, { ordered: false })
+                insertedCount = result.upsertedCount
             }
 
             await metaCol.updateOne(
@@ -143,17 +141,19 @@ export class WaPreKeyMongoStore extends BaseMongoStore implements WaPreKeyStore 
                 { $max: { next_prekey_id: maxId + 1 } }
             )
 
-            const finalAvailable = await this.selectAvailablePreKeys(count)
-            if (finalAvailable.length >= count) {
-                return finalAvailable
-            }
-            if (finalAvailable.length <= lastAvailableCount) {
+            // No new docs: the generator returned already-stored key ids (upsert
+            // no-op). Bail instead of looping; robust to a concurrent consume.
+            if (insertedCount === 0) {
                 throw new Error(
                     'getOrGenPreKeys made no progress; the generator returned key ids ' +
                         'that collide with stored prekeys'
                 )
             }
-            lastAvailableCount = finalAvailable.length
+
+            const finalAvailable = await this.selectAvailablePreKeys(count)
+            if (finalAvailable.length >= count) {
+                return finalAvailable
+            }
         }
     }
 

--- a/packages/store-mysql/src/pre-key.store.ts
+++ b/packages/store-mysql/src/pre-key.store.ts
@@ -3,7 +3,7 @@ import type { PreKeyRecord } from 'zapo-js/signal'
 import type { WaPreKeyStore } from 'zapo-js/store'
 
 import { BaseMysqlStore } from './BaseMysqlStore'
-import { type MysqlRow, queryFirst, queryRows, safeLimit, toBytes } from './helpers'
+import { affectedRows, type MysqlRow, queryFirst, queryRows, safeLimit, toBytes } from './helpers'
 import type { MysqlParam, WaMysqlStorageOptions } from './types'
 
 const BATCH_SIZE = 250
@@ -36,10 +36,6 @@ export class WaPreKeyMysqlStore extends BaseMysqlStore implements WaPreKeyStore 
         if (!Number.isSafeInteger(count) || count <= 0) {
             throw new Error(`invalid prekey count: ${count}`)
         }
-
-        // Bail if a round adds no available prekey (a colliding keyId makes the
-        // insert a no-op); without this the loop would spin forever.
-        let lastAvailableCount = -1
 
         while (true) {
             const reservation = await this.withTransaction(async (conn) => {
@@ -77,10 +73,11 @@ export class WaPreKeyMysqlStore extends BaseMysqlStore implements WaPreKeyStore 
                 }
             }
 
-            await this.withTransaction(async (conn) => {
+            const insertedCount = await this.withTransaction(async (conn) => {
                 await this.ensureMetaRow(conn)
                 const sizes = this.powerOfTwoChunks(generated.length)
                 let cursor = 0
+                let inserted = 0
                 for (const size of sizes) {
                     const chunk = generated.slice(cursor, cursor + size)
                     cursor += size
@@ -95,11 +92,13 @@ export class WaPreKeyMysqlStore extends BaseMysqlStore implements WaPreKeyStore 
                             record.uploaded === true ? 1 : 0
                         )
                     }
-                    await conn.execute(
-                        `INSERT IGNORE INTO ${this.t('signal_prekey')} (
-                            session_id, key_id, pub_key, priv_key, uploaded
-                        ) VALUES ${placeholders}`,
-                        params
+                    inserted += affectedRows(
+                        await conn.execute(
+                            `INSERT IGNORE INTO ${this.t('signal_prekey')} (
+                                session_id, key_id, pub_key, priv_key, uploaded
+                            ) VALUES ${placeholders}`,
+                            params
+                        )
                     )
                 }
                 await conn.execute(
@@ -108,7 +107,17 @@ export class WaPreKeyMysqlStore extends BaseMysqlStore implements WaPreKeyStore 
                      WHERE session_id = ?`,
                     [maxId + 1, this.sessionId]
                 )
+                return inserted
             })
+
+            // No new rows: the generator returned already-stored key ids (insert
+            // no-op). Bail instead of looping; robust to a concurrent consume.
+            if (insertedCount === 0) {
+                throw new Error(
+                    'getOrGenPreKeys made no progress; the generator returned key ids ' +
+                        'that collide with stored prekeys'
+                )
+            }
 
             const available = await this.withTransaction(async (conn) =>
                 this.selectAvailablePreKeys(conn, count)
@@ -116,13 +125,6 @@ export class WaPreKeyMysqlStore extends BaseMysqlStore implements WaPreKeyStore 
             if (available.length >= count) {
                 return available
             }
-            if (available.length <= lastAvailableCount) {
-                throw new Error(
-                    'getOrGenPreKeys made no progress; the generator returned key ids ' +
-                        'that collide with stored prekeys'
-                )
-            }
-            lastAvailableCount = available.length
         }
     }
 

--- a/packages/store-mysql/src/pre-key.store.ts
+++ b/packages/store-mysql/src/pre-key.store.ts
@@ -37,6 +37,10 @@ export class WaPreKeyMysqlStore extends BaseMysqlStore implements WaPreKeyStore 
             throw new Error(`invalid prekey count: ${count}`)
         }
 
+        // Bail if a round adds no available prekey (a colliding keyId makes the
+        // insert a no-op); without this the loop would spin forever.
+        let lastAvailableCount = -1
+
         while (true) {
             const reservation = await this.withTransaction(async (conn) => {
                 await this.ensureMetaRow(conn)
@@ -112,6 +116,13 @@ export class WaPreKeyMysqlStore extends BaseMysqlStore implements WaPreKeyStore 
             if (available.length >= count) {
                 return available
             }
+            if (available.length <= lastAvailableCount) {
+                throw new Error(
+                    'getOrGenPreKeys made no progress; the generator returned key ids ' +
+                        'that collide with stored prekeys'
+                )
+            }
+            lastAvailableCount = available.length
         }
     }
 

--- a/packages/store-postgres/src/pre-key.store.ts
+++ b/packages/store-postgres/src/pre-key.store.ts
@@ -31,6 +31,10 @@ export class WaPreKeyPgStore extends BasePgStore implements WaPreKeyStore {
             throw new Error(`invalid prekey count: ${count}`)
         }
 
+        // Bail if a round adds no available prekey (a colliding keyId makes the
+        // insert a no-op); without this the loop would spin forever.
+        let lastAvailableCount = -1
+
         while (true) {
             const reservation = await this.withTransaction(async (client) => {
                 await this.ensureMetaRow(client)
@@ -105,6 +109,13 @@ export class WaPreKeyPgStore extends BasePgStore implements WaPreKeyStore {
             if (available.length >= count) {
                 return available
             }
+            if (available.length <= lastAvailableCount) {
+                throw new Error(
+                    'getOrGenPreKeys made no progress; the generator returned key ids ' +
+                        'that collide with stored prekeys'
+                )
+            }
+            lastAvailableCount = available.length
         }
     }
 

--- a/packages/store-postgres/src/pre-key.store.ts
+++ b/packages/store-postgres/src/pre-key.store.ts
@@ -31,10 +31,6 @@ export class WaPreKeyPgStore extends BasePgStore implements WaPreKeyStore {
             throw new Error(`invalid prekey count: ${count}`)
         }
 
-        // Bail if a round adds no available prekey (a colliding keyId makes the
-        // insert a no-op); without this the loop would spin forever.
-        let lastAvailableCount = -1
-
         while (true) {
             const reservation = await this.withTransaction(async (client) => {
                 await this.ensureMetaRow(client)
@@ -66,10 +62,11 @@ export class WaPreKeyPgStore extends BasePgStore implements WaPreKeyStore {
                 }
             }
 
-            await this.withTransaction(async (client) => {
+            const insertedCount = await this.withTransaction(async (client) => {
                 await this.ensureMetaRow(client)
                 const sizes = this.powerOfTwoChunks(generated.length)
                 let cursor = 0
+                let inserted = 0
                 for (const size of sizes) {
                     const chunk = generated.slice(cursor, cursor + size)
                     cursor += size
@@ -91,7 +88,7 @@ export class WaPreKeyPgStore extends BasePgStore implements WaPreKeyStore {
                             record.uploaded === true ? 1 : 0
                         )
                     }
-                    await client.query({
+                    const result = await client.query({
                         name: this.stmtName(`prekey_insert_batch_${chunk.length}`),
                         text: `INSERT INTO ${this.t('signal_prekey')} (
                             session_id, key_id, pub_key, priv_key, uploaded
@@ -99,9 +96,20 @@ export class WaPreKeyPgStore extends BasePgStore implements WaPreKeyStore {
                         ON CONFLICT (session_id, key_id) DO NOTHING`,
                         values: params
                     })
+                    inserted += result.rowCount ?? 0
                 }
                 await this.updateNextPreKeyId(client, maxId + 1)
+                return inserted
             })
+
+            // No new rows: the generator returned already-stored key ids (insert
+            // no-op). Bail instead of looping; robust to a concurrent consume.
+            if (insertedCount === 0) {
+                throw new Error(
+                    'getOrGenPreKeys made no progress; the generator returned key ids ' +
+                        'that collide with stored prekeys'
+                )
+            }
 
             const available = await this.withTransaction(async (client) =>
                 this.selectAvailablePreKeys(client, count)
@@ -109,13 +117,6 @@ export class WaPreKeyPgStore extends BasePgStore implements WaPreKeyStore {
             if (available.length >= count) {
                 return available
             }
-            if (available.length <= lastAvailableCount) {
-                throw new Error(
-                    'getOrGenPreKeys made no progress; the generator returned key ids ' +
-                        'that collide with stored prekeys'
-                )
-            }
-            lastAvailableCount = available.length
         }
     }
 

--- a/packages/store-redis/src/pre-key.store.ts
+++ b/packages/store-redis/src/pre-key.store.ts
@@ -71,6 +71,10 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
             throw new Error(`invalid prekey count: ${count}`)
         }
 
+        // Bail if a round adds no available prekey; without this the loop would
+        // spin forever.
+        let lastAvailableCount = -1
+
         while (true) {
             await this.ensureMetaHash()
             const availKey = this.k('signal:pk:avail', this.sessionId)
@@ -188,6 +192,13 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
                     return finalKeys.slice(0, count)
                 }
             }
+            if (recheckIds.length <= lastAvailableCount) {
+                throw new Error(
+                    'getOrGenPreKeys made no progress; the generator returned key ids ' +
+                        'that collide with stored prekeys'
+                )
+            }
+            lastAvailableCount = recheckIds.length
         }
     }
 

--- a/packages/store-redis/src/pre-key.store.ts
+++ b/packages/store-redis/src/pre-key.store.ts
@@ -71,10 +71,6 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
             throw new Error(`invalid prekey count: ${count}`)
         }
 
-        // Bail if a round adds no available prekey; without this the loop would
-        // spin forever.
-        let lastAvailableCount = -1
-
         while (true) {
             await this.ensureMetaHash()
             const availKey = this.k('signal:pk:avail', this.sessionId)
@@ -133,8 +129,10 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
 
             const pipeline = this.redis.pipeline()
             const idsKey = this.k('signal:pk:ids', this.sessionId)
+            const idStrs: string[] = []
             for (const record of generated) {
                 const idStr = String(record.keyId)
+                idStrs.push(idStr)
                 const pkKey = this.k('signal:pk', this.sessionId, idStr)
                 ;(pipeline.hset as (...args: unknown[]) => unknown)(
                     pkKey,
@@ -145,12 +143,19 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
                     'priv',
                     toRedisBuffer(record.keyPair.privKey)
                 )
-                pipeline.sadd(idsKey, idStr)
                 if (record.uploaded !== true) {
                     pipeline.zadd(availKey, record.keyId, idStr)
                 }
             }
-            await pipeline.exec()
+            // One variadic SADD (the last command) returns how many ids were
+            // genuinely new, i.e. how many prekeys this round actually inserted.
+            pipeline.sadd(idsKey, ...idStrs)
+            const execResults = await pipeline.exec()
+            const saddResult = execResults ? execResults[execResults.length - 1] : undefined
+            const insertedCount =
+                saddResult && saddResult[0] === null && typeof saddResult[1] === 'number'
+                    ? saddResult[1]
+                    : 0
             // Atomically reconcile if the generator produced IDs beyond the reserved range
             if (maxId + 1 > reservedIds[reservedIds.length - 1] + 1) {
                 await this.redis.eval(
@@ -192,13 +197,14 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
                     return finalKeys.slice(0, count)
                 }
             }
-            if (recheckIds.length <= lastAvailableCount) {
+            // No new ids: the generator returned already-stored key ids. Bail
+            // instead of looping; robust to a concurrent consume.
+            if (insertedCount === 0) {
                 throw new Error(
                     'getOrGenPreKeys made no progress; the generator returned key ids ' +
                         'that collide with stored prekeys'
                 )
             }
-            lastAvailableCount = recheckIds.length
         }
     }
 

--- a/packages/store-sqlite/src/__tests__/sqlite-runtime.test.ts
+++ b/packages/store-sqlite/src/__tests__/sqlite-runtime.test.ts
@@ -531,6 +531,21 @@ test('sqlite signal store covers prekeys, sessions, identities and state helpers
         await preKeyStore.setServerHasPreKeys(true)
         assert.equal(await preKeyStore.getServerHasPreKeys(), true)
 
+        // Regression: a generator returning an already-stored keyId must fail fast
+        // (insert is a no-op) instead of looping forever - the bootstrap hang.
+        const collidingPair = await X25519.generateKeyPair()
+        await preKeyStore.putPreKey({ keyId: 4242, keyPair: collidingPair, uploaded: false })
+        await preKeyStore.markKeyAsUploaded(4242)
+        await assert.rejects(
+            () =>
+                preKeyStore.getOrGenSinglePreKey(async () => ({
+                    keyId: 4242,
+                    keyPair: collidingPair,
+                    uploaded: false
+                })),
+            /made no progress/
+        )
+
         const sessionAddressA = makeAddress('5511', 0)
         const sessionAddressB = makeAddress('5522', 0)
         assert.equal(await sessionStore.hasSession(sessionAddressA), false)

--- a/packages/store-sqlite/src/pre-key.store.ts
+++ b/packages/store-sqlite/src/pre-key.store.ts
@@ -54,6 +54,9 @@ export class WaPreKeySqliteStore extends BaseSqliteStore implements WaPreKeyStor
         if (!Number.isSafeInteger(count) || count <= 0) {
             throw new Error(`invalid prekey count: ${count}`)
         }
+        // Bail if a round adds no available prekey (a colliding keyId makes the
+        // insert a no-op); without this the loop would spin forever.
+        let lastAvailableCount = -1
         while (true) {
             const reservation = await this.withTransaction((db) => {
                 this.ensureMetaRow(db)
@@ -117,6 +120,13 @@ export class WaPreKeySqliteStore extends BaseSqliteStore implements WaPreKeyStor
             if (available.length >= count) {
                 return available
             }
+            if (available.length <= lastAvailableCount) {
+                throw new Error(
+                    'getOrGenPreKeys made no progress; the generator returned key ids ' +
+                        'that collide with stored prekeys'
+                )
+            }
+            lastAvailableCount = available.length
         }
     }
 

--- a/packages/store-sqlite/src/pre-key.store.ts
+++ b/packages/store-sqlite/src/pre-key.store.ts
@@ -54,9 +54,6 @@ export class WaPreKeySqliteStore extends BaseSqliteStore implements WaPreKeyStor
         if (!Number.isSafeInteger(count) || count <= 0) {
             throw new Error(`invalid prekey count: ${count}`)
         }
-        // Bail if a round adds no available prekey (a colliding keyId makes the
-        // insert a no-op); without this the loop would spin forever.
-        let lastAvailableCount = -1
         while (true) {
             const reservation = await this.withTransaction((db) => {
                 this.ensureMetaRow(db)
@@ -101,8 +98,9 @@ export class WaPreKeySqliteStore extends BaseSqliteStore implements WaPreKeyStor
                 }
             }
 
-            await this.withTransaction((db) => {
+            const insertedCount = await this.withTransaction((db) => {
                 this.ensureMetaRow(db)
+                const before = this.countPreKeys(db)
                 for (const record of generated) {
                     this.insertPreKeyIfMissing(db, record)
                 }
@@ -112,7 +110,17 @@ export class WaPreKeySqliteStore extends BaseSqliteStore implements WaPreKeyStor
                      WHERE session_id = ?`,
                     [maxGeneratedKeyId + 1, this.options.sessionId]
                 )
+                return this.countPreKeys(db) - before
             })
+
+            // No new rows: the generator returned already-stored key ids (insert
+            // no-op). Bail instead of looping; robust to a concurrent consume.
+            if (insertedCount === 0) {
+                throw new Error(
+                    'getOrGenPreKeys made no progress; the generator returned key ids ' +
+                        'that collide with stored prekeys'
+                )
+            }
 
             const available = await this.withTransaction((db) =>
                 this.selectAvailablePreKeys(db, count)
@@ -120,13 +128,6 @@ export class WaPreKeySqliteStore extends BaseSqliteStore implements WaPreKeyStor
             if (available.length >= count) {
                 return available
             }
-            if (available.length <= lastAvailableCount) {
-                throw new Error(
-                    'getOrGenPreKeys made no progress; the generator returned key ids ' +
-                        'that collide with stored prekeys'
-                )
-            }
-            lastAvailableCount = available.length
         }
     }
 
@@ -260,6 +261,14 @@ export class WaPreKeySqliteStore extends BaseSqliteStore implements WaPreKeyStor
             records[index] = decodeSignalPreKeyRow(rows[index])
         }
         return records
+    }
+
+    private countPreKeys(db: WaSqliteConnection): number {
+        const row = db.get<{ count: number }>(
+            `SELECT COUNT(*) AS count FROM signal_prekey WHERE session_id = ?`,
+            [this.options.sessionId]
+        )
+        return row?.count ?? 0
     }
 
     private upsertPreKey(db: WaSqliteConnection, record: PreKeyRecord): void {

--- a/src/signal/registration/utils.ts
+++ b/src/signal/registration/utils.ts
@@ -31,8 +31,9 @@ export async function createAndStoreInitialKeys(
     // Keep writes ordered so partial commit failures don't leave split registration bootstrap state.
     await store.setRegistrationInfo(registrationInfo)
     await store.setSignedPreKey(signedPreKey)
-    // eslint-disable-next-line @typescript-eslint/require-await
-    await preKeyStore.getOrGenSinglePreKey(async () => firstPreKey)
+    // putPreKey (idempotent), not getOrGenSinglePreKey: a fixed-keyId generator
+    // collides with a stale keyId 1 and would spin forever inside getOrGen*.
+    await preKeyStore.putPreKey(firstPreKey)
 
     return {
         registrationInfo,

--- a/src/store/locks/__tests__/locks.test.ts
+++ b/src/store/locks/__tests__/locks.test.ts
@@ -2,11 +2,13 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import type { WaMessageStore, WaStoredMessageRecord } from '@store/contracts/message.store'
+import type { WaPreKeyStore } from '@store/contracts/pre-key.store'
 import type {
     WaPrivacyTokenStore,
     WaStoredPrivacyTokenRecord
 } from '@store/contracts/privacy-token.store'
 import { withMessageLock } from '@store/locks/message.lock'
+import { withPreKeyLock } from '@store/locks/pre-key.lock'
 import { withPrivacyTokenLock } from '@store/locks/privacy-token.lock'
 import { delay } from '@util/async'
 
@@ -95,6 +97,36 @@ function createPrivacyTokenStore(
         clear: async () => {
             records.clear()
         }
+    }
+}
+
+function createPreKeyStore(handlers: {
+    readonly onGenerate?: () => Promise<void>
+    readonly onConsume?: () => Promise<void>
+}): WaPreKeyStore {
+    return {
+        putPreKey: async () => undefined,
+        getOrGenPreKeys: async () => {
+            if (handlers.onGenerate) {
+                await handlers.onGenerate()
+            }
+            return []
+        },
+        getPreKeyById: async () => null,
+        getPreKeysById: async () => [],
+        consumePreKeyById: async () => {
+            if (handlers.onConsume) {
+                await handlers.onConsume()
+            }
+            return null
+        },
+        getOrGenSinglePreKey: async () => {
+            throw new Error('unused')
+        },
+        markKeyAsUploaded: async () => undefined,
+        setServerHasPreKeys: async () => undefined,
+        getServerHasPreKeys: async () => false,
+        clear: async () => undefined
     }
 }
 
@@ -218,4 +250,37 @@ test('privacy token lock allows parallel writes for different jids', async (t) =
     await done
 
     assert.equal(maxInFlight, 2)
+})
+
+test('prekey lock lets consume run while a generation holds the lock', async () => {
+    let releaseGeneration: () => void = () => undefined
+    const generationBlocked = new Promise<void>((resolve) => {
+        releaseGeneration = resolve
+    })
+    let signalGenerationStarted: () => void = () => undefined
+    const generationStarted = new Promise<void>((resolve) => {
+        signalGenerationStarted = resolve
+    })
+
+    const store = withPreKeyLock(
+        createPreKeyStore({
+            onGenerate: async () => {
+                signalGenerationStarted()
+                await generationBlocked
+            }
+        })
+    )
+
+    const generation = store.getOrGenPreKeys(8, (keyId) => ({
+        keyId,
+        keyPair: { pubKey: new Uint8Array(32), privKey: new Uint8Array(32) },
+        uploaded: false
+    }))
+    await generationStarted
+
+    // Shared with the generation lock this would deadlock; per-id it resolves now.
+    assert.equal(await store.consumePreKeyById(5), null)
+
+    releaseGeneration()
+    await generation
 })

--- a/src/store/locks/__tests__/locks.test.ts
+++ b/src/store/locks/__tests__/locks.test.ts
@@ -252,35 +252,39 @@ test('privacy token lock allows parallel writes for different jids', async (t) =
     assert.equal(maxInFlight, 2)
 })
 
-test('prekey lock lets consume run while a generation holds the lock', async () => {
-    let releaseGeneration: () => void = () => undefined
-    const generationBlocked = new Promise<void>((resolve) => {
-        releaseGeneration = resolve
-    })
-    let signalGenerationStarted: () => void = () => undefined
-    const generationStarted = new Promise<void>((resolve) => {
-        signalGenerationStarted = resolve
-    })
-
-    const store = withPreKeyLock(
-        createPreKeyStore({
-            onGenerate: async () => {
-                signalGenerationStarted()
-                await generationBlocked
-            }
+test(
+    'prekey lock lets consume run while a generation holds the lock',
+    { timeout: 5_000 },
+    async () => {
+        let releaseGeneration: () => void = () => undefined
+        const generationBlocked = new Promise<void>((resolve) => {
+            releaseGeneration = resolve
         })
-    )
+        let signalGenerationStarted: () => void = () => undefined
+        const generationStarted = new Promise<void>((resolve) => {
+            signalGenerationStarted = resolve
+        })
 
-    const generation = store.getOrGenPreKeys(8, (keyId) => ({
-        keyId,
-        keyPair: { pubKey: new Uint8Array(32), privKey: new Uint8Array(32) },
-        uploaded: false
-    }))
-    await generationStarted
+        const store = withPreKeyLock(
+            createPreKeyStore({
+                onGenerate: async () => {
+                    signalGenerationStarted()
+                    await generationBlocked
+                }
+            })
+        )
 
-    // Shared with the generation lock this would deadlock; per-id it resolves now.
-    assert.equal(await store.consumePreKeyById(5), null)
+        const generation = store.getOrGenPreKeys(8, (keyId) => ({
+            keyId,
+            keyPair: { pubKey: new Uint8Array(32), privKey: new Uint8Array(32) },
+            uploaded: false
+        }))
+        await generationStarted
 
-    releaseGeneration()
-    await generation
-})
+        // Shared with the generation lock this would deadlock; per-id it resolves now.
+        assert.equal(await store.consumePreKeyById(5), null)
+
+        releaseGeneration()
+        await generation
+    }
+)

--- a/src/store/locks/pre-key.lock.ts
+++ b/src/store/locks/pre-key.lock.ts
@@ -6,6 +6,9 @@ import type { WithDestroyLifecycle } from '@store/types'
 const WA_PREKEY_KEY = 'prekey:prekeys'
 const WA_PREKEY_SERVER_KEY = 'prekey:serverHasPreKeys'
 const WA_PREKEY_CLEAR_KEY = 'prekey:clear'
+// consume is independent of the counter/generation and atomic in the store, so it
+// uses a per-id key instead of WA_PREKEY_KEY: no queueing behind generation/upload.
+const WA_PREKEY_CONSUME_PREFIX = 'prekey:consume:'
 
 export function withPreKeyLock(store: WaPreKeyStore): WithDestroyLifecycle<WaPreKeyStore> {
     const lock = new StoreLock()
@@ -21,7 +24,11 @@ export function withPreKeyLock(store: WaPreKeyStore): WithDestroyLifecycle<WaPre
         getPreKeyById: (keyId) => gate.runShared(() => store.getPreKeyById(keyId)),
         getPreKeysById: (keyIds) => gate.runShared(() => store.getPreKeysById(keyIds)),
         consumePreKeyById: (keyId) =>
-            gate.runShared(() => lock.run(WA_PREKEY_KEY, () => store.consumePreKeyById(keyId))),
+            gate.runShared(() =>
+                lock.run(`${WA_PREKEY_CONSUME_PREFIX}${keyId}`, () =>
+                    store.consumePreKeyById(keyId)
+                )
+            ),
         getOrGenSinglePreKey: (generator) =>
             gate.runShared(() =>
                 lock.run(WA_PREKEY_KEY, () => store.getOrGenSinglePreKey(generator))


### PR DESCRIPTION
Guard every prekey provider's regeneration loop so a generator returning an already-stored keyId (insert becomes a no-op) fails fast instead of looping forever. Switch consume to a per-id lock so it no longer queues behind generation/upload, and use idempotent putPreKey for the registration bootstrap key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-key generation now detects and fails immediately when no new pre-keys are inserted, preventing infinite loops in collision scenarios across all database stores.

* **New Features**
  * Added per-prekey locking mechanism to improve concurrency handling for pre-key consumption operations.

* **Tests**
  * Added regression test for pre-key collision scenarios.
  * Added test coverage for pre-key locking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->