### PR TITLE
feat(message): opt-in persistAllSecrets for all message secrets

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -39,7 +39,6 @@ import { proto, type Proto } from '@proto'
 import { WA_DEFAULTS, WA_MESSAGE_TYPES } from '@protocol/constants'
 import { normalizeDeviceJid } from '@protocol/jid'
 import { WA_DISCONNECT_REASONS, WA_LOGOUT_REASONS, type WaLogoutReason } from '@protocol/stream'
-import { NOOP_MESSAGE_SECRET_STORE } from '@store/noop.store'
 import { buildRemoveCompanionDeviceIq } from '@transport/node/builders/device'
 import { assertIqResult, queryWithContext as queryNodeWithContext } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
@@ -135,17 +134,6 @@ export class WaClient extends EventEmitter {
             this.logger,
             this.options.writeBehind
         )
-
-        if (
-            this.options.addons?.autoDecrypt !== false &&
-            this.stores.messageSecret === NOOP_MESSAGE_SECRET_STORE
-        ) {
-            this.logger.warn(
-                'addons.autoDecrypt is on (default) but messageSecret cache is noop – ' +
-                    'addon decryption will only work if secrets are in the message store. ' +
-                    'Set addons.autoDecrypt: false to silence this warning.'
-            )
-        }
 
         const dependencies = buildWaClientDependencies({
             base,
@@ -296,6 +284,7 @@ export class WaClient extends EventEmitter {
                 logger: this.logger,
                 writeBehind: this.writeBehind,
                 messageSecretStore: this.stores.messageSecret,
+                persistAllSecrets: this.options.addons?.persistAllSecrets === true,
                 event
             })
             if (this.options.addons?.autoDecrypt !== false && event.message) {

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -750,6 +750,7 @@ export function buildWaClientDependencies(input: {
         deviceListStore: sessionStore.deviceList,
         signalDeviceSync,
         messageSecretStore: sessionStore.messageSecret,
+        persistAllMessageSecrets: options.addons?.persistAllSecrets === true,
         getCurrentCredentials,
         resolvePrivacyTokenNode: (recipientJid) =>
             trustedContactToken.resolveTokenForMessage(recipientJid),

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -110,6 +110,12 @@ interface WaMessageDispatchCoordinatorOptions {
     readonly deviceListStore: WaDeviceListStore
     readonly signalDeviceSync: SignalDeviceSyncApi
     readonly messageSecretStore: WaMessageSecretStore
+    /**
+     * When `true`, persist the message secret for every outgoing message, not
+     * only the poll / event / bot prompts that `needsSecretPersistence` flags.
+     * Wired from the client-level `addons.persistAllSecrets` option.
+     */
+    readonly persistAllMessageSecrets?: boolean
     readonly getCurrentCredentials: () => WaAuthCredentials | null
     readonly resolvePrivacyTokenNode: (recipientJid: string) => Promise<BinaryNode | null>
     readonly onDirectMessageSent: (recipientJid: string) => void
@@ -399,7 +405,7 @@ export class WaMessageDispatchCoordinator {
             rawSecret &&
             rawSecret.length > 0 &&
             sendOptions.id &&
-            needsSecretPersistence(messageWithSecret)
+            (this.deps.persistAllMessageSecrets || needsSecretPersistence(messageWithSecret))
         ) {
             const meJid = this.deps.getCurrentCredentials()?.meJid ?? ''
             void this.deps.messageSecretStore

--- a/src/client/persistence/__tests__/mailbox.test.ts
+++ b/src/client/persistence/__tests__/mailbox.test.ts
@@ -27,6 +27,19 @@ function captureWriteBehind(): {
     return { captured, writeBehind }
 }
 
+function captureSecretStore(): {
+    readonly sets: { readonly id: string }[]
+    readonly store: unknown
+} {
+    const sets: { id: string }[] = []
+    const store = {
+        set: async (id: string) => {
+            sets.push({ id })
+        }
+    }
+    return { sets, store }
+}
+
 function baseEvent(
     overrides: Partial<WaIncomingMessageEvent> & {
         readonly keyOverrides?: Partial<WaIncomingMessageEvent['key']>
@@ -134,4 +147,43 @@ test('mailbox persist does NOT treat remoteJid pair as user pair for groups', ()
     const crossRefRows = captured.contacts.filter((c) => c.phoneNumber || c.lid)
     assert.equal(crossRefRows.length, 1)
     assert.equal(crossRefRows[0].jid, '111111111111111@lid')
+})
+
+const PLAIN_SECRET = new Uint8Array(32).fill(7)
+
+function plainSecretEvent(): WaIncomingMessageEvent {
+    return baseEvent({
+        keyOverrides: {
+            id: 'plain-1',
+            remoteJid: '5511999999999@s.whatsapp.net',
+            isGroup: false
+        },
+        message: { conversation: 'oi', messageContextInfo: { messageSecret: PLAIN_SECRET } }
+    })
+}
+
+test('mailbox persist skips a plain-message secret by default (only poll/event/bot persist)', () => {
+    const { writeBehind } = captureWriteBehind()
+    const { sets, store } = captureSecretStore()
+    persistIncomingMailboxEntities({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        messageSecretStore: store as never,
+        event: plainSecretEvent()
+    })
+    assert.equal(sets.length, 0)
+})
+
+test('mailbox persist stores a plain-message secret when persistAllSecrets is set', () => {
+    const { writeBehind } = captureWriteBehind()
+    const { sets, store } = captureSecretStore()
+    persistIncomingMailboxEntities({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        messageSecretStore: store as never,
+        persistAllSecrets: true,
+        event: plainSecretEvent()
+    })
+    assert.equal(sets.length, 1)
+    assert.equal(sets[0].id, 'plain-1')
 })

--- a/src/client/persistence/mailbox.ts
+++ b/src/client/persistence/mailbox.ts
@@ -11,6 +11,12 @@ interface WaPersistIncomingMailboxOptions {
     readonly logger: Logger
     readonly writeBehind: WriteBehindPersistence
     readonly messageSecretStore: WaMessageSecretStore
+    /**
+     * When `true`, persist the secret of every incoming message, not only the
+     * poll / event / bot prompts that `needsSecretPersistence` flags. Wired
+     * from the client-level `addons.persistAllSecrets` option.
+     */
+    readonly persistAllSecrets?: boolean
     readonly event: WaIncomingMessageEvent
 }
 
@@ -74,7 +80,7 @@ function persistContacts(
 }
 
 export function persistIncomingMailboxEntities(options: WaPersistIncomingMailboxOptions): void {
-    const { logger, writeBehind, messageSecretStore, event } = options
+    const { logger, writeBehind, messageSecretStore, persistAllSecrets, event } = options
     const stanzaId = event.key.id
     const chatJid = event.key.remoteJid
     if (!stanzaId || !chatJid) {
@@ -103,7 +109,7 @@ export function persistIncomingMailboxEntities(options: WaPersistIncomingMailbox
             rawSecret &&
             rawSecret.length > 0 &&
             event.message &&
-            needsSecretPersistence(event.message)
+            (persistAllSecrets || needsSecretPersistence(event.message))
         ) {
             const rawSender =
                 event.key.participant ?? event.rawNode.attrs.participant ?? event.key.remoteJid

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -258,6 +258,26 @@ export interface WaAddonOptions {
      * poll votes, event responses, comments).
      */
     readonly autoDecrypt?: boolean
+    /**
+     * Persist the 32-byte message secret of every sent and received message,
+     * not just the poll / event / bot-prompt messages the library knows will
+     * get a follow-up. Off by default.
+     *
+     * Encrypted addons whose parent can be any message type - reactions,
+     * comments, and `secretEncryptedMessage` edits - need the parent's secret
+     * to decrypt. Without this, those parents stay decryptable after a restart
+     * only when the full `messages` archive is persistent. Enable this to keep
+     * them decryptable while storing only the secret, not the message body
+     * (e.g. with `messages: 'none'`).
+     *
+     * Has no effect when the `messageSecret` cache is `'none'`: every write
+     * lands in the noop store and is silently discarded. With the default
+     * `'memory'` provider it works for the lifetime of the process but is lost
+     * on restart and bounded by the cache's LRU and `messageSecretMs` TTL;
+     * point `messageSecret` at a persistent backend to keep the secrets across
+     * restarts.
+     */
+    readonly persistAllSecrets?: boolean
 }
 
 export interface WaPrivacyTokenOptions {


### PR DESCRIPTION
By default only poll/event/bot-prompt secrets are persisted. The new addons.persistAllSecrets option persists the 32-byte secret of every sent and received message, so encrypted addons whose parent can be any message type - reactions, comments, secretEncryptedMessage edits - stay decryptable after a restart without archiving full message bodies (messages: 'none').

It relaxes the secret-persistence gate at both persist sites (outgoing dispatch + incoming mailbox); the rawSecret/length/id guards are unchanged. The option only takes effect with a non-'none' messageSecret store, as documented on the option.

Also drop the construction-time messageSecret cache warnings (the new persistAllSecrets one and the pre-existing autoDecrypt one): the library does not warn about any other 'none' config, and the autoDecrypt warning fired even for the documented messageSecret:'none' + persistent messages setup where the message-store fallback covers decryption.

Fixes: #159

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `persistAllSecrets` configuration option to enable persistent storage of message secrets for all sent and received messages, regardless of message type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->