### PR TITLE
perf(store): write only the index/value delta in setCollectionStates

### DIFF
--- a/packages/store-mongo/src/appstate.store.ts
+++ b/packages/store-mongo/src/appstate.store.ts
@@ -15,8 +15,17 @@ import type {
 } from 'zapo-js/store'
 
 import { BaseMongoStore } from './BaseMongoStore'
-import { bytesToHex, fromBinary, fromBinaryOrNull, toBinary, uint8Equal } from './helpers'
+import {
+    bytesToHex,
+    fromBinary,
+    fromBinaryOrNull,
+    toBinary,
+    uint8Equal,
+    uint8TimingSafeEqual
+} from './helpers'
 import type { WaMongoStorageOptions } from './types'
+
+const INDEX_VALUE_DELETE_BATCH = 1000
 
 interface SyncKeyDoc {
     _id: { session_id: string; key_id: Binary }
@@ -355,16 +364,26 @@ export class WaAppStateMongoStore extends BaseMongoStore implements WaAppStateSt
             await versionsCol.bulkWrite(versionOps, { session })
 
             for (const update of updates) {
-                await valuesCol.deleteMany(
-                    {
-                        '_id.session_id': this.sessionId,
-                        '_id.collection': update.collection
-                    },
-                    { session }
-                )
+                const existingDocs = await valuesCol
+                    .find(
+                        {
+                            '_id.session_id': this.sessionId,
+                            '_id.collection': update.collection
+                        },
+                        { session }
+                    )
+                    .toArray()
+                const existing = new Map<string, Uint8Array>()
+                for (const doc of existingDocs) {
+                    existing.set(doc._id.index_mac_hex, fromBinary(doc.value_mac))
+                }
 
                 const valueOps: AnyBulkWriteOperation<IndexValueDoc>[] = []
                 for (const [indexMacHex, valueMac] of update.indexValueMap.entries()) {
+                    const current = existing.get(indexMacHex)
+                    if (current && uint8TimingSafeEqual(current, valueMac)) {
+                        continue
+                    }
                     valueOps.push({
                         updateOne: {
                             filter: {
@@ -381,6 +400,27 @@ export class WaAppStateMongoStore extends BaseMongoStore implements WaAppStateSt
                         }
                     })
                 }
+
+                const toDelete: string[] = []
+                for (const indexMacHex of existing.keys()) {
+                    if (!update.indexValueMap.has(indexMacHex)) {
+                        toDelete.push(indexMacHex)
+                    }
+                }
+                for (let start = 0; start < toDelete.length; start += INDEX_VALUE_DELETE_BATCH) {
+                    valueOps.push({
+                        deleteMany: {
+                            filter: {
+                                '_id.session_id': this.sessionId,
+                                '_id.collection': update.collection,
+                                '_id.index_mac_hex': {
+                                    $in: toDelete.slice(start, start + INDEX_VALUE_DELETE_BATCH)
+                                }
+                            }
+                        }
+                    })
+                }
+
                 if (valueOps.length > 0) {
                     await valuesCol.bulkWrite(valueOps, { session })
                 }

--- a/packages/store-mongo/src/helpers.ts
+++ b/packages/store-mongo/src/helpers.ts
@@ -1,5 +1,11 @@
 import { Binary } from 'mongodb'
-import { bytesToHex, normalizeQueryLimit, toBytesView, uint8Equal } from 'zapo-js/util'
+import {
+    bytesToHex,
+    normalizeQueryLimit,
+    toBytesView,
+    uint8Equal,
+    uint8TimingSafeEqual
+} from 'zapo-js/util'
 
 export function toBinary(bytes: Uint8Array): Binary {
     return new Binary(bytes)
@@ -29,4 +35,4 @@ export function assertSafeCollectionPrefix(prefix: string): void {
     }
 }
 
-export { bytesToHex, normalizeQueryLimit as safeLimit, uint8Equal }
+export { bytesToHex, normalizeQueryLimit as safeLimit, uint8Equal, uint8TimingSafeEqual }

--- a/packages/store-mysql/src/appstate.store.ts
+++ b/packages/store-mysql/src/appstate.store.ts
@@ -15,7 +15,15 @@ import type {
 } from 'zapo-js/store'
 
 import { BaseMysqlStore } from './BaseMysqlStore'
-import { bytesToHex, queryFirst, queryRows, toBytes, toBytesOrNull, uint8Equal } from './helpers'
+import {
+    bytesToHex,
+    queryFirst,
+    queryRows,
+    toBytes,
+    toBytesOrNull,
+    uint8Equal,
+    uint8TimingSafeEqual
+} from './helpers'
 import type { MysqlParam, WaMysqlStorageOptions } from './types'
 
 const BATCH_SIZE = 500
@@ -303,22 +311,71 @@ export class WaAppStateMysqlStore extends BaseMysqlStore implements WaAppStateSt
                     [this.sessionId, update.collection, update.version, update.hash]
                 )
 
-                await conn.execute(
-                    `DELETE FROM ${this.t('appstate_collection_index_values')}
-                     WHERE session_id = ? AND collection = ?`,
-                    [this.sessionId, update.collection]
-                )
-
-                for (const [indexMacHex, valueMac] of update.indexValueMap.entries()) {
-                    await conn.execute(
-                        `INSERT INTO ${this.t('appstate_collection_index_values')} (
-                            session_id, collection, index_mac_hex, value_mac
-                        ) VALUES (?, ?, ?, ?)`,
-                        [this.sessionId, update.collection, indexMacHex, valueMac]
-                    )
-                }
+                await this.applyIndexValueDiff(conn, update)
             }
         })
