### PR TITLE
chore(retry): always emit error on retry receipt and map future-message reason

### DIFF
--- a/src/retry/__tests__/retry.test.ts
+++ b/src/retry/__tests__/retry.test.ts
@@ -111,6 +111,14 @@ test('retry state ranking and reason mapping favor higher-priority states', () =
         mapRetryReasonFromError(new Error('invalid signature data')),
         RETRY_REASON.SignalErrorInvalidSignature
     )
+    assert.equal(
+        mapRetryReasonFromError(new Error('message too far in future')),
+        RETRY_REASON.SignalErrorFutureMessage
+    )
+    assert.equal(
+        mapRetryReasonFromError(new Error('sender key message is too far in future')),
+        RETRY_REASON.SignalErrorFutureMessage
+    )
     assert.equal(mapRetryReasonFromError(new Error('totally unknown error')), undefined)
 })
 

--- a/src/retry/reason.ts
+++ b/src/retry/reason.ts
@@ -18,7 +18,7 @@ const RETRY_REASON_MATCHERS = [
     },
     { matches: ['invalid signature'], code: RETRY_REASON.SignalErrorInvalidSignature },
     {
-        matches: ['too many messages in future', 'future message'],
+        matches: ['too far in future', 'too many messages in future', 'future message'],
         code: RETRY_REASON.SignalErrorFutureMessage
     },
     { matches: ['invalid mac'], code: RETRY_REASON.SignalErrorBadMac },

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -1313,6 +1313,7 @@ test('retry builder emits registration and key bundle payload', () => {
     assert.ok(Array.isArray(node.content))
     assert.ok(node.content.some((child) => child.tag === WA_NODE_TAGS.REGISTRATION))
     assert.ok(node.content.some((child) => child.tag === 'keys'))
+    assert.equal(node.content[0].attrs.error, '0')
 
     const nodeWithoutKeys = buildRetryReceiptNode({
         stanzaId: 'stanza-2',

--- a/src/transport/node/builders/retry.ts
+++ b/src/transport/node/builders/retry.ts
@@ -89,10 +89,8 @@ export function buildRetryReceiptNode(input: {
         v: RETRY_RECEIPT_VERSION,
         count: String(input.retryCount),
         id: input.originalMsgId,
-        t: input.t
-    }
-    if (input.error !== undefined && input.error !== 0) {
-        retryAttrs.error = String(input.error)
+        t: input.t,
+        error: String(input.error ?? 0)
     }
 
     const content: BinaryNode[] = [


### PR DESCRIPTION
Map the signal "message too far in future" (and the group sender-key variant) to SignalErrorFutureMessage, and always include the error attr on the <retry> node (defaulting to 0 when no reason maps), mirroring Baileys.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error detection for messages with future timing issues to enable the system to properly recognize and handle these edge cases with greater accuracy.
  * Enhanced error attribute consistency in retry operations to ensure error information is reliably tracked and propagated across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->