### PR TITLE
fix(build): resolve spec bridges in emitted types and ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,88 +11,88 @@
     "packageManager": "npm@10.0.0",
     "main": "dist/index.js",
     "module": "dist/esm/index.js",
-    "types": "dist/types/index.d.ts",
+    "types": "dist/index.d.ts",
     "exports": {
         ".": {
-            "types": "./dist/types/index.d.ts",
+            "types": "./dist/index.d.ts",
             "require": "./dist/index.js",
             "import": "./dist/esm/index.js",
             "default": "./dist/index.js"
         },
         "./client": {
-            "types": "./dist/types/client/index.d.ts",
+            "types": "./dist/client/index.d.ts",
             "require": "./dist/client/index.js",
             "import": "./dist/esm/client/index.js",
             "default": "./dist/client/index.js"
         },
         "./appstate": {
-            "types": "./dist/types/appstate/index.d.ts",
+            "types": "./dist/appstate/index.d.ts",
             "require": "./dist/appstate/index.js",
             "import": "./dist/esm/appstate/index.js",
             "default": "./dist/appstate/index.js"
         },
         "./auth": {
-            "types": "./dist/types/auth/index.d.ts",
+            "types": "./dist/auth/index.d.ts",
             "require": "./dist/auth/index.js",
             "import": "./dist/esm/auth/index.js",
             "default": "./dist/auth/index.js"
         },
         "./crypto": {
-            "types": "./dist/types/crypto/index.d.ts",
+            "types": "./dist/crypto/index.d.ts",
             "require": "./dist/crypto/index.js",
             "import": "./dist/esm/crypto/index.js",
             "default": "./dist/crypto/index.js"
         },
         "./media": {
-            "types": "./dist/types/media/index.d.ts",
+            "types": "./dist/media/index.d.ts",
             "require": "./dist/media/index.js",
             "import": "./dist/esm/media/index.js",
             "default": "./dist/media/index.js"
         },
         "./message": {
-            "types": "./dist/types/message/index.d.ts",
+            "types": "./dist/message/index.d.ts",
             "require": "./dist/message/index.js",
             "import": "./dist/esm/message/index.js",
             "default": "./dist/message/index.js"
         },
         "./signal": {
-            "types": "./dist/types/signal/index.d.ts",
+            "types": "./dist/signal/index.d.ts",
             "require": "./dist/signal/index.js",
             "import": "./dist/esm/signal/index.js",
             "default": "./dist/signal/index.js"
         },
         "./store": {
-            "types": "./dist/types/store/index.d.ts",
+            "types": "./dist/store/index.d.ts",
             "require": "./dist/store/index.js",
             "import": "./dist/esm/store/index.js",
             "default": "./dist/store/index.js"
         },
         "./transport": {
-            "types": "./dist/types/transport/index.d.ts",
+            "types": "./dist/transport/index.d.ts",
             "require": "./dist/transport/index.js",
             "import": "./dist/esm/transport/index.js",
             "default": "./dist/transport/index.js"
         },
         "./protocol": {
-            "types": "./dist/types/protocol/index.d.ts",
+            "types": "./dist/protocol/index.d.ts",
             "require": "./dist/protocol/index.js",
             "import": "./dist/esm/protocol/index.js",
             "default": "./dist/protocol/index.js"
         },
         "./retry": {
-            "types": "./dist/types/retry/index.d.ts",
+            "types": "./dist/retry/index.d.ts",
             "require": "./dist/retry/index.js",
             "import": "./dist/esm/retry/index.js",
             "default": "./dist/retry/index.js"
         },
         "./util": {
-            "types": "./dist/types/util/index.d.ts",
+            "types": "./dist/util/index.d.ts",
             "require": "./dist/util/index.js",
             "import": "./dist/esm/util/index.js",
             "default": "./dist/util/index.js"
         },
         "./proto": {
-            "types": "./dist/types/proto.d.ts",
+            "types": "./dist/proto.d.ts",
             "require": "./dist/proto.js",
             "import": "./dist/esm/proto.js",
             "default": "./dist/proto.js"

--- a/packages/tsconfig.build.paths.json
+++ b/packages/tsconfig.build.paths.json
@@ -2,18 +2,18 @@
     "compilerOptions": {
         "baseUrl": "..",
         "paths": {
-            "zapo-js": ["dist/types/index.d.ts"],
-            "zapo-js/store": ["dist/types/store/index.d.ts"],
-            "zapo-js/signal": ["dist/types/signal/index.d.ts"],
-            "zapo-js/auth": ["dist/types/auth/index.d.ts"],
-            "zapo-js/appstate": ["dist/types/appstate/index.d.ts"],
-            "zapo-js/retry": ["dist/types/retry/index.d.ts"],
-            "zapo-js/proto": ["dist/types/proto.d.ts"],
-            "zapo-js/protocol": ["dist/types/protocol/index.d.ts"],
-            "zapo-js/crypto": ["dist/types/crypto/index.d.ts"],
-            "zapo-js/media": ["dist/types/media/index.d.ts"],
-            "zapo-js/util": ["dist/types/util/index.d.ts"],
-            "zapo-js/transport": ["dist/types/transport/index.d.ts"]
+            "zapo-js": ["dist/index.d.ts"],
+            "zapo-js/store": ["dist/store/index.d.ts"],
+            "zapo-js/signal": ["dist/signal/index.d.ts"],
+            "zapo-js/auth": ["dist/auth/index.d.ts"],
+            "zapo-js/appstate": ["dist/appstate/index.d.ts"],
+            "zapo-js/retry": ["dist/retry/index.d.ts"],
+            "zapo-js/proto": ["dist/proto.d.ts"],
+            "zapo-js/protocol": ["dist/protocol/index.d.ts"],
+            "zapo-js/crypto": ["dist/crypto/index.d.ts"],
+            "zapo-js/media": ["dist/media/index.d.ts"],
+            "zapo-js/util": ["dist/util/index.d.ts"],
+            "zapo-js/transport": ["dist/transport/index.d.ts"]
         }
     }
 }

--- a/scripts/finalize-esm-build.cjs
+++ b/scripts/finalize-esm-build.cjs
@@ -108,5 +108,30 @@ function resolveSpecifier(filePath, specifier) {
         return `${specifier}/index.js`
     }
 
+    const specBridge = resolveSpecBridgeSpecifier(fileDirectory, specifier)
+    if (specBridge) {
+        return specBridge
+    }
+
     return specifier
+}
+
+// The vendored spec lives at <projectRoot>/spec, outside dist. The spec bridges
+// (proto/appstate-spec/mex/version-spec) import it via '../spec/<name>', which
+// only resolves from dist/ (depth 1); from dist/esm/ (depth 2) it would point at
+// the non-existent dist/spec. Repoint such specifiers at the real
+// <projectRoot>/spec/<name>/index.js with a correct relative path.
+function resolveSpecBridgeSpecifier(fileDirectory, specifier) {
+    const match = /^\.\.\/spec\/(.+)$/.exec(specifier)
+    if (!match) {
+        return null
+    }
+
+    const target = path.join(projectRoot, 'spec', match[1], 'index.js')
+    if (!existsSync(target)) {
+        return null
+    }
+
+    const relative = path.relative(fileDirectory, target).replaceAll(path.sep, '/')
+    return relative.startsWith('.') ? relative : `./${relative}`
 }