+    }
+
+    private async applyIndexValueDiff(
+        conn: PoolConnection,
+        update: WaAppStateCollectionStateUpdate
+    ): Promise<void> {
+        const existingRows = queryRows(
+            await conn.execute(
+                `SELECT index_mac_hex, value_mac
+                 FROM ${this.t('appstate_collection_index_values')}
+                 WHERE session_id = ? AND collection = ?`,
+                [this.sessionId, update.collection]
+            )
+        )
+        const existing = new Map<string, Uint8Array>()
+        for (const row of existingRows) {
+            existing.set(String(row.index_mac_hex), toBytes(row.value_mac))
+        }
+
+        const toUpsert: [string, Uint8Array][] = []
+        for (const [indexMacHex, valueMac] of update.indexValueMap.entries()) {
+            const current = existing.get(indexMacHex)
+            if (!current || !uint8TimingSafeEqual(current, valueMac)) {
+                toUpsert.push([indexMacHex, valueMac])
+            }
+        }
+        const toDelete: string[] = []
+        for (const indexMacHex of existing.keys()) {
+            if (!update.indexValueMap.has(indexMacHex)) {
+                toDelete.push(indexMacHex)
+            }
+        }
+
+        let cursor = 0
+        for (const size of this.powerOfTwoChunks(toUpsert.length)) {
+            const chunk = toUpsert.slice(cursor, cursor + size)
+            cursor += size
+            const placeholders = chunk.map(() => '(?, ?, ?, ?)').join(', ')
+            const params: MysqlParam[] = []
+            for (const [indexMacHex, valueMac] of chunk) {
+                params.push(this.sessionId, update.collection, indexMacHex, valueMac)
+            }
+            await conn.execute(
+                `INSERT INTO ${this.t('appstate_collection_index_values')} (
+                    session_id, collection, index_mac_hex, value_mac
+                ) VALUES ${placeholders}
+                ON DUPLICATE KEY UPDATE value_mac = VALUES(value_mac)`,
+                params
+            )
+        }
+
+        cursor = 0
+        for (const size of this.powerOfTwoChunks(toDelete.length)) {
+            const chunk = toDelete.slice(cursor, cursor + size)
+            cursor += size
+            const placeholders = chunk.map(() => '?').join(', ')
+            await conn.execute(
+                `DELETE FROM ${this.t('appstate_collection_index_values')}
+                 WHERE session_id = ? AND collection = ? AND index_mac_hex IN (${placeholders})`,
+                [this.sessionId, update.collection, ...chunk]
+            )
+        }
     }
 
     public async clear(): Promise<void> {

--- a/packages/store-mysql/src/helpers.ts
+++ b/packages/store-mysql/src/helpers.ts
@@ -1,5 +1,11 @@
 import type { FieldPacket, ResultSetHeader } from 'mysql2/promise'
-import { bytesToHex, normalizeQueryLimit, toBytesView, uint8Equal } from 'zapo-js/util'
+import {
+    bytesToHex,
+    normalizeQueryLimit,
+    toBytesView,
+    uint8Equal,
+    uint8TimingSafeEqual
+} from 'zapo-js/util'
 
 export type MysqlRow = Record<string, unknown>
 type QueryOutput = [unknown, FieldPacket[]]
@@ -36,4 +42,4 @@ export function assertSafeTablePrefix(prefix: string): void {
     }
 }
 
