### PR TITLE
fix(transport): prevent a stopped comms from being resurrected by a stale resume

### DIFF
--- a/src/transport/WaComms.ts
+++ b/src/transport/WaComms.ts
@@ -227,6 +227,10 @@ export class WaComms {
     }
 
     public async closeSocketAndResume(): Promise<void> {
+        if (!this.started || this.preventRetry) {
+            this.logger.debug('comms resume skipped: comms stopped or retry disabled')
+            return
+        }
         this.logger.debug('comms close socket and resume requested')
         this.resetConnectionState({
             started: true,

--- a/src/transport/__tests__/wa-comms.test.ts
+++ b/src/transport/__tests__/wa-comms.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createNoopLogger } from '@infra/log/types'
+import type { RawWebSocketConstructor } from '@transport/types'
+import { WaComms } from '@transport/WaComms'
+
+const NOOP_SOCKET_CTOR = class {
+    public binaryType = 'arraybuffer'
+    public readyState = 0
+    public onopen: unknown = null
+    public onclose: unknown = null
+    public onerror: unknown = null
+    public onmessage: unknown = null
+    public close(): void {
+        return
+    }
+    public send(): void {
+        return
+    }
+} as unknown as RawWebSocketConstructor
+
+function createComms(): WaComms {
+    return new WaComms(
+        {
+            urls: ['wss://example.invalid/ws'],
+            rawWebSocketConstructor: NOOP_SOCKET_CTOR,
+            noise: {
+                clientStaticKeyPair: {
+                    pubKey: new Uint8Array(32),
+                    privKey: new Uint8Array(32)
+                },
+                isRegistered: false
+            }
+        },
+        createNoopLogger()
+    )
+}
+
+test('closeSocketAndResume does not revive a comms that was never started', async () => {
+    const comms = createComms()
+    assert.equal(comms.getCommsState().started, false)
+
+    await comms.closeSocketAndResume()
+
+    assert.equal(comms.getCommsState().started, false)
+    assert.equal(comms.getCommsState().connected, false)
+})
+
+test('closeSocketAndResume does not revive a comms after stopComms', async () => {
+    const comms = createComms()
+    await comms.stopComms()
+
+    await comms.closeSocketAndResume()
+
+    assert.equal(comms.getCommsState().started, false)
+    assert.equal(comms.getCommsState().connected, false)
+})

--- a/src/transport/keepalive/WaKeepAlive.ts
+++ b/src/transport/keepalive/WaKeepAlive.ts
@@ -145,6 +145,10 @@ export class WaKeepAlive {
                 }
             }
         } catch (error) {
+            if (generation !== this.generation) {
+                this.logger.trace('keepalive stopped during in-flight ping, not resuming')
+                return
+            }
             this.logger.warn('keepalive ping failed, reconnecting socket', {
                 message: toError(error).message
             })

--- a/src/transport/keepalive/__tests__/keepalive.test.ts
+++ b/src/transport/keepalive/__tests__/keepalive.test.ts
@@ -182,3 +182,43 @@ test('keepalive ignores invalid t attribute', async (t) => {
 
     assert.equal(skewUpdates.length, 0)
 })
+
+test('keepalive does not resume when stopped while a ping is in flight', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    let resumed = 0
+    let rejectPing: (error: Error) => void = () => undefined
+    const keepAlive = new WaKeepAlive({
+        logger: createNoopLogger(),
+        nodeOrchestrator: {
+            hasPending: () => false,
+            query: () =>
+                new Promise<never>((_resolve, reject) => {
+                    rejectPing = reject
+                })
+        },
+        getComms: () =>
+            ({
+                getCommsState: () => ({ connected: true }),
+                closeSocketAndResume: async () => {
+                    resumed += 1
+                }
+            }) as never,
+        intervalMs: 5,
+        timeoutMs: 5,
+        jitterRatio: 0,
+        minJitterMs: 0
+    })
+
+    keepAlive.start()
+    t.mock.timers.tick(5)
+    await Promise.resolve()
+
+    keepAlive.stop()
+    rejectPing(new Error('client disconnected'))
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    assert.equal(resumed, 0)
+})


### PR DESCRIPTION
A keepalive ping that settled after the comms was stopped called closeSocketAndResume, which reset started=true and preventRetry=false and reopened the socket on the dead comms. That orphan reconnected forever with handlingRequests=false (never processing the success node), kept alive by its own reconnect timer and unreachable until a process restart.

WaKeepAlive.run() now re-checks the keepalive generation in the ping-failure catch before resuming. stop()/start() bump the generation synchronously, before any await in the disconnect path, so this holds regardless of microtask ordering. WaComms.closeSocketAndResume() also bails when the comms is no longer started or retry is disabled, as defense-in-depth for the decode-failure and queue-overflow resume callers. The stopped comms stays dead; a fresh comms still comes from the normal connect() path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection management to prevent socket reconnection attempts when the service is stopped or retry functionality is disabled.
  * Enhanced keepalive monitoring to properly handle service shutdown during active ping operations without triggering unnecessary reconnections.

* **Tests**
  * Added comprehensive unit tests verifying proper behavior when socket operations occur in stopped or disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->