### PR TITLE
fix(history): ack hist_sync chunks even when history sync is disabled

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -346,12 +346,29 @@ export class WaClient extends EventEmitter {
             }
 
             if (protocolType === proto.Message.ProtocolMessage.Type.HISTORY_SYNC_NOTIFICATION) {
-                if (
-                    this.options.history?.enabled !== false &&
-                    protocolMessage.historySyncNotification
-                ) {
-                    const peerRemoteJid = event.key.remoteJid
-                    const peerStanzaId = event.key.id
+                if (!protocolMessage.historySyncNotification) {
+                    return
+                }
+                const peerRemoteJid = event.key.remoteJid
+                const peerStanzaId = event.key.id
+                const sendHistSyncReceipt =
+                    peerRemoteJid && peerStanzaId
+                        ? async () => {
+                              try {
+                                  await this.message.sendReceipt(peerRemoteJid, peerStanzaId, {
+                                      type: WA_MESSAGE_TYPES.RECEIPT_TYPE_HISTORY_SYNC
+                                  })
+                              } catch (err) {
+                                  this.logger.warn('failed to send hist_sync receipt', {
+                                      id: peerStanzaId,
+                                      to: peerRemoteJid,
+                                      message: toError(err).message
+                                  })
+                              }
+                          }
+                        : undefined
+
+                if (this.options.history?.enabled !== false) {
                     await runHistorySyncNotification(
                         {
                             logger: this.logger,
@@ -362,29 +379,12 @@ export class WaClient extends EventEmitter {
                                 this.deps.trustedContactToken.hydrateFromHistorySync(conversations),
                             onNctSalt: (salt) =>
                                 this.deps.trustedContactToken.hydrateNctSaltFromHistorySync(salt),
-                            onProcessed:
-                                peerRemoteJid && peerStanzaId
-                                    ? async () => {
-                                          try {
-                                              await this.message.sendReceipt(
-                                                  peerRemoteJid,
-                                                  peerStanzaId,
-                                                  {
-                                                      type: WA_MESSAGE_TYPES.RECEIPT_TYPE_HISTORY_SYNC
-                                                  }
-                                              )
-                                          } catch (err) {
-                                              this.logger.warn('failed to send hist_sync receipt', {
-                                                  id: peerStanzaId,
-                                                  to: peerRemoteJid,
-                                                  message: toError(err).message
-                                              })
-                                          }
-                                      }
-                                    : undefined
+                            onProcessed: sendHistSyncReceipt
                         },
                         protocolMessage.historySyncNotification
                     )
+                } else if (sendHistSyncReceipt) {
+                    await sendHistSyncReceipt()
                 }
                 return
             }


### PR DESCRIPTION
Decouple the hist_sync receipt from chunk processing so it is sent even when history.enabled is false. Disabled now skips processing but still acks the chunk, matching wa-web (which always acks, like the INITIAL_STATUS_V3 path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the handling of message history synchronization. The system now processes message history receipts more consistently, with improved support for scenarios where history synchronization is either enabled or disabled. This results in more reliable message processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->