-export { bytesToHex, normalizeQueryLimit as safeLimit, uint8Equal }
+export { bytesToHex, normalizeQueryLimit as safeLimit, uint8Equal, uint8TimingSafeEqual }

--- a/packages/store-postgres/src/appstate.store.ts
+++ b/packages/store-postgres/src/appstate.store.ts
@@ -15,7 +15,15 @@ import type {
 } from 'zapo-js/store'
 
 import { BasePgStore } from './BasePgStore'
-import { bytesToHex, queryFirst, queryRows, toBytes, toBytesOrNull, uint8Equal } from './helpers'
+import {
+    bytesToHex,
+    queryFirst,
+    queryRows,
+    toBytes,
+    toBytesOrNull,
+    uint8Equal,
+    uint8TimingSafeEqual
+} from './helpers'
 import type { PgParam, WaPgStorageOptions } from './types'
 
 const BATCH_SIZE = 500
@@ -309,24 +317,72 @@ export class WaAppStatePgStore extends BasePgStore implements WaAppStateStore {
                     values: [this.sessionId, update.collection, update.version, update.hash]
                 })
 
-                await client.query({
-                    name: this.stmtName('appstate_delete_collection_values'),
-                    text: `DELETE FROM ${this.t('appstate_collection_index_values')}
-                     WHERE session_id = $1 AND collection = $2`,
-                    values: [this.sessionId, update.collection]
-                })
-
-                for (const [indexMacHex, valueMac] of update.indexValueMap.entries()) {
-                    await client.query({
-                        name: this.stmtName('appstate_insert_collection_value'),
-                        text: `INSERT INTO ${this.t('appstate_collection_index_values')} (
-                            session_id, collection, index_mac_hex, value_mac
-                        ) VALUES ($1, $2, $3, $4)`,
-                        values: [this.sessionId, update.collection, indexMacHex, valueMac]
-                    })
-                }
+                await this.applyIndexValueDiff(client, update)
             }
         })
