### PR TITLE
feat(store-redis): add optional per-domain key TTL via storeTtlMs

### DIFF
--- a/packages/store-redis/README.md
+++ b/packages/store-redis/README.md
@@ -46,8 +46,49 @@ const client = new WaClient({ store, sessionId: 'default' })
 | `redis`      | A live `ioredis` instance **or** `RedisOptions` for a new client. When the store builds the client itself, `destroy()` will `quit()` it for you. |
 | `keyPrefix`  | String prepended to every key (e.g. `'wa:'`, `'tenant-A:'`).                                                                                     |
 | `cacheTtlMs` | TTLs for `retry`, `groupMetadata`, `deviceList`, `messageSecret` (Redis `EX`/`PEXPIRE`).                                                         |
+| `storeTtlMs` | Opt-in TTLs for the otherwise-persistent store domains (see [Store TTLs](#store-ttls)). Any domain left unset stays persistent.                  |
 
 The return value extends `WaStoreBackend` with `{ redis, destroy }` so you can reuse the same connection elsewhere and shut it down cleanly on app exit.
+
+## Store TTLs
+
+The persistent domains never expire by default. `storeTtlMs` lets you put an
+optional Redis-native TTL on individual domains (applied as `PEXPIRE` on each
+write - no cleanup job), with two semantics depending on the domain kind:
+
+```ts
+createRedisStore({
+    redis: { host: '127.0.0.1', port: 6379 },
+    storeTtlMs: {
+        // Data domains - expire N ms after the last write (history/retention):
+        messagesMs: 30 * 24 * 60 * 60 * 1000,
+        threadsMs: 30 * 24 * 60 * 60 * 1000,
+        contactsMs: 30 * 24 * 60 * 60 * 1000,
+        privacyTokenMs: 7 * 24 * 60 * 60 * 1000,
+        // Crypto & session domains - sliding TTL, refreshed on read too, so
+        // only idle sessions are evicted (active ones never expire):
+        signalMs: 90 * 24 * 60 * 60 * 1000,
+        preKeyMs: 90 * 24 * 60 * 60 * 1000,
+        sessionMs: 90 * 24 * 60 * 60 * 1000,
+        identityMs: 90 * 24 * 60 * 60 * 1000,
+        senderKeyMs: 90 * 24 * 60 * 60 * 1000,
+        appStateMs: 90 * 24 * 60 * 60 * 1000
+    }
+})
+```
+
+- **Data** (`messagesMs`, `threadsMs`, `contactsMs`, `privacyTokenMs`): TTL is
+  refreshed on write only - keys expire a fixed window after their last update.
+- **Crypto & session** (`signalMs`, `preKeyMs`, `sessionMs`, `identityMs`,
+  `senderKeyMs`, `appStateMs`): TTL is refreshed on read **and** write, so an
+  actively used session keeps its keys alive and only genuinely idle sessions
+  are reclaimed.
+- **`auth` has no TTL knob** on purpose: expiring login credentials would log
+  the device out. It always persists.
+
+> Set a crypto/session TTL short relative to how often a session connects at
+> your own risk - an idle window longer than the TTL evicts the Signal / app-state
+> keys and forces a re-handshake or re-sync on next use.
 
 ## Notes
 

--- a/packages/store-redis/src/BaseRedisStore.ts
+++ b/packages/store-redis/src/BaseRedisStore.ts
@@ -49,6 +49,20 @@ export abstract class BaseRedisStore {
     }
 
     /**
+     * Atomic single-key `SET` that also stamps the sliding TTL in the same
+     * command (`SET ... PX`), so a write never leaves a key without its expiry
+     * even if the connection drops mid-sequence. Falls back to a plain `SET`
+     * when `ttlMs` is unset.
+     */
+    protected async setWithTtl(key: string, value: Buffer | string): Promise<void> {
+        if (this.keyTtlMs === undefined) {
+            await this.redis.set(key, value)
+        } else {
+            await this.redis.set(key, value, 'PX', this.keyTtlMs)
+        }
+    }
+
+    /**
      * Refreshes the sliding TTL on keys outside a write pipeline - used by
      * single-command writes and by read paths (touch-on-access) so an actively
      * used session keeps its keys alive. No-op (no round-trip) when `ttlMs` is

--- a/packages/store-redis/src/BaseRedisStore.ts
+++ b/packages/store-redis/src/BaseRedisStore.ts
@@ -1,4 +1,4 @@
-import type Redis from 'ioredis'
+import type { ChainableCommander, default as Redis } from 'ioredis'
 import type { Logger } from 'zapo-js'
 
 import { assertSafeKeyPrefix } from './helpers'
@@ -8,18 +8,64 @@ export abstract class BaseRedisStore {
     protected readonly redis: Redis
     protected readonly sessionId: string
     protected readonly keyPrefix: string
+    /**
+     * Sliding TTL (ms) applied to keys this store writes/reads via {@link touch}
+     * and {@link refreshTtl}. Distinct from the cache stores' own `ttlMs`, which
+     * predates this and is managed independently in those subclasses.
+     */
+    protected readonly keyTtlMs: number | undefined
     protected readonly logger: Logger | undefined
 
     protected constructor(options: WaRedisStorageOptions) {
         this.redis = options.redis
         this.sessionId = options.sessionId
         this.keyPrefix = options.keyPrefix ?? ''
+        this.keyTtlMs = options.ttlMs
         this.logger = options.logger
         assertSafeKeyPrefix(this.keyPrefix)
+        if (
+            this.keyTtlMs !== undefined &&
+            (!Number.isSafeInteger(this.keyTtlMs) || this.keyTtlMs <= 0)
+        ) {
+            throw new Error('store ttlMs must be a positive integer')
+        }
     }
 
     protected k(...parts: readonly string[]): string {
         return `${this.keyPrefix}${parts.join(':')}`
+    }
+
+    /**
+     * Appends a `PEXPIRE` for each key onto an existing pipeline/multi when a
+     * sliding TTL is configured, refreshing the keys atomically with the write
+     * they accompany. No-op (zero extra commands) when `ttlMs` is unset, so the
+     * default persistent behavior is byte-identical.
+     */
+    protected touch(pipeline: ChainableCommander, keys: readonly string[]): void {
+        if (this.keyTtlMs === undefined) return
+        for (const key of keys) {
+            pipeline.pexpire(key, this.keyTtlMs)
+        }
+    }
+
+    /**
+     * Refreshes the sliding TTL on keys outside a write pipeline - used by
+     * single-command writes and by read paths (touch-on-access) so an actively
+     * used session keeps its keys alive. No-op (no round-trip) when `ttlMs` is
+     * unset. `PEXPIRE` on a missing key is itself a harmless no-op, so callers
+     * need not pre-check existence.
+     */
+    protected async refreshTtl(keys: readonly string[]): Promise<void> {
+        if (this.keyTtlMs === undefined || keys.length === 0) return
+        if (keys.length === 1) {
+            await this.redis.pexpire(keys[0], this.keyTtlMs)
+            return
+        }
+        const pipeline = this.redis.pipeline()
+        for (const key of keys) {
+            pipeline.pexpire(key, this.keyTtlMs)
+        }
+        await pipeline.exec()
     }
 
     public async destroy(): Promise<void> {

--- a/packages/store-redis/src/BaseRedisStore.ts
+++ b/packages/store-redis/src/BaseRedisStore.ts
@@ -63,6 +63,31 @@ export abstract class BaseRedisStore {
     }
 
     /**
+     * Batch equivalent of {@link setWithTtl}: a single `MSET` when no TTL is
+     * configured, otherwise a pipeline of per-key `SET ... PX` so every key is
+     * born with its expiry rather than stamped by a follow-up `PEXPIRE` that a
+     * dropped connection could skip.
+     */
+    protected async msetWithTtl(pairs: ReadonlyArray<readonly [string, Buffer]>): Promise<void> {
+        if (pairs.length === 0) return
+        if (this.keyTtlMs === undefined) {
+            const args: (string | Buffer)[] = []
+            for (const [key, value] of pairs) {
+                args.push(key, value)
+            }
+            await (
+                this.redis as unknown as { mset: (...args: unknown[]) => Promise<unknown> }
+            ).mset(...args)
+            return
+        }
+        const pipeline = this.redis.pipeline()
+        for (const [key, value] of pairs) {
+            pipeline.set(key, value, 'PX', this.keyTtlMs)
+        }
+        await pipeline.exec()
+    }
+
+    /**
      * Refreshes the sliding TTL on keys outside a write pipeline - used by
      * single-command writes and by read paths (touch-on-access) so an actively
      * used session keeps its keys alive. No-op (no round-trip) when `ttlMs` is

--- a/packages/store-redis/src/__tests__/integration.test.ts
+++ b/packages/store-redis/src/__tests__/integration.test.ts
@@ -1382,3 +1382,126 @@ describe('store-redis integration', { timeout: 60_000 }, () => {
         await session.clear()
     })
 })
+
+describe('store-redis storeTtlMs', { timeout: 60_000 }, () => {
+    const TTL = 5_000
+    let redis: Redis | undefined
+    let store: WaRedisStoreResult | undefined
+
+    before(async () => {
+        if (!host || !port) return
+        redis = new Redis({ host, port: Number(port) })
+        store = createRedisStore({
+            redis,
+            storeTtlMs: {
+                messagesMs: TTL,
+                signalMs: TTL,
+                appStateMs: TTL
+            }
+        })
+    })
+
+    after(async () => {
+        if (store) await store.destroy()
+        if (redis) await redis.quit()
+    })
+
+    it('data store expires written keys after the configured TTL window', async (t) => {
+        if (!store || !redis) return t.skip('ZAPO_TEST_REDIS_* not set')
+
+        const sessionId = nextSessionId('ttl-messages')
+        const messages = store.stores.messages(sessionId)
+        await messages.clear()
+
+        await messages.upsert({
+            id: 'ttl-msg-1',
+            threadJid: 'ttl-thread@s.whatsapp.net',
+            fromMe: true,
+            timestampMs: 1_000,
+            messageBytes: new Uint8Array([1, 2, 3])
+        })
+
+        const msgPttl = await redis.pttl(`msg:${sessionId}:ttl-msg-1`)
+        assert.ok(msgPttl > 0 && msgPttl <= TTL, `msg pttl out of range: ${msgPttl}`)
+        const binPttl = await redis.pttl(`msg:${sessionId}:ttl-msg-1:message_bytes`)
+        assert.ok(binPttl > 0 && binPttl <= TTL, `bin pttl out of range: ${binPttl}`)
+        const idxPttl = await redis.pttl(`msg:idx:${sessionId}:ttl-thread@s.whatsapp.net`)
+        assert.ok(idxPttl > 0 && idxPttl <= TTL, `idx pttl out of range: ${idxPttl}`)
+
+        await messages.clear()
+    })
+
+    it('crypto store refreshes TTL on read so an active session stays alive', async (t) => {
+        if (!store || !redis) return t.skip('ZAPO_TEST_REDIS_* not set')
+
+        const sessionId = nextSessionId('ttl-signal')
+        const signal = store.stores.signal(sessionId)
+        await signal.clear()
+
+        await signal.setRegistrationInfo({
+            registrationId: 7,
+            identityKeyPair: {
+                pubKey: new Uint8Array(33).fill(1),
+                privKey: new Uint8Array(32).fill(2)
+            }
+        })
+
+        const regKey = `signal:reg:${sessionId}`
+        const afterWrite = await redis.pttl(regKey)
+        assert.ok(afterWrite > 0 && afterWrite <= TTL, `reg pttl out of range: ${afterWrite}`)
+
+        await new Promise((resolve) => setTimeout(resolve, 400))
+        const beforeRead = await redis.pttl(regKey)
+        const loaded = await signal.getRegistrationInfo()
+        assert.ok(loaded)
+        assert.equal(loaded.registrationId, 7)
+        const afterRead = await redis.pttl(regKey)
+        assert.ok(
+            afterRead > beforeRead,
+            `read did not refresh TTL: before=${beforeRead} after=${afterRead}`
+        )
+
+        await signal.clear()
+    })
+
+    it('auth keys never receive a TTL even when storeTtlMs is set', async (t) => {
+        if (!store || !redis) return t.skip('ZAPO_TEST_REDIS_* not set')
+
+        const sessionId = nextSessionId('ttl-auth')
+        const auth = store.stores.auth(sessionId)
+        await auth.clear()
+
+        await auth.save({
+            noiseKeyPair: { pubKey: new Uint8Array(32), privKey: new Uint8Array(32) },
+            registrationInfo: {
+                registrationId: 1,
+                identityKeyPair: { pubKey: new Uint8Array(33), privKey: new Uint8Array(32) }
+            },
+            signedPreKey: {
+                keyId: 1,
+                keyPair: { pubKey: new Uint8Array(33), privKey: new Uint8Array(32) },
+                signature: new Uint8Array(64),
+                uploaded: false
+            },
+            advSecretKey: new Uint8Array(32)
+        })
+
+        assert.equal(await redis.pttl(`auth:${sessionId}`), -1)
+        assert.equal(await redis.pttl(`auth:${sessionId}:noise_pub_key`), -1)
+
+        await auth.clear()
+    })
+
+    it('rejects a non-positive ttlMs at store construction', (t) => {
+        if (!store || !redis) return t.skip('ZAPO_TEST_REDIS_* not set')
+        const reused = redis
+        assert.throws(
+            () =>
+                createRedisStore({
+                    redis: reused,
+                    storeTtlMs: { messagesMs: 0 }
+                }).stores.messages('x'),
+            /ttlMs must be a positive integer/
+        )
+    })
+})

--- a/packages/store-redis/src/appstate.store.ts
+++ b/packages/store-redis/src/appstate.store.ts
@@ -26,6 +26,8 @@ import {
 } from './helpers'
 import type { WaRedisStorageOptions } from './types'
 
+const ACTIVE_SYNC_KEY_PAGE_SIZE = 16
+
 export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateStore {
     public constructor(options: WaRedisStorageOptions) {
         super(options)
@@ -310,41 +312,63 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
 
     public async getActiveSyncKey(): Promise<WaAppStateSyncKey | null> {
         const idxKey = this.k('appstate:key:idx', this.sessionId)
-        const members = await this.redis.zrevrange(idxKey, 0, -1)
+        const stale: string[] = []
+        let start = 0
 
-        for (const keyIdHex of members) {
-            const hashKey = this.k('appstate:key', this.sessionId, keyIdHex)
-            const dataKey = this.k('appstate:key', this.sessionId, keyIdHex, 'data')
-            const fpKey = this.k('appstate:key', this.sessionId, keyIdHex, 'fp')
+        for (;;) {
+            const members = await this.redis.zrevrange(
+                idxKey,
+                start,
+                start + ACTIVE_SYNC_KEY_PAGE_SIZE - 1
+            )
+            if (members.length === 0) break
+
             const pipeline = this.redis.pipeline()
-            pipeline.hgetall(hashKey)
-            pipeline.getBuffer(dataKey)
-            pipeline.getBuffer(fpKey)
+            for (const keyIdHex of members) {
+                pipeline.hgetall(this.k('appstate:key', this.sessionId, keyIdHex))
+                pipeline.getBuffer(this.k('appstate:key', this.sessionId, keyIdHex, 'data'))
+                pipeline.getBuffer(this.k('appstate:key', this.sessionId, keyIdHex, 'fp'))
+            }
             const results = await pipeline.exec()
-            if (!results) return null
+            if (!results) break
 
-            const [err, hashData] = results[0]
-            const data =
-                !err && hashData && typeof hashData === 'object'
-                    ? (hashData as Record<string, string>)
-                    : null
-            const keyData =
-                data && Object.keys(data).length > 0 ? toBytesOrNull(results[1][1]) : null
-            if (!data || !keyData) {
-                await this.redis.zrem(idxKey, keyIdHex)
-                continue
+            for (let i = 0; i < members.length; i += 1) {
+                const base = i * 3
+                const keyIdHex = members[i]
+                const [err, hashData] = results[base]
+                const data =
+                    !err && hashData && typeof hashData === 'object'
+                        ? (hashData as Record<string, string>)
+                        : null
+                const keyData =
+                    data && Object.keys(data).length > 0
+                        ? toBytesOrNull(results[base + 1][1])
+                        : null
+                if (!data || !keyData) {
+                    stale.push(keyIdHex)
+                    continue
+                }
+                const fingerprint = toBytesOrNull(results[base + 2][1])
+                const hashKey = this.k('appstate:key', this.sessionId, keyIdHex)
+                const dataKey = this.k('appstate:key', this.sessionId, keyIdHex, 'data')
+                const fpKey = this.k('appstate:key', this.sessionId, keyIdHex, 'fp')
+
+                if (stale.length > 0) await this.redis.zrem(idxKey, ...stale)
+                await this.refreshTtl([idxKey, hashKey, dataKey, fpKey])
+
+                return {
+                    keyId: hexToBytes(keyIdHex),
+                    keyData,
+                    timestamp: Number(data.timestamp),
+                    fingerprint: decodeAppStateFingerprint(fingerprint)
+                }
             }
-            const fingerprint = toBytesOrNull(results[2][1])
 
-            await this.refreshTtl([idxKey, hashKey, dataKey, fpKey])
-
-            return {
-                keyId: hexToBytes(keyIdHex),
-                keyData,
-                timestamp: Number(data.timestamp),
-                fingerprint: decodeAppStateFingerprint(fingerprint)
-            }
+            if (members.length < ACTIVE_SYNC_KEY_PAGE_SIZE) break
+            start += ACTIVE_SYNC_KEY_PAGE_SIZE
         }
+
+        if (stale.length > 0) await this.redis.zrem(idxKey, ...stale)
         return null
     }
 

--- a/packages/store-redis/src/appstate.store.ts
+++ b/packages/store-redis/src/appstate.store.ts
@@ -166,6 +166,7 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
         const existingResults = await existingPipeline.exec()
 
         const writePipeline = this.redis.pipeline()
+        const refreshUnchanged: string[] = []
         for (let i = 0; i < syncKeys.length; i += 1) {
             const sk = syncKeys[i]
             const keyIdHex = bytesToHex(sk.keyId)
@@ -175,6 +176,11 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
                 if (!err && data) {
                     const existingData = toBytesOrNull(data)
                     if (existingData && uint8Equal(existingData, sk.keyData)) {
+                        refreshUnchanged.push(
+                            this.k('appstate:key', this.sessionId, keyIdHex),
+                            this.k('appstate:key', this.sessionId, keyIdHex, 'data'),
+                            this.k('appstate:key', this.sessionId, keyIdHex, 'fp')
+                        )
                         continue
                     }
                 }
@@ -203,6 +209,9 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
 
         if (inserted > 0) {
             await writePipeline.exec()
+        }
+        if (refreshUnchanged.length > 0) {
+            await this.refreshTtl([...refreshUnchanged, idxKey])
         }
         return inserted
     }
@@ -247,6 +256,9 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
                 this.k('appstate:key', this.sessionId, keyIdHex, 'fp')
             )
         }
+        if (refreshKeys.length > 0) {
+            refreshKeys.push(this.k('appstate:key:idx', this.sessionId))
+        }
         await this.refreshTtl(refreshKeys)
         return out
     }
@@ -259,7 +271,8 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
         await this.refreshTtl([
             this.k('appstate:key', this.sessionId, keyIdHex),
             binKey,
-            this.k('appstate:key', this.sessionId, keyIdHex, 'fp')
+            this.k('appstate:key', this.sessionId, keyIdHex, 'fp'),
+            this.k('appstate:key:idx', this.sessionId)
         ])
         return new Uint8Array(raw)
     }
@@ -287,6 +300,9 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
                 this.k('appstate:key', this.sessionId, keyIdHex, 'data'),
                 this.k('appstate:key', this.sessionId, keyIdHex, 'fp')
             )
+        }
+        if (refreshKeys.length > 0) {
+            refreshKeys.push(this.k('appstate:key:idx', this.sessionId))
         }
         await this.refreshTtl(refreshKeys)
         return out

--- a/packages/store-redis/src/appstate.store.ts
+++ b/packages/store-redis/src/appstate.store.ts
@@ -181,24 +181,23 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
             }
 
             const hashKey = this.k('appstate:key', this.sessionId, keyIdHex)
+            const dataKey = this.k('appstate:key', this.sessionId, keyIdHex, 'data')
             const epoch = keyEpoch(sk.keyId)
             writePipeline.hset(hashKey, {
                 key_id_hex: keyIdHex,
                 timestamp: String(sk.timestamp),
                 key_epoch: String(epoch)
             })
-            writePipeline.set(
-                this.k('appstate:key', this.sessionId, keyIdHex, 'data'),
-                toRedisBuffer(sk.keyData)
-            )
+            writePipeline.set(dataKey, toRedisBuffer(sk.keyData))
+            const ttlKeys = [hashKey, dataKey, idxKey]
             const fingerprint = encodeAppStateFingerprint(sk.fingerprint)
             if (fingerprint) {
-                writePipeline.set(
-                    this.k('appstate:key', this.sessionId, keyIdHex, 'fp'),
-                    toRedisBuffer(fingerprint)
-                )
+                const fpKey = this.k('appstate:key', this.sessionId, keyIdHex, 'fp')
+                writePipeline.set(fpKey, toRedisBuffer(fingerprint))
+                ttlKeys.push(fpKey)
             }
             writePipeline.zadd(idxKey, epoch, keyIdHex)
+            this.touch(writePipeline, ttlKeys)
             inserted += 1
         }
 
@@ -222,7 +221,7 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
         const results = await pipeline.exec()
         if (!results) return keyIds.map(() => null)
 
-        return keyIds.map((keyId, index) => {
+        const out = keyIds.map((keyId, index) => {
             const base = index * 3
             const [err, hashData] = results[base]
             if (err || !hashData || typeof hashData !== 'object') return null
@@ -238,12 +237,30 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
                 fingerprint: decodeAppStateFingerprint(fingerprint)
             }
         })
+        const refreshKeys: string[] = []
+        for (let index = 0; index < keyIds.length; index += 1) {
+            if (out[index] === null) continue
+            const keyIdHex = bytesToHex(keyIds[index])
+            refreshKeys.push(
+                this.k('appstate:key', this.sessionId, keyIdHex),
+                this.k('appstate:key', this.sessionId, keyIdHex, 'data'),
+                this.k('appstate:key', this.sessionId, keyIdHex, 'fp')
+            )
+        }
+        await this.refreshTtl(refreshKeys)
+        return out
     }
 
     public async getSyncKeyData(keyId: Uint8Array): Promise<Uint8Array | null> {
-        const binKey = this.k('appstate:key', this.sessionId, bytesToHex(keyId), 'data')
+        const keyIdHex = bytesToHex(keyId)
+        const binKey = this.k('appstate:key', this.sessionId, keyIdHex, 'data')
         const raw = await this.redis.getBuffer(binKey)
         if (!raw) return null
+        await this.refreshTtl([
+            this.k('appstate:key', this.sessionId, keyIdHex),
+            binKey,
+            this.k('appstate:key', this.sessionId, keyIdHex, 'fp')
+        ])
         return new Uint8Array(raw)
     }
 
@@ -257,10 +274,22 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
         }
         const results = await pipeline.exec()
         if (!results) return keyIds.map(() => null)
-        return results.map(([err, data]) => {
+        const out = results.map(([err, data]) => {
             if (err || !data) return null
             return new Uint8Array(data as Uint8Array)
         })
+        const refreshKeys: string[] = []
+        for (let index = 0; index < keyIds.length; index += 1) {
+            if (out[index] === null) continue
+            const keyIdHex = bytesToHex(keyIds[index])
+            refreshKeys.push(
+                this.k('appstate:key', this.sessionId, keyIdHex),
+                this.k('appstate:key', this.sessionId, keyIdHex, 'data'),
+                this.k('appstate:key', this.sessionId, keyIdHex, 'fp')
+            )
+        }
+        await this.refreshTtl(refreshKeys)
+        return out
     }
 
     public async getActiveSyncKey(): Promise<WaAppStateSyncKey | null> {
@@ -269,10 +298,13 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
         if (topMembers.length === 0) return null
 
         const keyIdHex = topMembers[0]
+        const hashKey = this.k('appstate:key', this.sessionId, keyIdHex)
+        const dataKey = this.k('appstate:key', this.sessionId, keyIdHex, 'data')
+        const fpKey = this.k('appstate:key', this.sessionId, keyIdHex, 'fp')
         const pipeline = this.redis.pipeline()
-        pipeline.hgetall(this.k('appstate:key', this.sessionId, keyIdHex))
-        pipeline.getBuffer(this.k('appstate:key', this.sessionId, keyIdHex, 'data'))
-        pipeline.getBuffer(this.k('appstate:key', this.sessionId, keyIdHex, 'fp'))
+        pipeline.hgetall(hashKey)
+        pipeline.getBuffer(dataKey)
+        pipeline.getBuffer(fpKey)
         const results = await pipeline.exec()
         if (!results) return null
 
@@ -283,6 +315,8 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
         const keyData = toBytesOrNull(results[1][1])
         if (!keyData) return null
         const fingerprint = toBytesOrNull(results[2][1])
+
+        await this.refreshTtl([this.k('appstate:key:idx', this.sessionId), hashKey, dataKey, fpKey])
 
         return {
             keyId: hexToBytes(keyIdHex),
@@ -350,6 +384,13 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
             }
         }
 
+        await this.refreshTtl([
+            colKey,
+            this.k('appstate:col', this.sessionId, collection, 'hash'),
+            idxSetKey,
+            ...indexMacs.map((macHex) => this.k('appstate:idx', this.sessionId, collection, macHex))
+        ])
+
         return {
             initialized: true,
             version: Number(data.version),
@@ -399,14 +440,12 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
                 }
             }
 
+            const colHashKey = this.k('appstate:col', this.sessionId, update.collection, 'hash')
             const multi = this.redis.multi()
             multi.hset(colKey, {
                 version: String(update.version)
             })
-            multi.set(
-                this.k('appstate:col', this.sessionId, update.collection, 'hash'),
-                toRedisBuffer(update.hash)
-            )
+            multi.set(colHashKey, toRedisBuffer(update.hash))
 
             const addMacs: string[] = []
             for (const [indexMacHex, valueMac] of update.indexValueMap.entries()) {
@@ -431,6 +470,13 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
             if (delMacs.length > 0) {
                 multi.srem(idxSetKey, ...delMacs)
             }
+
+            this.touch(multi, [
+                colKey,
+                colHashKey,
+                idxSetKey,
+                ...[...update.indexValueMap.keys()].map(buildIdxKey)
+            ])
 
             await multi.exec()
         }

--- a/packages/store-redis/src/appstate.store.ts
+++ b/packages/store-redis/src/appstate.store.ts
@@ -310,36 +310,42 @@ export class WaAppStateRedisStore extends BaseRedisStore implements WaAppStateSt
 
     public async getActiveSyncKey(): Promise<WaAppStateSyncKey | null> {
         const idxKey = this.k('appstate:key:idx', this.sessionId)
-        const topMembers = await this.redis.zrevrange(idxKey, 0, 0)
-        if (topMembers.length === 0) return null
+        const members = await this.redis.zrevrange(idxKey, 0, -1)
 
-        const keyIdHex = topMembers[0]
-        const hashKey = this.k('appstate:key', this.sessionId, keyIdHex)
-        const dataKey = this.k('appstate:key', this.sessionId, keyIdHex, 'data')
-        const fpKey = this.k('appstate:key', this.sessionId, keyIdHex, 'fp')
-        const pipeline = this.redis.pipeline()
-        pipeline.hgetall(hashKey)
-        pipeline.getBuffer(dataKey)
-        pipeline.getBuffer(fpKey)
-        const results = await pipeline.exec()
-        if (!results) return null
+        for (const keyIdHex of members) {
+            const hashKey = this.k('appstate:key', this.sessionId, keyIdHex)
+            const dataKey = this.k('appstate:key', this.sessionId, keyIdHex, 'data')
+            const fpKey = this.k('appstate:key', this.sessionId, keyIdHex, 'fp')
+            const pipeline = this.redis.pipeline()
+            pipeline.hgetall(hashKey)
+            pipeline.getBuffer(dataKey)
+            pipeline.getBuffer(fpKey)
+            const results = await pipeline.exec()
+            if (!results) return null
 
-        const [err, hashData] = results[0]
-        if (err || !hashData || typeof hashData !== 'object') return null
-        const data = hashData as Record<string, string>
-        if (Object.keys(data).length === 0) return null
-        const keyData = toBytesOrNull(results[1][1])
-        if (!keyData) return null
-        const fingerprint = toBytesOrNull(results[2][1])
+            const [err, hashData] = results[0]
+            const data =
+                !err && hashData && typeof hashData === 'object'
+                    ? (hashData as Record<string, string>)
+                    : null
+            const keyData =
+                data && Object.keys(data).length > 0 ? toBytesOrNull(results[1][1]) : null
+            if (!data || !keyData) {
+                await this.redis.zrem(idxKey, keyIdHex)
+                continue
+            }
+            const fingerprint = toBytesOrNull(results[2][1])
 
-        await this.refreshTtl([this.k('appstate:key:idx', this.sessionId), hashKey, dataKey, fpKey])
+            await this.refreshTtl([idxKey, hashKey, dataKey, fpKey])
 
-        return {
-            keyId: hexToBytes(keyIdHex),
-            keyData,
-            timestamp: Number(data.timestamp),
-            fingerprint: decodeAppStateFingerprint(fingerprint)
+            return {
+                keyId: hexToBytes(keyIdHex),
+                keyData,
+                timestamp: Number(data.timestamp),
+                fingerprint: decodeAppStateFingerprint(fingerprint)
+            }
         }
+        return null
     }
 
     public async getCollectionState(

--- a/packages/store-redis/src/contact.store.ts
+++ b/packages/store-redis/src/contact.store.ts
@@ -81,7 +81,11 @@ export class WaContactRedisStore extends BaseRedisStore implements WaContactStor
             }
         }
         if (mergedRecord.phoneNumber) {
-            await this.redis.set(this.phoneLookupKey(mergedRecord.phoneNumber), mergedRecord.jid)
+            const lookupKey = this.phoneLookupKey(mergedRecord.phoneNumber)
+            await this.redis.set(lookupKey, mergedRecord.jid)
+            await this.refreshTtl([key, lookupKey])
+        } else {
+            await this.refreshTtl([key])
         }
     }
 

--- a/packages/store-redis/src/createRedisStore.ts
+++ b/packages/store-redis/src/createRedisStore.ts
@@ -44,6 +44,35 @@ export interface WaRedisStoreConfig {
         readonly messageSecretMs?: number
     }
     /**
+     * Opt-in sliding TTLs (in ms) for the otherwise-persistent store domains,
+     * applied as Redis `PEXPIRE` on each write - no background cleanup. Any
+     * domain left unset stays persistent (current behavior).
+     *
+     * Two semantics, by domain kind:
+     * - Data (`messagesMs`/`threadsMs`/`contactsMs`/`privacyTokenMs`): expire
+     *   N ms after the last write - history/retention bounding.
+     * - Crypto & session (`preKeyMs`/`sessionMs`/`identityMs`/`signalMs`/
+     *   `senderKeyMs`/`appStateMs`): TTL also refreshed on read, so an actively
+     *   used session never expires and only idle sessions are evicted.
+     *
+     * `auth` is intentionally absent: expiring login credentials would log the
+     * device out. Set a TTL short relative to how often a session is used at
+     * your own risk - an idle window longer than the crypto TTL evicts the
+     * Signal/app-state keys and forces a re-handshake or re-sync.
+     */
+    readonly storeTtlMs?: {
+        readonly preKeyMs?: number
+        readonly sessionMs?: number
+        readonly identityMs?: number
+        readonly signalMs?: number
+        readonly senderKeyMs?: number
+        readonly appStateMs?: number
+        readonly messagesMs?: number
+        readonly threadsMs?: number
+        readonly contactsMs?: number
+        readonly privacyTokenMs?: number
+    }
+    /**
      * Logger for connection lifecycle and degraded paths emitted by the
      * factory (connect/ready/reconnecting/end/error). The factory binds
      * `{ scope: 'store', provider: 'redis' }` and each per-domain store
@@ -114,6 +143,7 @@ export function createRedisStore(config: WaRedisStoreConfig): WaRedisStoreResult
     const groupMetadataTtlMs = config.cacheTtlMs?.groupMetadataMs
     const deviceListTtlMs = config.cacheTtlMs?.deviceListMs
     const messageSecretTtlMs = config.cacheTtlMs?.messageSecretMs
+    const storeTtl = config.storeTtlMs ?? {}
     const ownsRedis = !isRedis(config.redis)
     const baseLogger = config.logger?.child({ scope: 'store', provider: 'redis' })
 
@@ -133,10 +163,11 @@ export function createRedisStore(config: WaRedisStoreConfig): WaRedisStoreResult
         redis.on('error', (err: Error) => baseLogger.warn('redis error', { message: err.message }))
     }
 
-    const opts = (sessionId: string, domain: string): WaRedisStorageOptions => ({
+    const opts = (sessionId: string, domain: string, ttlMs?: number): WaRedisStorageOptions => ({
         redis,
         sessionId,
         keyPrefix,
+        ttlMs,
         logger: baseLogger?.child({ domain, sessionId })
     })
 
@@ -144,17 +175,28 @@ export function createRedisStore(config: WaRedisStoreConfig): WaRedisStoreResult
         redis,
         stores: {
             auth: (sessionId) => new WaAuthRedisStore(opts(sessionId, 'auth')),
-            preKey: (sessionId) => new WaPreKeyRedisStore(opts(sessionId, 'preKey')),
-            session: (sessionId) => new WaSessionRedisStore(opts(sessionId, 'session')),
-            identity: (sessionId) => new WaIdentityRedisStore(opts(sessionId, 'identity')),
-            signal: (sessionId) => new WaSignalRedisStore(opts(sessionId, 'signal')),
-            senderKey: (sessionId) => new WaSenderKeyRedisStore(opts(sessionId, 'senderKey')),
-            appState: (sessionId) => new WaAppStateRedisStore(opts(sessionId, 'appState')),
-            messages: (sessionId) => new WaMessageRedisStore(opts(sessionId, 'messages')),
-            threads: (sessionId) => new WaThreadRedisStore(opts(sessionId, 'threads')),
-            contacts: (sessionId) => new WaContactRedisStore(opts(sessionId, 'contacts')),
+            preKey: (sessionId) =>
+                new WaPreKeyRedisStore(opts(sessionId, 'preKey', storeTtl.preKeyMs)),
+            session: (sessionId) =>
+                new WaSessionRedisStore(opts(sessionId, 'session', storeTtl.sessionMs)),
+            identity: (sessionId) =>
+                new WaIdentityRedisStore(opts(sessionId, 'identity', storeTtl.identityMs)),
+            signal: (sessionId) =>
+                new WaSignalRedisStore(opts(sessionId, 'signal', storeTtl.signalMs)),
+            senderKey: (sessionId) =>
+                new WaSenderKeyRedisStore(opts(sessionId, 'senderKey', storeTtl.senderKeyMs)),
+            appState: (sessionId) =>
+                new WaAppStateRedisStore(opts(sessionId, 'appState', storeTtl.appStateMs)),
+            messages: (sessionId) =>
+                new WaMessageRedisStore(opts(sessionId, 'messages', storeTtl.messagesMs)),
+            threads: (sessionId) =>
+                new WaThreadRedisStore(opts(sessionId, 'threads', storeTtl.threadsMs)),
+            contacts: (sessionId) =>
+                new WaContactRedisStore(opts(sessionId, 'contacts', storeTtl.contactsMs)),
             privacyToken: (sessionId) =>
-                new WaPrivacyTokenRedisStore(opts(sessionId, 'privacyToken'))
+                new WaPrivacyTokenRedisStore(
+                    opts(sessionId, 'privacyToken', storeTtl.privacyTokenMs)
+                )
         },
         caches: {
             retry: (sessionId) => new WaRetryRedisStore(opts(sessionId, 'retry'), retryTtlMs),

--- a/packages/store-redis/src/identity.store.ts
+++ b/packages/store-redis/src/identity.store.ts
@@ -66,8 +66,7 @@ export class WaIdentityRedisStore extends BaseRedisStore implements WaIdentitySt
         }[]
     ): Promise<void> {
         if (entries.length === 0) return
-        const args: Array<string | Buffer> = []
-        const keys: string[] = []
+        const pairs: Array<readonly [string, Buffer]> = []
         for (const entry of entries) {
             const target = toSignalAddressParts(entry.address)
             const key = this.k(
@@ -77,13 +76,9 @@ export class WaIdentityRedisStore extends BaseRedisStore implements WaIdentitySt
                 target.server,
                 String(target.device)
             )
-            keys.push(key)
-            args.push(key, toRedisBuffer(entry.identityKey))
+            pairs.push([key, toRedisBuffer(entry.identityKey)])
         }
-        const pipeline = this.redis.pipeline()
-        ;(pipeline.mset as (...args: unknown[]) => unknown)(...args)
-        this.touch(pipeline, keys)
-        await pipeline.exec()
+        await this.msetWithTtl(pairs)
     }
 
     // ── Clear ─────────────────────────────────────────────────────────

--- a/packages/store-redis/src/identity.store.ts
+++ b/packages/store-redis/src/identity.store.ts
@@ -23,6 +23,7 @@ export class WaIdentityRedisStore extends BaseRedisStore implements WaIdentitySt
         )
         const data = await this.redis.getBuffer(key)
         if (!data) return null
+        await this.refreshTtl([key])
         return new Uint8Array(data)
     }
 
@@ -42,6 +43,7 @@ export class WaIdentityRedisStore extends BaseRedisStore implements WaIdentitySt
             )
         }
         const values = await this.redis.mgetBuffer(...keys)
+        await this.refreshTtl(keys.filter((_key, i) => values[i] !== null))
         return values.map((data) => (data ? new Uint8Array(data) : null))
     }
 
@@ -55,6 +57,7 @@ export class WaIdentityRedisStore extends BaseRedisStore implements WaIdentitySt
             String(target.device)
         )
         await this.redis.set(key, toRedisBuffer(identityKey))
+        await this.refreshTtl([key])
     }
 
     public async setRemoteIdentities(
@@ -65,22 +68,23 @@ export class WaIdentityRedisStore extends BaseRedisStore implements WaIdentitySt
     ): Promise<void> {
         if (entries.length === 0) return
         const args: Array<string | Buffer> = []
+        const keys: string[] = []
         for (const entry of entries) {
             const target = toSignalAddressParts(entry.address)
-            args.push(
-                this.k(
-                    'signal:ident',
-                    this.sessionId,
-                    target.user,
-                    target.server,
-                    String(target.device)
-                ),
-                toRedisBuffer(entry.identityKey)
+            const key = this.k(
+                'signal:ident',
+                this.sessionId,
+                target.user,
+                target.server,
+                String(target.device)
             )
+            keys.push(key)
+            args.push(key, toRedisBuffer(entry.identityKey))
         }
         await (this.redis as unknown as { mset: (...args: unknown[]) => Promise<unknown> }).mset(
             ...args
         )
+        await this.refreshTtl(keys)
     }
 
     // ── Clear ─────────────────────────────────────────────────────────

--- a/packages/store-redis/src/identity.store.ts
+++ b/packages/store-redis/src/identity.store.ts
@@ -56,8 +56,7 @@ export class WaIdentityRedisStore extends BaseRedisStore implements WaIdentitySt
             target.server,
             String(target.device)
         )
-        await this.redis.set(key, toRedisBuffer(identityKey))
-        await this.refreshTtl([key])
+        await this.setWithTtl(key, toRedisBuffer(identityKey))
     }
 
     public async setRemoteIdentities(
@@ -81,10 +80,10 @@ export class WaIdentityRedisStore extends BaseRedisStore implements WaIdentitySt
             keys.push(key)
             args.push(key, toRedisBuffer(entry.identityKey))
         }
-        await (this.redis as unknown as { mset: (...args: unknown[]) => Promise<unknown> }).mset(
-            ...args
-        )
-        await this.refreshTtl(keys)
+        const pipeline = this.redis.pipeline()
+        ;(pipeline.mset as (...args: unknown[]) => unknown)(...args)
+        this.touch(pipeline, keys)
+        await pipeline.exec()
     }
 
     // ── Clear ─────────────────────────────────────────────────────────

--- a/packages/store-redis/src/message.store.ts
+++ b/packages/store-redis/src/message.store.ts
@@ -37,15 +37,13 @@ export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStor
         pipeline.hset(key, recordToHash(record))
         pipeline.zadd(idxKey, String(score), record.id)
 
-        const ttlKeys = [key, idxKey]
         if (record.messageBytes !== undefined) {
             pipeline.set(`${key}:message_bytes`, toRedisBuffer(record.messageBytes))
-            ttlKeys.push(`${key}:message_bytes`)
         }
         for (const field of LEGACY_BINARY_FIELDS) {
             pipeline.del(`${key}:${field}`)
         }
-        this.touch(pipeline, ttlKeys)
+        this.touch(pipeline, [key, idxKey, `${key}:message_bytes`])
 
         await pipeline.exec()
     }
@@ -78,15 +76,13 @@ export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStor
             pipeline.hset(key, recordToHash(record))
             pipeline.zadd(idxKey, String(score), record.id)
 
-            const ttlKeys = [key, idxKey]
             if (record.messageBytes !== undefined) {
                 pipeline.set(`${key}:message_bytes`, toRedisBuffer(record.messageBytes))
-                ttlKeys.push(`${key}:message_bytes`)
             }
             for (const field of LEGACY_BINARY_FIELDS) {
                 pipeline.del(`${key}:${field}`)
             }
-            this.touch(pipeline, ttlKeys)
+            this.touch(pipeline, [key, idxKey, `${key}:message_bytes`])
         }
         await pipeline.exec()
     }

--- a/packages/store-redis/src/message.store.ts
+++ b/packages/store-redis/src/message.store.ts
@@ -37,12 +37,15 @@ export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStor
         pipeline.hset(key, recordToHash(record))
         pipeline.zadd(idxKey, String(score), record.id)
 
+        const ttlKeys = [key, idxKey]
         if (record.messageBytes !== undefined) {
             pipeline.set(`${key}:message_bytes`, toRedisBuffer(record.messageBytes))
+            ttlKeys.push(`${key}:message_bytes`)
         }
         for (const field of LEGACY_BINARY_FIELDS) {
             pipeline.del(`${key}:${field}`)
         }
+        this.touch(pipeline, ttlKeys)
 
         await pipeline.exec()
     }
@@ -75,12 +78,15 @@ export class WaMessageRedisStore extends BaseRedisStore implements WaMessageStor
             pipeline.hset(key, recordToHash(record))
             pipeline.zadd(idxKey, String(score), record.id)
 
+            const ttlKeys = [key, idxKey]
             if (record.messageBytes !== undefined) {
                 pipeline.set(`${key}:message_bytes`, toRedisBuffer(record.messageBytes))
+                ttlKeys.push(`${key}:message_bytes`)
             }
             for (const field of LEGACY_BINARY_FIELDS) {
                 pipeline.del(`${key}:${field}`)
             }
+            this.touch(pipeline, ttlKeys)
         }
         await pipeline.exec()
     }

--- a/packages/store-redis/src/pre-key.store.ts
+++ b/packages/store-redis/src/pre-key.store.ts
@@ -147,10 +147,15 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
                     pipeline.zadd(availKey, record.keyId, idStr)
                 }
             }
+            this.touch(pipeline, [
+                ...idStrs.map((id) => this.k('signal:pk', this.sessionId, id)),
+                availKey
+            ])
             // One variadic SADD (the last command) returns how many ids were
             // genuinely new, i.e. how many prekeys this round actually inserted.
             pipeline.sadd(idsKey, ...idStrs)
             const execResults = await pipeline.exec()
+            await this.refreshTtl([idsKey])
             const saddResult = execResults ? execResults[execResults.length - 1] : undefined
             const insertedCount =
                 saddResult && saddResult[0] === null && typeof saddResult[1] === 'number'
@@ -209,10 +214,11 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
     }
 
     public async getPreKeyById(keyId: number): Promise<PreKeyRecord | null> {
-        const data = await this.redis.hgetallBuffer(
-            this.k('signal:pk', this.sessionId, String(keyId))
-        )
-        return this.decodePreKey(keyId, data)
+        const pkKey = this.k('signal:pk', this.sessionId, String(keyId))
+        const data = await this.redis.hgetallBuffer(pkKey)
+        const record = this.decodePreKey(keyId, data)
+        if (record) await this.refreshTtl([pkKey])
+        return record
     }
 
     public async getPreKeysById(
@@ -227,11 +233,17 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
         }
         const results = await pipeline.exec()
         if (!results) return keyIds.map(() => null)
-        return keyIds.map((keyId, index) => {
+        const out = keyIds.map((keyId, index) => {
             const [err, data] = results[index]
             if (err || !data) return null
             return this.decodePreKey(keyId, data as Record<string, Buffer>)
         })
+        await this.refreshTtl(
+            keyIds
+                .filter((_keyId, index) => out[index] !== null)
+                .map((keyId) => this.k('signal:pk', this.sessionId, String(keyId)))
+        )
+        return out
     }
 
     public async consumePreKeyById(keyId: number): Promise<PreKeyRecord | null> {
@@ -276,13 +288,18 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
         const allIds = await this.redis.smembers(idsKey)
         const availKey = this.k('signal:pk:avail', this.sessionId)
         const pipeline = this.redis.pipeline()
+        const touchedKeys: string[] = []
         for (const idStr of allIds) {
             const id = Number(idStr)
             if (id <= keyId) {
                 const pkKey = this.k('signal:pk', this.sessionId, idStr)
                 pipeline.hset(pkKey, 'uploaded', '1')
                 pipeline.zrem(availKey, idStr)
+                touchedKeys.push(pkKey)
             }
+        }
+        if (touchedKeys.length > 0) {
+            this.touch(pipeline, [...touchedKeys, availKey])
         }
         await pipeline.exec()
     }
@@ -298,6 +315,7 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
     public async getServerHasPreKeys(): Promise<boolean> {
         const metaKey = this.k('signal:meta', this.sessionId)
         const raw = await this.redis.hget(metaKey, 'server_has_prekeys')
+        if (raw !== null) await this.refreshTtl([metaKey])
         return raw === '1'
     }
 
@@ -330,6 +348,7 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
             await this.redis.hsetnx(metaKey, 'server_has_prekeys', '0')
             await this.redis.hsetnx(metaKey, 'next_prekey_id', '1')
         }
+        await this.refreshTtl([metaKey])
     }
 
     private decodePreKey(
@@ -371,6 +390,7 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
         } else {
             pipeline.zrem(availKey, idStr)
         }
+        this.touch(pipeline, [pkKey, idsKey, availKey])
         await pipeline.exec()
     }
 }

--- a/packages/store-redis/src/pre-key.store.ts
+++ b/packages/store-redis/src/pre-key.store.ts
@@ -102,6 +102,10 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
                         if (record) available.push(record)
                     }
                 }
+                await this.refreshTtl([
+                    ...availableIds.map((id) => this.k('signal:pk', this.sessionId, id)),
+                    availKey
+                ])
             }
 
             const missing = count - available.length
@@ -315,7 +319,6 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
     public async getServerHasPreKeys(): Promise<boolean> {
         const metaKey = this.k('signal:meta', this.sessionId)
         const raw = await this.redis.hget(metaKey, 'server_has_prekeys')
-        if (raw !== null) await this.refreshTtl([metaKey])
         return raw === '1'
     }
 
@@ -348,7 +351,6 @@ export class WaPreKeyRedisStore extends BaseRedisStore implements WaPreKeyStore 
             await this.redis.hsetnx(metaKey, 'server_has_prekeys', '0')
             await this.redis.hsetnx(metaKey, 'next_prekey_id', '1')
         }
-        await this.refreshTtl([metaKey])
     }
 
     private decodePreKey(

--- a/packages/store-redis/src/privacy-token.store.ts
+++ b/packages/store-redis/src/privacy-token.store.ts
@@ -33,16 +33,13 @@ export class WaPrivacyTokenRedisStore extends BaseRedisStore implements WaPrivac
             pipeline.hset(key, newFields)
         }
 
-        const ttlKeys = [key]
         if (record.tcToken !== undefined) {
             pipeline.set(`${key}:tc_token`, toRedisBuffer(record.tcToken))
-            ttlKeys.push(`${key}:tc_token`)
         }
         if (record.nctSalt !== undefined) {
             pipeline.set(`${key}:nct_salt`, toRedisBuffer(record.nctSalt))
-            ttlKeys.push(`${key}:nct_salt`)
         }
-        this.touch(pipeline, ttlKeys)
+        this.touch(pipeline, [key, `${key}:tc_token`, `${key}:nct_salt`])
 
         await pipeline.exec()
     }

--- a/packages/store-redis/src/privacy-token.store.ts
+++ b/packages/store-redis/src/privacy-token.store.ts
@@ -33,12 +33,16 @@ export class WaPrivacyTokenRedisStore extends BaseRedisStore implements WaPrivac
             pipeline.hset(key, newFields)
         }
 
+        const ttlKeys = [key]
         if (record.tcToken !== undefined) {
             pipeline.set(`${key}:tc_token`, toRedisBuffer(record.tcToken))
+            ttlKeys.push(`${key}:tc_token`)
         }
         if (record.nctSalt !== undefined) {
             pipeline.set(`${key}:nct_salt`, toRedisBuffer(record.nctSalt))
+            ttlKeys.push(`${key}:nct_salt`)
         }
+        this.touch(pipeline, ttlKeys)
 
         await pipeline.exec()
     }

--- a/packages/store-redis/src/sender-key.store.ts
+++ b/packages/store-redis/src/sender-key.store.ts
@@ -28,19 +28,22 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
             String(sender.device)
         )
         const encoded = encodeSenderKeyRecord(record)
-        await this.redis.set(key, toRedisBuffer(encoded))
-
         const groupIdxKey = this.k('sk:grp', this.sessionId, record.groupId)
-        await this.redis.sadd(groupIdxKey, `${sender.user}:${sender.server}:${sender.device}`)
-        await this.refreshTtl([key, groupIdxKey])
+        const pipeline = this.redis.pipeline()
+        pipeline.set(key, toRedisBuffer(encoded))
+        pipeline.sadd(groupIdxKey, `${sender.user}:${sender.server}:${sender.device}`)
+        this.touch(pipeline, [key, groupIdxKey])
+        await pipeline.exec()
     }
 
     public async upsertSenderKeyDistribution(record: SenderKeyDistributionRecord): Promise<void> {
         const sender = toSignalAddressParts(record.sender)
         const hashKey = this.k('skd', this.sessionId, record.groupId)
         const field = `${sender.user}:${sender.server}:${sender.device}`
-        await this.redis.hset(hashKey, field, `${record.keyId}:${record.timestampMs}`)
-        await this.refreshTtl([hashKey])
+        const pipeline = this.redis.pipeline()
+        pipeline.hset(hashKey, field, `${record.keyId}:${record.timestampMs}`)
+        this.touch(pipeline, [hashKey])
+        await pipeline.exec()
     }
 
     public async upsertSenderKeyDistributions(
@@ -62,8 +65,10 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
         }
         if (byGroupKey.size === 1) {
             const [hashKey, args] = byGroupKey.entries().next().value as [string, string[]]
-            await this.redis.hset(hashKey, ...args)
-            await this.refreshTtl([hashKey])
+            const pipeline = this.redis.pipeline()
+            pipeline.hset(hashKey, ...args)
+            this.touch(pipeline, [hashKey])
+            await pipeline.exec()
             return
         }
         const pipeline = this.redis.pipeline()

--- a/packages/store-redis/src/sender-key.store.ts
+++ b/packages/store-redis/src/sender-key.store.ts
@@ -32,6 +32,7 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
 
         const groupIdxKey = this.k('sk:grp', this.sessionId, record.groupId)
         await this.redis.sadd(groupIdxKey, `${sender.user}:${sender.server}:${sender.device}`)
+        await this.refreshTtl([key, groupIdxKey])
     }
 
     public async upsertSenderKeyDistribution(record: SenderKeyDistributionRecord): Promise<void> {
@@ -39,6 +40,7 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
         const hashKey = this.k('skd', this.sessionId, record.groupId)
         const field = `${sender.user}:${sender.server}:${sender.device}`
         await this.redis.hset(hashKey, field, `${record.keyId}:${record.timestampMs}`)
+        await this.refreshTtl([hashKey])
     }
 
     public async upsertSenderKeyDistributions(
@@ -61,12 +63,14 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
         if (byGroupKey.size === 1) {
             const [hashKey, args] = byGroupKey.entries().next().value as [string, string[]]
             await this.redis.hset(hashKey, ...args)
+            await this.refreshTtl([hashKey])
             return
         }
         const pipeline = this.redis.pipeline()
         for (const [hashKey, args] of byGroupKey) {
             pipeline.hset(hashKey, ...args)
         }
+        this.touch(pipeline, [...byGroupKey.keys()])
         await pipeline.exec()
     }
 
@@ -81,6 +85,7 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
             this.redis.hgetall(skdHashKey)
         ])
 
+        const skKeys: string[] = []
         const skList: SenderKeyRecord[] = []
         if (members.length > 0) {
             const skPipeline = this.redis.pipeline()
@@ -91,9 +96,9 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
                 const server = parts[1]
                 const device = Number(parts[2])
                 parsedMembers.push({ user, server, device })
-                skPipeline.getBuffer(
-                    this.k('sk', this.sessionId, groupId, user, server, String(device))
-                )
+                const skKey = this.k('sk', this.sessionId, groupId, user, server, String(device))
+                skKeys.push(skKey)
+                skPipeline.getBuffer(skKey)
             }
             const skResults = await skPipeline.exec()
             if (skResults) {
@@ -121,6 +126,7 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
             })
         }
 
+        await this.refreshTtl([groupIdxKey, skdHashKey, ...skKeys])
         return { skList, skDistribList }
     }
 
@@ -139,6 +145,7 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
         )
         const data = await this.redis.getBuffer(key)
         if (!data) return null
+        await this.refreshTtl([key])
         return decodeSenderKeyRecord(new Uint8Array(data), groupId, {
             user: target.user,
             server: target.server,
@@ -156,6 +163,9 @@ export class WaSenderKeyRedisStore extends BaseRedisStore implements WaSenderKey
         // HGETALL per member which dominated the redis call profile.
         const hashKey = this.k('skd', this.sessionId, groupId)
         const all = await this.redis.hgetall(hashKey)
+        if (Object.keys(all).length > 0) {
+            await this.refreshTtl([hashKey])
+        }
         const out = new Array<SenderKeyDistributionRecord | null>(senders.length)
         for (let i = 0; i < senders.length; i += 1) {
             const t = toSignalAddressParts(senders[i])

--- a/packages/store-redis/src/session.store.ts
+++ b/packages/store-redis/src/session.store.ts
@@ -61,6 +61,7 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
         )
         const data = await this.redis.getBuffer(key)
         if (!data) return null
+        await this.refreshTtl([key])
         return decodeSignalSessionRecord(new Uint8Array(data))
     }
 
@@ -81,6 +82,7 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
         }
         // mgetBuffer: single MGET command server-side returning binary values.
         const values = await this.redis.mgetBuffer(...keys)
+        await this.refreshTtl(keys.filter((_key, i) => values[i] !== null))
         return values.map((data) => {
             if (!data) return null
             return decodeSignalSessionRecord(new Uint8Array(data))
@@ -98,6 +100,7 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
         )
         const encoded = encodeSignalSessionRecord(session)
         await this.redis.set(key, toRedisBuffer(encoded))
+        await this.refreshTtl([key])
     }
 
     public async setSessionsBatch(
@@ -111,22 +114,23 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
         // command is processed as one unit server-side, replacing what would
         // otherwise be N pipelined SETs.
         const args: Array<string | Buffer> = []
+        const keys: string[] = []
         for (const entry of entries) {
             const target = toSignalAddressParts(entry.address)
-            args.push(
-                this.k(
-                    'signal:sess',
-                    this.sessionId,
-                    target.user,
-                    target.server,
-                    String(target.device)
-                ),
-                toRedisBuffer(encodeSignalSessionRecord(entry.session))
+            const key = this.k(
+                'signal:sess',
+                this.sessionId,
+                target.user,
+                target.server,
+                String(target.device)
             )
+            keys.push(key)
+            args.push(key, toRedisBuffer(encodeSignalSessionRecord(entry.session)))
         }
         await (this.redis as unknown as { mset: (...args: unknown[]) => Promise<unknown> }).mset(
             ...args
         )
+        await this.refreshTtl(keys)
     }
 
     public async deleteSession(address: SignalAddress): Promise<void> {

--- a/packages/store-redis/src/session.store.ts
+++ b/packages/store-redis/src/session.store.ts
@@ -27,7 +27,9 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
             target.server,
             String(target.device)
         )
-        return (await this.redis.exists(key)) === 1
+        const exists = (await this.redis.exists(key)) === 1
+        if (exists) await this.refreshTtl([key])
+        return exists
     }
 
     public async hasSessions(addresses: readonly SignalAddress[]): Promise<readonly boolean[]> {
@@ -47,6 +49,7 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
             )
         }
         const values = await this.redis.mget(...keys)
+        await this.refreshTtl(keys.filter((_key, i) => values[i] !== null))
         return values.map((v) => v !== null)
     }
 
@@ -99,8 +102,7 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
             String(target.device)
         )
         const encoded = encodeSignalSessionRecord(session)
-        await this.redis.set(key, toRedisBuffer(encoded))
-        await this.refreshTtl([key])
+        await this.setWithTtl(key, toRedisBuffer(encoded))
     }
 
     public async setSessionsBatch(
@@ -127,10 +129,10 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
             keys.push(key)
             args.push(key, toRedisBuffer(encodeSignalSessionRecord(entry.session)))
         }
-        await (this.redis as unknown as { mset: (...args: unknown[]) => Promise<unknown> }).mset(
-            ...args
-        )
-        await this.refreshTtl(keys)
+        const pipeline = this.redis.pipeline()
+        ;(pipeline.mset as (...args: unknown[]) => unknown)(...args)
+        this.touch(pipeline, keys)
+        await pipeline.exec()
     }
 
     public async deleteSession(address: SignalAddress): Promise<void> {

--- a/packages/store-redis/src/session.store.ts
+++ b/packages/store-redis/src/session.store.ts
@@ -112,11 +112,7 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
         }[]
     ): Promise<void> {
         if (entries.length === 0) return
-        // Single MSET — ioredis accepts variadic (key, value) pairs and the
-        // command is processed as one unit server-side, replacing what would
-        // otherwise be N pipelined SETs.
-        const args: Array<string | Buffer> = []
-        const keys: string[] = []
+        const pairs: Array<readonly [string, Buffer]> = []
         for (const entry of entries) {
             const target = toSignalAddressParts(entry.address)
             const key = this.k(
@@ -126,13 +122,9 @@ export class WaSessionRedisStore extends BaseRedisStore implements WaSessionStor
                 target.server,
                 String(target.device)
             )
-            keys.push(key)
-            args.push(key, toRedisBuffer(encodeSignalSessionRecord(entry.session)))
+            pairs.push([key, toRedisBuffer(encodeSignalSessionRecord(entry.session))])
         }
-        const pipeline = this.redis.pipeline()
-        ;(pipeline.mset as (...args: unknown[]) => unknown)(...args)
-        this.touch(pipeline, keys)
-        await pipeline.exec()
+        await this.msetWithTtl(pairs)
     }
 
     public async deleteSession(address: SignalAddress): Promise<void> {

--- a/packages/store-redis/src/signal.store.ts
+++ b/packages/store-redis/src/signal.store.ts
@@ -14,10 +14,12 @@ export class WaSignalRedisStore extends BaseRedisStore implements WaSignalStore 
 
     public async getRegistrationInfo(): Promise<RegistrationInfo | null> {
         const baseKey = this.k('signal:reg', this.sessionId)
+        const pubRef = this.k('signal:reg', this.sessionId, 'pub')
+        const privRef = this.k('signal:reg', this.sessionId, 'priv')
         const pipeline = this.redis.pipeline()
         pipeline.hgetall(baseKey)
-        pipeline.getBuffer(this.k('signal:reg', this.sessionId, 'pub'))
-        pipeline.getBuffer(this.k('signal:reg', this.sessionId, 'priv'))
+        pipeline.getBuffer(pubRef)
+        pipeline.getBuffer(privRef)
         const results = await pipeline.exec()
         if (!results) return null
         const [, hashData] = results[0]
@@ -26,6 +28,7 @@ export class WaSignalRedisStore extends BaseRedisStore implements WaSignalStore 
         const pubKey = toBytesOrNull(results[1][1])
         const privKey = toBytesOrNull(results[2][1])
         if (!pubKey || !privKey) return null
+        await this.refreshTtl([baseKey, pubRef, privRef])
         return {
             registrationId: Number(data.registration_id),
             identityKeyPair: { pubKey, privKey }
@@ -34,16 +37,13 @@ export class WaSignalRedisStore extends BaseRedisStore implements WaSignalStore 
 
     public async setRegistrationInfo(info: RegistrationInfo): Promise<void> {
         const baseKey = this.k('signal:reg', this.sessionId)
+        const pubRef = this.k('signal:reg', this.sessionId, 'pub')
+        const privRef = this.k('signal:reg', this.sessionId, 'priv')
         const pipeline = this.redis.pipeline()
         pipeline.hset(baseKey, { registration_id: String(info.registrationId) })
-        pipeline.set(
-            this.k('signal:reg', this.sessionId, 'pub'),
-            toRedisBuffer(info.identityKeyPair.pubKey)
-        )
-        pipeline.set(
-            this.k('signal:reg', this.sessionId, 'priv'),
-            toRedisBuffer(info.identityKeyPair.privKey)
-        )
+        pipeline.set(pubRef, toRedisBuffer(info.identityKeyPair.pubKey))
+        pipeline.set(privRef, toRedisBuffer(info.identityKeyPair.privKey))
+        this.touch(pipeline, [baseKey, pubRef, privRef])
         await pipeline.exec()
     }
 
@@ -55,20 +55,18 @@ export class WaSignalRedisStore extends BaseRedisStore implements WaSignalStore 
 
     public async setSignedPreKey(record: SignedPreKeyRecord): Promise<void> {
         const baseKey = this.k('signal:spk', this.sessionId)
+        const pubRef = this.k('signal:spk', this.sessionId, 'pub')
+        const privRef = this.k('signal:spk', this.sessionId, 'priv')
+        const sigRef = this.k('signal:spk', this.sessionId, 'sig')
         const pipeline = this.redis.pipeline()
         pipeline.hset(baseKey, {
             key_id: String(record.keyId),
             uploaded: record.uploaded === true ? '1' : '0'
         })
-        pipeline.set(
-            this.k('signal:spk', this.sessionId, 'pub'),
-            toRedisBuffer(record.keyPair.pubKey)
-        )
-        pipeline.set(
-            this.k('signal:spk', this.sessionId, 'priv'),
-            toRedisBuffer(record.keyPair.privKey)
-        )
-        pipeline.set(this.k('signal:spk', this.sessionId, 'sig'), toRedisBuffer(record.signature))
+        pipeline.set(pubRef, toRedisBuffer(record.keyPair.pubKey))
+        pipeline.set(privRef, toRedisBuffer(record.keyPair.privKey))
+        pipeline.set(sigRef, toRedisBuffer(record.signature))
+        this.touch(pipeline, [baseKey, pubRef, privRef, sigRef])
         await pipeline.exec()
     }
 
@@ -86,12 +84,14 @@ export class WaSignalRedisStore extends BaseRedisStore implements WaSignalStore 
         } else {
             await this.redis.hdel(metaKey, 'signed_prekey_rotation_ts')
         }
+        await this.refreshTtl([metaKey])
     }
 
     public async getSignedPreKeyRotationTs(): Promise<number | null> {
         const metaKey = this.k('signal:meta', this.sessionId)
         const raw = await this.redis.hget(metaKey, 'signed_prekey_rotation_ts')
         if (raw === null || raw === '') return null
+        await this.refreshTtl([metaKey])
         return Number(raw)
     }
 
@@ -123,15 +123,19 @@ export class WaSignalRedisStore extends BaseRedisStore implements WaSignalStore 
             await this.redis.hsetnx(metaKey, 'server_has_prekeys', '0')
             await this.redis.hsetnx(metaKey, 'next_prekey_id', '1')
         }
+        await this.refreshTtl([metaKey])
     }
 
     private async readSignedPreKey(): Promise<SignedPreKeyRecord | null> {
         const baseKey = this.k('signal:spk', this.sessionId)
+        const pubRef = this.k('signal:spk', this.sessionId, 'pub')
+        const privRef = this.k('signal:spk', this.sessionId, 'priv')
+        const sigRef = this.k('signal:spk', this.sessionId, 'sig')
         const pipeline = this.redis.pipeline()
         pipeline.hgetall(baseKey)
-        pipeline.getBuffer(this.k('signal:spk', this.sessionId, 'pub'))
-        pipeline.getBuffer(this.k('signal:spk', this.sessionId, 'priv'))
-        pipeline.getBuffer(this.k('signal:spk', this.sessionId, 'sig'))
+        pipeline.getBuffer(pubRef)
+        pipeline.getBuffer(privRef)
+        pipeline.getBuffer(sigRef)
         const results = await pipeline.exec()
         if (!results) return null
         const [, hashData] = results[0]
@@ -141,6 +145,7 @@ export class WaSignalRedisStore extends BaseRedisStore implements WaSignalStore 
         const privKey = toBytesOrNull(results[2][1])
         const signature = toBytesOrNull(results[3][1])
         if (!pubKey || !privKey || !signature) return null
+        await this.refreshTtl([baseKey, pubRef, privRef, sigRef])
         return {
             keyId: Number(data.key_id),
             keyPair: { pubKey, privKey },

--- a/packages/store-redis/src/signal.store.ts
+++ b/packages/store-redis/src/signal.store.ts
@@ -84,14 +84,12 @@ export class WaSignalRedisStore extends BaseRedisStore implements WaSignalStore 
         } else {
             await this.redis.hdel(metaKey, 'signed_prekey_rotation_ts')
         }
-        await this.refreshTtl([metaKey])
     }
 
     public async getSignedPreKeyRotationTs(): Promise<number | null> {
         const metaKey = this.k('signal:meta', this.sessionId)
         const raw = await this.redis.hget(metaKey, 'signed_prekey_rotation_ts')
         if (raw === null || raw === '') return null
-        await this.refreshTtl([metaKey])
         return Number(raw)
     }
 
@@ -123,7 +121,6 @@ export class WaSignalRedisStore extends BaseRedisStore implements WaSignalStore 
             await this.redis.hsetnx(metaKey, 'server_has_prekeys', '0')
             await this.redis.hsetnx(metaKey, 'next_prekey_id', '1')
         }
-        await this.refreshTtl([metaKey])
     }
 
     private async readSignedPreKey(): Promise<SignedPreKeyRecord | null> {

--- a/packages/store-redis/src/thread.store.ts
+++ b/packages/store-redis/src/thread.store.ts
@@ -77,6 +77,7 @@ export class WaThreadRedisStore extends BaseRedisStore implements WaThreadStore 
         } else {
             await this.redis.hset(key, newFields)
         }
+        await this.refreshTtl([key])
     }
 
     public async upsertBatch(records: readonly WaStoredThreadRecord[]): Promise<void> {

--- a/packages/store-redis/src/types.ts
+++ b/packages/store-redis/src/types.ts
@@ -6,6 +6,18 @@ export interface WaRedisStorageOptions {
     readonly sessionId: string
     readonly keyPrefix?: string
     /**
+     * Optional sliding TTL (in ms) applied to every key this store writes,
+     * implemented as Redis `PEXPIRE` so the server prunes expired entries -
+     * no background cleanup. Leave unset for persistent (non-expiring) keys;
+     * when unset every TTL helper is a no-op, so behavior is unchanged.
+     *
+     * Data stores (messages/threads/contacts/privacyToken) refresh the TTL on
+     * write only (retention from last write). Crypto/session stores refresh on
+     * read too (idle-session GC), so an actively-used session keeps its keys
+     * alive. Wired per-domain by `createRedisStore` via `storeTtlMs`.
+     */
+    readonly ttlMs?: number
+    /**
      * Logger passed through by `createRedisStore`. The factory binds
      * `{ scope: 'store', provider: 'redis' }` for Redis connection lifecycle
      * logs, then adds `{ domain: '<name>', sessionId }` on the child logger


### PR DESCRIPTION
Persistent store domains never expired before. storeTtlMs adds an opt-in Redis-native TTL (PEXPIRE on write) per domain, off by default - an unset domain stays persistent (byte-identical behavior).

Two semantics by domain kind:
- data (messages/threads/contacts/privacyToken): refreshed on write only, so keys expire a fixed window after their last update.
- crypto/session (signal/preKey/session/identity/senderKey/appState): refreshed on read and write (sliding), so an active session keeps its keys alive and only idle sessions are reclaimed.

auth has no TTL knob on purpose: expiring login credentials would log the device out.

Adds BaseRedisStore.touch()/refreshTtl() helpers, wires storeTtlMs in createRedisStore, documents it in the README, and covers it with integration tests (TTL applied on data keys, read-refresh keeps signal:reg alive, auth never gets a TTL, non-positive ttlMs rejected).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Redis key TTL settings for persistent store data, with per-domain configuration.
  * Sessions, crypto data, messages, contacts, app state, threads, and related records can now stay active via sliding expiration on reads and writes.
* **Bug Fixes**
  * Improved expiration handling so key metadata stays in sync across batch updates and lookups.
  * Ensured auth records continue to persist without TTL expiration.
* **Documentation**
  * Expanded Redis store docs with TTL examples, expiration behavior, and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->