### PR TITLE
fix(profile): apply pushName changes locally and route app-state

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -855,6 +855,19 @@ export function buildWaClientDependencies(input: {
         }
     })
 
+    // Persists a pushName change and re-broadcasts presence carrying it (how the
+    // name reaches peers on primary connections). No-op when unchanged, which
+    // also collapses the app-state echo of our own SettingPushName write.
+    const applyOwnPushName = async (name: string): Promise<void> => {
+        if (getCurrentCredentials()?.meDisplayName === name) {
+            return
+        }
+        await authClient.persistSuccessAttributes({ meDisplayName: name })
+        if (connectionManager?.isConnected()) {
+            await presenceCoordinator.send()
+        }
+    }
+
     const appStateMutations = new WaAppStateMutationCoordinator({
         logger,
         messageStore: sessionStore.messages,
@@ -865,7 +878,14 @@ export function buildWaClientDependencies(input: {
         emitSnapshotMutations: options.chatEvents?.emitSnapshotMutations === true,
         emitMutation: (event) => runtime.emitEvent('mutation', event),
         nctSaltSink: (salt) => trustedContactToken.handleNctSaltSync(salt),
-        contactSink: runtime.persistContact
+        contactSink: runtime.persistContact,
+        pushNameSink: (name) => {
+            void applyOwnPushName(name).catch((error) =>
+                logger.debug('apply own pushName from app-state sync failed', {
+                    message: toError(error).message
+                })
+            )
+        }
     })
 
     const profileCoordinator = createProfileCoordinator({
@@ -874,6 +894,7 @@ export function buildWaClientDependencies(input: {
         mexSocket: { query: runtime.query },
         queryLidsByPhoneJids: (phoneJids) => signalDeviceSync.queryLidsByPhoneJids(phoneJids),
         mutations: appStateMutations,
+        applyOwnPushName,
         logger
     })
 

--- a/src/client/coordinators/WaAppStateMutationCoordinator.ts
+++ b/src/client/coordinators/WaAppStateMutationCoordinator.ts
@@ -293,6 +293,12 @@ interface WaAppStateMutationCoordinatorOptions {
      * bootstrapped at pair-time regardless of `emitSnapshotMutations`.
      */
     readonly contactSink?: (record: WaStoredContactRecord) => void
+    /**
+     * Sink for applied `SettingPushName` mutations (the account's own display
+     * name). Invoked on every winning mutation including snapshot ones, so the
+     * local display name is bootstrapped at pair-time.
+     */
+    readonly pushNameSink?: (name: string) => void
 }
 
 export interface WaSetStatusPrivacyInput {
@@ -331,6 +337,7 @@ export class WaAppStateMutationCoordinator {
     private readonly emitSnapshotMutations: boolean
     private readonly nctSaltSink?: (salt: Uint8Array | null) => Promise<void>
     private readonly contactSink?: (record: WaStoredContactRecord) => void
+    private readonly pushNameSink?: (name: string) => void
     private readonly pendingMutations: Map<string, WaAppStateMutationInput>
     private flushPromise: Promise<void> | null
 
@@ -350,6 +357,7 @@ export class WaAppStateMutationCoordinator {
         this.emitSnapshotMutations = options.emitSnapshotMutations === true
         this.nctSaltSink = options.nctSaltSink
         this.contactSink = options.contactSink
+        this.pushNameSink = options.pushNameSink
         this.pendingMutations = new Map()
         this.flushPromise = null
     }
@@ -402,11 +410,10 @@ export class WaAppStateMutationCoordinator {
         for (const collectionResult of syncResult.collections) {
             const mutations = collectionResult.mutations ?? []
 
-            // Persistence sinks (contact store, ...): run on the last-wins
-            // mutation per key INCLUDING snapshot sources, so pair-time
-            // bootstrap of the address book always lands in the store even
-            // when public events are suppressed for snapshot mutations.
-            if (this.contactSink) {
+            // Persistence sinks (contact store, own pushName): run on the
+            // last-wins mutation per key INCLUDING snapshot sources, so
+            // pair-time bootstrap lands even when snapshot events are suppressed.
+            if (this.contactSink || this.pushNameSink) {
                 const sinkLastIndex = new Map<string, number>()
                 for (let i = 0; i < mutations.length; i += 1) {
                     const m = mutations[i]
@@ -421,6 +428,15 @@ export class WaAppStateMutationCoordinator {
                         this.handleContactMutation(m)
                     } catch (error) {
                         this.logger.debug('contact sink failed', {
+                            collection: m.collection,
+                            index: m.index,
+                            message: toError(error).message
+                        })
+                    }
+                    try {
+                        this.handlePushNameMutation(m)
+                    } catch (error) {
+                        this.logger.debug('pushName sink failed', {
                             collection: m.collection,
                             index: m.index,
                             message: toError(error).message
@@ -537,6 +553,17 @@ export class WaAppStateMutationCoordinator {
             phoneNumber,
             lastUpdatedMs
         })
+    }
+
+    private handlePushNameMutation(mutation: WaAppStateMutation): void {
+        if (!this.pushNameSink) return
+        // A `set` under the literal index ["setting_pushName"]; cheap reject
+        // before reading the value.
+        if (mutation.operation !== 'set') return
+        if (!mutation.index.includes('setting_pushName')) return
+        const name = mutation.value?.pushNameSetting?.name
+        if (typeof name !== 'string') return
+        this.pushNameSink(name)
     }
 
     /**

--- a/src/client/coordinators/WaProfileCoordinator.ts
+++ b/src/client/coordinators/WaProfileCoordinator.ts
@@ -121,12 +121,11 @@ export interface WaProfileCoordinator {
     readonly setStatus: (text: string) => Promise<void>
     /**
      * Sets the account's pushName - the display name broadcast to other
-     * users in chats and group participant lists. WhatsApp Web applies the
-     * change via a `SettingPushName` app-state mutation (collection
-     * `critical_block`); the new value reaches peers as their next
-     * incoming-message envelope from this account carries the updated
-     * `notify` attr. Empty strings are accepted but reset the display name
-     * to the device fingerprint default.
+     * users in chats and group participant lists. Writes a `SettingPushName`
+     * app-state mutation to sync the account's other devices, persists the
+     * name locally, and re-broadcasts an available presence carrying it (the
+     * step that propagates the name on primary connections, where no phone
+     * re-broadcasts on this device's behalf). Empty strings clear the name.
      */
     readonly setPushName: (name: string) => Promise<void>
     /** Batched usync fetch of picture id + status for many JIDs. */
@@ -197,6 +196,12 @@ interface WaProfileCoordinatorOptions {
      * mutations.
      */
     readonly mutations: WaAppStateMutationCoordinator
+    /**
+     * Applies a pushName change locally: persists the display name and
+     * re-broadcasts an available presence carrying it. Expected to be
+     * idempotent (a no-op when the name already matches).
+     */
+    readonly applyOwnPushName: (name: string) => Promise<void>
     readonly logger: Logger
 }
 
@@ -431,8 +436,15 @@ function buildTextStatusMutationInput(input: WaSetTextStatusInput): {
 export function createProfileCoordinator(
     options: WaProfileCoordinatorOptions
 ): WaProfileCoordinator {
-    const { queryWithContext, generateSid, mexSocket, queryLidsByPhoneJids, mutations, logger } =
-        options
+    const {
+        queryWithContext,
+        generateSid,
+        mexSocket,
+        queryLidsByPhoneJids,
+        mutations,
+        applyOwnPushName,
+        logger
+    } = options
 
     return {
         getProfilePicture: async (jid, type, existingId) => {
@@ -488,6 +500,9 @@ export function createProfileCoordinator(
         },
 
         setPushName: async (name) => {
+            // Local apply first: the app-state echo of this same write then
+            // collapses into a no-op via applyOwnPushName's idempotency guard.
+            await applyOwnPushName(name)
             await mutations.set({ schema: 'SettingPushName', name })
         },
 

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -1329,6 +1329,45 @@ test('app-state mutation coordinator emits business_broadcast_list set/remove pa
     assert.deepEqual(JSON.parse(removeMutation.index), ['business_broadcast_list', 'list-1'])
 })
 
+test('app-state mutation coordinator routes applied SettingPushName to pushNameSink', () => {
+    const names: string[] = []
+    const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
+        logger: createNoopLogger(),
+        messageStore: new WaMessageMemoryStore(),
+        ...fakeSyncImpl(async () => ({ collections: [] })),
+        pushNameSink: (name) => {
+            names.push(name)
+        }
+    })
+
+    // Snapshot-source mutations still route to the sink (pair-time bootstrap).
+    coordinator.emitEventsFromSyncResult({
+        collections: [
+            {
+                collection: 'critical_block',
+                state: WA_APP_STATE_COLLECTION_STATES.SUCCESS,
+                mutations: [
+                    {
+                        collection: 'critical_block',
+                        operation: 'set',
+                        source: 'snapshot',
+                        index: JSON.stringify(['setting_pushName']),
+                        value: { pushNameSetting: { name: 'Maria' } },
+                        version: 1,
+                        indexMac: new Uint8Array(),
+                        valueMac: new Uint8Array(),
+                        keyId: new Uint8Array(),
+                        timestamp: 1_000
+                    }
+                ]
+            }
+        ]
+    })
+
+    assert.deepEqual(names, ['Maria'])
+})
+
 function createPassiveTasksCoordinator(overrides: {
     readonly takeDanglingReceipts: () => BinaryNode[]
     readonly sendNodeDirect: (node: BinaryNode) => Promise<void>

--- a/src/client/coordinators/__tests__/profile-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/profile-coordinator.test.ts
@@ -24,6 +24,7 @@ test('profile coordinator gets profile picture url', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -66,6 +67,7 @@ test('profile coordinator gets profile picture url', async () => {
 test('profile coordinator returns empty result when no picture node', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -85,6 +87,7 @@ test('profile coordinator gets full image picture with existing id', async () =>
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -122,6 +125,7 @@ test('profile coordinator sets profile picture and returns id', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -157,6 +161,7 @@ test('profile coordinator sets group profile picture with target jid', async () 
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -180,6 +185,7 @@ test('profile coordinator deletes profile picture', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -207,6 +213,7 @@ test('profile coordinator gets status via usync', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -253,6 +260,7 @@ test('profile coordinator gets status via usync', async () => {
 test('profile coordinator returns null status when no content', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -287,6 +295,7 @@ test('profile coordinator returns null status when no content', async () => {
 test('profile coordinator returns empty string for status code 401', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -326,6 +335,7 @@ test('profile coordinator gets multiple profiles via usync', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -391,6 +401,7 @@ test('profile coordinator sets status text', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -412,14 +423,21 @@ test('profile coordinator sets status text', async () => {
     assert.equal(statusNode.content, 'Hello World')
 })
 
-test('profile coordinator routes setPushName through mutations.set with SettingPushName schema', async () => {
+test('profile coordinator setPushName applies locally before the SettingPushName write', async () => {
+    const events: string[] = []
     const setCalls: unknown[] = []
+    const appliedNames: string[] = []
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async (name: string) => {
+            events.push('apply')
+            appliedNames.push(name)
+        },
         logger: createNoopLogger(),
         mutations: {
             set: async (input: unknown) => {
+                events.push('mutation')
                 setCalls.push(input)
             }
         } as never,
@@ -431,10 +449,12 @@ test('profile coordinator routes setPushName through mutations.set with SettingP
     await coordinator.setPushName('Maria')
     await coordinator.setPushName('')
 
+    assert.deepEqual(appliedNames, ['Maria', ''])
     assert.deepEqual(setCalls, [
         { schema: 'SettingPushName', name: 'Maria' },
         { schema: 'SettingPushName', name: '' }
     ])
+    assert.deepEqual(events, ['apply', 'mutation', 'apply', 'mutation'])
 })
 
 test('profile coordinator sets account default disappearing mode', async () => {
@@ -446,6 +466,7 @@ test('profile coordinator sets account default disappearing mode', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -474,6 +495,7 @@ test('profile coordinator sets account default disappearing mode', async () => {
 test('profile coordinator gets disappearing mode via usync', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -535,6 +557,7 @@ test('profile coordinator returns empty disappearing mode for empty jids', async
     const calls: string[] = []
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -558,6 +581,7 @@ test('profile coordinator gets text statuses via usync', async () => {
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -641,6 +665,7 @@ test('profile coordinator gets text statuses via usync', async () => {
 test('profile coordinator emits null text_status entry on error nodes', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -695,6 +720,7 @@ test('profile coordinator returns empty text statuses for empty jids', async () 
     const calls: string[] = []
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -734,6 +760,7 @@ test('profile coordinator sets text status via mex', async () => {
     }
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -786,6 +813,7 @@ test('profile coordinator setTextStatus normalizes empty inputs to clear payload
     }
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -810,6 +838,7 @@ test('profile coordinator gets usernames via usync', async () => {
     const calls: Array<{ readonly context: string; readonly node: BinaryNode }> = []
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -884,6 +913,7 @@ test('profile coordinator returns empty usernames for empty jids', async () => {
     const calls: string[] = []
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -901,6 +931,7 @@ test('profile coordinator returns empty usernames for empty jids', async () => {
 test('profile coordinator getOwnUsername parses mex payload', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -938,6 +969,7 @@ test('profile coordinator getOwnUsername parses mex payload', async () => {
 test('profile coordinator getOwnUsername swallows 404 GraphQL errors', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -973,6 +1005,7 @@ test('profile coordinator getOwnUsername swallows 404 GraphQL errors', async () 
 test('profile coordinator getOwnUsername returns nulls when info missing', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -1001,6 +1034,7 @@ test('profile coordinator setUsername sends mex variables with defaults', async 
     const captured: BinaryNode[] = []
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -1047,6 +1081,7 @@ test('profile coordinator setUsername sends mex variables with defaults', async 
 test('profile coordinator setUsername returns false on non-SUCCESS result', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -1074,6 +1109,7 @@ test('profile coordinator deleteUsername sends empty variables', async () => {
     const captured: BinaryNode[] = []
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -1117,6 +1153,7 @@ test('profile coordinator returns empty array for empty jids list', async () => 
 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -1137,6 +1174,7 @@ test('profile coordinator resolves lids by phone numbers', async () => {
     const portCalls: Array<readonly string[]> = []
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
@@ -1170,6 +1208,7 @@ test('profile coordinator returns empty lid result without calling port', async 
     let called = false
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },


### PR DESCRIPTION
Propagates pushName changes on primary connections, where no phone re-broadcasts on this device's behalf:

- `setPushName` persists the display name and re-broadcasts an available presence before writing the `SettingPushName` app-state mutation (the up-front local apply also collapses the app-state echo of the same write into a no-op).
- New `pushNameSink` on the app-state mutation coordinator routes applied `SettingPushName` mutations (including snapshot ones, for pair-time bootstrap) to the same apply step.

Test plan: `npm run typecheck`, `npm run test` (799 pass) with new coordinator and profile tests.