+    }
+
+    private async applyIndexValueDiff(
+        client: PoolClient,
+        update: WaAppStateCollectionStateUpdate
+    ): Promise<void> {
+        const existingRows = queryRows(
+            await client.query({
+                name: this.stmtName('appstate_select_collection_values'),
+                text: `SELECT index_mac_hex, value_mac
+                     FROM ${this.t('appstate_collection_index_values')}
+                     WHERE session_id = $1 AND collection = $2`,
+                values: [this.sessionId, update.collection]
+            })
+        )
+        const existing = new Map<string, Uint8Array>()
+        for (const row of existingRows) {
+            existing.set(String(row.index_mac_hex), toBytes(row.value_mac))
+        }
+
+        const toUpsert: [string, Uint8Array][] = []
+        for (const [indexMacHex, valueMac] of update.indexValueMap.entries()) {
+            const current = existing.get(indexMacHex)
+            if (!current || !uint8TimingSafeEqual(current, valueMac)) {
+                toUpsert.push([indexMacHex, valueMac])
+            }
+        }
+        const toDelete: string[] = []
+        for (const indexMacHex of existing.keys()) {
+            if (!update.indexValueMap.has(indexMacHex)) {
+                toDelete.push(indexMacHex)
+            }
+        }
+
+        for (let start = 0; start < toUpsert.length; start += BATCH_SIZE) {
+            const chunk = toUpsert.slice(start, start + BATCH_SIZE)
+            const rows: string[] = []
+            const params: PgParam[] = []
+            let paramIdx = 1
+            for (const [indexMacHex, valueMac] of chunk) {
+                rows.push(`($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++})`)
+                params.push(this.sessionId, update.collection, indexMacHex, valueMac)
+            }
+            await client.query(
+                `INSERT INTO ${this.t('appstate_collection_index_values')} (
+                    session_id, collection, index_mac_hex, value_mac
+                ) VALUES ${rows.join(', ')}
+                ON CONFLICT (session_id, collection, index_mac_hex)
+                DO UPDATE SET value_mac = EXCLUDED.value_mac`,
+                params
+            )
+        }
+
+        for (let start = 0; start < toDelete.length; start += BATCH_SIZE) {
+            const chunk = toDelete.slice(start, start + BATCH_SIZE)
+            let paramIdx = 3
+            const placeholders = chunk.map(() => `$${paramIdx++}`).join(', ')
+            await client.query(
+                `DELETE FROM ${this.t('appstate_collection_index_values')}
+                 WHERE session_id = $1 AND collection = $2 AND index_mac_hex IN (${placeholders})`,
+                [this.sessionId, update.collection, ...chunk]
+            )
+        }
     }
 
     public async clear(): Promise<void> {

--- a/packages/store-postgres/src/helpers.ts
+++ b/packages/store-postgres/src/helpers.ts
@@ -1,5 +1,11 @@
 import type { QueryResult } from 'pg'
-import { bytesToHex, normalizeQueryLimit, toBytesView, uint8Equal } from 'zapo-js/util'
+import {
+    bytesToHex,
+    normalizeQueryLimit,
+    toBytesView,
+    uint8Equal,
+    uint8TimingSafeEqual
+} from 'zapo-js/util'
 
 export type PgRow = Record<string, unknown>
 
@@ -35,4 +41,4 @@ export function assertSafeTablePrefix(prefix: string): void {
     }
 }
 
-export { bytesToHex, normalizeQueryLimit as safeLimit, uint8Equal }
+export { bytesToHex, normalizeQueryLimit as safeLimit, uint8Equal, uint8TimingSafeEqual }

--- a/packages/store-redis/src/appstate.store.ts
+++ b/packages/store-redis/src/appstate.store.ts
@@ -21,7 +21,8 @@ import {
     scanKeys,
     toBytesOrNull,
     toRedisBuffer,
-    uint8Equal
+    uint8Equal,
+    uint8TimingSafeEqual
 } from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
@@ -376,11 +377,29 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
         for (const update of updates) {
             const colKey = this.k('appstate:col', this.sessionId, update.collection)
             const idxSetKey = this.k('appstate:idx:set', this.sessionId, update.collection)
+            const buildIdxKey = (macHex: string): string =>
+                this.k('appstate:idx', this.sessionId, update.collection, macHex)
 
             const oldMacs = await this.redis.smembers(idxSetKey)
+            const oldMacSet = new Set(oldMacs)
+            const oldValues = new Map<string, Uint8Array>()
+            if (oldMacs.length > 0) {
+                const readPipeline = this.redis.pipeline()
+                for (const macHex of oldMacs) {
+                    readPipeline.getBuffer(buildIdxKey(macHex))
+                }
+                const results = await readPipeline.exec()
+                if (results) {
+                    for (let i = 0; i < results.length; i += 1) {
+                        const value = toBytesOrNull(results[i][1])
+                        if (value) {
+                            oldValues.set(oldMacs[i], value)
+                        }
+                    }
+                }
+            }
 
             const multi = this.redis.multi()
-
             multi.hset(colKey, {
                 version: String(update.version)
             })
@@ -389,26 +408,28 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
                 toRedisBuffer(update.hash)
             )
 
