### PR TITLE
feat(mcp-server): auto-enable mobile transport from persisted deviceInfo

### DIFF
--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -656,10 +656,21 @@ export class McpRuntime {
         await mkdir(dirname(this.config.authPath), { recursive: true })
         const store = this.ensureStore()
         const sessionLogger = this.createSessionLogger(state.sessionId)
+        // Mobile-registered credentials carry deviceInfo: pass mobileTransport so
+        // the factory's mobilePrimary gating matches the transport auto-detection.
+        const persisted = await store
+            .session(state.sessionId)
+            .auth.load()
+            .catch(() => null)
+        const mobileTransport =
+            persisted?.deviceInfo !== undefined && persisted?.deviceInfo !== null
+                ? { deviceInfo: persisted.deviceInfo, passive: false }
+                : undefined
         const client = new WaClient(
             {
                 store,
                 sessionId: state.sessionId,
+                ...(mobileTransport ? { mobileTransport } : {}),
                 connectTimeoutMs: 60_000,
                 deviceBrowser: this.config.deviceBrowser ?? 'Chrome',
                 deviceOsDisplayName: this.config.deviceOsDisplayName ?? 'Windows',


### PR DESCRIPTION
When the persisted credentials carry mobile `deviceInfo`, the MCP runtime now passes `mobileTransport` to the `WaClient` it spins up, so mobilePrimary-gated behavior matches the transport's own auto-detection without per-session manual configuration.

Test plan: `npm run typecheck -w @zapo-js/mcp-server`.