### PR TITLE
fix(message): stamp peer_recipient_pn on LID-addressed 1:1 sends

### DIFF
--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -54,6 +54,7 @@ import {
     isHostedDeviceJid,
     isLidJid,
     isNewsletterJid,
+    isUserJid,
     normalizeDeviceJid,
     normalizeRecipientJid,
     parseJidFull,
@@ -468,11 +469,18 @@ export class WaMessageDispatchCoordinator {
         const directRecipientJid = isGroup
             ? recipientJid
             : await this.resolveDirectRecipientLid(toUserJid(recipientJid))
+        const peerRecipientPn = isGroup
+            ? undefined
+            : await this.resolvePeerRecipientPn(toUserJid(recipientJid), directRecipientJid)
         const publishResult = isGroup
             ? this.shouldUseGroupDirectPath(messageWithIcdc)
                 ? await this.publishGroupDirectMessage(recipientJid, envelope)
                 : await this.publishGroupSenderKeyMessage(recipientJid, envelope)
-            : await this.publishDirectSignalMessageWithFanout(directRecipientJid, envelope)
+            : await this.publishDirectSignalMessageWithFanout(
+                  directRecipientJid,
+                  envelope,
+                  peerRecipientPn
+              )
         return upload ? { ...publishResult, upload } : publishResult
     }
 
@@ -502,6 +510,34 @@ export class WaMessageDispatchCoordinator {
             })
         }
         return pnUserJid