-            if (oldMacs.length > 0) {
-                for (const macHex of oldMacs) {
-                    multi.del(this.k('appstate:idx', this.sessionId, update.collection, macHex))
-                }
-                multi.del(idxSetKey)
-            }
-
-            const newMacs: string[] = []
+            const addMacs: string[] = []
             for (const [indexMacHex, valueMac] of update.indexValueMap.entries()) {
-                const idxBinKey = this.k(
-                    'appstate:idx',
-                    this.sessionId,
-                    update.collection,
-                    indexMacHex
-                )
-                multi.set(idxBinKey, toRedisBuffer(valueMac))
-                newMacs.push(indexMacHex)
+                const current = oldValues.get(indexMacHex)
+                if (!current || !uint8TimingSafeEqual(current, valueMac)) {
+                    multi.set(buildIdxKey(indexMacHex), toRedisBuffer(valueMac))
+                }
+                if (!oldMacSet.has(indexMacHex)) {
+                    addMacs.push(indexMacHex)
+                }
             }
-            if (newMacs.length > 0) {
-                multi.sadd(idxSetKey, ...newMacs)
+            const delMacs: string[] = []
+            for (const macHex of oldMacs) {
+                if (!update.indexValueMap.has(macHex)) {
+                    multi.del(buildIdxKey(macHex))
+                    delMacs.push(macHex)
+                }
+            }
+            if (addMacs.length > 0) {
+                multi.sadd(idxSetKey, ...addMacs)
+            }
+            if (delMacs.length > 0) {
+                multi.srem(idxSetKey, ...delMacs)
             }
 
             await multi.exec()

--- a/packages/store-redis/src/helpers.ts
+++ b/packages/store-redis/src/helpers.ts
@@ -1,5 +1,12 @@
 import type Redis from 'ioredis'
-import { bytesToHex, hexToBytes, normalizeQueryLimit, toBytesView, uint8Equal } from 'zapo-js/util'
+import {
+    bytesToHex,
+    hexToBytes,
+    normalizeQueryLimit,
+    toBytesView,
+    uint8Equal,
+    uint8TimingSafeEqual
+} from 'zapo-js/util'
 
 function toBytes(value: unknown): Uint8Array {
     if (value instanceof Uint8Array) return value
@@ -63,4 +70,10 @@ export function toRedisBuffer(bytes: Uint8Array): Buffer {
     return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)
 }
 
-export { bytesToHex, hexToBytes, normalizeQueryLimit as safeLimit, uint8Equal }
+export {
+    bytesToHex,
+    hexToBytes,
+    normalizeQueryLimit as safeLimit,
+    uint8Equal,
+    uint8TimingSafeEqual
+}

--- a/packages/store-sqlite/src/__tests__/sqlite-runtime.test.ts
+++ b/packages/store-sqlite/src/__tests__/sqlite-runtime.test.ts
@@ -17,7 +17,7 @@ import {
 } from 'zapo-js/signal'
 
 import { WaAppStateSqliteStore } from '../appstate.store'
-import type { WaSqliteConnection } from '../connection'
+import { openSqliteConnection, type WaSqliteConnection } from '../connection'
 import { WaDeviceListSqliteStore } from '../device-list.store'
 import { WaGroupMetadataSqliteStore } from '../group-metadata.store'
 import { WaIdentitySqliteStore } from '../identity.store'
@@ -187,6 +187,81 @@ test('sqlite appstate store handles sync keys, collection state and session scop
         assert.deepEqual(afterClear.collections, {})
     } finally {
         await Promise.all([storeA.destroy(), storeB.destroy()])
+        await rm(dir, { recursive: true, force: true })
+    }
+})
+
+test('sqlite appstate setCollectionStates writes only the index/value delta', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zapo-sqlite-appstate-diff-'))
+    const connection = await openSqliteConnection({
+        path: join(dir, 'state.sqlite'),
+        sessionId: 'session-diff',
+        driver: 'better-sqlite3'
+    })
+
+    // Count write statements so the test asserts the delta is written, not a
+    // full delete-and-reinsert.
+    const writes = { INSERT: 0, DELETE: 0 }
+    const runImpl = connection.run.bind(connection)
+    ;(connection as unknown as { run: WaSqliteConnection['run'] }).run = (sql, params) => {
+        const verb = sql.trim().split(/\s+/)[0]?.toUpperCase()
+        if (verb === 'INSERT' || verb === 'DELETE') writes[verb] += 1
+        return runImpl(sql, params)
+    }
+
+    const store = new WaAppStateSqliteStore({ connection, sessionId: 'session-diff' })
+    const COL = WA_APP_STATE_COLLECTIONS.REGULAR_HIGH
+
+    try {
+        const seed = new Map<string, Uint8Array>()
+        for (let i = 0; i < 200; i += 1) seed.set('idx' + i, makeBytes(8, i & 0xff))
+        await store.setCollectionStates([
+            { collection: COL, version: 1, hash: makeBytes(128, 1), indexValueMap: seed }
+        ])
+
+        // Change exactly one of the 200 entries: only the version row and that
+        // single value row are written, nothing is deleted.
+        writes.INSERT = 0
+        writes.DELETE = 0
+        const changed = new Map(seed)
+        changed.set('idx7', makeBytes(8, 0xee))
+        await store.setCollectionStates([
+            { collection: COL, version: 2, hash: makeBytes(128, 9), indexValueMap: changed }
+        ])
+        assert.equal(writes.INSERT, 2) // 1 version upsert + 1 changed value
+        assert.equal(writes.DELETE, 0)
+
+        // Change one, add one, remove one.
+        writes.INSERT = 0
+        writes.DELETE = 0
+        const mixed = new Map(changed)
+        mixed.delete('idx0')
+        mixed.set('idx200', makeBytes(8, 0x55))
+        mixed.set('idx9', makeBytes(8, 0xcd))
+        await store.setCollectionStates([
+            { collection: COL, version: 3, hash: makeBytes(128, 3), indexValueMap: mixed }
+        ])
+        assert.equal(writes.INSERT, 3) // version + changed + added
+        assert.equal(writes.DELETE, 1) // only the removed entry
+
+        const state = await store.getCollectionState(COL)
+        assert.equal(state.version, 3)
+        assert.equal(state.indexValueMap.size, 200)
+        assert.deepEqual(state.indexValueMap.get('idx7'), makeBytes(8, 0xee))
+        assert.deepEqual(state.indexValueMap.get('idx9'), makeBytes(8, 0xcd))
+        assert.deepEqual(state.indexValueMap.get('idx200'), makeBytes(8, 0x55))
+        assert.equal(state.indexValueMap.has('idx0'), false)
+
+        // Emptying the map deletes the remaining rows.
+        await store.setCollectionStates([
+            { collection: COL, version: 4, hash: APP_STATE_EMPTY_LT_HASH, indexValueMap: new Map() }
+        ])
+        const emptied = await store.getCollectionState(COL)
+        assert.equal(emptied.version, 4)
+        assert.equal(emptied.indexValueMap.size, 0)
+    } finally {
+        await store.destroy()
+        connection.close()
         await rm(dir, { recursive: true, force: true })
     }
 })

