### PR TITLE
fix(message): emit quote remoteJid only for cross-chat quotes

### DIFF
--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -332,7 +332,8 @@ export class WaMessageDispatchCoordinator {
             quote: options.quote,
             forward: options.forward,
             mentions: options.mentions,
-            meLid: this.deps.getCurrentCredentials()?.meLid
+            meLid: this.deps.getCurrentCredentials()?.meLid,
+            targetJid: recipientJid
         })
         const withCtx = ctx ? applyContextInfo(built.message, ctx) : built.message
         const withViewOnce = options.viewOnce ? wrapAsViewOnce(withCtx) : withCtx

--- a/src/message/__tests__/context-info.test.ts
+++ b/src/message/__tests__/context-info.test.ts
@@ -202,6 +202,15 @@ test('resolveSendContextInfo emits quotedRemoteJid when no target is provided', 
     assert.equal(result?.quotedRemoteJid, 'peer@lid')
 })
 
+test('resolveSendContextInfo clears an inherited quotedRemoteJid for a same-chat quote', () => {
+    const result = resolveSendContextInfo({
+        optionsLevel: { quotedRemoteJid: 'stale@lid' },
+        quote: { id: 'm-13', remoteJid: 'peer@lid', fromMe: false },
+        targetJid: 'peer@lid'
+    })
+    assert.equal(result?.quotedRemoteJid, undefined)
+})
+
 test('resolveSendContextInfo applies forward with default score', () => {
     const result = resolveSendContextInfo({ forward: true })
     assert.equal(result?.isForwarded, true)

--- a/src/message/__tests__/context-info.test.ts
+++ b/src/message/__tests__/context-info.test.ts
@@ -169,6 +169,39 @@ test('resolveSendContextInfo uses peer for a flat WaMessageKey quote not fromMe'
     assert.equal(result?.quotedParticipant, 'peer@lid')
 })
 
+test('resolveSendContextInfo omits quotedRemoteJid for a same-chat quote', () => {
+    const result = resolveSendContextInfo({
+        quote: { id: 'm-9', remoteJid: 'peer@lid', fromMe: false },
+        targetJid: 'peer@lid'
+    })
+    assert.equal(result?.quotedRemoteJid, undefined)
+    assert.equal(result?.quotedParticipant, 'peer@lid')
+    assert.equal(result?.quotedMessageId, 'm-9')
+})
+
+test('resolveSendContextInfo emits quotedRemoteJid for a cross-chat quote', () => {
+    const result = resolveSendContextInfo({
+        quote: { id: 'm-10', remoteJid: 'other@lid', fromMe: false },
+        targetJid: 'peer@lid'
+    })
+    assert.equal(result?.quotedRemoteJid, 'other@lid')
+})
+
+test('resolveSendContextInfo treats a device-suffixed target as the same chat', () => {
+    const result = resolveSendContextInfo({
+        quote: { id: 'm-11', remoteJid: 'peer@lid', fromMe: false },
+        targetJid: 'peer:3@lid'
+    })
+    assert.equal(result?.quotedRemoteJid, undefined)
+})
+
+test('resolveSendContextInfo emits quotedRemoteJid when no target is provided', () => {
+    const result = resolveSendContextInfo({
+        quote: { id: 'm-12', remoteJid: 'peer@lid', fromMe: false }
+    })
+    assert.equal(result?.quotedRemoteJid, 'peer@lid')
+})
+
 test('resolveSendContextInfo applies forward with default score', () => {
     const result = resolveSendContextInfo({ forward: true })
     assert.equal(result?.isForwarded, true)

--- a/src/message/context-info.ts
+++ b/src/message/context-info.ts
@@ -198,8 +198,12 @@ export function resolveSendContextInfo(input: WaSendContextResolveInput): WaSend
         const crossChat =
             quotedRemote !== undefined &&
             (input.targetJid === undefined || !isSameChatJid(quotedRemote, input.targetJid))
-        if (crossChat) {
-            ctx.quotedRemoteJid = quotedRemote
+        if (quotedRemote !== undefined) {
+            if (crossChat) {
+                ctx.quotedRemoteJid = quotedRemote
+            } else {
+                delete ctx.quotedRemoteJid
+            }
         }
         ctx.quotedMessage = q.message ?? ctx.quotedMessage
     }

--- a/src/message/context-info.ts
+++ b/src/message/context-info.ts
@@ -1,5 +1,5 @@
 import type { Proto } from '@proto'
-import { isGroupOrBroadcastJid } from '@protocol/jid'
+import { isGroupOrBroadcastJid, toUserJid } from '@protocol/jid'
 
 export interface WaSendContextInfo {
     readonly quotedMessageId?: string
@@ -158,6 +158,14 @@ export interface WaSendContextResolveInput {
     readonly forward?: WaForwardSource
     readonly mentions?: readonly string[]
     /**
+     * Chat the message is being sent to. When provided, the quote's
+     * `remoteJid` is emitted only for a cross-chat quote (the quoted message
+     * lives in a different chat), mirroring wa-web's `msgContextInfo`, which
+     * sets `remoteJid` only when `quotedMsg.remote !== targetChat`. Omit it to
+     * keep emitting `remoteJid` unconditionally.
+     */
+    readonly targetJid?: string
+    /**
      * LID-form self user JID. Used as the DM-quote `participant` fallback when
      * the quoted message is `fromMe` and no explicit participant was provided.
      * Mirrors wa-web's `getSender(msg)` (returns `msg.from`, which for 1:1 is
@@ -187,7 +195,12 @@ export function resolveSendContextInfo(input: WaSendContextResolveInput): WaSend
                     : quotedRemote
                 : undefined
         ctx.quotedParticipant = explicit ?? dmFallback ?? ctx.quotedParticipant
-        ctx.quotedRemoteJid = quotedRemote ?? ctx.quotedRemoteJid
+        const crossChat =
+            quotedRemote !== undefined &&
+            (input.targetJid === undefined || !isSameChatJid(quotedRemote, input.targetJid))
+        if (crossChat) {
+            ctx.quotedRemoteJid = quotedRemote
+        }
         ctx.quotedMessage = q.message ?? ctx.quotedMessage
     }
 
@@ -210,4 +223,8 @@ function hasAnyKey(value: object): boolean {
         return true
     }
     return false
+}
+
+function isSameChatJid(a: string, b: string): boolean {
+    return toUserJid(a) === toUserJid(b)
 }


### PR DESCRIPTION
resolveSendContextInfo emitted contextInfo.remoteJid on every quote. wa-web's MsgModel.msgContextInfo sets it only when the quoted message lives in a different chat than the send target (quotedMsg.remote !== targetChat); a same-chat reply omits it. Always emitting it can make some clients treat a 1:1 reply as a cross-chat reference.

Thread the send target (recipientJid, already derived from 'to') into the resolver and emit quotedRemoteJid only when it differs from the target, via a device-insensitive chat-jid comparison (toUserJid, mirroring Wid.equals). targetJid is internal, so the public send API is unchanged; with no target the previous always-emit behavior is kept.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quotes now preserve or clear origin info correctly: same-chat quotes no longer leak remote origin, cross-chat quotes retain origin (including when recipients include device suffixes).
* **Tests**
  * Added tests validating quote context behavior across same-chat and cross-chat scenarios, and when recipient identifiers include device suffixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->