### PR TITLE
fix(retry): omit recipient from group decrypt-failure retry receipts

### DIFF
--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -293,7 +293,7 @@ export class WaRetryCoordinator {
         context: WaRetryDecryptFailureContext,
         prepared: RetryDecryptFailurePreparation
     ): Promise<void> {
-        const recipient = context.recipient ?? this.resolvePeerRetryRecipient(context)
+        const { recipient } = context
         const retryReceiptNode = buildRetryReceiptNode({
             stanzaId: context.stanzaId,
             to: context.from,
@@ -317,26 +317,6 @@ export class WaRetryCoordinator {
             reason: prepared.retryReason,
             withKeys: prepared.retryKeys !== undefined
         })
-    }
-
-    private resolvePeerRetryRecipient(context: WaRetryDecryptFailureContext): string | undefined {
-        if (!context.participant) {
-            return undefined
-        }
-        const meLid = this.deps.getCurrentCredentials()?.meLid
-        if (!meLid) {
-            return undefined
-        }
-        try {
-            const participantUser = toUserJid(context.participant)
-            const meUserLid = toUserJid(meLid)
-            if (participantUser !== meUserLid) {
-                return undefined
-            }
-            return meUserLid
-        } catch {
-            return undefined
-        }
     }
 
     private async handleParsedRetryRequest(


### PR DESCRIPTION
Group retry receipts must not include a recipient field, wa-web only sets it for 1:1 peer messages, sourced from the original stanza attr.

resolvePeerRetryRecipient was firing for group messages where the sender's participant JID matched the bot's own LID, adding a spurious recipient that caused the server to never trigger a resend.

Remove the method and use context.recipient (stanza attr passthrough) directly so recipient is only present when the server originally set it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for retry receipt handling, simplifying recipient resolution logic and reducing code complexity with no impact on user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->