--- a/packages/store-sqlite/src/appstate.store.ts
+++ b/packages/store-sqlite/src/appstate.store.ts
@@ -14,7 +14,14 @@ import type {
     WaAppStateCollectionStoreState,
     WaAppStateStore
 } from 'zapo-js/store'
-import { asBytes, asNumber, asString, bytesToHex, uint8Equal } from 'zapo-js/util'
+import {
+    asBytes,
+    asNumber,
+    asString,
+    bytesToHex,
+    uint8Equal,
+    uint8TimingSafeEqual
+} from 'zapo-js/util'
 
 import { BaseSqliteStore } from './BaseSqliteStore'
 import type { WaSqliteConnection } from './connection'
@@ -303,24 +310,62 @@ export class WaAppStateSqliteStore extends BaseSqliteStore implements WaAppState
                     [this.options.sessionId, update.collection, update.version, update.hash]
                 )
 
-                db.run(
-                    `DELETE FROM appstate_collection_index_values
-                     WHERE session_id = ? AND collection = ?`,
-                    [this.options.sessionId, update.collection]
-                )
-                for (const [indexMacHex, valueMac] of update.indexValueMap.entries()) {
-                    db.run(
-                        `INSERT INTO appstate_collection_index_values (
-                            session_id,
-                            collection,
-                            index_mac_hex,
-                            value_mac
-                        ) VALUES (?, ?, ?, ?)`,
-                        [this.options.sessionId, update.collection, indexMacHex, valueMac]
-                    )
-                }
+                this.applyIndexValueDiff(db, update)
             }
         })