--- a/tsconfig.build.types.json
+++ b/tsconfig.build.types.json
@@ -5,7 +5,7 @@
         "moduleResolution": "Node",
         "declaration": true,
         "emitDeclarationOnly": true,
-        "outDir": "dist/types"
+        "outDir": "dist"
     },
     "exclude": ["dist", "node_modules", "src/**/__tests__/**"]
 }


### PR DESCRIPTION
The proto/appstate-spec/mex/version-spec bridges import the vendored spec via the relative '../spec/<name>', which only resolves at dist/ depth (the CJS output). The declaration build emitted them one level deeper (dist/types/), so '../spec' pointed at the non-existent dist/spec: consumers hit TS2307 and the types silently degraded to any under skipLibCheck. The ESM build emits to dist/esm/ (also deeper), so the appstate-spec/mex/version-spec ESM modules failed to load at runtime (Cannot find module dist/spec/...); only proto's ESM was special-cased by the finalize step, so even import 'zapo-js' threw in ESM.

Types: emit declarations alongside the JS (build:types outDir dist/types -> dist), so '../spec' resolves from depth 1 like CJS. Update the package exports types fields and packages/tsconfig.build.paths.json to dist/.

ESM: in finalize-esm-build.cjs, repoint '../spec/<name>' to the real <root>/spec/<name>/index.js for dist/esm files, so the remaining bridges load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized TypeScript type definitions output structure to improve type resolution efficiency and package configuration.
  * Updated build configuration paths to align with new type definitions location.
  * Enhanced build finalization process for improved module import handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->