### PR TITLE
fix(client): derive mobile-primary from persisted deviceInfo

### DIFF
--- a/src/appstate/sync/WaAppStateSyncClient.ts
+++ b/src/appstate/sync/WaAppStateSyncClient.ts
@@ -77,7 +77,12 @@ interface WaAppStateSyncClientOptions {
     readonly defaultTimeoutMs?: number
     readonly onMissingKeys?: (event: WaAppStateMissingKeysEvent) => Promise<void>
     readonly skipMacVerification?: boolean
-    readonly mobilePrimary?: boolean
+    /**
+     * Resolved per sync operation (post-connect, after credentials load) so a
+     * registered mobile-primary session reconnecting without an explicit
+     * `mobileTransport` option still drives the primary-authoritative sync path.
+     */
+    readonly mobilePrimary?: () => boolean
     readonly isOwnAccountDevice?: (deviceJid: string) => boolean
     readonly sendKeyShare?: (
         toDeviceJid: string,
@@ -125,7 +130,7 @@ export class WaAppStateSyncClient {
     ) => Promise<void>
     private readonly triggerSync?: () => Promise<void>
     private readonly crypto: WaAppStateCrypto
-    private readonly mobilePrimary: boolean
+    private readonly mobilePrimary: () => boolean
     private syncContext: {
         readonly keys: Map<string, Uint8Array | null>
         readonly collections: Map<AppStateCollectionName, WaAppStateCollectionStoreState>
@@ -147,7 +152,7 @@ export class WaAppStateSyncClient {
         this.triggerSync = options.triggerSync
 
         this.crypto = new WaAppStateCrypto(undefined, options.skipMacVerification === true)
-        this.mobilePrimary = options.mobilePrimary ?? false
+        this.mobilePrimary = options.mobilePrimary ?? (() => false)
         this.syncContext = null
         this.syncPromise = null
     }
@@ -592,7 +597,7 @@ export class WaAppStateSyncClient {
     }> {
         const collectionState = await this.getCollectionState(collection)
         const hasPersistedState = collectionState.initialized
-        const requestSnapshot = !this.mobilePrimary && !hasPersistedState
+        const requestSnapshot = !this.mobilePrimary() && !hasPersistedState
         const attrs: Record<string, string> = {
             name: collection,
             version: String(
@@ -606,7 +611,7 @@ export class WaAppStateSyncClient {
         let outgoingContext: OutgoingPatchContext | undefined
         let skippedUpload = false
         if (pendingMutations.length > 0) {
-            if (!hasPersistedState && !this.mobilePrimary) {
+            if (!hasPersistedState && !this.mobilePrimary()) {
                 skippedUpload = true
                 this.logger.debug(
                     'app-state skipped outgoing patch upload until snapshot bootstrap',
@@ -654,7 +659,7 @@ export class WaAppStateSyncClient {
             content: [
                 {
                     tag: WA_NODE_TAGS.SYNC,
-                    attrs: this.mobilePrimary ? { data_namespace: '3' } : {},
+                    attrs: this.mobilePrimary() ? { data_namespace: '3' } : {},
                     content: collectionNodes
                 }
             ]
@@ -736,7 +741,7 @@ export class WaAppStateSyncClient {
 
         try {
             let appliedMutations: WaAppStateMutation[] = []
-            if (payload.snapshotReference && this.mobilePrimary) {
+            if (payload.snapshotReference && this.mobilePrimary()) {
                 collectionLogger.debug('app-state ignoring server snapshot on primary device')
             } else if (payload.snapshotReference) {
                 const downloader = options.downloadExternalBlob

--- a/src/appstate/sync/__tests__/appstate-sync.test.ts
+++ b/src/appstate/sync/__tests__/appstate-sync.test.ts
@@ -426,7 +426,7 @@ test('appstate sync applies catch-up patches on 409 conflict and re-uploads the 
         logger: createNoopLogger(),
         query,
         store,
-        mobilePrimary: true,
+        mobilePrimary: () => true,
         skipMacVerification: true
     })
 
@@ -491,7 +491,7 @@ test('mobile primary uploads patch from fresh state without requesting a snapsho
         logger: createNoopLogger(),
         query,
         store,
-        mobilePrimary: true,
+        mobilePrimary: () => true,
         skipMacVerification: true
     })
 

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -457,7 +457,7 @@ export function buildWaClientDependencies(input: {
         logger,
         defaultTimeoutMs: options.nodeQueryTimeoutMs,
         hostDomain: WA_DEFAULTS.HOST_DOMAIN,
-        mobileIqIdFormat: options.mobileTransport !== undefined
+        mobileIqIdFormat: () => isMobilePrimary()
     })
     const keepAlive = new WaKeepAlive({
         logger,
@@ -617,6 +617,9 @@ export function buildWaClientDependencies(input: {
 
     const getCurrentCredentials = authClient.getCurrentCredentials.bind(authClient)
 
+    const isMobilePrimary = (): boolean =>
+        options.mobileTransport !== undefined || Boolean(getCurrentCredentials()?.deviceInfo)
+
     const groupCoordinator = createGroupCoordinator({
         queryWithContext: runtime.queryWithContext,
         mexSocket: { query: runtime.query }
@@ -760,7 +763,7 @@ export function buildWaClientDependencies(input: {
                 additionalAttributes: sendOptions.additionalAttributes
             }),
         getIcdcHashLength: () => abPropsCoordinator.getConfigValue('md_icdc_hash_length'),
-        mobileMessageIdFormat: options.mobileTransport !== undefined,
+        mobileMessageIdFormat: isMobilePrimary,
         serverClock
     })
 
@@ -808,17 +811,13 @@ export function buildWaClientDependencies(input: {
         resolvePrivacyTokenNode: (recipientJid) =>
             trustedContactToken.resolveTokenForMessage(recipientJid),
         // Placeholder resend asks the primary phone (a peer) for the plaintext.
-        // A mobile primary has no peer to ask, so withhold the deps and fall
-        // back to plain retry receipts.
-        peerDataOperation: options.mobileTransport !== undefined ? undefined : peerDataOperation,
-        emitIncomingMessage:
-            options.mobileTransport !== undefined
-                ? undefined
-                : (event) => {
-                      void runtime
-                          .handleIncomingMessageEvent(event)
-                          .catch((err) => runtime.handleError(toError(err)))
-                  }
+        peerDataOperation,
+        emitIncomingMessage: (event) => {
+            void runtime
+                .handleIncomingMessageEvent(event)
+                .catch((err) => runtime.handleError(toError(err)))
+        },
+        isMobilePrimary
     })
 
     const botCoordinator = createBotCoordinator({
@@ -846,7 +845,7 @@ export function buildWaClientDependencies(input: {
             await messageDispatch.requestAppStateSyncKeys(keyIds)
         },
         skipMacVerification: options.dangerous?.disableAppStateMacVerification,
-        mobilePrimary: options.mobileTransport !== undefined,
+        mobilePrimary: isMobilePrimary,
         isOwnAccountDevice: (deviceJid) => {
             const credentials = getCurrentCredentials()
             if (!credentials) return false
@@ -1360,7 +1359,7 @@ export function buildWaClientDependencies(input: {
             abPropsCoordinator,
             markOnlineOnConnect: options.markOnlineOnConnect ?? false
         }),
-        mobilePrimary: options.mobileTransport !== undefined,
+        mobilePrimary: isMobilePrimary,
         appStateSync
     })
 

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -118,7 +118,12 @@ interface WaMessageDispatchCoordinatorOptions {
         contextInfo: WaSendContextInfo | null
     ) => Promise<WaMessagePublishResult>
     readonly getIcdcHashLength?: () => number
-    readonly mobileMessageIdFormat?: boolean
+    /**
+     * Resolved per outgoing message (post-connect, after credentials load) so a
+     * registered mobile session reconnecting without an explicit
+     * `mobileTransport` option still emits the mobile message-id format.
+     */
+    readonly mobileMessageIdFormat?: () => boolean
     readonly serverClock: ServerClock
 }
 
@@ -143,7 +148,7 @@ interface WaOutboundEnvelope {
 
 export class WaMessageDispatchCoordinator {
     private readonly deps: WaMessageDispatchCoordinatorOptions
-    private readonly mobileMessageIdFormat: boolean
+    private readonly mobileMessageIdFormat: () => boolean
     private readonly serverClock: ServerClock
     private readonly icdcDedup = new PromiseDedup()
     private readonly privacyTokenDedup = new PromiseDedup()
@@ -151,7 +156,7 @@ export class WaMessageDispatchCoordinator {
 
     public constructor(options: WaMessageDispatchCoordinatorOptions) {
         this.deps = options
-        this.mobileMessageIdFormat = options.mobileMessageIdFormat ?? false
+        this.mobileMessageIdFormat = options.mobileMessageIdFormat ?? (() => false)
         this.serverClock = options.serverClock
     }
 
@@ -1642,7 +1647,7 @@ export class WaMessageDispatchCoordinator {
                 timestampBytes.byteOffset,
                 timestampBytes.byteLength
             )
-            if (this.mobileMessageIdFormat) {
+            if (this.mobileMessageIdFormat()) {
                 dv.setBigUint64(0, BigInt(Date.now()), false)
                 const digest = md5Bytes([
                     timestampBytes,
@@ -1663,7 +1668,7 @@ export class WaMessageDispatchCoordinator {
             this.deps.logger.warn('failed to generate message id, falling back to random', {
                 message: toError(error).message
             })
-            if (this.mobileMessageIdFormat) {
+            if (this.mobileMessageIdFormat()) {
                 const bytes = await randomBytesAsync(16)
                 bytes[0] = 0xac
                 return bytesToHex(bytes).toUpperCase()

--- a/src/client/coordinators/WaPassiveTasksCoordinator.ts
+++ b/src/client/coordinators/WaPassiveTasksCoordinator.ts
@@ -47,7 +47,7 @@ export class WaPassiveTasksCoordinator {
     private readonly signedPreKeyRotationIntervalMs: number
     private readonly signedPreKeyServerErrorBackoffMs: number
     private readonly runtime: WaPassiveTasksRuntime
-    private readonly mobilePrimary: boolean
+    private readonly mobilePrimary: () => boolean
     private readonly appStateSync?: WaAppStateSyncClient
     private passiveTasksPromise: Promise<void> | null
 
@@ -60,7 +60,12 @@ export class WaPassiveTasksCoordinator {
         readonly signedPreKeyRotationIntervalMs?: number
         readonly signedPreKeyServerErrorBackoffMs?: number
         readonly runtime: WaPassiveTasksRuntime
-        readonly mobilePrimary?: boolean
+        /**
+         * Resolved when passive tasks run (post-connect, after credentials
+         * load) so a registered mobile-primary session reconnecting without an
+         * explicit `mobileTransport` option still bootstraps the primary path.
+         */
+        readonly mobilePrimary?: () => boolean
         readonly appStateSync?: WaAppStateSyncClient
     }) {
         this.logger = options.logger
@@ -73,7 +78,7 @@ export class WaPassiveTasksCoordinator {
         this.signedPreKeyServerErrorBackoffMs =
             options.signedPreKeyServerErrorBackoffMs ?? SIGNAL_SIGNED_PREKEY_SERVER_ERROR_BACKOFF_MS
         this.runtime = options.runtime
-        this.mobilePrimary = options.mobilePrimary ?? false
+        this.mobilePrimary = options.mobilePrimary ?? (() => false)
         this.appStateSync = options.appStateSync
         this.passiveTasksPromise = null
     }
@@ -123,7 +128,7 @@ export class WaPassiveTasksCoordinator {
 
         this.runtime.syncAbProps()
 
-        if (this.mobilePrimary && this.appStateSync) {
+        if (this.mobilePrimary() && this.appStateSync) {
             await this.appStateSync.ensureInitialSyncKey().catch((error) => {
                 this.logger.warn('app-state initial key generation failed', {
                     message: toError(error).message
@@ -238,7 +243,7 @@ export class WaPassiveTasksCoordinator {
                 count: preKeys.length,
                 lastPreKeyId
             },
-            this.mobilePrimary ? { useSystemId: true } : undefined
+            this.mobilePrimary() ? { useSystemId: true } : undefined
         )
         if (response.attrs.type === WA_IQ_TYPES.RESULT) {
             // Mark uploaded key first so the serverHasPreKeys flag never commits ahead of local key progress.

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -70,6 +70,15 @@ interface WaRetryCoordinatorOptions {
     readonly peerDataOperation?: PeerDataOperationRequester
     readonly emitIncomingMessage?: (event: WaIncomingMessageEvent) => void
     /**
+     * Placeholder resend asks the primary phone (a peer) for the plaintext. A
+     * mobile primary is itself the phone and has no peer to ask, so when this
+     * resolves true the coordinator skips the resend and falls back to plain
+     * retry receipts. Resolved per failure (post-connect, after credentials
+     * load) so a registered mobile session reconnecting without an explicit
+     * `mobileTransport` option still takes the fallback path.
+     */
+    readonly isMobilePrimary?: () => boolean
+    /**
      * Resolves the trusted-contact (privacy) token node for a recipient user
      * jid: retry resends must carry the same `<tctoken>` the original send did,
      * or privacy-gated recipients nack them with error 463.
@@ -1079,6 +1088,9 @@ export class WaRetryCoordinator {
 
     private enqueuePlaceholderResend(context: WaRetryDecryptFailureContext): boolean {
         if (!this.deps.peerDataOperation || !this.deps.emitIncomingMessage) {
+            return false
+        }
+        if (this.deps.isMobilePrimary?.()) {
             return false
         }
         const subtype = context.messageNode.attrs.subtype

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -111,7 +111,7 @@ function createMessageDispatchCoordinator(
     groupMetadataStore: WaGroupMetadataMemoryStore,
     overrides?: {
         readonly meJid?: string
-        readonly mobileMessageIdFormat?: boolean
+        readonly mobileMessageIdFormat?: () => boolean
         readonly serverClock?: ServerClock
     }
 ): WaMessageDispatchCoordinator {
@@ -742,7 +742,7 @@ test('mobile message id format: AC + 30 hex chars uppercase', async () => {
     const groupMetadataStore = new WaGroupMetadataMemoryStore(60_000)
     const coordinator = createMessageDispatchCoordinator(groupMetadataStore, {
         meJid: '5596965746475@s.whatsapp.net',
-        mobileMessageIdFormat: true
+        mobileMessageIdFormat: () => true
     })
     const gen = coordinator as unknown as {
         generateOutgoingMessageId(): Promise<string>

--- a/src/transport/node/WaNodeOrchestrator.ts
+++ b/src/transport/node/WaNodeOrchestrator.ts
@@ -16,7 +16,12 @@ interface WaNodeOrchestratorOptions {
     readonly sendNode: (node: BinaryNode) => Promise<void>
     readonly defaultTimeoutMs?: number
     readonly hostDomain?: string
-    readonly mobileIqIdFormat?: boolean
+    /**
+     * Resolved lazily on first id-generator creation (post-connect, after
+     * credentials load) so a registered mobile session reconnecting without an
+     * explicit `mobileTransport` option still picks the mobile id format.
+     */
+    readonly mobileIqIdFormat?: () => boolean
 }
 
 /**
@@ -29,7 +34,7 @@ export class WaNodeOrchestrator {
     private readonly sendNodeFn: (node: BinaryNode) => Promise<void>
     private readonly defaultTimeoutMs: number
     private readonly hostDomain: string
-    private readonly mobileIqIdFormat: boolean
+    private readonly mobileIqIdFormat: () => boolean
     private idGenerator: NodeIdGenerator | null
     private idGeneratorReady: Promise<NodeIdGenerator> | null
     private readonly pendingQueries: Map<string, PendingNodeQuery>
@@ -39,7 +44,7 @@ export class WaNodeOrchestrator {
         this.sendNodeFn = options.sendNode
         this.defaultTimeoutMs = options.defaultTimeoutMs ?? WA_DEFAULTS.NODE_QUERY_TIMEOUT_MS
         this.hostDomain = options.hostDomain ?? WA_DEFAULTS.HOST_DOMAIN
-        this.mobileIqIdFormat = options.mobileIqIdFormat === true
+        this.mobileIqIdFormat = options.mobileIqIdFormat ?? (() => false)
         this.idGenerator = null
         this.idGeneratorReady = null
         this.pendingQueries = new Map()
@@ -180,7 +185,7 @@ export class WaNodeOrchestrator {
         if (this.idGenerator) {
             return this.idGenerator
         }
-        if (this.mobileIqIdFormat) {
+        if (this.mobileIqIdFormat()) {
             this.idGenerator = createMobileNodeIdGenerator()
             this.logger.debug('generated stanza prefix (mobile)', {
                 prefix: this.idGenerator.prefix

--- a/src/transport/node/__tests__/node.test.ts
+++ b/src/transport/node/__tests__/node.test.ts
@@ -244,6 +244,40 @@ test('WaNodeOrchestrator query timeout supports fake timers', async (t) => {
     await assert.rejects(() => pending, /query timeout/)
 })
 
+test('WaNodeOrchestrator resolves the mobile id format lazily at first send', async () => {
+    const sentNodes: BinaryNode[] = []
+    let mobile = false
+    const orchestrator = new WaNodeOrchestrator({
+        logger: createNoopLogger(),
+        sendNode: async (node) => {
+            sentNodes.push(node)
+        },
+        mobileIqIdFormat: () => mobile
+    })
+
+    mobile = true
+    await orchestrator.sendNode({ tag: 'iq', attrs: { type: 'get', xmlns: 'w:test' } })
+
+    const id = sentNodes[0]?.attrs.id ?? ''
+    assert.match(id, /^0[0-9a-f]*$/, `id '${id}' is not the mobile format`)
+})
+
+test('WaNodeOrchestrator uses the web id format when the mobile thunk stays false', async () => {
+    const sentNodes: BinaryNode[] = []
+    const orchestrator = new WaNodeOrchestrator({
+        logger: createNoopLogger(),
+        sendNode: async (node) => {
+            sentNodes.push(node)
+        },
+        mobileIqIdFormat: () => false
+    })
+
+    await orchestrator.sendNode({ tag: 'iq', attrs: { type: 'get', xmlns: 'w:test' } })
+
+    const id = sentNodes[0]?.attrs.id ?? ''
+    assert.match(id, /^\d+\.\d+-\d+$/, `id '${id}' is not the web format`)
+})
+
 test('xml formatter escapes attributes and supports string bytes and children nodes', () => {
     const xml = formatBinaryNodeAsXml({
         tag: 'iq',


### PR DESCRIPTION
A registered mobile session reconnects in mobile mode straight from persisted credentials.deviceInfo via buildCommsConfig, but the factory independently derived its mobile-primary flags from options.mobileTransport. Omitting the option on reconnect left IQ/message id format, app-state primary gating, and placeholder-resend withholding stuck in web mode.

Replace those static booleans with a single isMobilePrimary() thunk (the option wins, otherwise persisted deviceInfo decides), read lazily by each consumer after credentials load. A registered mobile session no longer needs the caller to re-pass { mobileTransport } on every construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Mobile device detection now evaluates dynamically during operations rather than at initialization.
  * Centralized mobile detection logic across multiple system components for consistent device handling.
  * Updated message ID generation and sync operations to reflect real-time device configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->