+    }
+
+    private applyIndexValueDiff(
+        db: WaSqliteConnection,
+        update: WaAppStateCollectionStateUpdate
+    ): void {
+        const existingRows = db.all<Readonly<Record<string, unknown>>>(
+            `SELECT index_mac_hex, value_mac
+             FROM appstate_collection_index_values
+             WHERE session_id = ? AND collection = ?`,
+            [this.options.sessionId, update.collection]
+        )
+        const existing = new Map<string, Uint8Array>()
+        for (const row of existingRows) {
+            existing.set(
+                asString(row.index_mac_hex, 'appstate_collection_index_values.index_mac_hex'),
+                asBytes(row.value_mac, 'appstate_collection_index_values.value_mac')
+            )
+        }
+
+        for (const [indexMacHex, valueMac] of update.indexValueMap.entries()) {
+            const current = existing.get(indexMacHex)
+            if (!current || !uint8TimingSafeEqual(current, valueMac)) {
+                db.run(
+                    `INSERT INTO appstate_collection_index_values (
+                        session_id,
+                        collection,
+                        index_mac_hex,
+                        value_mac
+                    ) VALUES (?, ?, ?, ?)
+                    ON CONFLICT(session_id, collection, index_mac_hex)
+                    DO UPDATE SET value_mac = excluded.value_mac`,
+                    [this.options.sessionId, update.collection, indexMacHex, valueMac]
+                )
+            }
+        }
+
+        const toDelete: string[] = []
+        for (const indexMacHex of existing.keys()) {
+            if (!update.indexValueMap.has(indexMacHex)) {
+                toDelete.push(indexMacHex)
+            }
+        }
+        const deleteBatchSize = 500
+        for (let start = 0; start < toDelete.length; start += deleteBatchSize) {
+            const chunk = toDelete.slice(start, start + deleteBatchSize)
+            const placeholders = repeatSqlToken('?', chunk.length, ', ')
+            db.run(
+                `DELETE FROM appstate_collection_index_values
+                 WHERE session_id = ? AND collection = ? AND index_mac_hex IN (${placeholders})`,
+                [this.options.sessionId, update.collection, ...chunk]
+            )
+        }
     }
 
     public async clear(): Promise<void> {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -7,7 +7,8 @@ export {
     hexToBytes,
     TEXT_DECODER,
     toBytesView,
-    uint8Equal
+    uint8Equal,
+    uint8TimingSafeEqual
 } from '@util/bytes'
 export {
     asBytes,


### PR DESCRIPTION
setCollectionStates rewrote the entire index_value set on every change (DELETE all + one INSERT per row), so a single-mutation patch on a large collection issued ~N writes. Diff against the persisted state and write only the delta: upsert changed/new entries, delete removed ones, leave unchanged rows untouched. Applied across mysql, postgres, sqlite, mongo and redis.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection index values now update incrementally across storage backends, preserving unchanged entries, updating changed ones, and removing only stale keys.
  * Clearing a collection now reliably leaves it empty with the expected version state.
* **Tests**
  * Added runtime coverage for repeated collection updates, including added, updated, removed, and unchanged index values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->