### PR TITLE
fix(privacy-token): attach tctoken to presence subscribe, picture get and status usync

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -769,7 +769,8 @@ export function buildWaClientDependencies(input: {
 
     const presenceCoordinator = createPresenceCoordinator({
         sendNode: (node) => nodeOrchestrator.sendNode(node, false),
-        getCurrentCredentials
+        getCurrentCredentials,
+        resolvePrivacyTokenNode: (jid) => trustedContactToken.resolveReceiverTokenNode(jid)
     })
 
     const peerDataOperation = createPeerDataOperationRequester({
@@ -902,6 +903,7 @@ export function buildWaClientDependencies(input: {
         queryLidsByPhoneJids: (phoneJids) => signalDeviceSync.queryLidsByPhoneJids(phoneJids),
         mutations: appStateMutations,
         applyOwnPushName,
+        resolvePrivacyTokenNode: (jid) => trustedContactToken.resolveReceiverTokenNode(jid),
         logger
     })
 

--- a/src/client/coordinators/WaPresenceCoordinator.ts
+++ b/src/client/coordinators/WaPresenceCoordinator.ts
@@ -1,4 +1,5 @@
 import type { WaAuthCredentials } from '@auth/types'
+import { isGroupJid } from '@protocol/jid'
 import {
     buildChatstateNode,
     type BuildChatstateNodeInput
@@ -36,13 +37,19 @@ export interface WaPresenceCoordinator {
 interface WaPresenceCoordinatorOptions {
     readonly sendNode: (node: BinaryNode) => Promise<void>
     readonly getCurrentCredentials: () => WaAuthCredentials | null
+    /**
+     * Resolves the receiver-mode `<tctoken>` node for a contact, echoed back
+     * on a user presence subscription to unlock the target's presence
+     * visibility. Returns `null` when no valid token is held.
+     */
+    readonly resolvePrivacyTokenNode: (jid: string) => Promise<BinaryNode | null>
 }
 
 /** Builds a {@link WaPresenceCoordinator} from its node-send dependency. */
 export function createPresenceCoordinator(
     options: WaPresenceCoordinatorOptions
 ): WaPresenceCoordinator {
-    const { sendNode, getCurrentCredentials } = options
+    const { sendNode, getCurrentCredentials, resolvePrivacyTokenNode } = options
     return {
         send: async (type) => {
             const credentials = getCurrentCredentials()
@@ -54,7 +61,14 @@ export function createPresenceCoordinator(
             await sendNode(buildChatstateNode({ jid, ...opts }))
         },
         subscribe: async (jid, opts) => {
-            await sendNode(buildPresenceSubscribeNode({ jid, ...opts }))
+            const privacyTokenNode = isGroupJid(jid) ? null : await resolvePrivacyTokenNode(jid)
+            await sendNode(
+                buildPresenceSubscribeNode({
+                    jid,
+                    ...opts,
+                    ...(privacyTokenNode ? { privacyTokenNode } : {})
+                })
+            )
         }
     }
 }

--- a/src/client/coordinators/WaProfileCoordinator.ts
+++ b/src/client/coordinators/WaProfileCoordinator.ts
@@ -202,6 +202,13 @@ interface WaProfileCoordinatorOptions {
      * idempotent (a no-op when the name already matches).
      */
     readonly applyOwnPushName: (name: string) => Promise<void>
+    /**
+     * Resolves the receiver-mode `<tctoken>` node for a contact, echoed back on
+     * privacy-gated profile queries (picture get, about/status usync) to prove
+     * this account is a trusted contact. Returns `null` when no valid token is
+     * held for the JID.
+     */
+    readonly resolvePrivacyTokenNode: (jid: string) => Promise<BinaryNode | null>
     readonly logger: Logger
 }
 
@@ -443,12 +450,14 @@ export function createProfileCoordinator(
         queryLidsByPhoneJids,
         mutations,
         applyOwnPushName,
+        resolvePrivacyTokenNode,
         logger
     } = options
 
     return {
         getProfilePicture: async (jid, type, existingId) => {
-            const node = buildGetProfilePictureIq(jid, type, existingId)
+            const privacyTokenNode = (await resolvePrivacyTokenNode(jid)) ?? undefined
+            const node = buildGetProfilePictureIq(jid, type, existingId, privacyTokenNode)
             const result = await queryWithContext('profile.getPicture', node, undefined, {
                 jid,
                 type: type ?? 'preview'
@@ -478,10 +487,11 @@ export function createProfileCoordinator(
         getStatus: async (jid) => {
             const sid = await generateSid()
             const queryNodes = buildGetStatusUsyncQueryNodes()
+            const privacyTokenNode = await resolvePrivacyTokenNode(jid)
             const usyncNode = buildUsyncIq({
                 sid,
                 queryProtocolNodes: [queryNodes[1]],
-                users: [{ jid }]
+                users: [{ jid, ...(privacyTokenNode ? { content: [privacyTokenNode] } : {}) }]
             })
             const result = await queryWithContext('profile.getStatus', usyncNode, undefined, {
                 jid
@@ -512,10 +522,16 @@ export function createProfileCoordinator(
             }
             const sid = await generateSid()
             const queryProtocolNodes = buildGetStatusUsyncQueryNodes()
+            const users = await Promise.all(
+                jids.map(async (jid) => {
+                    const privacyTokenNode = await resolvePrivacyTokenNode(jid)
+                    return { jid, ...(privacyTokenNode ? { content: [privacyTokenNode] } : {}) }
+                })
+            )
             const usyncNode = buildUsyncIq({
                 sid,
                 queryProtocolNodes,
-                users: jids.map((jid) => ({ jid }))
+                users
             })
             const result = await queryWithContext('profile.getProfiles', usyncNode, undefined, {
                 count: jids.length

--- a/src/client/coordinators/WaTrustedContactTokenCoordinator.ts
+++ b/src/client/coordinators/WaTrustedContactTokenCoordinator.ts
@@ -110,17 +110,31 @@ export class WaTrustedContactTokenCoordinator {
         }
     }
 
-    public async resolveTokenForMessage(recipientJid: string): Promise<BinaryNode | null> {
-        const record = await this.store.getByJid(recipientJid)
-        const nowS = this.serverClock.nowSeconds()
-
+    /**
+     * Resolves the receiver-mode `<tctoken>` node to echo back on outbound
+     * queries against a contact's privacy-gated data (presence subscribe,
+     * profile-picture get, about/status usync). Returns the token only when a
+     * non-expired receiver token exists for `jid`; unlike
+     * {@link resolveTokenForMessage} it does **not** fall back to a `<cstoken>`
+     * (the gated query flows attach the trusted-contact token only).
+     */
+    public async resolveReceiverTokenNode(jid: string): Promise<BinaryNode | null> {
+        const record = await this.store.getByJid(jid)
+        if (!record?.tcToken || record.tcTokenTimestamp === undefined) {
+            return null
+        }
         const config = this.resolveConfig()
-        if (
-            record?.tcToken &&
-            record.tcTokenTimestamp !== undefined &&
-            !isTokenExpired(record.tcTokenTimestamp, nowS, config.durationS, config.numBuckets)
-        ) {
-            return buildTcTokenMessageNode(record.tcToken)
+        const nowS = this.serverClock.nowSeconds()
+        if (isTokenExpired(record.tcTokenTimestamp, nowS, config.durationS, config.numBuckets)) {
+            return null
+        }
+        return buildTcTokenMessageNode(record.tcToken)
+    }
+
+    public async resolveTokenForMessage(recipientJid: string): Promise<BinaryNode | null> {
+        const tcTokenNode = await this.resolveReceiverTokenNode(recipientJid)
+        if (tcTokenNode) {
+            return tcTokenNode
         }
 
         const nctSalt = await this.getNctSalt()

--- a/src/client/coordinators/__tests__/presence-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/presence-coordinator.test.ts
@@ -5,15 +5,23 @@ import type { WaAuthCredentials } from '@auth/types'
 import { createPresenceCoordinator } from '@client/coordinators/WaPresenceCoordinator'
 import type { BinaryNode } from '@transport/types'
 
-function makeHarness(credentials: Partial<WaAuthCredentials> | null = null) {
+function makeHarness(
+    credentials: Partial<WaAuthCredentials> | null = null,
+    privacyTokenNode: BinaryNode | null = null
+) {
     const sent: BinaryNode[] = []
+    const tokenRequests: string[] = []
     const coordinator = createPresenceCoordinator({
         sendNode: async (node) => {
             sent.push(node)
         },
-        getCurrentCredentials: () => (credentials as WaAuthCredentials | null) ?? null
+        getCurrentCredentials: () => (credentials as WaAuthCredentials | null) ?? null,
+        resolvePrivacyTokenNode: async (jid) => {
+            tokenRequests.push(jid)
+            return privacyTokenNode
+        }
     })
-    return { coordinator, sent }
+    return { coordinator, sent, tokenRequests }
 }
 
 test('presence.send emits a presence node with the current display name', async () => {
@@ -51,4 +59,21 @@ test('presence.subscribe sends a presence subscribe node for the jid', async () 
     assert.equal(sent[0].tag, 'presence')
     assert.equal(sent[0].attrs.type, 'subscribe')
     assert.equal(sent[0].attrs.to, '5511999999999@s.whatsapp.net')
+    assert.equal(sent[0].content, undefined)
+})
+
+test('presence.subscribe attaches the receiver tctoken when held', async () => {
+    const tokenNode: BinaryNode = { tag: 'tctoken', attrs: {}, content: new Uint8Array([1, 2, 3]) }
+    const { coordinator, sent, tokenRequests } = makeHarness(null, tokenNode)
+    await coordinator.subscribe('5511999999999@s.whatsapp.net')
+    assert.deepEqual(tokenRequests, ['5511999999999@s.whatsapp.net'])
+    assert.deepEqual(sent[0].content, [tokenNode])
+})
+
+test('presence.subscribe skips the tctoken lookup for group jids', async () => {
+    const tokenNode: BinaryNode = { tag: 'tctoken', attrs: {}, content: new Uint8Array([1]) }
+    const { coordinator, sent, tokenRequests } = makeHarness(null, tokenNode)
+    await coordinator.subscribe('123456789-987654321@g.us')
+    assert.deepEqual(tokenRequests, [])
+    assert.equal(sent[0].content, undefined)
 })

--- a/src/client/coordinators/__tests__/profile-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/profile-coordinator.test.ts
@@ -25,6 +25,7 @@ test('profile coordinator gets profile picture url', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -68,6 +69,7 @@ test('profile coordinator returns empty result when no picture node', async () =
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -88,6 +90,7 @@ test('profile coordinator gets full image picture with existing id', async () =>
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -126,6 +129,7 @@ test('profile coordinator sets profile picture and returns id', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -162,6 +166,7 @@ test('profile coordinator sets group profile picture with target jid', async () 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -186,6 +191,7 @@ test('profile coordinator deletes profile picture', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -214,6 +220,7 @@ test('profile coordinator gets status via usync', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -261,6 +268,7 @@ test('profile coordinator returns null status when no content', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -296,6 +304,7 @@ test('profile coordinator returns empty string for status code 401', async () =>
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -336,6 +345,7 @@ test('profile coordinator gets multiple profiles via usync', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -402,6 +412,7 @@ test('profile coordinator sets status text', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -434,6 +445,7 @@ test('profile coordinator setPushName applies locally before the SettingPushName
             events.push('apply')
             appliedNames.push(name)
         },
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: {
             set: async (input: unknown) => {
@@ -467,6 +479,7 @@ test('profile coordinator sets account default disappearing mode', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -496,6 +509,7 @@ test('profile coordinator gets disappearing mode via usync', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -558,6 +572,7 @@ test('profile coordinator returns empty disappearing mode for empty jids', async
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -582,6 +597,7 @@ test('profile coordinator gets text statuses via usync', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -666,6 +682,7 @@ test('profile coordinator emits null text_status entry on error nodes', async ()
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -721,6 +738,7 @@ test('profile coordinator returns empty text statuses for empty jids', async () 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -761,6 +779,7 @@ test('profile coordinator sets text status via mex', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -814,6 +833,7 @@ test('profile coordinator setTextStatus normalizes empty inputs to clear payload
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -839,6 +859,7 @@ test('profile coordinator gets usernames via usync', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -914,6 +935,7 @@ test('profile coordinator returns empty usernames for empty jids', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -932,6 +954,7 @@ test('profile coordinator getOwnUsername parses mex payload', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -970,6 +993,7 @@ test('profile coordinator getOwnUsername swallows 404 GraphQL errors', async () 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -1006,6 +1030,7 @@ test('profile coordinator getOwnUsername returns nulls when info missing', async
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -1035,6 +1060,7 @@ test('profile coordinator setUsername sends mex variables with defaults', async 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -1082,6 +1108,7 @@ test('profile coordinator setUsername returns false on non-SUCCESS result', asyn
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -1110,6 +1137,7 @@ test('profile coordinator deleteUsername sends empty variables', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -1154,6 +1182,7 @@ test('profile coordinator returns empty array for empty jids list', async () => 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         queryLidsByPhoneJids: async () => [],
@@ -1175,6 +1204,7 @@ test('profile coordinator resolves lids by phone numbers', async () => {
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
@@ -1209,6 +1239,7 @@ test('profile coordinator returns empty lid result without calling port', async 
     const coordinator = createProfileCoordinator({
         generateSid: async () => 'test-sid',
         applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
         logger: createNoopLogger(),
         mutations: { set: async () => undefined } as never,
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },

--- a/src/transport/node/builders/presence.ts
+++ b/src/transport/node/builders/presence.ts
@@ -26,6 +26,12 @@ export interface BuildPresenceSubscribeNodeInput {
     readonly jid: string
     readonly name?: string
     readonly context?: string
+    /**
+     * Receiver-mode `<tctoken>` node echoed back to prove this account is a
+     * trusted contact, gating the target's presence/last-seen visibility.
+     * Attached as a child of the `<presence>` stanza when present.
+     */
+    readonly privacyTokenNode?: BinaryNode
 }
 
 function assertSubscribeJid(jid: string): void {
@@ -49,6 +55,7 @@ export function buildPresenceSubscribeNode(input: BuildPresenceSubscribeNodeInpu
     }
     return {
         tag: WA_NODE_TAGS.PRESENCE,
-        attrs
+        attrs,
+        ...(input.privacyTokenNode ? { content: [input.privacyTokenNode] } : {})
     }
 }

--- a/src/transport/node/builders/profile.ts
+++ b/src/transport/node/builders/profile.ts
@@ -7,7 +7,8 @@ export type WaProfilePictureType = 'preview' | 'image'
 export function buildGetProfilePictureIq(
     targetJid: string,
     type: WaProfilePictureType = 'preview',
-    existingId?: string
+    existingId?: string,
+    privacyTokenNode?: BinaryNode
 ): BinaryNode {
     const pictureAttrs: Record<string, string> = {
         type,
@@ -23,7 +24,8 @@ export function buildGetProfilePictureIq(
         [
             {
                 tag: WA_NODE_TAGS.PICTURE,
-                attrs: pictureAttrs
+                attrs: pictureAttrs,
+                ...(privacyTokenNode ? { content: [privacyTokenNode] } : {})
             }
         ],
         {


### PR DESCRIPTION
WhatsApp Web echoes the receiver-mode trusted-contact token back on outbound queries against a contact's privacy-gated data, to prove the account is a trusted contact. Previously zapo attached the tctoken only on message send; these read queries went out without it.

- add resolveReceiverTokenNode() on the trusted-contact coordinator: returns the <tctoken> node only when a non-expired receiver token is held, with no cstoken fallback (that fallback is message-send only). resolveTokenForMessage now reuses it.
- presence subscribe: attach the token for user jids, skipping group jids (parity with the tokenless group subscription path).
- profile picture get: nest the token inside <picture>.
- about/status usync (getStatus, getProfiles): attach the token as a direct child of the per-user <user> node, matching the status protocol element.

Verified live against registered sessions: the token lands in the exact protocol position on all four flows and the server accepts the queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Presence subscriptions can optionally include per-contact privacy tokens for individual JIDs.
  * Profile operations (profile picture, status, bulk lookups) now support optional privacy tokens per target.
  * Privacy tokens are resolved and conditionally attached to outgoing presence/profile requests.

* **Tests**
  * Presence tests added to verify token attachment for individual JIDs and skipping for groups.
  * Profile tests updated to initialize coordinators with the privacy-token resolver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->