### PR TITLE
fix(message): read top-level fromMe from WaMessageKey quotes

### DIFF
--- a/src/message/__tests__/context-info.test.ts
+++ b/src/message/__tests__/context-info.test.ts
@@ -152,6 +152,23 @@ test('resolveSendContextInfo prefers explicit quote participant over DM fallback
     assert.equal(result?.quotedParticipant, 'explicit@lid')
 })
 
+test('resolveSendContextInfo reads top-level fromMe from a flat WaMessageKey quote', () => {
+    const result = resolveSendContextInfo({
+        quote: { id: 'm-7', remoteJid: 'peer@lid', fromMe: true },
+        meLid: 'me@lid'
+    })
+    assert.equal(result?.quotedParticipant, 'me@lid')
+    assert.equal(result?.quotedRemoteJid, 'peer@lid')
+})
+
+test('resolveSendContextInfo uses peer for a flat WaMessageKey quote not fromMe', () => {
+    const result = resolveSendContextInfo({
+        quote: { id: 'm-8', remoteJid: 'peer@lid', fromMe: false },
+        meLid: 'me@lid'
+    })
+    assert.equal(result?.quotedParticipant, 'peer@lid')
+})
+
 test('resolveSendContextInfo applies forward with default score', () => {
     const result = resolveSendContextInfo({ forward: true })
     assert.equal(result?.isForwarded, true)

--- a/src/message/context-info.ts
+++ b/src/message/context-info.ts
@@ -145,6 +145,7 @@ type WaQuoteSource = {
     readonly id?: string
     readonly remoteJid?: string
     readonly participant?: string
+    readonly fromMe?: boolean
     readonly message?: Proto.IMessage
 }
 
@@ -178,9 +179,10 @@ export function resolveSendContextInfo(input: WaSendContextResolveInput): WaSend
         ctx.quotedMessageId = q.id ?? q.key?.id ?? ctx.quotedMessageId
         const explicit = q.participant ?? q.key?.participant
         const quotedRemote = q.remoteJid ?? q.key?.remoteJid
+        const quotedFromMe = q.fromMe ?? q.key?.fromMe
         const dmFallback =
             explicit === undefined && quotedRemote && !isGroupOrBroadcastJid(quotedRemote)
-                ? q.key?.fromMe
+                ? quotedFromMe
                     ? input.meLid
                     : quotedRemote
                 : undefined


### PR DESCRIPTION
resolveSendContextInfo read the quoted id/remoteJid/participant from both a flat key and a nested .key, but read fromMe only from q.key?.fromMe. A WaMessageKey quote carries fromMe at the top level, so quoting a self-sent DM with a WaMessageKey dropped fromMe and the DM participant fallback resolved to the peer instead of meLid.

Read q.fromMe ?? q.key?.fromMe like the other addressing fields, add fromMe to the internal quote source type, and cover the flat WaMessageKey quote (fromMe true -> meLid, false -> peer).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved quote handling in direct messages to accurately identify the sender of quoted messages.

* **Tests**
  * Extended test coverage for quote resolution logic in direct message contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->