### PR TITLE
fix(client): strip device segment from ignoreKey predicate context

### DIFF
--- a/src/client/messaging/__tests__/ignore-key.test.ts
+++ b/src/client/messaging/__tests__/ignore-key.test.ts
@@ -181,6 +181,30 @@ test('extractIgnoreKeyContext returns null for non-addressable tags', () => {
     assert.equal(extractIgnoreKeyContext(iq, ME_JID), null)
 })
 
+test('extractIgnoreKeyContext strips the device segment from remoteJid and participant', () => {
+    const direct = message({ from: '5511999990000:12@s.whatsapp.net', id: 'X' })
+    assert.equal(extractIgnoreKeyContext(direct, ME_JID)?.remoteJid, PN)
+
+    const group = message({ from: 'group@g.us', participant: '99887766554433:7@lid', id: 'X' })
+    assert.equal(extractIgnoreKeyContext(group, ME_JID)?.participant, LID)
+})
+
+test('predicate sees device-stripped remoteJid so a bare-JID compare catches device stanzas', () => {
+    const filter = createIgnoreKeyFilter(
+        (m) => m.remoteJid === PN,
+        () => ME_JID
+    )
+    assert.equal(filter(message({ from: '5511999990000:12@s.whatsapp.net', id: 'X' })), true)
+    assert.equal(filter(message({ from: PN, id: 'X' })), true)
+    assert.equal(filter(message({ from: '5511000001111:3@s.whatsapp.net', id: 'X' })), false)
+})
+
+test('userless server JID (from=s.whatsapp.net) passes through without throwing', () => {
+    const node = notification({ from: 's.whatsapp.net' })
+    assert.equal(extractIgnoreKeyContext(node, ME_JID)?.remoteJid, 's.whatsapp.net')
+    assert.equal(matchesIgnoreKey(node, { remoteJid: PN }, null), false)
+})
+
 test('createIgnoreKeyFilter with predicate routes the parsed context, drops non-addressable', () => {
     const filter = createIgnoreKeyFilter(
         (m) => m.kind === 'message' && m.id === 'DROP',

--- a/src/client/messaging/ignore-key.ts
+++ b/src/client/messaging/ignore-key.ts
@@ -94,12 +94,14 @@ export function extractIgnoreKeyContext(
     const fromCandidates = collectFromCandidates(kind, a)
     const fromMe =
         me !== null && fromCandidates.some((f) => tryParseJid(f)?.address.user === me.address.user)
+    // Device-stripped to match the JID form used by events/keys; a userless
+    // server `from` like `s.whatsapp.net` is unparseable, so fall back to raw.
     return {
         kind,
-        remoteJid: a.from ?? null,
+        remoteJid: tryParseJid(a.from)?.userJid ?? a.from ?? null,
         fromMe,
         id: a.id,
-        participant: a.participant ?? null
+        participant: tryParseJid(a.participant)?.userJid ?? a.participant ?? null
     }
 }
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -460,28 +460,31 @@ export interface WaIgnoreKey {
  * Lib derives `kind` from the stanza tag and resolves `fromMe` by comparing
  * every from-candidate (`from`, `sender_pn`, `sender_lid`) against `meJid`.
  *
- * `remoteJid` and `participant` expose the **raw** `from` / `participant`
- * attrs verbatim and do NOT include the descriptor-style alt-attr lookups
- * (`sender_pn` / `sender_lid` / `participant_pn` / `participant_lid`) or
- * PN↔LID normalization. If the predicate needs to match by user identity
- * regardless of addressing mode, run the raw JID through `parseJidFull` and
- * compare on `userJid`, or use the descriptor form which handles it.
+ * `remoteJid` and `participant` are the `from` / `participant` attrs with the
+ * `:device` segment stripped (bare `user@server`), matching the JID form used
+ * by message events and keys. A value that does not parse as a JID (e.g. a
+ * userless server `from` like `s.whatsapp.net`) is passed through unchanged.
+ * They do NOT include the descriptor-style
+ * alt-attr lookups (`sender_pn` / `sender_lid` / `participant_pn` /
+ * `participant_lid`) or PN↔LID normalization, so they stay in whichever
+ * addressing mode the stanza arrived in. To match by user identity regardless
+ * of addressing mode, use the descriptor form, which handles it.
  */
 export interface WaIgnoreKeyContext {
     readonly kind: WaIgnoreStanzaKind
-    /** Raw `from` attr (group JID for groups, PN or LID device JID for 1:1). */
+    /** `from` attr without `:device` (group JID for groups, PN or LID user JID for 1:1). */
     readonly remoteJid: string | null
     readonly fromMe: boolean
     readonly id: string | undefined
-    /** Raw `participant` attr; `null` for non-group stanzas. */
+    /** `participant` attr without `:device`; `null` for non-group stanzas. */
     readonly participant: string | null
 }
 
 /**
  * Predicate form of {@link WaClient.ignoreKey}. Return `true` to drop the
  * stanza, `false` to let it through. Receives a {@link WaIgnoreKeyContext}
- * with the raw `from`/`participant` attrs (see the context's JSDoc for the
- * PN↔LID caveat) plus lib-resolved `kind` and `fromMe`.
+ * with the device-stripped `from`/`participant` (see the context's JSDoc for
+ * the addressing-mode caveat) plus lib-resolved `kind` and `fromMe`.
  */
 export type WaIgnoreKeyPredicate = (ctx: WaIgnoreKeyContext) => boolean
 


### PR DESCRIPTION
The WaIgnoreKeyContext passed to an ignoreKey predicate exposed the raw from/participant attrs with the :device segment, unlike the message events and keys which already use the bare user@server form. A predicate comparing m.remoteJid to a device-less JID missed device-suffixed stanzas.

Strip the device on both, falling back to the raw value for userless JIDs (a server from like s.whatsapp.net) instead of throwing, so the predicate sees the same device-stripped form as the rest of the event surface. The descriptor matcher still compares on userJid; PN/LID addressing is not normalized in the predicate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for context extraction and message-filtering edge cases, verifying device-segment stripping, device‑stripped matching, and server-JID handling.

* **Documentation**
  * Clarified how message context attributes are normalized and derived from stanza data, including fallback behavior for unparseable or server-style JIDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->