### PR TITLE
fix(message): resolve self-author participant on recovered group events

### DIFF
--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -1142,6 +1142,7 @@ export class WaRetryCoordinator {
                         }))
                     }
                 )
+                const meJid = this.deps.getCurrentCredentials()?.meJid
                 for (const result of results) {
                     const bytes = result.placeholderMessageResendResponse?.webMessageInfoBytes
                     if (!bytes) {
@@ -1149,7 +1150,7 @@ export class WaRetryCoordinator {
                     }
                     try {
                         const recovered = proto.WebMessageInfo.decode(bytes)
-                        emitIncomingMessage(buildRecoveredIncomingEvent(recovered))
+                        emitIncomingMessage(buildRecoveredIncomingEvent(recovered, meJid))
                     } catch (error) {
                         this.deps.logger.warn(
                             'placeholder resend: failed to decode WebMessageInfo',

--- a/src/message/primitives/__tests__/incoming.test.ts
+++ b/src/message/primitives/__tests__/incoming.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test'
 
 import type { WaIncomingMessageEvent } from '@client/types'
 import { createNoopLogger } from '@infra/log/types'
-import { handleIncomingMessageAck } from '@message/primitives/incoming'
+import { buildRecoveredIncomingEvent, handleIncomingMessageAck } from '@message/primitives/incoming'
 import { proto } from '@proto'
 import type { BinaryNode } from '@transport/types'
 
@@ -137,6 +137,65 @@ test('group incoming message keeps the group remoteJid and carries the device on
     assert.equal(key.isGroup, true)
     assert.equal(key.participant, '5511999999999@s.whatsapp.net')
     assert.equal(key.senderDevice, 7)
+})
+
+test('recovered self group message resolves participant from originalSelfAuthorUserJidString', () => {
+    const event = buildRecoveredIncomingEvent(
+        {
+            key: { remoteJid: '120363000000000000@g.us', fromMe: true, id: 'ID-0' },
+            message: { conversation: 'hello' },
+            messageTimestamp: 1700000000,
+            originalSelfAuthorUserJidString: '133300000000000@lid'
+        },
+        '5511999999999:2@s.whatsapp.net'
+    )
+
+    assert.equal(event.key.fromMe, true)
+    assert.equal(event.key.isGroup, true)
+    assert.equal(event.key.participant, '133300000000000@lid')
+    assert.equal(event.rawNode.attrs.participant, '133300000000000@lid')
+})
+
+test('recovered self group message falls back to the me user when no self author is present', () => {
+    const event = buildRecoveredIncomingEvent(
+        {
+            key: { remoteJid: '120363000000000000@g.us', fromMe: true, id: 'ID-1' },
+            message: { conversation: 'hello' }
+        },
+        '5511999999999:2@s.whatsapp.net'
+    )
+
+    assert.equal(event.key.participant, '5511999999999@s.whatsapp.net')
+})
+
+test('recovered self group message keeps an explicit participant over the self author', () => {
+    const event = buildRecoveredIncomingEvent(
+        {
+            key: {
+                remoteJid: '120363000000000000@g.us',
+                fromMe: true,
+                id: 'ID-2',
+                participant: '5511777777777@s.whatsapp.net'
+            },
+            originalSelfAuthorUserJidString: '133300000000000@lid'
+        },
+        '5511999999999:2@s.whatsapp.net'
+    )
+
+    assert.equal(event.key.participant, '5511777777777@s.whatsapp.net')
+})
+
+test('recovered self 1:1 message keeps participant unset', () => {
+    const event = buildRecoveredIncomingEvent(
+        {
+            key: { remoteJid: '5511888888888@s.whatsapp.net', fromMe: true, id: 'ID-3' },
+            message: { conversation: 'hello' },
+            originalSelfAuthorUserJidString: '133300000000000@lid'
+        },
+        '5511999999999:2@s.whatsapp.net'
+    )
+
+    assert.equal(event.key.participant, undefined)
 })
 
 test('incoming message ack falls back to retry receipt when decrypt fails', async () => {

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -117,16 +117,26 @@ function buildIncomingEventRawNode(node: BinaryNode): BinaryNode {
     }
 }
 
+/**
+ * Rebuilds a `message` event from a recovered {@link proto.IWebMessageInfo}
+ * (placeholder resend). `meJid` is the current account user JID, used as the
+ * author fallback for self-sent group messages when the proto carries no
+ * participant and no `originalSelfAuthorUserJidString`.
+ */
 export function buildRecoveredIncomingEvent(
-    webMessageInfo: proto.IWebMessageInfo
+    webMessageInfo: proto.IWebMessageInfo,
+    meJid?: string | null
 ): WaIncomingMessageEvent {
     const key = webMessageInfo.key ?? {}
     const chatJid = key.remoteJid ?? undefined
     const fromMe = key.fromMe === true
-    const participant = webMessageInfo.participant ?? key.participant ?? undefined
-    const pushName = webMessageInfo.pushName ?? undefined
     const isGroup = chatJid ? isGroupJid(chatJid) : false
     const isBroadcast = chatJid ? isBroadcastJid(chatJid) : false
+    const rawSelfAuthor = webMessageInfo.originalSelfAuthorUserJidString ?? meJid ?? undefined
+    const selfAuthor =
+        fromMe && (isGroup || isBroadcast) && rawSelfAuthor ? toUserJid(rawSelfAuthor) : undefined
+    const participant = webMessageInfo.participant ?? key.participant ?? selfAuthor
+    const pushName = webMessageInfo.pushName ?? undefined
     const rawSender = fromMe ? undefined : isGroup || isBroadcast ? participant : chatJid
     const sender = rawSender ? parseJidFull(rawSender) : null
     const senderDevice = sender?.address.device


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved participant attribution for recovered placeholder resend messages by capturing the current account JID as a fallback when author info is missing, ensuring correct sender identification for self-sent group/broadcast messages.
  * Preserves explicitly provided participant info and adds tests covering recovered self-message participant resolution and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->