### PR TITLE
chore(log): lower routing-info bulletin update from info to debug

### DIFF
--- a/src/client/coordinators/WaIncomingNodeCoordinator.ts
+++ b/src/client/coordinators/WaIncomingNodeCoordinator.ts
@@ -535,7 +535,7 @@ export class WaIncomingNodeCoordinator {
                         `ib.${WA_NODE_TAGS.EDGE_ROUTING}.${WA_NODE_TAGS.ROUTING_INFO}`
                     )
                     await this.runtime.persistRoutingInfo(routingInfo)
-                    this.logger.info('updated routing info from info bulletin', {
+                    this.logger.debug('updated routing info from info bulletin', {
                         byteLength: routingInfo.byteLength
                     })
                 } catch (error) {


### PR DESCRIPTION
It fires on every connect and routing change, not once per lifecycle, so it does not belong in the default info stream. persistRoutingInfo already logs the byte-level detail at trace; this is the per-operation outcome, which belongs at debug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal logging level for routing information updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->