### PR TITLE
fix(message): strip device segment from incoming remoteJid

### DIFF
--- a/src/message/primitives/__tests__/incoming.test.ts
+++ b/src/message/primitives/__tests__/incoming.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
+import type { WaIncomingMessageEvent } from '@client/types'
 import { createNoopLogger } from '@infra/log/types'
 import { handleIncomingMessageAck } from '@message/primitives/incoming'
+import { proto } from '@proto'
 import type { BinaryNode } from '@transport/types'
 
 function createEncryptedMessageNode(): BinaryNode {
@@ -22,6 +24,29 @@ function createEncryptedMessageNode(): BinaryNode {
                 content: new Uint8Array([1, 2, 3])
             }
         ]
+    }
+}
+
+// Encodes a message and appends a single PKCS7 pad byte so the handler's
+// unpadPkcs7 + proto.Message.decode round-trip yields back the same message.
+function paddedPlaintext(message: proto.IMessage): Uint8Array {
+    const encoded = proto.Message.encode(message).finish()
+    const out = new Uint8Array(encoded.length + 1)
+    out.set(encoded, 0)
+    out[encoded.length] = 1
+    return out
+}
+
+function createDecryptingOptions(emitted: WaIncomingMessageEvent[]) {
+    return {
+        logger: createNoopLogger(),
+        sendNode: async () => undefined,
+        signalProtocol: {
+            decryptMessage: async () => paddedPlaintext({ conversation: 'hi' })
+        } as never,
+        emitIncomingMessage: (event: WaIncomingMessageEvent) => {
+            emitted.push(event)
+        }
     }
 }
 
@@ -63,6 +88,55 @@ test('incoming message ack suppresses standard receipt when decrypt failure is d
     assert.equal(decryptFailures[0].context.t, '123')
     assert.match((decryptFailures[0].error as Error).message, /decrypt failed/)
     assert.equal(sentNodes.length, 0)
+})
+
+test('1:1 incoming message strips the device from remoteJid and keeps it in senderDevice', async () => {
+    const emitted: WaIncomingMessageEvent[] = []
+    const handled = await handleIncomingMessageAck(
+        {
+            tag: 'message',
+            attrs: {
+                id: 'msg-dev',
+                from: '5511999999999:12@s.whatsapp.net',
+                t: '123'
+            },
+            content: [{ tag: 'enc', attrs: { type: 'msg' }, content: new Uint8Array([1]) }]
+        },
+        createDecryptingOptions(emitted)
+    )
+
+    assert.equal(handled, true)
+    assert.equal(emitted.length, 1)
+    const { key } = emitted[0]
+    assert.equal(key.remoteJid, '5511999999999@s.whatsapp.net')
+    assert.equal(key.senderDevice, 12)
+    assert.equal(key.isGroup, false)
+    assert.equal(key.participant, undefined)
+})
+
+test('group incoming message keeps the group remoteJid and carries the device on the participant', async () => {
+    const emitted: WaIncomingMessageEvent[] = []
+    const handled = await handleIncomingMessageAck(
+        {
+            tag: 'message',
+            attrs: {
+                id: 'msg-grp',
+                from: '120363000000000000@g.us',
+                participant: '5511999999999:7@s.whatsapp.net',
+                t: '123'
+            },
+            content: [{ tag: 'enc', attrs: { type: 'msg' }, content: new Uint8Array([1]) }]
+        },
+        createDecryptingOptions(emitted)
+    )
+
+    assert.equal(handled, true)
+    assert.equal(emitted.length, 1)
+    const { key } = emitted[0]
+    assert.equal(key.remoteJid, '120363000000000000@g.us')
+    assert.equal(key.isGroup, true)
+    assert.equal(key.participant, '5511999999999@s.whatsapp.net')
+    assert.equal(key.senderDevice, 7)
 })
 
 test('incoming message ack falls back to retry receipt when decrypt fails', async () => {

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -317,7 +317,7 @@ function processMsmsgEncNode(
                 encPayload: decoded.encPayload
             }
         }
-        const chatJid = node.attrs.from
+        const chatJid = node.attrs.from ? toUserJid(node.attrs.from) : node.attrs.from
         const sender = senderJid ? parseJidFull(senderJid) : null
         const isGroup = chatJid ? isGroupJid(chatJid) : false
         const isBroadcast = chatJid ? isBroadcastJid(chatJid) : false
@@ -403,7 +403,11 @@ async function decryptAndProcessEncNode(
             }
         }
         if (shouldEmitIncomingMessage(message)) {
-            const chatJid = node.attrs.from
+            // remoteJid is the chat identity, which is deviceless: the device
+            // lives in senderDevice (from senderAddress), so strip any `:device`
+            // segment the `from` attr carries for 1:1 chats.
+            const fromAttr = node.attrs.from
+            const chatJid = fromAttr ? toUserJid(fromAttr) : fromAttr
             const isGroup = chatJid ? isGroupJid(chatJid) : false
             const isBroadcast = chatJid ? isBroadcastJid(chatJid) : false
             const senderUserJid = `${senderAddress.user}@${senderAddress.server}`


### PR DESCRIPTION
The 1:1 'from' attr can carry a ':device' segment, which leaked into key.remoteJid. Normalize it with toUserJid so remoteJid is the deviceless chat identity; the device stays exposed via senderDevice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved incoming message processing for direct conversations to properly manage device information, ensuring device identifiers are correctly separated from user identification data.
  * Enhanced group message handling with better tracking of participant information and sender device identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->