### PR TITLE
fix(signal): key own-account self traffic to a single LID session

### DIFF
--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -48,6 +48,7 @@ import type { WaMessageClient } from '@message/WaMessageClient'
 import { proto, type Proto } from '@proto'
 import { WA_DEFAULTS, WA_NACK_REASONS, type WaStatusDistributionSetting } from '@protocol/constants'
 import {
+    canonicalizeOwnAccountJid,
     isBotJid,
     isGroupJid,
     isHostedDeviceJid,
@@ -216,7 +217,13 @@ export class WaMessageDispatchCoordinator {
         options: WaMessagePublishOptions = {}
     ): Promise<WaMessagePublishResult> {
         this.requireCurrentMeJid('publishSignalMessage')
-        const address = parseSignalAddressFromJid(input.to)
+        const credentials = this.deps.getCurrentCredentials()
+        const sessionJid = canonicalizeOwnAccountJid(
+            input.to,
+            credentials?.meJid,
+            credentials?.meLid
+        )
+        const address = parseSignalAddressFromJid(sessionJid)
         if (address.server === WA_DEFAULTS.GROUP_SERVER) {
             throw new Error(
                 'publishSignalMessage currently supports only direct chats; use sender-key flow for groups'
@@ -224,11 +231,12 @@ export class WaMessageDispatchCoordinator {
         }
         this.deps.logger.trace('wa client publish signal message', {
             to: input.to,
+            sessionJid,
             type: input.type
         })
         const [paddedPlaintext] = await Promise.all([
             writeRandomPadMax16(input.plaintext),
-            this.deps.sessionResolver.ensureSession(address, input.to, input.expectedIdentity)
+            this.deps.sessionResolver.ensureSession(address, sessionJid, input.expectedIdentity)
         ])
         const encrypted = await this.deps.signalProtocol.encryptMessage(
             address,
@@ -513,7 +521,8 @@ export class WaMessageDispatchCoordinator {
         protocolMessage: Proto.Message.IProtocolMessage,
         options?: { readonly id?: string; readonly pushPriority?: 'high' | 'high_force' }
     ): Promise<WaMessagePublishResult> {
-        const meJid = this.deps.getCurrentCredentials()?.meJid
+        const credentials = this.deps.getCurrentCredentials()
+        const meJid = credentials?.meJid
         const meParsed = meJid ? parseJidFull(meJid) : undefined
         const meUserJid = meParsed?.userJid
         let senderIcdc: IcdcMeta | null = null

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -705,19 +705,23 @@ export class WaRetryCoordinator {
             } else if (regIdMismatch) {
                 await this.deps.sessionStore.deleteSession(requesterAddress)
             }
-            await this.deps.signalProtocol.establishOutgoingSession(requesterAddress, {
-                regId: request.regId,
-                identity: request.keyBundle.identity,
-                signedKey: {
-                    id: request.keyBundle.skey.id,
-                    publicKey: request.keyBundle.skey.publicKey,
-                    signature: request.keyBundle.skey.signature
+            await this.deps.signalProtocol.establishOutgoingSession(
+                requesterAddress,
+                {
+                    regId: request.regId,
+                    identity: request.keyBundle.identity,
+                    signedKey: {
+                        id: request.keyBundle.skey.id,
+                        publicKey: request.keyBundle.skey.publicKey,
+                        signature: request.keyBundle.skey.signature
+                    },
+                    oneTimeKey: {
+                        id: request.keyBundle.key.id,
+                        publicKey: request.keyBundle.key.publicKey
+                    }
                 },
-                oneTimeKey: {
-                    id: request.keyBundle.key.id,
-                    publicKey: request.keyBundle.key.publicKey
-                }
-            })
+                { reuseExisting: true }
+            )
             return this.applySessionBaseKeyPolicy(
                 request,
                 requesterJid,

--- a/src/client/coordinators/__tests__/retry-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/retry-coordinator.test.ts
@@ -6,7 +6,10 @@ import type { WaIncomingMessageEvent } from '@client/types'
 import { createNoopLogger } from '@infra/log/types'
 import type { PeerDataOperationRequester } from '@message/primitives/peer-data-operation'
 import { proto, type Proto } from '@proto'
+import { WA_MESSAGE_TYPES } from '@protocol/constants'
+import { parseJidFull } from '@protocol/jid'
 import type {
+    WaParsedRetryRequest,
     WaRetryDecryptFailureContext,
     WaRetryOutboundMessageRecord,
     WaRetryOutboundState
@@ -560,4 +563,142 @@ test('retry coordinator serializes outbound receipt tracking per message id', as
 
     assert.equal(retryStore.getCurrentState(), 'read')
     assert.deepEqual(retryStore.getTransitions(), ['delivered', 'read'])
+})
+
+function buildKeyBundleRequest(retryCount: number, requesterJid: string): WaParsedRetryRequest {
+    return {
+        type: WA_MESSAGE_TYPES.RECEIPT_TYPE_RETRY,
+        stanzaId: `retry-${retryCount}`,
+        from: requesterJid,
+        offline: false,
+        isLid: false,
+        originalMsgId: 'churn-msg',
+        retryCount,
+        regId: 555,
+        keyBundle: {
+            identity: new Uint8Array(33),
+            key: { id: 1, publicKey: new Uint8Array(32) },
+            skey: { id: 2, publicKey: new Uint8Array(32), signature: new Uint8Array(64) }
+        }
+    }
+}
+
+type RetrySessionInternals = {
+    updateLocalSessionFromRetryRequest: (
+        request: WaParsedRetryRequest,
+        requesterJid: string,
+        requesterAddress: ReturnType<typeof parseJidFull>['address'],
+        requesterNormalizedDeviceJid: string
+    ) => Promise<boolean>
+}
+
+test('retry session update reuses an existing compatible session instead of re-keying', async () => {
+    const existingSession = {
+        remote: { regId: 555, pubKey: new Uint8Array(33) },
+        aliceBaseKey: new Uint8Array([9, 9, 9])
+    } as never
+
+    const establishOptions: unknown[] = []
+    const coordinator = new WaRetryCoordinator({
+        logger: createNoopLogger(),
+        retryStore: { getTtlMs: () => 60_000 } as unknown as WaRetryStore,
+        signalStore: {} as never,
+        preKeyStore: {} as never,
+        sessionStore: {
+            getSession: async () => existingSession,
+            deleteSession: async () => undefined
+        } as never,
+        senderKeyStore: {} as never,
+        signalProtocol: {
+            establishOutgoingSession: async (
+                _address: unknown,
+                _bundle: unknown,
+                options: unknown
+            ) => {
+                establishOptions.push(options)
+                return existingSession
+            }
+        } as never,
+        sessionResolver: {} as never,
+        signalDeviceSync: {} as never,
+        signalMissingPreKeysSync: {} as never,
+        messageClient: {} as never,
+        sendNode: async () => undefined,
+        getCurrentCredentials: () => null
+    })
+
+    const internals = coordinator as unknown as RetrySessionInternals
+    const requesterJid = '551100000000:3@s.whatsapp.net'
+    const parsed = parseJidFull(requesterJid)
+    const ready = await internals.updateLocalSessionFromRetryRequest(
+        buildKeyBundleRequest(2, requesterJid),
+        requesterJid,
+        parsed.address,
+        parsed.normalizedJid
+    )
+
+    assert.equal(ready, true)
+    // The keyBundle establish reuses the existing session rather than minting a
+    // fresh base key on every retry.
+    assert.deepEqual(establishOptions, [{ reuseExisting: true }])
+})
+
+test('retry session update resets the session once the base key repeats at retry 3', async () => {
+    const existingSession = {
+        remote: { regId: 555, pubKey: new Uint8Array(33) },
+        aliceBaseKey: new Uint8Array([7, 7, 7])
+    } as never
+
+    let deleteCount = 0
+    let fetchCount = 0
+    const coordinator = new WaRetryCoordinator({
+        logger: createNoopLogger(),
+        retryStore: { getTtlMs: () => 60_000 } as unknown as WaRetryStore,
+        signalStore: {} as never,
+        preKeyStore: {} as never,
+        sessionStore: {
+            getSession: async () => existingSession,
+            deleteSession: async () => {
+                deleteCount += 1
+            }
+        } as never,
+        senderKeyStore: {} as never,
+        signalProtocol: {
+            establishOutgoingSession: async () => existingSession
+        } as never,
+        sessionResolver: {} as never,
+        signalDeviceSync: {} as never,
+        signalMissingPreKeysSync: {
+            fetchMissingPreKeys: async () => {
+                fetchCount += 1
+                return [{ devices: [{ deviceJid: '551100000000:3@s.whatsapp.net', bundle: {} }] }]
+            }
+        } as never,
+        messageClient: {} as never,
+        sendNode: async () => undefined,
+        getCurrentCredentials: () => null
+    })
+
+    const internals = coordinator as unknown as RetrySessionInternals
+    const requesterJid = '551100000000:3@s.whatsapp.net'
+    const parsed = parseJidFull(requesterJid)
+    const run = (retryCount: number): Promise<boolean> =>
+        internals.updateLocalSessionFromRetryRequest(
+            buildKeyBundleRequest(retryCount, requesterJid),
+            requesterJid,
+            parsed.address,
+            parsed.normalizedJid
+        )
+
+    // Retry 2 only records the session base key.
+    await run(2)
+    assert.equal(deleteCount, 0)
+    assert.equal(fetchCount, 0)
+
+    // Retry 3 sees the same (reused) base key and forces a clean session:
+    // delete + fetch fresh prekeys + re-establish.
+    const ready = await run(3)
+    assert.equal(ready, true)
+    assert.equal(deleteCount, 1)
+    assert.equal(fetchCount, 1)
 })

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -12,6 +12,7 @@ import { processIncomingNewsletterMessage } from '@message/kinds/newsletter'
 import { proto } from '@proto'
 import { WA_MESSAGE_TAGS, WA_MESSAGE_TYPES } from '@protocol/constants'
 import {
+    canonicalizeOwnAccountJid,
     isBroadcastJid,
     isGroupJid,
     isNewsletterJid,
@@ -575,11 +576,22 @@ export async function handleIncomingMessageAck(
                         encType,
                         senderJid,
                         options,
-                        (ciphertext, senderAddress) =>
-                            options.signalProtocol!.decryptMessage(senderAddress, {
-                                type: encType,
-                                ciphertext
-                            })
+                        (ciphertext, senderAddress) => {
+                            const sessionJid = canonicalizeOwnAccountJid(
+                                senderJid,
+                                options.getMeJid?.(),
+                                options.getMeLid?.()
+                            )
+                            return options.signalProtocol!.decryptMessage(
+                                sessionJid === senderJid
+                                    ? senderAddress
+                                    : parseSignalAddressFromJid(sessionJid),
+                                {
+                                    type: encType,
+                                    ciphertext
+                                }
+                            )
+                        }
                     )
                     break
                 }

--- a/src/protocol/__tests__/protocol.test.ts
+++ b/src/protocol/__tests__/protocol.test.ts
@@ -19,6 +19,7 @@ import {
 import {
     applyDeviceToJid,
     buildDeviceJid,
+    canonicalizeOwnAccountJid,
     canonicalizeSignalJid,
     canonicalizeSignalServer,
     getLoginIdentity,
@@ -43,6 +44,35 @@ import type {
     WaPrivacyDisallowedListSettingName,
     WaPrivacySettingValueMap
 } from '@protocol/privacy'
+
+test('canonicalizeOwnAccountJid maps own PN device JIDs to LID', () => {
+    const meJid = '5512988950329:15@s.whatsapp.net'
+    const meLid = '91379841634519:15@lid'
+    assert.equal(
+        canonicalizeOwnAccountJid('5512988950329@s.whatsapp.net', meJid, meLid),
+        '91379841634519@lid'
+    )
+    assert.equal(
+        canonicalizeOwnAccountJid('5512988950329:0@s.whatsapp.net', meJid, meLid),
+        '91379841634519@lid'
+    )
+    assert.equal(
+        canonicalizeOwnAccountJid('5512988950329:12@s.whatsapp.net', meJid, meLid),
+        '91379841634519:12@lid'
+    )
+    assert.equal(
+        canonicalizeOwnAccountJid('91379841634519@lid', meJid, meLid),
+        '91379841634519@lid'
+    )
+    assert.equal(
+        canonicalizeOwnAccountJid('5511999999999@s.whatsapp.net', meJid, meLid),
+        '5511999999999@s.whatsapp.net'
+    )
+    assert.equal(
+        canonicalizeOwnAccountJid('5512988950329@s.whatsapp.net', meJid, null),
+        '5512988950329@s.whatsapp.net'
+    )
+})
 
 test('jid split and normalization helpers', () => {
     assert.deepEqual(splitJid('123@s.whatsapp.net'), {

--- a/src/protocol/jid.ts
+++ b/src/protocol/jid.ts
@@ -239,6 +239,38 @@ export function isOwnAccountJid(
 }
 
 /**
+ * Rewrites the account's own PN device JID to its LID equivalent so self traffic
+ * keys one LID session instead of forking into separate PN and LID ratchets.
+ * No-op for other users, already-LID/unparseable JIDs, or unknown identity.
+ */
+export function canonicalizeOwnAccountJid(
+    jid: string,
+    meJid: string | null | undefined,
+    meLid: string | null | undefined
+): string {
+    if (!meJid || !meLid) return jid
+    let address: SignalAddress
+    try {
+        address = parseSignalAddressFromJid(jid)
+    } catch {
+        return jid
+    }
+    if ((address.server ?? WA_DEFAULTS.HOST_DOMAIN) !== WA_DEFAULTS.HOST_DOMAIN) return jid
+    let mePnUser: string
+    let meLidUser: string
+    try {
+        mePnUser = parseSignalAddressFromJid(meJid).user
+        meLidUser = parseSignalAddressFromJid(meLid).user
+    } catch {
+        return jid
+    }
+    if (address.user !== mePnUser) return jid
+    return address.device === 0
+        ? `${meLidUser}@${WA_DEFAULTS.LID_SERVER}`
+        : `${meLidUser}:${address.device}@${WA_DEFAULTS.LID_SERVER}`
+}
+
+/**
  * Returns the JID in its full device form. JIDs with `device === 0` lose the
  * device segment (`user@server`); all others keep `user:device@server`.
  */


### PR DESCRIPTION
A companion forks its session to the own primary when keyed by the raw wire address: a PN ratchet for 1:1 peer traffic (peer-data-operation) and a LID ratchet for group traffic. The LID fork never completes a handshake, so incoming msg/skmsg from the own primary fail to decrypt and only recover via the slow placeholder/pdo round-trip.

Add canonicalizeOwnAccountJid and route both the incoming decrypt and the outgoing encrypt through the own LID address, mirroring how the primary canonicalizes PN to LID at its session store. The wire stays on its original domain (the primary replies to peer traffic on PN), so only the Signal session keying converges onto one LID record.

On retry, reuse an existing compatible session instead of re-keying each attempt: a fresh handshake mints a new base key every time and defeats the repeated-base-key reset, so the session never converges.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of outgoing messages for multi-device accounts to ensure consistent session management.

* **Performance**
  * Optimized session reuse during retry operations to avoid unnecessary re-keying.

* **Tests**
  * Expanded test coverage for session management and retry request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->