### PR TITLE
fix(appstate): make mobile primary authoritative and resolve sync conflicts

### DIFF
--- a/src/appstate/sync/WaAppStateSyncClient.ts
+++ b/src/appstate/sync/WaAppStateSyncClient.ts
@@ -155,13 +155,26 @@ export class WaAppStateSyncClient {
     /**
      * Returns the active app-state sync key, generating and persisting a new
      * one when the store is empty (used during initial setup).
+     *
+     * The key id mirrors the primary device layout: 2 big-endian bytes of
+     * device id followed by a 4 big-endian byte epoch. `keyEpoch` and
+     * `pickActiveSyncKey` read that structure, so a shorter id would make the
+     * generated key invisible to active-key selection.
      */
     public async ensureInitialSyncKey(): Promise<WaAppStateSyncKey> {
         const existing = await this.store.getActiveSyncKey()
         if (existing) {
             return existing
         }
-        const keyIdBytes = await randomBytesAsync(2)
+        const deviceId = this.resolveDeviceIndex() ?? 0
+        const epoch = await randomIntAsync(1, 65_537)
+        const keyIdBytes = new Uint8Array(6)
+        keyIdBytes[0] = (deviceId >>> 8) & 0xff
+        keyIdBytes[1] = deviceId & 0xff
+        keyIdBytes[2] = (epoch >>> 24) & 0xff
+        keyIdBytes[3] = (epoch >>> 16) & 0xff
+        keyIdBytes[4] = (epoch >>> 8) & 0xff
+        keyIdBytes[5] = epoch & 0xff
         const keyData = await randomBytesAsync(32)
         const rawId = await randomIntAsync(0, 0xffff_ffff)
         const key: WaAppStateSyncKey = {
@@ -174,6 +187,7 @@ export class WaAppStateSyncClient {
         this.crypto.clearCache()
         this.logger.info('app-state initial sync key generated (mobile primary)', {
             keyId: bytesToHex(keyIdBytes),
+            epoch,
             rawId
         })
         return key
@@ -578,12 +592,13 @@ export class WaAppStateSyncClient {
     }> {
         const collectionState = await this.getCollectionState(collection)
         const hasPersistedState = collectionState.initialized
+        const requestSnapshot = !this.mobilePrimary && !hasPersistedState
         const attrs: Record<string, string> = {
             name: collection,
             version: String(
                 hasPersistedState ? collectionState.version : APP_STATE_DEFAULT_COLLECTION_VERSION
             ),
-            return_snapshot: hasPersistedState ? 'false' : 'true'
+            return_snapshot: requestSnapshot ? 'true' : 'false'
         }
 
         const children: BinaryNode[] = []
@@ -591,7 +606,7 @@ export class WaAppStateSyncClient {
         let outgoingContext: OutgoingPatchContext | undefined
         let skippedUpload = false
         if (pendingMutations.length > 0) {
-            if (!hasPersistedState) {
+            if (!hasPersistedState && !this.mobilePrimary) {
                 skippedUpload = true
                 this.logger.debug(
                     'app-state skipped outgoing patch upload until snapshot bootstrap',
@@ -710,28 +725,20 @@ export class WaAppStateSyncClient {
         }
 
         const pendingMutationsCount = pendingByCollection.get(collection)?.length ?? 0
-        if (
+        const isConflict =
             payload.state === WA_APP_STATE_COLLECTION_STATES.CONFLICT ||
             payload.state === WA_APP_STATE_COLLECTION_STATES.CONFLICT_HAS_MORE
-        ) {
+        if (isConflict) {
             shouldRefetch =
                 payload.state === WA_APP_STATE_COLLECTION_STATES.CONFLICT_HAS_MORE ||
                 pendingMutationsCount > 0
-            return this.createCollectionOutcome(
-                collection,
-                payload.state === WA_APP_STATE_COLLECTION_STATES.CONFLICT
-                    ? pendingMutationsCount > 0
-                        ? WA_APP_STATE_COLLECTION_STATES.CONFLICT
-                        : WA_APP_STATE_COLLECTION_STATES.SUCCESS
-                    : payload.state,
-                payload.version,
-                shouldRefetch
-            )
         }
 
         try {
             let appliedMutations: WaAppStateMutation[] = []
-            if (payload.snapshotReference) {
+            if (payload.snapshotReference && this.mobilePrimary) {
+                collectionLogger.debug('app-state ignoring server snapshot on primary device')
+            } else if (payload.snapshotReference) {
                 const downloader = options.downloadExternalBlob
                 if (!downloader) {
                     throw new Error(
@@ -796,14 +803,22 @@ export class WaAppStateSyncClient {
                 (payload.state === WA_APP_STATE_COLLECTION_STATES.SUCCESS &&
                     skippedUploadCollections.has(collection))
 
+            const resolvedState = !isConflict
+                ? payload.state
+                : payload.state === WA_APP_STATE_COLLECTION_STATES.CONFLICT
+                  ? pendingMutationsCount > 0
+                      ? WA_APP_STATE_COLLECTION_STATES.CONFLICT
+                      : WA_APP_STATE_COLLECTION_STATES.SUCCESS
+                  : payload.state
+
             collectionLogger.debug('app-state collection processed', {
-                state: payload.state,
+                state: resolvedState,
                 version: payload.version,
                 appliedMutations: appliedMutations.length
             })
             return this.createCollectionOutcome(
                 collection,
-                payload.state,
+                resolvedState,
                 payload.version,
                 shouldRefetch,
                 collectionStateChanged,

--- a/src/appstate/sync/__tests__/appstate-sync.test.ts
+++ b/src/appstate/sync/__tests__/appstate-sync.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import { APP_STATE_EMPTY_LT_HASH } from '@appstate/constants'
 import { WaAppStateSyncClient } from '@appstate/sync/WaAppStateSyncClient'
+import { keyEpoch } from '@appstate/utils'
 import { createNoopLogger } from '@infra/log/types'
 import { type Proto, proto } from '@proto'
 import {
@@ -351,7 +352,10 @@ test('ensureInitialSyncKey mints a 32-byte key with fingerprint when store is em
 
     assert.equal(await store.getActiveSyncKey(), null)
     const first = await client.ensureInitialSyncKey()
-    assert.equal(first.keyId.length, 2)
+    assert.equal(first.keyId.length, 6)
+    assert.equal(first.keyId[0], 0)
+    assert.equal(first.keyId[1], 0)
+    assert.ok(keyEpoch(first.keyId) >= 1)
     assert.equal(first.keyData.length, 32)
     assert.ok(first.fingerprint)
     assert.equal(first.fingerprint?.currentIndex, 0)
@@ -361,4 +365,151 @@ test('ensureInitialSyncKey mints a 32-byte key with fingerprint when store is em
     const second = await client.ensureInitialSyncKey()
     assert.deepEqual(second.keyId, first.keyId)
     assert.deepEqual(second.keyData, first.keyData)
+})
+
+test('appstate sync applies catch-up patches on 409 conflict and re-uploads the pending mutation', async () => {
+    const store = new WaAppStateMemoryStore()
+    const key = {
+        keyId: new Uint8Array([0, 0, 0, 0, 0, 8]),
+        keyData: new Uint8Array(32).fill(9),
+        timestamp: 4
+    }
+    await store.upsertSyncKeys([key])
+
+    const conflictPatches = [
+        {
+            tag: WA_NODE_TAGS.PATCH,
+            attrs: {},
+            content: proto.SyncdPatch.encode({ version: { version: 1 } }).finish()
+        },
+        {
+            tag: WA_NODE_TAGS.PATCH,
+            attrs: {},
+            content: proto.SyncdPatch.encode({ version: { version: 2 } }).finish()
+        }
+    ]
+
+    let call = 0
+    const patchByCall: boolean[] = []
+    const query = async (node: BinaryNode): Promise<BinaryNode> => {
+        call += 1
+        const syncNode = (node.content as readonly BinaryNode[])[0]
+        const collectionNode = (syncNode.content as readonly BinaryNode[])[0]
+        const content = collectionNode.content as readonly BinaryNode[] | undefined
+        patchByCall.push(content?.some((child) => child.tag === WA_NODE_TAGS.PATCH) ?? false)
+        const collection: BinaryNode =
+            call === 1
+                ? {
+                      tag: WA_NODE_TAGS.COLLECTION,
+                      attrs: { type: 'error', name: WA_APP_STATE_COLLECTIONS.CRITICAL_BLOCK },
+                      content: [
+                          {
+                              tag: WA_NODE_TAGS.ERROR,
+                              attrs: { code: '409', text: 'conflict' }
+                          },
+                          { tag: WA_NODE_TAGS.PATCHES, attrs: {}, content: conflictPatches }
+                      ]
+                  }
+                : {
+                      tag: WA_NODE_TAGS.COLLECTION,
+                      attrs: { name: WA_APP_STATE_COLLECTIONS.CRITICAL_BLOCK, version: '3' }
+                  }
+        return {
+            tag: WA_NODE_TAGS.IQ,
+            attrs: { type: WA_IQ_TYPES.RESULT },
+            content: [{ tag: WA_NODE_TAGS.SYNC, attrs: {}, content: [collection] }]
+        }
+    }
+
+    const client = new WaAppStateSyncClient({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
+        logger: createNoopLogger(),
+        query,
+        store,
+        mobilePrimary: true,
+        skipMacVerification: true
+    })
+
+    const result = await client.sync({
+        collections: [WA_APP_STATE_COLLECTIONS.CRITICAL_BLOCK],
+        pendingMutations: [
+            {
+                collection: WA_APP_STATE_COLLECTIONS.CRITICAL_BLOCK,
+                operation: 'set',
+                index: JSON.stringify(['setting_pushName']),
+                value: { timestamp: 4_000, pushNameSetting: { name: 'Maria' } },
+                version: 1,
+                timestamp: 4_000
+            }
+        ]
+    })
+
+    assert.equal(call, 2)
+    assert.deepEqual(patchByCall, [true, true])
+    assert.equal(result.collections[0].state, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
+    const persisted = await store.getCollectionState(WA_APP_STATE_COLLECTIONS.CRITICAL_BLOCK)
+    assert.equal(persisted.version, 3)
+})
+
+test('mobile primary uploads patch from fresh state without requesting a snapshot', async () => {
+    const store = new WaAppStateMemoryStore()
+    const key = {
+        keyId: new Uint8Array([0, 0, 0, 0, 0, 7]),
+        keyData: new Uint8Array(32).fill(9),
+        timestamp: 4
+    }
+    await store.upsertSyncKeys([key])
+
+    const returnSnapshotByCall: string[] = []
+    const patchByCall: boolean[] = []
+    const query = async (node: BinaryNode): Promise<BinaryNode> => {
+        const syncNode = (node.content as readonly BinaryNode[])[0]
+        const collectionNode = (syncNode.content as readonly BinaryNode[])[0]
+        const content = collectionNode.content as readonly BinaryNode[] | undefined
+        returnSnapshotByCall.push(collectionNode.attrs.return_snapshot)
+        patchByCall.push(content?.some((child) => child.tag === WA_NODE_TAGS.PATCH) ?? false)
+        return {
+            tag: WA_NODE_TAGS.IQ,
+            attrs: { type: WA_IQ_TYPES.RESULT },
+            content: [
+                {
+                    tag: WA_NODE_TAGS.SYNC,
+                    attrs: {},
+                    content: [
+                        {
+                            tag: WA_NODE_TAGS.COLLECTION,
+                            attrs: { name: WA_APP_STATE_COLLECTIONS.CRITICAL_BLOCK, version: '1' }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+
+    const client = new WaAppStateSyncClient({
+        serverClock: { nowMs: () => Date.now(), nowSeconds: () => Math.floor(Date.now() / 1000) },
+        logger: createNoopLogger(),
+        query,
+        store,
+        mobilePrimary: true,
+        skipMacVerification: true
+    })
+
+    const result = await client.sync({
+        collections: [WA_APP_STATE_COLLECTIONS.CRITICAL_BLOCK],
+        pendingMutations: [
+            {
+                collection: WA_APP_STATE_COLLECTIONS.CRITICAL_BLOCK,
+                operation: 'set',
+                index: JSON.stringify(['setting_pushName']),
+                value: { timestamp: 4_000, pushNameSetting: { name: 'Maria' } },
+                version: 1,
+                timestamp: 4_000
+            }
+        ]
+    })
+
+    assert.deepEqual(returnSnapshotByCall, ['false'])
+    assert.deepEqual(patchByCall, [true])
+    assert.equal(result.collections[0].state, WA_APP_STATE_COLLECTION_STATES.SUCCESS)
 })


### PR DESCRIPTION
A mobile-transport session is the primary device for app-state, but the sync client ran the companion bootstrap path: it requested and decrypted the server snapshot and gated patch upload on that bootstrap. With no peer device to source a missing key from, setPushName and other mutations deadlocked on a blocked collection.

Treat the local collection state as the source of truth when running as the primary: never request or adopt a server snapshot, and upload pending patches straight from local state (a fresh collection starts at version 0). The 6-byte sync key id is now generated with the device id and a 4-byte epoch so keyEpoch and pickActiveSyncKey can read it.

On a 409 conflict the server returns the catch-up patches; apply them to advance the local version and let the pending mutation re-upload rebased, instead of resending the same version until the round cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sync key generation for improved consistency and reliability across application sessions
  * Strengthened conflict resolution mechanisms during data synchronization to handle complex edge cases more effectively
  * Optimized synchronization behavior for mobile primary devices to ensure faster and smoother data updates during conflict scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->