### PR TITLE
chore(retry): map invalid-message-mac to the bad-mac reason

### DIFF
--- a/src/retry/__tests__/retry.test.ts
+++ b/src/retry/__tests__/retry.test.ts
@@ -119,6 +119,10 @@ test('retry state ranking and reason mapping favor higher-priority states', () =
         mapRetryReasonFromError(new Error('sender key message is too far in future')),
         RETRY_REASON.SignalErrorFutureMessage
     )
+    assert.equal(
+        mapRetryReasonFromError(new Error('invalid message mac')),
+        RETRY_REASON.SignalErrorBadMac
+    )
     assert.equal(mapRetryReasonFromError(new Error('totally unknown error')), undefined)
 })
 

--- a/src/retry/reason.ts
+++ b/src/retry/reason.ts
@@ -21,7 +21,7 @@ const RETRY_REASON_MATCHERS = [
         matches: ['too far in future', 'too many messages in future', 'future message'],
         code: RETRY_REASON.SignalErrorFutureMessage
     },
-    { matches: ['invalid mac'], code: RETRY_REASON.SignalErrorBadMac },
+    { matches: ['invalid message mac', 'invalid mac'], code: RETRY_REASON.SignalErrorBadMac },
     { matches: ['invalid session'], code: RETRY_REASON.SignalErrorInvalidSession },
     { matches: ['invalid message key'], code: RETRY_REASON.SignalErrorInvalidMsgKey },
     {


### PR DESCRIPTION
The signal MAC check throws "invalid message mac", which the matcher's "invalid mac" substring missed (the word "message" sits in between), so bad-MAC retries went out with error=0. Match it to SignalErrorBadMac.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of message authentication errors to ensure proper retry behavior across additional error cases.

* **Tests**
  * Enhanced test coverage for error mapping logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->