### PR TITLE
build: run build via prepare so the lib installs from a git url

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     },
     "scripts": {
         "preinstall": "node ./scripts/check-node-version.cjs",
-        "prepack": "npm run build",
+        "prepare": "npm run build",
         "changeset": "changeset",
         "changeset:status": "changeset status --verbose",
         "version:packages": "changeset version",


### PR DESCRIPTION
npm only runs the prepare lifecycle hook when installing a git dependency; prepack ran only on npm pack/publish, so installing zapo-js straight from a GitHub URL shipped without a built dist (dist is gitignored). prepare also covers pack and publish, so it replaces prepack rather than adding a second build pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

