### PR TITLE
fix(message): resolve fromMe and chat for self-sent 1:1 messages

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -99,7 +99,12 @@ import {
     WA_NOTIFICATION_TYPES,
     WA_PRIVACY_TOKEN_NOTIFICATION_TYPE
 } from '@protocol/constants'
-import { isNewsletterJid, parseSignalAddressFromJid, toUserJid } from '@protocol/jid'
+import {
+    isNewsletterJid,
+    isOwnAccountJid,
+    parseSignalAddressFromJid,
+    toUserJid
+} from '@protocol/jid'
 import { WA_PRESENCE_TYPES } from '@protocol/presence'
 import type { WaConnectionCode, WaConnectionOpenReason, WaDisconnectReason } from '@protocol/stream'
 import { createOutboundRetryTracker } from '@retry/tracker'
@@ -850,11 +855,7 @@ export function buildWaClientDependencies(input: {
         isOwnAccountDevice: (deviceJid) => {
             const credentials = getCurrentCredentials()
             if (!credentials) return false
-            const candidateUser = toUserJid(deviceJid)
-            return (
-                (!!credentials.meJid && toUserJid(credentials.meJid) === candidateUser) ||
-                (!!credentials.meLid && toUserJid(credentials.meLid) === candidateUser)
-            )
+            return isOwnAccountJid(deviceJid, credentials.meJid, credentials.meLid)
         },
         sendKeyShare: (toDeviceJid, keys, missingKeyIds) =>
             messageDispatch.sendAppStateSyncKeyShare(toDeviceJid, keys, missingKeyIds),
@@ -999,6 +1000,7 @@ export function buildWaClientDependencies(input: {
         logger,
         sendNode: runtime.sendNode,
         getMeJid: () => getCurrentCredentials()?.meJid,
+        getMeLid: () => getCurrentCredentials()?.meLid,
         signalProtocol,
         senderKeyManager,
         onDecryptFailure: (context: WaRetryDecryptFailureContext, error: unknown) =>

--- a/src/message/primitives/__tests__/incoming.test.ts
+++ b/src/message/primitives/__tests__/incoming.test.ts
@@ -37,12 +37,21 @@ function paddedPlaintext(message: proto.IMessage): Uint8Array {
     return out
 }
 
-function createDecryptingOptions(emitted: WaIncomingMessageEvent[]) {
+function createDecryptingOptions(
+    emitted: WaIncomingMessageEvent[],
+    overrides: {
+        readonly message?: proto.IMessage
+        readonly getMeJid?: () => string | null | undefined
+        readonly getMeLid?: () => string | null | undefined
+    } = {}
+) {
     return {
         logger: createNoopLogger(),
         sendNode: async () => undefined,
+        getMeJid: overrides.getMeJid,
+        getMeLid: overrides.getMeLid,
         signalProtocol: {
-            decryptMessage: async () => paddedPlaintext({ conversation: 'hi' })
+            decryptMessage: async () => paddedPlaintext(overrides.message ?? { conversation: 'hi' })
         } as never,
         emitIncomingMessage: (event: WaIncomingMessageEvent) => {
             emitted.push(event)
@@ -112,6 +121,112 @@ test('1:1 incoming message strips the device from remoteJid and keeps it in send
     assert.equal(key.senderDevice, 12)
     assert.equal(key.isGroup, false)
     assert.equal(key.participant, undefined)
+})
+
+test('1:1 message authored by my own other device is fromMe with the recipient as remoteJid', async () => {
+    const emitted: WaIncomingMessageEvent[] = []
+    const handled = await handleIncomingMessageAck(
+        {
+            tag: 'message',
+            attrs: {
+                id: 'msg-self',
+                from: '5511999999999:12@s.whatsapp.net',
+                recipient: '5511888888888@s.whatsapp.net',
+                t: '123'
+            },
+            content: [{ tag: 'enc', attrs: { type: 'msg' }, content: new Uint8Array([1]) }]
+        },
+        createDecryptingOptions(emitted, {
+            getMeJid: () => '5511999999999:2@s.whatsapp.net'
+        })
+    )
+
+    assert.equal(handled, true)
+    assert.equal(emitted.length, 1)
+    const { key } = emitted[0]
+    assert.equal(key.fromMe, true)
+    assert.equal(key.remoteJid, '5511888888888@s.whatsapp.net')
+    assert.equal(key.senderDevice, 12)
+    assert.equal(key.isGroup, false)
+    assert.equal(key.participant, undefined)
+})
+
+test('1:1 self-sent message resolves the chat from the deviceSentMessage destination', async () => {
+    const emitted: WaIncomingMessageEvent[] = []
+    const handled = await handleIncomingMessageAck(
+        {
+            tag: 'message',
+            attrs: {
+                id: 'msg-dsm',
+                from: '5511999999999:12@s.whatsapp.net',
+                t: '123'
+            },
+            content: [{ tag: 'enc', attrs: { type: 'msg' }, content: new Uint8Array([1]) }]
+        },
+        createDecryptingOptions(emitted, {
+            getMeJid: () => '5511999999999@s.whatsapp.net',
+            message: {
+                deviceSentMessage: {
+                    destinationJid: '5511888888888@s.whatsapp.net',
+                    message: { conversation: 'hi from my phone' }
+                }
+            }
+        })
+    )
+
+    assert.equal(handled, true)
+    assert.equal(emitted.length, 1)
+    const { key } = emitted[0]
+    assert.equal(key.fromMe, true)
+    assert.equal(key.remoteJid, '5511888888888@s.whatsapp.net')
+})
+
+test('1:1 message from my lid identity is detected as fromMe', async () => {
+    const emitted: WaIncomingMessageEvent[] = []
+    await handleIncomingMessageAck(
+        {
+            tag: 'message',
+            attrs: {
+                id: 'msg-self-lid',
+                from: '133300000000000:5@lid',
+                recipient: '144400000000000@lid',
+                t: '123'
+            },
+            content: [{ tag: 'enc', attrs: { type: 'msg' }, content: new Uint8Array([1]) }]
+        },
+        createDecryptingOptions(emitted, {
+            getMeJid: () => '5511999999999@s.whatsapp.net',
+            getMeLid: () => '133300000000000@lid'
+        })
+    )
+
+    assert.equal(emitted.length, 1)
+    const { key } = emitted[0]
+    assert.equal(key.fromMe, true)
+    assert.equal(key.remoteJid, '144400000000000@lid')
+})
+
+test('1:1 incoming message from a peer stays fromMe false with the peer as remoteJid', async () => {
+    const emitted: WaIncomingMessageEvent[] = []
+    await handleIncomingMessageAck(
+        {
+            tag: 'message',
+            attrs: {
+                id: 'msg-peer',
+                from: '5511888888888:3@s.whatsapp.net',
+                t: '123'
+            },
+            content: [{ tag: 'enc', attrs: { type: 'msg' }, content: new Uint8Array([1]) }]
+        },
+        createDecryptingOptions(emitted, {
+            getMeJid: () => '5511999999999@s.whatsapp.net'
+        })
+    )
+
+    assert.equal(emitted.length, 1)
+    const { key } = emitted[0]
+    assert.equal(key.fromMe, false)
+    assert.equal(key.remoteJid, '5511888888888@s.whatsapp.net')
 })
 
 test('group incoming message keeps the group remoteJid and carries the device on the participant', async () => {

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -1,5 +1,6 @@
 import type {
     WaIncomingMessageEvent,
+    WaIncomingMessageKey,
     WaIncomingNewsletterMessageUpdateEvent,
     WaIncomingUnhandledStanzaEvent
 } from '@client/types'
@@ -14,6 +15,7 @@ import {
     isBroadcastJid,
     isGroupJid,
     isNewsletterJid,
+    isOwnAccountJid,
     parseJidFull,
     parseSignalAddressFromJid,
     toUserJid
@@ -31,6 +33,7 @@ interface WaIncomingMessageAckHandlerOptions {
     readonly logger: Logger
     readonly sendNode: (node: BinaryNode) => Promise<void>
     readonly getMeJid?: () => string | null | undefined
+    readonly getMeLid?: () => string | null | undefined
     readonly signalProtocol?: SignalProtocol
     readonly senderKeyManager?: SenderKeyManager
     readonly onDecryptFailure?: (
@@ -68,6 +71,62 @@ function extractMessageIdentityAttrs(attrs: BinaryNode['attrs']): MessageIdentit
         ...(rawRecipient ? { recipientJid: toUserJid(rawRecipient) } : {}),
         ...(rawRecipientAlt ? { recipientAlt: toUserJid(rawRecipientAlt) } : {}),
         pushName: attrs.notify
+    }
+}
+
+type MessageKeyIdentity = Omit<MessageIdentityAttrs, 'pushName'>
+
+/**
+ * Self-authored 1:1 chat is the recipient, so its alternate addressing is the
+ * `recipient*` attrs (the `sender*` attrs describe me). Promotes `recipientAlt`
+ * to `remoteJidAlt` and drops the stale sender/recipient fields.
+ */
+function promoteRecipientAddressing(identity: MessageKeyIdentity): MessageKeyIdentity {
+    return {
+        ...(identity.recipientAlt ? { remoteJidAlt: identity.recipientAlt } : {}),
+        ...(identity.senderUsername !== undefined
+            ? { senderUsername: identity.senderUsername }
+            : {})
+    }
+}
+
+/**
+ * Resolves the {@link WaIncomingMessageKey} for a decrypted stanza. `remoteJid`
+ * is the chat: the `from`, or the recipient (`recipient` attr, then the
+ * deviceSentMessage `destinationJid`) when the message is `fromMe`.
+ */
+function buildIncomingMessageKey(
+    node: BinaryNode,
+    sender: { readonly userJid: string; readonly device: number } | null,
+    options: WaIncomingMessageAckHandlerOptions,
+    destinationJid?: string
+): { readonly key: WaIncomingMessageKey; readonly pushName: string | undefined } {
+    const fromUserJid = node.attrs.from ? toUserJid(node.attrs.from) : node.attrs.from
+    const isGroup = fromUserJid ? isGroupJid(fromUserJid) : false
+    const isBroadcast = fromUserJid ? isBroadcastJid(fromUserJid) : false
+    const fromMe = sender
+        ? isOwnAccountJid(sender.userJid, options.getMeJid?.(), options.getMeLid?.())
+        : false
+    const selfSentChat =
+        fromMe && !isGroup && !isBroadcast
+            ? (node.attrs.recipient ?? destinationJid ?? undefined)
+            : undefined
+    const chatJid = selfSentChat ? toUserJid(selfSentChat) : fromUserJid
+    const { pushName, ...identity } = extractMessageIdentityAttrs(node.attrs)
+    const keyIdentity = selfSentChat ? promoteRecipientAddressing(identity) : identity
+    return {
+        pushName,
+        key: {
+            remoteJid: chatJid ?? '',
+            id: node.attrs.id ?? '',
+            fromMe,
+            isGroup,
+            isBroadcast,
+            isNewsletter: false,
+            ...keyIdentity,
+            senderDevice: sender?.device ?? 0,
+            ...((isGroup || isBroadcast) && sender ? { participant: sender.userJid } : {})
+        }
     }
 }
 
@@ -330,26 +389,15 @@ function processMsmsgEncNode(
                 encPayload: decoded.encPayload
             }
         }
-        const chatJid = node.attrs.from ? toUserJid(node.attrs.from) : node.attrs.from
         const sender = senderJid ? parseJidFull(senderJid) : null
-        const isGroup = chatJid ? isGroupJid(chatJid) : false
-        const isBroadcast = chatJid ? isBroadcastJid(chatJid) : false
-        const { pushName, ...keyIdentity } = extractMessageIdentityAttrs(node.attrs)
+        const { key, pushName } = buildIncomingMessageKey(
+            node,
+            sender ? { userJid: sender.userJid, device: sender.address.device } : null,
+            options
+        )
         options.emitIncomingMessage?.({
             rawNode: buildIncomingEventRawNode(node),
-            key: {
-                remoteJid: chatJid ?? '',
-                id: node.attrs.id ?? '',
-                fromMe: false,
-                isGroup,
-                isBroadcast,
-                isNewsletter: false,
-                ...keyIdentity,
-                ...((isGroup || isBroadcast) && sender?.userJid
-                    ? { participant: sender.userJid }
-                    : {}),
-                senderDevice: sender?.address.device ?? 0
-            },
+            key,
             stanzaType: node.attrs.type,
             offline: node.attrs.offline !== undefined,
             timestampSeconds: parseOptionalInt(node.attrs.t),
@@ -416,29 +464,19 @@ async function decryptAndProcessEncNode(
             }
         }
         if (shouldEmitIncomingMessage(message)) {
-            // remoteJid is the chat identity, which is deviceless: the device
-            // lives in senderDevice (from senderAddress), so strip any `:device`
-            // segment the `from` attr carries for 1:1 chats.
-            const fromAttr = node.attrs.from
-            const chatJid = fromAttr ? toUserJid(fromAttr) : fromAttr
-            const isGroup = chatJid ? isGroupJid(chatJid) : false
-            const isBroadcast = chatJid ? isBroadcastJid(chatJid) : false
-            const senderUserJid = `${senderAddress.user}@${senderAddress.server}`
-            const { pushName, ...keyIdentity } = extractMessageIdentityAttrs(node.attrs)
+            const { key, pushName } = buildIncomingMessageKey(
+                node,
+                {
+                    userJid: `${senderAddress.user}@${senderAddress.server}`,
+                    device: senderAddress.device
+                },
+                options,
+                decodedMessage.deviceSentMessage?.destinationJid ?? undefined
+            )
             const expirationSeconds = pickIncomingExpirationSeconds(message)
             options.emitIncomingMessage?.({
                 rawNode: buildIncomingEventRawNode(node),
-                key: {
-                    remoteJid: chatJid ?? '',
-                    id: node.attrs.id ?? '',
-                    fromMe: false,
-                    isGroup,
-                    isBroadcast,
-                    isNewsletter: false,
-                    ...keyIdentity,
-                    senderDevice: senderAddress.device,
-                    ...(isGroup || isBroadcast ? { participant: senderUserJid } : {})
-                },
+                key,
                 stanzaType: node.attrs.type,
                 offline: node.attrs.offline !== undefined,
                 timestampSeconds: parseOptionalInt(node.attrs.t),

--- a/src/protocol/__tests__/protocol.test.ts
+++ b/src/protocol/__tests__/protocol.test.ts
@@ -30,6 +30,7 @@ import {
     isHostedDeviceJid,
     isHostedServer,
     isNewsletterJid,
+    isOwnAccountJid,
     isStatusBroadcastJid,
     normalizeDeviceJid,
     normalizeRecipientJid,
@@ -83,6 +84,12 @@ test('jid type detection and device handling', () => {
     assert.throws(() => parseSignalAddressFromJid('5511:x@s.whatsapp.net'), /invalid jid device/)
 
     assert.equal(toUserJid('5511:3@s.whatsapp.net'), '5511@s.whatsapp.net')
+
+    assert.equal(isOwnAccountJid('5511:7@s.whatsapp.net', '5511@s.whatsapp.net', null), true)
+    assert.equal(isOwnAccountJid('1330@lid', '5511@s.whatsapp.net', '1330@lid'), true)
+    assert.equal(isOwnAccountJid('5599@s.whatsapp.net', '5511@s.whatsapp.net', '1330@lid'), false)
+    assert.equal(isOwnAccountJid('5511@s.whatsapp.net', null, null), false)
+
     assert.equal(normalizeDeviceJid('5511:0@s.whatsapp.net'), '5511@s.whatsapp.net')
     assert.equal(normalizeDeviceJid('5511:5@s.whatsapp.net'), '5511:5@s.whatsapp.net')
 

--- a/src/protocol/jid.ts
+++ b/src/protocol/jid.ts
@@ -222,6 +222,23 @@ export function toUserJid(
 }
 
 /**
+ * True when `jid` is the account's own user, matching the `meJid` (pn) or
+ * `meLid` (lid) identity device-insensitively. Mirrors WhatsApp Web's
+ * `isMeAccount`.
+ */
+export function isOwnAccountJid(
+    jid: string,
+    meJid: string | null | undefined,
+    meLid: string | null | undefined
+): boolean {
+    const candidateUser = toUserJid(jid)
+    return (
+        (!!meJid && toUserJid(meJid) === candidateUser) ||
+        (!!meLid && toUserJid(meLid) === candidateUser)
+    )
+}
+
+/**
  * Returns the JID in its full device form. JIDs with `device === 0` lose the
  * device segment (`user@server`); all others keep `user:device@server`.
  */


### PR DESCRIPTION
A 1:1 message authored by one of my own devices arrives with `from` set to my own jid, but the decrypt paths hardcoded `fromMe: false` and used `from` as the remoteJid, so self-sent messages surfaced as inbound from myself with the wrong chat.

Detect self-authorship against the account pn/lid identities and, for a self-sent 1:1, resolve the chat from the `recipient` attr (falling back to the deviceSentMessage destinationJid), promoting the recipient alt addressing to remoteJidAlt. Both decrypt paths now go through a single buildIncomingMessageKey, and the pn/lid match is factored into a shared isOwnAccountJid helper reused by the factory self-device check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Refined device identification logic to more accurately determine whether incoming messages originated from your own devices
  * Enhanced message routing and identity resolution for improved reliability in multi-device scenarios
  * Better handling of edge cases in message processing to ensure accuracy across different account configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->