+    }
+
+    /**
+     * Resolves the `peer_recipient_pn` cross-reference for a 1:1 send, or
+     * `undefined` to drop the attribute. Only set when the envelope is
+     * LID-addressed (`directRecipientJid` is a LID): the PN is the caller's own
+     * JID when they passed a PN (zapo switched it to LID for sending), else the
+     * device-list snapshot counterpart for a recipient passed in LID form.
+     * Mirrors wa-web, which sets `peer_recipient_pn = getPhoneNumber($)` for a
+     * LID destination.
+     */
+    private async resolvePeerRecipientPn(
+        recipientUserJid: string,
+        directRecipientJid: string
+    ): Promise<string | undefined> {
+        if (!isLidJid(directRecipientJid)) return undefined
+        if (isUserJid(recipientUserJid)) return recipientUserJid
+        try {
+            const snapshot = await this.deps.deviceListStore.findByAnyUserJid(directRecipientJid)
+            if (snapshot?.userJid && isUserJid(snapshot.userJid)) return snapshot.userJid
+            if (snapshot?.altUserJid && isUserJid(snapshot.altUserJid)) return snapshot.altUserJid
+        } catch (error) {
+            this.deps.logger.trace('peer_recipient_pn store lookup failed', {
+                lid: directRecipientJid,
+                message: toError(error).message
+            })
+        }
+        return undefined
     }
 
     public async syncSignalSession(jid: string, reasonIdentity = false): Promise<void> {
@@ -1394,7 +1430,8 @@ export class WaMessageDispatchCoordinator {
 
     private async publishDirectSignalMessageWithFanout(
         recipientJid: string,
-        envelope: WaOutboundEnvelope
+        envelope: WaOutboundEnvelope,
+        peerRecipientPn?: string
     ): Promise<WaMessagePublishResult> {
         const { message, plaintext, type, edit, mediatype, sendOptions } = envelope
         const meJid = this.requireCurrentMeJid('sendMessage')
@@ -1605,6 +1642,7 @@ export class WaMessageDispatchCoordinator {
             customNodes: customNodes.length > 0 ? customNodes : undefined,
             mediatype,
             decryptFail: envelope.decryptFail,
+            peerRecipientPn,
             additionalAttributes: sendOptions.additionalAttributes
         })
 

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -113,6 +113,9 @@ function createMessageDispatchCoordinator(
         readonly meJid?: string
         readonly mobileMessageIdFormat?: () => boolean
         readonly serverClock?: ServerClock
+        readonly deviceListStore?: {
+            readonly findByAnyUserJid: (jid: string) => Promise<unknown>
+        }
     }
 ): WaMessageDispatchCoordinator {
     const groupMetadataCache = createGroupMetadataCache({
@@ -135,7 +138,7 @@ function createMessageDispatchCoordinator(
         signalStore: {} as never,
         sessionStore: {} as never,
         identityStore: {} as never,
-        deviceListStore: {} as never,
+        deviceListStore: (overrides?.deviceListStore ?? {}) as never,
         signalDeviceSync: {} as never,
         messageSecretStore: {
             set: async (_id: string, _entry: { secret: Uint8Array; senderJid: string }) => {}
@@ -164,6 +167,61 @@ function buildAppStateSyncResult(
     )
     return { collections }
 }
+
+function callResolvePeerRecipientPn(
+    coordinator: WaMessageDispatchCoordinator,
+    recipientUserJid: string,
+    directRecipientJid: string
+): Promise<string | undefined> {
+    return (
+        coordinator as unknown as {
+            resolvePeerRecipientPn(a: string, b: string): Promise<string | undefined>
+        }
+    ).resolvePeerRecipientPn(recipientUserJid, directRecipientJid)
+}
+
+test('resolvePeerRecipientPn: a PN-addressed caller on a LID envelope stamps that PN', async () => {
+    const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore())
+    const pn = await callResolvePeerRecipientPn(
+        coordinator,
+        '5511999999999@s.whatsapp.net',
+        '88880000@lid'
+    )
+    assert.equal(pn, '5511999999999@s.whatsapp.net')
+})
+
+test('resolvePeerRecipientPn: a LID-addressed caller resolves the PN from the device-list store', async () => {
+    const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore(), {
+        deviceListStore: {
+            findByAnyUserJid: async () => ({
+                userJid: '5511999999999@s.whatsapp.net',
+                altUserJid: '88880000@lid',
+                deviceJids: [],
+                updatedAtMs: 0
+            })
+        }
+    })
+    const pn = await callResolvePeerRecipientPn(coordinator, '88880000@lid', '88880000@lid')
+    assert.equal(pn, '5511999999999@s.whatsapp.net')
+})
+
+test('resolvePeerRecipientPn: a LID-addressed caller with a device-list miss drops the attribute', async () => {
+    const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore(), {
+        deviceListStore: { findByAnyUserJid: async () => null }
+    })
+    const pn = await callResolvePeerRecipientPn(coordinator, '88880000@lid', '88880000@lid')
+    assert.equal(pn, undefined)
+})
+
+test('resolvePeerRecipientPn: a PN-addressed envelope stamps nothing', async () => {
+    const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore())
+    const pn = await callResolvePeerRecipientPn(
+        coordinator,
+        '5511999999999@s.whatsapp.net',
+        '5511999999999@s.whatsapp.net'
+    )
+    assert.equal(pn, undefined)
+})
 
 test('incoming node coordinator supports dynamic handler registration and unregistration', async () => {
     const { runtime, unhandled } = createIncomingRuntime()

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -1174,6 +1174,33 @@ test('message builders merge additionalAttributes with user-wins semantics', () 
     assert.equal(group.attrs.type, 'text')
 })
 
+test('direct fanout stamps peer_recipient_pn when provided and omits it otherwise', () => {
+    const participants = [
+        {
+            jid: '88880000:1@lid',
+            encType: 'msg' as const,
+            ciphertext: new Uint8Array([1])
+        }
+    ]
+    const withPn = buildDirectMessageFanoutNode({
+        to: '88880000@lid',
+        type: 'text',
+        id: 'm1',
+        participants,
+        peerRecipientPn: '5511999999999@s.whatsapp.net'
+    })
+    assert.equal(withPn.attrs.to, '88880000@lid')
+    assert.equal(withPn.attrs.peer_recipient_pn, '5511999999999@s.whatsapp.net')
+
+    const withoutPn = buildDirectMessageFanoutNode({
+        to: '88880000@lid',
+        type: 'text',
+        id: 'm2',
+        participants
+    })
+    assert.equal(withoutPn.attrs.peer_recipient_pn, undefined)
+})
+
 test('pairing builders generate link-code nodes and ack helpers', () => {
     const hello = buildCompanionHelloRequestNode({
         phoneJid: '5511999999999@s.whatsapp.net',

--- a/src/transport/node/builders/message.ts
+++ b/src/transport/node/builders/message.ts
@@ -18,6 +18,8 @@ type DirectMessageFanoutInput = {
     readonly customNodes?: readonly BinaryNode[]
     readonly mediatype?: string
     readonly decryptFail?: string
+    // 1:1 only: PN counterpart stamped as `peer_recipient_pn` when `to` is a LID.
+    readonly peerRecipientPn?: string
     readonly additionalAttributes?: Readonly<Record<string, string>>
 }
 
@@ -78,6 +80,7 @@ function buildMessageAttrs(input: {
     readonly edit?: string
     readonly phash?: string
     readonly addressingMode?: string
+    readonly peerRecipientPn?: string
     readonly additionalAttributes?: Readonly<Record<string, string>>
 }): Record<string, string> {
     const attrs: Record<string, string> = {
@@ -95,6 +98,9 @@ function buildMessageAttrs(input: {
     }
     if (input.addressingMode) {
         attrs.addressing_mode = input.addressingMode
+    }
+    if (input.peerRecipientPn) {
+        attrs.peer_recipient_pn = input.peerRecipientPn
     }
     if (input.additionalAttributes) {
         Object.assign(attrs, input.additionalAttributes)


### PR DESCRIPTION
A 1:1 stanza addressed by LID needs the phone-number counterpart in peer_recipient_pn for WhatsApp to attribute the message to a known contact. Without it the recipient renders as an unknown user in the chat.

zapo is LID-first, so the PN is resolved as: the PN the caller passed as the recipient (when it gets switched to LID for sending), otherwise the device-list snapshot counterpart for a recipient already in LID form. The attribute is dropped when no PN is known or the envelope stays PN-addressed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added peer recipient identifier support to direct messaging, with proper resolution for 1:1 conversations in both PN and LID addressing formats.

* **Tests**
  * Added test coverage for peer recipient identifier resolution logic, validating behavior across addressing formats and device lookup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->