### PR TITLE
fix(transport): drop noisy clear-pending log on empty disconnect

### DIFF
--- a/src/transport/node/WaNodeOrchestrator.ts
+++ b/src/transport/node/WaNodeOrchestrator.ts
@@ -55,8 +55,12 @@ export class WaNodeOrchestrator {
     }
 
     public clearPending(reason: Error): void {
-        this.logger.warn('clearing pending node queries', {
-            count: this.pendingQueries.size,
+        const count = this.pendingQueries.size
+        if (count === 0) {
+            return
+        }
+        this.logger.debug('clearing pending node queries', {
+            count,
             reason: reason.message
         })
         for (const pending of this.pendingQueries.values()) {


### PR DESCRIPTION
clearPending logged at warn on every disconnect, including the common case where no query was in flight (count: 0). A routine disconnect cleanup is a lifecycle event, not an operator-visible warning, and a zero-count clear has nothing to report.

Skip logging entirely when the pending map is empty and lower the remaining log to debug.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized cleanup logic for pending queries with early-return conditions when no queries are pending.
  * Adjusted internal diagnostic logging levels for improved debugging visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->