### PR TITLE
feat(media): add standalone downloadMediaMessage helper

### DIFF
--- a/src/client/__tests__/media.test.ts
+++ b/src/client/__tests__/media.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
-import { Agent } from 'node:http'
+import { Agent as HttpAgent } from 'node:http'
+import { Agent as HttpsAgent } from 'node:https'
 import { Readable } from 'node:stream'
 import test from 'node:test'
 
@@ -55,22 +56,23 @@ test('downloadMediaMessage forwards the resolved payload to the transfer client'
     assert.equal(captured?.agent, undefined)
 })
 
-test('downloadMediaMessage forwards an http.Agent proxy as the request agent', async () => {
-    let captured: Record<string, unknown> | undefined
-    const transfer = fakeTransfer((req) => {
-        captured = req
-    }, Readable.from([]))
-    const agent = new Agent()
+test('downloadMediaMessage forwards an http(s).Agent proxy as the request agent', async () => {
+    for (const agent of [new HttpAgent(), new HttpsAgent()]) {
+        let captured: Record<string, unknown> | undefined
+        const transfer = fakeTransfer((req) => {
+            captured = req
+        }, Readable.from([]))
 
-    await downloadMediaMessage(
-        { imageMessage: { directPath: '/i', mediaKey: key } },
-        { transfer, proxy: agent }
-    )
+        await downloadMediaMessage(
+            { imageMessage: { directPath: '/i', mediaKey: key } },
+            { transfer, proxy: agent }
+        )
 
-    assert.equal(captured?.agent, agent)
+        assert.equal(captured?.agent, agent)
+    }
 })
 
-test('downloadMediaMessage ignores a non-agent (dispatcher) proxy', async () => {
+test('downloadMediaMessage ignores an undici-style dispatcher proxy', async () => {
     let captured: Record<string, unknown> | undefined
     const transfer = fakeTransfer((req) => {
         captured = req

--- a/src/client/__tests__/media.test.ts
+++ b/src/client/__tests__/media.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict'
+import { Agent } from 'node:http'
+import { Readable } from 'node:stream'
+import test from 'node:test'
+
+import { downloadMediaMessage } from '@client/media'
+import type { WaIncomingMessageEvent } from '@client/types'
+import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
+
+const key = new Uint8Array([1, 2, 3])
+
+function fakeTransfer(
+    onRequest: (req: Record<string, unknown>) => void,
+    plaintext: Readable
+): WaMediaTransferClient {
+    return {
+        downloadAndDecryptStream: (req: Record<string, unknown>) => {
+            onRequest(req)
+            return Promise.resolve({ plaintext, metadata: Promise.resolve({}) })
+        }
+    } as unknown as WaMediaTransferClient
+}
+
+test('downloadMediaMessage throws when the message has no downloadable media', async () => {
+    await assert.rejects(
+        () => downloadMediaMessage({ conversation: 'hi' }),
+        /no downloadable media/
+    )
+})
+
+test('downloadMediaMessage forwards the resolved payload to the transfer client', async () => {
+    let captured: Record<string, unknown> | undefined
+    const plaintext = Readable.from([new Uint8Array([9])])
+    const transfer = fakeTransfer((req) => {
+        captured = req
+    }, plaintext)
+
+    const result = await downloadMediaMessage(
+        {
+            imageMessage: {
+                directPath: '/img',
+                mediaKey: key,
+                fileSha256: new Uint8Array([4]),
+                fileEncSha256: new Uint8Array([5])
+            }
+        },
+        { transfer, timeoutMs: 1234 }
+    )
+
+    assert.equal(result, plaintext)
+    assert.equal(captured?.directPath, '/img')
+    assert.equal(captured?.mediaType, 'image')
+    assert.equal(captured?.mediaKey, key)
+    assert.equal(captured?.timeoutMs, 1234)
+    assert.equal(captured?.agent, undefined)
+})
+
+test('downloadMediaMessage forwards an http.Agent proxy as the request agent', async () => {
+    let captured: Record<string, unknown> | undefined
+    const transfer = fakeTransfer((req) => {
+        captured = req
+    }, Readable.from([]))
+    const agent = new Agent()
+
+    await downloadMediaMessage(
+        { imageMessage: { directPath: '/i', mediaKey: key } },
+        { transfer, proxy: agent }
+    )
+
+    assert.equal(captured?.agent, agent)
+})
+
+test('downloadMediaMessage ignores a non-agent (dispatcher) proxy', async () => {
+    let captured: Record<string, unknown> | undefined
+    const transfer = fakeTransfer((req) => {
+        captured = req
+    }, Readable.from([]))
+
+    await downloadMediaMessage(
+        { imageMessage: { directPath: '/i', mediaKey: key } },
+        { transfer, proxy: { dispatch: () => undefined } }
+    )
+
+    assert.equal(captured?.agent, undefined)
+})
+
+test('downloadMediaMessage unwraps an incoming message event', async () => {
+    let captured: Record<string, unknown> | undefined
+    const plaintext = Readable.from([new Uint8Array([1])])
+    const transfer = fakeTransfer((req) => {
+        captured = req
+    }, plaintext)
+
+    const event = {
+        rawNode: { tag: 'message', attrs: {} },
+        message: { audioMessage: { directPath: '/a', mediaKey: key, ptt: true } }
+    } as unknown as WaIncomingMessageEvent
+
+    await downloadMediaMessage(event, { transfer })
+
+    assert.equal(captured?.mediaType, 'ptt')
+    assert.equal(captured?.directPath, '/a')
+})

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -5,6 +5,7 @@ import { pipeline } from 'node:stream/promises'
 import type { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
 import type { WaTrustedContactTokenCoordinator } from '@client/coordinators/WaTrustedContactTokenCoordinator'
 import { aggregateReceiptTargets } from '@client/events/receipt'
+import { downloadMediaMessage } from '@client/media'
 import type {
     WaDownloadMediaOptions,
     WaIncomingAddonEvent,
@@ -23,7 +24,6 @@ import {
     shouldUseAddonAdditionalData
 } from '@message/crypto/addon-crypto'
 import { unwrapMessage } from '@message/encode/content'
-import { resolveMediaPayload } from '@message/encode/media-payload'
 import type { PeerDataOperationRequester } from '@message/primitives/peer-data-operation'
 import type {
     WaMessagePublishResult,
@@ -385,24 +385,7 @@ export class WaMessageCoordinator {
         source: WaIncomingMessageEvent | Proto.IMessage,
         options: WaDownloadMediaOptions = {}
     ): Promise<Readable> {
-        const message: Proto.IMessage | null | undefined =
-            'rawNode' in source ? source.message : source
-        const payload = resolveMediaPayload(message)
-        if (!payload) {
-            throw new Error('message has no downloadable media')
-        }
-        const { plaintext, metadata } = await this.mediaTransfer.downloadAndDecryptStream({
-            directPath: payload.directPath,
-            mediaType: payload.mediaType,
-            mediaKey: payload.mediaKey,
-            fileSha256: payload.fileSha256,
-            fileEncSha256: payload.fileEncSha256,
-            timeoutMs: options.timeoutMs,
-            signal: options.signal,
-            maxBytes: options.maxBytes
-        })
-        metadata.catch(() => undefined)
-        return plaintext
+        return downloadMediaMessage(source, { ...options, transfer: this.mediaTransfer })
     }
 
     /**

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -6,12 +6,16 @@ import { join } from 'node:path'
 import { type Readable, Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 
-import type { WaMediaOptions } from '@client/types'
+import type { WaDownloadMediaOptions, WaIncomingMessageEvent, WaMediaOptions } from '@client/types'
 import { randomIntAsync, sha256 } from '@crypto/core'
 import type { Logger } from '@infra/log/types'
-import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
+import { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import type { WaMediaConn } from '@media/types'
+import { resolveMediaPayload } from '@message/encode/media-payload'
 import type { WaSendMediaMessage } from '@message/types'
+import type { Proto } from '@proto'
+import { toProxyAgent } from '@transport/proxy'
+import type { WaProxyTransport } from '@transport/types'
 import { bytesToBase64UrlSafe, TEXT_DECODER, toBytesView, toChunkBytes } from '@util/bytes'
 import { toError } from '@util/primitives'
 
@@ -570,4 +574,84 @@ export async function runMediaProcessor(
     }
 
     return result
+}
+
+export interface WaDownloadMediaMessageOptions extends WaDownloadMediaOptions {
+    /**
+     * Reuse an existing transfer client instead of creating a fresh one. Lets
+     * the download inherit proxy agents, timeouts, and the MAC-verification
+     * toggle, and avoids spinning up a new HTTP client per call in a loop. A
+     * stateless {@link WaMediaTransferClient} is created when omitted - fine
+     * for one-off downloads.
+     */
+    readonly transfer?: WaMediaTransferClient
+    /**
+     * Proxy for the CDN download leg, mirroring `proxy.mediaDownload` on the
+     * client. The fetch runs over `node:http`/`node:https`, so only the Node
+     * `http.Agent` form is used; an undici dispatcher is ignored (same as the
+     * client treats `mediaDownload`). Takes precedence over the default agent
+     * of a `transfer` you pass.
+     */
+    readonly proxy?: WaProxyTransport
+}
+
+/**
+ * Streams and decrypts the media attached to a message without a connected
+ * `WaClient`. Resolves the encrypted payload (directPath, mediaKey, file
+ * hashes) from `source`, fetches the ciphertext from the WhatsApp media CDN,
+ * and decrypts it on the fly.
+ *
+ * The media keys come from the (already decrypted) message itself, so this is
+ * for re-downloading media you have persisted - not for fetching media you
+ * never received. The CDN download needs no session or auth token; only the
+ * upload path does.
+ *
+ * **The caller owns the returned stream** - pipe it somewhere or call
+ * `.destroy()` to release the socket; an unconsumed stream leaks the
+ * connection. MAC + SHA-256 verification runs as bytes are consumed, so
+ * aborting mid-read leaves you with unverified bytes. Pass `options.signal`
+ * to cancel cleanly.
+ *
+ * @throws when `source` carries no downloadable media.
+ * @example
+ * ```ts
+ * import { downloadMediaMessage } from 'zapo-js'
+ * import { createWriteStream } from 'node:fs'
+ *
+ * const stream = await downloadMediaMessage(event)
+ * stream.pipe(createWriteStream('photo.jpg'))
+ * ```
+ * @example
+ * ```ts
+ * // Route the CDN download through an http.Agent-style proxy
+ * import { HttpsProxyAgent } from 'https-proxy-agent'
+ *
+ * const stream = await downloadMediaMessage(event, {
+ *     proxy: new HttpsProxyAgent('http://127.0.0.1:8080')
+ * })
+ * ```
+ */
+export async function downloadMediaMessage(
+    source: Proto.IMessage | WaIncomingMessageEvent,
+    options: WaDownloadMediaMessageOptions = {}
+): Promise<Readable> {
+    const message: Proto.IMessage | null | undefined = 'rawNode' in source ? source.message : source
+    const payload = resolveMediaPayload(message)
+    if (!payload) {
+        throw new Error('message has no downloadable media')
+    }
+    const transfer = options.transfer ?? new WaMediaTransferClient()
+    const { plaintext, metadata } = await transfer.downloadAndDecryptStream({
+        directPath: payload.directPath,
+        mediaType: payload.mediaType,
+        mediaKey: payload.mediaKey,
+        fileSha256: payload.fileSha256,
+        fileEncSha256: payload.fileEncSha256,
+        agent: toProxyAgent(options.proxy),
+        timeoutMs: options.timeoutMs,
+        signal: options.signal,
+        maxBytes: options.maxBytes
+    })
+    metadata.catch(() => undefined)
+    return plaintext
 }

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -641,7 +641,7 @@ export async function downloadMediaMessage(
         throw new Error('message has no downloadable media')
     }
     const transfer = options.transfer ?? new WaMediaTransferClient()
-    const { plaintext, metadata } = await transfer.downloadAndDecryptStream({
+    const { plaintext } = await transfer.downloadAndDecryptStream({
         directPath: payload.directPath,
         mediaType: payload.mediaType,
         mediaKey: payload.mediaKey,
@@ -652,6 +652,5 @@ export async function downloadMediaMessage(
         signal: options.signal,
         maxBytes: options.maxBytes
     })
-    metadata.catch(() => undefined)
     return plaintext
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,8 @@ export type {
     WaBusinessCoordinator,
     WaVerifiedNameBatchEntry
 } from '@client/coordinators/WaBusinessCoordinator'
-export type { WaUploadMediaSource } from '@client/media'
+export { downloadMediaMessage } from '@client/media'
+export type { WaDownloadMediaMessageOptions, WaUploadMediaSource } from '@client/media'
 export type { WaEditBusinessProfileInput } from '@transport/node/builders/business'
 export type {
     WaEmailCoordinator,
@@ -211,6 +212,8 @@ export type {
     WaSendTextMessage
 } from '@message/types'
 export { getContentType, resolveMessageTarget } from '@message/encode/content'
+export { resolveMediaPayload } from '@message/encode/media-payload'
+export type { WaResolvedMediaPayload } from '@message/encode/media-payload'
 export type { WaSendContextInfo } from '@message/context-info'
 export type {
     WaLinkPreviewFetcher,

--- a/src/message/encode/media-payload.ts
+++ b/src/message/encode/media-payload.ts
@@ -3,13 +3,26 @@ import { unwrapMessage } from '@message/encode/content'
 import type { Proto } from '@proto'
 import { longToNumber } from '@util/primitives'
 
+/**
+ * Decrypted media metadata pulled out of a message, carrying everything a CDN
+ * download needs (see `downloadMediaMessage`). Binary fields are raw
+ * `Uint8Array`s exactly as the protobuf message carried them - never base64
+ * strings.
+ */
 export interface WaResolvedMediaPayload {
+    /** Crypto/HKDF domain for the kind: image, video, gif, audio, ptt, document, sticker, ptv. */
     readonly mediaType: MediaCryptoType
+    /** Server-relative path (or absolute URL) of the encrypted blob on the media CDN. */
     readonly directPath: string
+    /** Media key used to derive the AES/MAC keys. Sensitive key material - do not log. */
     readonly mediaKey: Uint8Array
+    /** SHA-256 of the decrypted file, when the message carried it. */
     readonly fileSha256?: Uint8Array
+    /** SHA-256 of the encrypted file, when the message carried it. */
     readonly fileEncSha256?: Uint8Array
+    /** Declared MIME type, when present. */
     readonly mimetype?: string
+    /** Declared plaintext length in bytes, when present. */
     readonly fileLength?: number
 }
 
@@ -47,6 +60,24 @@ function buildPayload(
     }
 }
 
+/**
+ * Extracts the downloadable media metadata from a message, unwrapping
+ * ephemeral / view-once / document-with-caption envelopes first.
+ *
+ * Returns `null` when `message` is absent, carries no media, or the media node
+ * lacks the `directPath` / `mediaKey` needed to fetch and decrypt the blob (a
+ * non-`Uint8Array` `mediaKey` also yields `null`). Supported kinds: image,
+ * video (gif when `gifPlayback`), audio (ptt when `ptt`), document, sticker,
+ * ptv.
+ *
+ * @example
+ * ```ts
+ * const payload = resolveMediaPayload(event.message)
+ * if (payload) {
+ *     // payload.directPath, payload.mediaKey, payload.fileEncSha256, ...
+ * }
+ * ```
+ */
 export function resolveMediaPayload(
     message: Proto.IMessage | null | undefined
 ): WaResolvedMediaPayload | null {


### PR DESCRIPTION
Add a free downloadMediaMessage(source, options) that resolves a message's encrypted media payload and streams it from the WhatsApp CDN without a connected WaClient. Accepts a WaIncomingMessageEvent or a raw Proto.IMessage and returns a Readable the caller owns.

Export resolveMediaPayload and WaResolvedMediaPayload so callers can extract the media keys standalone. WaMessageCoordinator.download now delegates to the helper, keeping one source of truth.

Support a per-call proxy option, narrowed to an http.Agent like the client's proxy.mediaDownload. The client download path is unchanged: passing no proxy forwards agent: undefined, so the transfer's defaultDownloadAgent still wins via request.agent ?? defaultDownloadAgent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable media download API with proxy support and transfer-client reuse; made it publicly available.

* **Tests**
  * Added comprehensive tests for media download behaviors, error cases, and proxy scenarios.

* **Refactor**
  * Simplified internal media download flow to delegate to the new function.

* **Documentation**
  * Added JSDoc clarifications for resolved media payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->