### PR TITLE
feat(receipt): surface batch <list> message ids on incoming receipts

### DIFF
--- a/src/client/events/__tests__/events.test.ts
+++ b/src/client/events/__tests__/events.test.ts
@@ -9,7 +9,7 @@ import { parseGroupNotificationEvents } from '@client/events/group'
 import { parseMexNotification } from '@client/events/mex-notification'
 import { parsePresenceNode } from '@client/events/presence'
 import { parsePrivacyTokenNotification } from '@client/events/privacy-token'
-import { aggregateReceiptTargets } from '@client/events/receipt'
+import { aggregateReceiptTargets, extractReceiptIds } from '@client/events/receipt'
 import { parseRegistrationNotification } from '@client/events/registration'
 import { proto } from '@proto'
 import {
@@ -535,6 +535,65 @@ test('aggregateReceiptTargets groups by chat and sender, batching same-author id
         }
     ])
     assert.equal(broadcastExplicit[0].participant, 'erin@s.whatsapp.net')
+})
+
+test('extractReceiptIds returns just the top-level id for a single receipt', () => {
+    const node: BinaryNode = {
+        tag: 'receipt',
+        attrs: { id: 'A1', from: 'peer@s.whatsapp.net', type: 'read' }
+    }
+    assert.deepEqual(extractReceiptIds(node), ['A1'])
+})
+
+test('extractReceiptIds appends the top-level id after the <list><item> ids', () => {
+    const node: BinaryNode = {
+        tag: 'receipt',
+        attrs: { id: 'TOP', from: 'peer@s.whatsapp.net', type: 'read' },
+        content: [
+            {
+                tag: 'list',
+                attrs: {},
+                content: [
+                    { tag: 'item', attrs: { id: 'A' } },
+                    { tag: 'item', attrs: { id: 'B' } }
+                ]
+            }
+        ]
+    }
+    assert.deepEqual(extractReceiptIds(node), ['A', 'B', 'TOP'])
+})
+
+test('extractReceiptIds uses server_id and omits the top-level id for view receipts', () => {
+    const node: BinaryNode = {
+        tag: 'receipt',
+        attrs: { id: 'TOP', from: 'status@broadcast', type: 'view' },
+        content: [
+            {
+                tag: 'list',
+                attrs: {},
+                content: [
+                    { tag: 'item', attrs: { server_id: 'S1' } },
+                    { tag: 'item', attrs: { server_id: 'S2' } }
+                ]
+            }
+        ]
+    }
+    assert.deepEqual(extractReceiptIds(node), ['S1', 'S2'])
+})
+
+test('extractReceiptIds falls back to the top-level id for aggregated <participants> receipts', () => {
+    const node: BinaryNode = {
+        tag: 'receipt',
+        attrs: { id: 'TOP', from: 'group@g.us', type: 'read' },
+        content: [
+            {
+                tag: 'participants',
+                attrs: { key: 'k1' },
+                content: [{ tag: 'user', attrs: { jid: 'alice@s.whatsapp.net', t: '1' } }]
+            }
+        ]
+    }
+    assert.deepEqual(extractReceiptIds(node), ['TOP'])
 })
 
 function buildVerifiedNameCertBytes(opts: {

--- a/src/client/events/incoming.ts
+++ b/src/client/events/incoming.ts
@@ -4,6 +4,7 @@ import { parseCallNode } from '@client/events/call'
 import { parseGroupNotificationEvents } from '@client/events/group'
 import { parseMexNotification } from '@client/events/mex-notification'
 import { parsePictureNotificationEvents } from '@client/events/picture'
+import { extractReceiptIds } from '@client/events/receipt'
 import { parseRegistrationNotification } from '@client/events/registration'
 import type {
     WaAccountTakeoverNoticeEvent,
@@ -286,7 +287,8 @@ export function createIncomingReceiptHandler(
                 status: mapped.status,
                 fromSelfDevice: mapped.fromSelfDevice,
                 participantJid: node.attrs.participant,
-                recipientJid: node.attrs.recipient
+                recipientJid: node.attrs.recipient,
+                messageIds: extractReceiptIds(node)
             })
         } else if (node.attrs.type && !INTERNAL_ONLY_RECEIPT_TYPES.has(node.attrs.type)) {
             options.logger.warn('unrecognized receipt type suppressed', {

--- a/src/client/events/receipt.ts
+++ b/src/client/events/receipt.ts
@@ -1,4 +1,11 @@
+import { WA_MESSAGE_TYPES } from '@protocol/constants'
 import { isGroupOrBroadcastJid } from '@protocol/jid'
+import {
+    findNodeChild,
+    getNodeChildrenNonEmptyAttrValuesByTag,
+    hasNodeChild
+} from '@transport/node/helpers'
+import type { BinaryNode } from '@transport/types'
 
 interface ReceiptTarget {
     readonly chatJid: string
@@ -39,4 +46,36 @@ export function aggregateReceiptTargets(
         group.ids.push(target.id)
     }
     return [...groups.values()]
+}
+
+/**
+ * Resolves every message id a `<receipt>` acknowledges, mirroring WhatsApp
+ * Web's `externalIds`. A batch receipt carries the extra ids in a
+ * `<list><item id=.../>` block; the top-level `attrs.id` is just one of them.
+ *
+ * - `<list><item>` ids come first. For `type="view"` receipts the item key is
+ *   `server_id` (not `id`), and the top-level id is NOT appended.
+ * - Otherwise the top-level `attrs.id` is appended last.
+ * - Aggregated receipts (carrying a `<participants>` child) are out of scope:
+ *   their ids live in `<user>` children, so this falls back to the single
+ *   top-level id for them.
+ *
+ * No dedup: matches wa-web, which pushes the top id without checking the list.
+ */
+export function extractReceiptIds(node: BinaryNode): readonly string[] {
+    const topId = node.attrs.id
+    if (hasNodeChild(node, 'participants')) {
+        return topId ? [topId] : []
+    }
+
+    const isView = node.attrs.type === WA_MESSAGE_TYPES.RECEIPT_TYPE_VIEW
+    const list = findNodeChild(node, 'list')
+    const ids = list
+        ? [...getNodeChildrenNonEmptyAttrValuesByTag(list, 'item', isView ? 'server_id' : 'id')]
+        : []
+
+    if (!isView && topId) {
+        ids.push(topId)
+    }
+    return ids
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -556,6 +556,13 @@ export interface WaIncomingReceiptEvent extends WaIncomingBaseEvent {
     readonly fromSelfDevice: boolean
     readonly participantJid?: string
     readonly recipientJid?: string
+    /**
+     * All message ids this receipt acknowledges. For batch read/delivery
+     * receipts this is the `<list><item>` ids plus the top-level `stanzaId`;
+     * for single receipts it is just `[stanzaId]`. Mirrors WhatsApp Web's
+     * `externalIds`.
+     */
+    readonly messageIds: readonly string[]
 }
 
 export interface WaIncomingPresenceEvent extends WaIncomingBaseEvent {

--- a/src/protocol/message.ts
+++ b/src/protocol/message.ts
@@ -24,7 +24,8 @@ export const WA_MESSAGE_TYPES = Object.freeze({
     RECEIPT_TYPE_PEER: 'peer_msg',
     RECEIPT_TYPE_SERVER_ERROR: 'server-error',
     RECEIPT_TYPE_RETRY: 'retry',
-    RECEIPT_TYPE_ENC_REKEY_RETRY: 'enc_rekey_retry'
+    RECEIPT_TYPE_ENC_REKEY_RETRY: 'enc_rekey_retry',
+    RECEIPT_TYPE_VIEW: 'view'
 } as const)
 
 export type WaOutboundReceiptType =


### PR DESCRIPTION
Incoming receipt events only exposed the top-level attrs.id, so batch read/delivery receipts that carry their extra ids in a <list><item id=.../> block dropped every id but the first. Add extractReceiptIds() to resolve the full id set and expose it as WaIncomingReceiptEvent.messageIds.

Mirrors WhatsApp Web externalIds: list items first, top-level id appended last, except type="view" receipts which key on server_id and omit the top id. Aggregated <participants> receipts fall back to the single top-level id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Receipt events now identify which specific messages are being acknowledged, providing clarity in batch read/delivery scenarios.
  * Added support for 'view' type receipt messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->