### PR TITLE
fix(retry): carry the trusted-contact token on retry resends

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -805,6 +805,8 @@ export function buildWaClientDependencies(input: {
         sendNode: runtime.sendNode,
         getCurrentCredentials,
         resolveUserIcdc: (userJid) => messageDispatch.resolveUserIcdc(userJid),
+        resolvePrivacyTokenNode: (recipientJid) =>
+            trustedContactToken.resolveTokenForMessage(recipientJid),
         peerDataOperation,
         emitIncomingMessage: (event) => {
             void runtime

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -67,6 +67,12 @@ interface WaRetryCoordinatorOptions {
     readonly resolveUserIcdc?: (userJid: string) => Promise<IcdcMeta | null>
     readonly peerDataOperation?: PeerDataOperationRequester
     readonly emitIncomingMessage?: (event: WaIncomingMessageEvent) => void
+    /**
+     * Resolves the trusted-contact (privacy) token node for a recipient user
+     * jid: retry resends must carry the same `<tctoken>` the original send did,
+     * or privacy-gated recipients nack them with error 463.
+     */
+    readonly resolvePrivacyTokenNode?: (recipientJid: string) => Promise<BinaryNode | null>
 }
 
 type RetryAuthorization =
@@ -157,7 +163,8 @@ export class WaRetryCoordinator {
             signalProtocol: options.signalProtocol,
             sessionResolver: options.sessionResolver,
             getCurrentCredentials: options.getCurrentCredentials,
-            resolveUserIcdc: options.resolveUserIcdc
+            resolveUserIcdc: options.resolveUserIcdc,
+            resolvePrivacyTokenNode: options.resolvePrivacyTokenNode
         })
         this.retryProcessingByMessageId = new Map()
         this.retrySessionBaseKeys = new Map()

--- a/src/message/WaMessageClient.ts
+++ b/src/message/WaMessageClient.ts
@@ -240,6 +240,9 @@ export class WaMessageClient {
         if (input.metaNode) {
             content.push(input.metaNode)
         }
+        if (input.privacyTokenNode) {
+            content.push(input.privacyTokenNode)
+        }
         const node: BinaryNode = {
             tag: WA_MESSAGE_TAGS.MESSAGE,
             attrs,

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -354,6 +354,11 @@ export interface WaEncryptedMessageInput {
     readonly participant?: string
     readonly deviceFanout?: string
     readonly metaNode?: BinaryNode
+    /**
+     * Trusted-contact (privacy) token node, appended as a `<tctoken>` child.
+     * Recipients that require one nack a token-less send with error 463.
+     */
+    readonly privacyTokenNode?: BinaryNode
 }
 
 export interface WaSendReceiptInput {

--- a/src/retry/replay.ts
+++ b/src/retry/replay.ts
@@ -37,6 +37,12 @@ export interface WaRetryReplayServiceOptions {
     readonly sessionResolver: SignalSessionResolver
     readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly resolveUserIcdc?: (userJid: string) => Promise<IcdcMeta | null>
+    /**
+     * Resolves the trusted-contact (privacy) token node for a recipient user
+     * jid. A resend without it is nacked with error 463 by privacy-gated
+     * recipients.
+     */
+    readonly resolvePrivacyTokenNode?: (recipientJid: string) => Promise<BinaryNode | null>
 }
 
 export type WaRetryResendResult = 'resent' | 'ineligible'
@@ -138,6 +144,9 @@ export class WaRetryReplayService {
         const metaNode = isHostedDeviceJid(requesterJid)
             ? buildMetaNode({ sender_intent: 'hosted' })
             : undefined
+        const privacyTokenNode = requesterIsSelf
+            ? undefined
+            : await this.resolvePrivacyToken(requesterJid)
         await this.options.messageClient.sendEncrypted({
             to: requesterJid,
             encType: encrypted.type,
@@ -146,7 +155,8 @@ export class WaRetryReplayService {
             id: outbound.messageId,
             type: payload.type,
             deviceIdentity,
-            metaNode
+            metaNode,
+            privacyTokenNode
         })
         return 'resent'
     }
@@ -160,6 +170,31 @@ export class WaRetryReplayService {
             return undefined
         }
         return proto.ADVSignedDeviceIdentity.encode(signedIdentity).finish()
+    }
+
+    /**
+     * Resolves the trusted-contact token node for the requester's user jid. A
+     * failure (or absent resolver) yields no node and the resend still goes out.
+     */
+    private async resolvePrivacyToken(requesterJid: string): Promise<BinaryNode | undefined> {
+        if (!this.options.resolvePrivacyTokenNode) {
+            return undefined
+        }
+        let recipientUserJid: string
+        try {
+            recipientUserJid = toUserJid(requesterJid)
+        } catch {
+            return undefined
+        }
+        try {
+            return (await this.options.resolvePrivacyTokenNode(recipientUserJid)) ?? undefined
+        } catch (error) {
+            this.options.logger.warn('retry resend privacy token resolution failed', {
+                to: recipientUserJid,
+                message: toError(error).message
+            })
+            return undefined
+        }
     }
 
     private async refreshRetryPlaintext(
@@ -304,6 +339,9 @@ export class WaRetryReplayService {
         const metaNode = isHostedDeviceJid(requesterJid)
             ? buildMetaNode({ sender_intent: 'hosted' })
             : undefined
+        const privacyTokenNode = this.isRequesterCurrentAccount(requesterJid)
+            ? undefined
+            : await this.resolvePrivacyToken(requesterJid)
         await this.options.messageClient.sendEncrypted({
             to: requesterJid,
             encType: payload.encType,
@@ -313,7 +351,8 @@ export class WaRetryReplayService {
             type: payload.type,
             participant: payload.participant,
             deviceIdentity,
-            metaNode
+            metaNode,
+            privacyTokenNode
         })
         return 'resent'
     }


### PR DESCRIPTION
Retry resends now carry the same `<tctoken>` the original direct send did: recipients that gate inbound messages behind a privacy token nack a token-less resend with error 463, stalling the retry escalation.

- `WaEncryptedMessageInput.privacyTokenNode`, appended by `WaMessageClient` as a message child node.
- `WaRetryReplayService` resolves the token for the requester's user jid (skipped when the requester is the current account), tolerating resolver failures.
- Factory wires `trustedContactToken.resolveTokenForMessage` through the `WaRetryCoordinator` options.

Test plan: `npm run typecheck`, `npm run test` (798 pass).