### PR TITLE
fix(retry): send raw 32-byte public keys in the retry keys section

### DIFF
--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -1,5 +1,6 @@
 import type { WaAuthCredentials } from '@auth/types'
 import type { WaIncomingMessageEvent } from '@client/types'
+import { toRawPubKey } from '@crypto/core/keys'
 import type { Logger } from '@infra/log/types'
 import type { IcdcMeta } from '@message/crypto/icdc'
 import { buildRecoveredIncomingEvent } from '@message/primitives/incoming'
@@ -544,14 +545,14 @@ export class WaRetryCoordinator {
         await this.deps.preKeyStore.markKeyAsUploaded(preKey.keyId)
         const signedIdentity = this.deps.getCurrentCredentials()?.signedIdentity
         return {
-            identity,
+            identity: toRawPubKey(identity),
             key: {
                 id: preKey.keyId,
-                publicKey: preKey.keyPair.pubKey
+                publicKey: toRawPubKey(preKey.keyPair.pubKey)
             },
             skey: {
                 id: signedPreKey.keyId,
-                publicKey: signedPreKey.keyPair.pubKey,
+                publicKey: toRawPubKey(signedPreKey.keyPair.pubKey),
                 signature: signedPreKey.signature
             },
             deviceIdentity: signedIdentity


### PR DESCRIPTION
The retry-receipt keys section was sending serialized public keys; the wire expects raw 32-byte keys for identity, one-time prekey and signed prekey, matching how prekey uploads encode them. Wraps the three fields in `toRawPubKey()`.

Test plan: `npm run typecheck`, `npm run test` (798 pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of retry coordination by refining how cryptographic keys are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->