### PR TITLE
feat(auth): add Shortcake passkey companion-linking protocol

### DIFF
--- a/src/auth/WaAuthClient.ts
+++ b/src/auth/WaAuthClient.ts
@@ -18,6 +18,7 @@ import type { WaAuthStore } from '@store/contracts/auth.store'
 import type { WaPreKeyStore } from '@store/contracts/pre-key.store'
 import type { WaSignalStore } from '@store/contracts/signal.store'
 import { buildAckNode } from '@transport/node/builders/global'
+import { resolveDevicePropsPlatformType } from '@transport/noise/WaClientPayload'
 import type { WaNoiseRootCa } from '@transport/noise/WaNoiseCert'
 import type { BinaryNode, WaCommsConfig } from '@transport/types'
 import { uint8Equal } from '@util/bytes'
@@ -127,7 +128,8 @@ export class WaAuthClient {
                   auth: {
                       getCredentials: () => this.credentials,
                       updateCredentials: this.updateCredentials.bind(this)
-                  }
+                  },
+                  deviceType: resolveDevicePropsPlatformType(deviceBrowser)
               })
             : null
     }
@@ -217,6 +219,7 @@ export class WaAuthClient {
         this.logger.trace('auth client clear transient state')
         this.qrFlow.clear()
         this.pairingFlow.clearSession()
+        this.shortcakeFlow?.clearSession()
     }
 
     /**

--- a/src/auth/WaAuthClient.ts
+++ b/src/auth/WaAuthClient.ts
@@ -41,6 +41,8 @@ type WaAuthClientDeps = Readonly<{
         readonly onPairingRefresh?: (forceManual: boolean) => void
         readonly onPaired?: (credentials: WaAuthCredentials) => void
         readonly onError?: (error: Error) => void
+        /** Server forced a passkey (Shortcake) prologue; `hasSigner` = a signer is configured. */
+        readonly onPasskeyRequired?: (hasSigner: boolean) => void
         /** External WebAuthn signer – enables handling forced passkey (Shortcake) prologues. */
         readonly signPasskeyAssertion?: WaShortcakeAssertionSigner
     }
@@ -426,6 +428,9 @@ export class WaAuthClient {
      * `companion_finish`.
      */
     private async handleShortcakeNotification(node: BinaryNode): Promise<boolean> {
+        if (node.attrs.type === WA_NOTIFICATION_TYPES.PASSKEY_PROLOGUE_REQUEST) {
+            this.callbacks.onPasskeyRequired?.(this.shortcakeFlow !== null)
+        }
         if (this.shortcakeFlow) {
             return this.shortcakeFlow.handleIncomingNotification(node)
         }

--- a/src/auth/WaAuthClient.ts
+++ b/src/auth/WaAuthClient.ts
@@ -13,7 +13,7 @@ import type {
     WaSuccessPersistAttributes
 } from '@auth/types'
 import type { Logger } from '@infra/log/types'
-import { getWaCompanionPlatformId, WA_DEFAULTS } from '@protocol/constants'
+import { getWaCompanionPlatformId, WA_DEFAULTS, WA_NOTIFICATION_TYPES } from '@protocol/constants'
 import type { WaAuthStore } from '@store/contracts/auth.store'
 import type { WaPreKeyStore } from '@store/contracts/pre-key.store'
 import type { WaSignalStore } from '@store/contracts/signal.store'
@@ -408,7 +408,10 @@ export class WaAuthClient {
     /** Dispatcher: returns `true` when `node` is a link-code companion notification. */
     public async handleLinkCodeNotification(node: BinaryNode): Promise<boolean> {
         const type = node.attrs.type
-        if (type === 'passkey_prologue_request' || type === 'crsc_continuation') {
+        if (
+            type === WA_NOTIFICATION_TYPES.PASSKEY_PROLOGUE_REQUEST ||
+            type === WA_NOTIFICATION_TYPES.CRSC_CONTINUATION
+        ) {
             return this.runHandled(() => this.handleShortcakeNotification(node))
         }
         this.logger.trace('auth client handleLinkCodeNotification', { id: node.attrs.id })
@@ -426,7 +429,7 @@ export class WaAuthClient {
         if (this.shortcakeFlow) {
             return this.shortcakeFlow.handleIncomingNotification(node)
         }
-        if (node.attrs.type === 'passkey_prologue_request') {
+        if (node.attrs.type === WA_NOTIFICATION_TYPES.PASSKEY_PROLOGUE_REQUEST) {
             this.logger.warn(
                 'auth client: server requested passkey prologue but no signPasskeyAssertion configured',
                 { id: node.attrs.id }

--- a/src/auth/WaAuthClient.ts
+++ b/src/auth/WaAuthClient.ts
@@ -5,6 +5,7 @@ import {
 } from '@auth/credentials-flow'
 import { WaPairingFlow } from '@auth/pairing/WaPairingFlow'
 import { WaQrFlow } from '@auth/pairing/WaQrFlow'
+import { type WaShortcakeAssertionSigner, WaShortcakeFlow } from '@auth/pairing/WaShortcakeFlow'
 import type {
     WaAuthClientOptions,
     WaAuthCredentials,
@@ -16,6 +17,7 @@ import { getWaCompanionPlatformId, WA_DEFAULTS } from '@protocol/constants'
 import type { WaAuthStore } from '@store/contracts/auth.store'
 import type { WaPreKeyStore } from '@store/contracts/pre-key.store'
 import type { WaSignalStore } from '@store/contracts/signal.store'
+import { buildAckNode } from '@transport/node/builders/global'
 import type { WaNoiseRootCa } from '@transport/noise/WaNoiseCert'
 import type { BinaryNode, WaCommsConfig } from '@transport/types'
 import { uint8Equal } from '@util/bytes'
@@ -38,6 +40,8 @@ type WaAuthClientDeps = Readonly<{
         readonly onPairingRefresh?: (forceManual: boolean) => void
         readonly onPaired?: (credentials: WaAuthCredentials) => void
         readonly onError?: (error: Error) => void
+        /** External WebAuthn signer – enables handling forced passkey (Shortcake) prologues. */
+        readonly signPasskeyAssertion?: WaShortcakeAssertionSigner
     }
 }>
 
@@ -60,6 +64,8 @@ export class WaAuthClient {
     private readonly isConnected?: () => boolean
     private readonly qrFlow: WaQrFlow
     private readonly pairingFlow: WaPairingFlow
+    private readonly socket: WaAuthClientDeps['socket']
+    private readonly shortcakeFlow: WaShortcakeFlow | null
     private credentials: WaAuthCredentials | null
     private versionOverride: string | null = null
 
@@ -107,6 +113,23 @@ export class WaAuthClient {
             },
             dangerous: options.dangerous
         })
+
+        this.socket = deps.socket
+        const signAssertion = deps.callbacks?.signPasskeyAssertion
+        this.shortcakeFlow = signAssertion
+            ? new WaShortcakeFlow({
+                  logger: this.logger,
+                  socket: {
+                      sendNode: deps.socket.sendNode,
+                      query: (node, timeoutMs) => deps.socket.query(node, timeoutMs)
+                  },
+                  signAssertion,
+                  auth: {
+                      getCredentials: () => this.credentials,
+                      updateCredentials: this.updateCredentials.bind(this)
+                  }
+              })
+            : null
     }
 
     /**
@@ -381,8 +404,34 @@ export class WaAuthClient {
 
     /** Dispatcher: returns `true` when `node` is a link-code companion notification. */
     public async handleLinkCodeNotification(node: BinaryNode): Promise<boolean> {
+        const type = node.attrs.type
+        if (type === 'passkey_prologue_request' || type === 'crsc_continuation') {
+            return this.runHandled(() => this.handleShortcakeNotification(node))
+        }
         this.logger.trace('auth client handleLinkCodeNotification', { id: node.attrs.id })
         return this.runHandled(() => this.pairingFlow.handleLinkCodeNotification(node))
+    }
+
+    /**
+     * Handles the server-forced passkey (Shortcake) prologue. With a configured
+     * `signPasskeyAssertion` the full handshake runs; without one we just ack
+     * and warn instead of silently stalling – which is what happens today when
+     * the server demands a passkey after a successful pairing-code
+     * `companion_finish`.
+     */
+    private async handleShortcakeNotification(node: BinaryNode): Promise<boolean> {
+        if (this.shortcakeFlow) {
+            return this.shortcakeFlow.handleIncomingNotification(node)
+        }
+        if (node.attrs.type === 'passkey_prologue_request') {
+            this.logger.warn(
+                'auth client: server requested passkey prologue but no signPasskeyAssertion configured',
+                { id: node.attrs.id }
+            )
+            await this.socket.sendNode(buildAckNode({ kind: 'notification', node }))
+            return true
+        }
+        return false
     }
 
     /** Dispatcher: returns `true` when `node` is a companion-registration refresh notification. */

--- a/src/auth/__tests__/auth-client.test.ts
+++ b/src/auth/__tests__/auth-client.test.ts
@@ -6,6 +6,7 @@ import { WaAuthClient } from '@auth/WaAuthClient'
 import { createNoopLogger } from '@infra/log/types'
 import { WaPreKeyMemoryStore } from '@store/memory/pre-key.store'
 import { WaSignalMemoryStore } from '@store/memory/signal.store'
+import type { BinaryNode } from '@transport/types'
 
 function createInMemoryAuthStore(initial: WaAuthCredentials | null = null) {
     let current = initial
@@ -72,6 +73,50 @@ test('WaAuthClient creates credentials, persists fields and clears state', async
     assert.equal(client.getCurrentCredentials(), null)
     assert.equal(auth.getCurrent(), null)
     assert.ok(auth.getSaves() >= 1)
+})
+
+test('WaAuthClient emits onPasskeyRequired when the server forces a passkey', async () => {
+    const auth = createInMemoryAuthStore(null)
+    const sent: BinaryNode[] = []
+    let passkeyHasSigner: boolean | null = null
+
+    const client = new WaAuthClient(
+        {
+            deviceBrowser: 'Chrome',
+            deviceOsDisplayName: 'Windows'
+        },
+        {
+            logger: createNoopLogger(),
+            authStore: auth.store,
+            signalStore: new WaSignalMemoryStore(),
+            preKeyStore: new WaPreKeyMemoryStore(),
+            socket: {
+                sendNode: async (node: BinaryNode) => {
+                    sent.push(node)
+                },
+                query: async () => ({ tag: 'iq', attrs: { type: 'result' } })
+            },
+            callbacks: {
+                onPasskeyRequired: (hasSigner) => {
+                    passkeyHasSigner = hasSigner
+                }
+            }
+        }
+    )
+
+    const node: BinaryNode = {
+        tag: 'notification',
+        attrs: { from: 's.whatsapp.net', type: 'passkey_prologue_request', id: '1' }
+    }
+    const handled = await client.handleLinkCodeNotification(node)
+
+    // no signPasskeyAssertion configured: hasSigner is false and the request is acked
+    assert.equal(handled, true)
+    assert.equal(passkeyHasSigner, false)
+    assert.ok(
+        sent.some((n) => n.tag === 'ack'),
+        'the passkey prologue request was acked'
+    )
 })
 
 test('WaAuthClient throws when credentials are required but missing', async () => {

--- a/src/auth/pairing/WaShortcakeFlow.ts
+++ b/src/auth/pairing/WaShortcakeFlow.ts
@@ -1,0 +1,354 @@
+import {
+    decodePrimaryEphemeralIdentity,
+    deriveEncryptionKey,
+    deriveVerificationCode,
+    encryptPairingRequest,
+    generateCompanionEphemeralIdentity,
+    type ShortcakeCompanionEphemeralIdentity
+} from '@auth/pairing/shortcake-crypto'
+import type { WaAuthCredentials } from '@auth/types'
+import { hkdf, hmacSha256Sign, randomBytesAsync } from '@crypto'
+import type { Logger } from '@infra/log/types'
+import { proto } from '@proto'
+import { WA_DEFAULTS } from '@protocol/constants'
+import { buildAckNode } from '@transport/node/builders/global'
+import {
+    buildGetPasskeyRequestOptionsRequestNode,
+    buildSetCompanionNonceRequestNode,
+    buildSetEncryptedPairingRequestRequestNode,
+    buildSetPasskeyPrologueRequestNode,
+    buildShortcakeGetRefRequestNode
+} from '@transport/node/builders/shortcake'
+import {
+    decodeNodeContentUtf8OrBytes,
+    findNodeChild,
+    getFirstNodeChild
+} from '@transport/node/helpers'
+import { assertIqResult } from '@transport/node/query'
+import type { BinaryNode } from '@transport/types'
+import { TEXT_DECODER, TEXT_ENCODER } from '@util/bytes'
+
+/**
+ * Externally-provided WebAuthn assertion. The passkey/credential source lives
+ * OUTSIDE the protocol layer – the caller signs the server's request options
+ * however it likes (real authenticator, virtual authenticator, relay…) and
+ * hands back the raw assertion + credential id.
+ */
+export type WaShortcakeAssertionSigner = (
+    requestOptions: Uint8Array
+) => Promise<{ readonly credentialId: Uint8Array; readonly webauthnAssertion: Uint8Array }>
+
+const PASSKEY_PROLOGUE_REQUEST_TYPE = 'passkey_prologue_request'
+const PASSKEY_REQUEST_OPTIONS_TAG = 'passkey_request_options'
+const SHORTCAKE_NOTIFICATION_TYPE = 'crsc_continuation'
+const PRIMARY_EPHEMERAL_IDENTITY_TAG = 'primary_ephemeral_identity'
+
+/** HKDF info for the pairing handoff HMAC key (derived from the ADV secret). */
+const HANDOFF_KEY_INFO = TEXT_ENCODER.encode('shortcake-passkey-handoff-v1')
+const HANDOFF_KEY_TTL_MS = 5 * 60 * 1000
+
+interface PasskeyHandoffKey {
+    readonly hmac: Uint8Array
+    readonly ts: number
+}
+
+const enum Stage {
+    Idle = 'idle',
+    WaitingForPrimaryIdentity = 'waiting_for_primary_identity',
+    WaitingForConfirmation = 'waiting_for_confirmation',
+    WaitingForPairing = 'waiting_for_pairing'
+}
+
+interface ShortcakeSession {
+    readonly companion: ShortcakeCompanionEphemeralIdentity
+    readonly ref: string
+    readonly deviceType: proto.DeviceProps.PlatformType
+    /** True when a pairing handoff proof was sent (server may skip the code-matching UX). */
+    readonly skipHandoffUx: boolean
+    stage: Stage
+    encryptionKey: Uint8Array | null
+    verificationCode: string | null
+}
+
+export interface WaShortcakeFlowOptions {
+    readonly logger: Logger
+    readonly socket: {
+        readonly sendNode: (node: BinaryNode) => Promise<void>
+        readonly query: (node: BinaryNode, timeoutMs: number) => Promise<BinaryNode>
+    }
+    /** WebAuthn signer (passkey assertion) – external, keeps credentials out of the protocol. */
+    readonly signAssertion: WaShortcakeAssertionSigner
+    /**
+     * Companion credentials access. The pairing-request payload (`PairingRequest`:
+     * noise static + identity pubkey + ADV secret) is built internally from
+     * these; the ADV secret is also rotated on a prologue request (matching the
+     * official clients), so an updater is required.
+     */
+    readonly auth: {
+        readonly getCredentials: () => WaAuthCredentials | null
+        readonly updateCredentials: (credentials: WaAuthCredentials) => Promise<void>
+    }
+    /** Companion platform reported in the ephemeral identity. */
+    readonly deviceType?: proto.DeviceProps.PlatformType
+    /** Optional internal observability hooks. */
+    readonly callbacks?: {
+        /** Verification code derived after the primary replies. */
+        readonly emitVerificationCode?: (code: string) => void
+        /** Prologue accepted by the server; now waiting for the primary. */
+        readonly emitPrologueSent?: () => void
+    }
+}
+
+/**
+ * Drives the companion side of the WhatsApp "Shortcake" passkey-linking
+ * handshake (the `xmlns="md"` IQ exchange + commit/reveal ECDH). It owns the
+ * wire protocol and crypto only; the WebAuthn assertion and the registration
+ * payload are injected by the caller.
+ */
+export class WaShortcakeFlow {
+    private readonly opts: WaShortcakeFlowOptions
+    private session: ShortcakeSession | null
+    private handoffKey: PasskeyHandoffKey | null
+
+    public constructor(options: WaShortcakeFlowOptions) {
+        this.opts = options
+        this.session = null
+        this.handoffKey = null
+    }
+
+    public hasSession(): boolean {
+        return this.session !== null
+    }
+
+    public clearSession(): void {
+        this.session = null
+    }
+
+    /**
+     * Runs the prologue: fetch the request options, obtain the WebAuthn
+     * assertion (external), fetch the ref, build the companion ephemeral
+     * identity + commitment, and send the `passkey_prologue` IQ.
+     */
+    public async executePrologue(
+        args: {
+            readonly requestOptions?: Uint8Array
+            readonly pairingHandoffProof?: Uint8Array
+        } = {}
+    ): Promise<void> {
+        const deviceType = this.opts.deviceType ?? proto.DeviceProps.PlatformType.CHROME
+
+        // The server usually embeds the WebAuthn options in the prologue-request
+        // notification; fall back to an explicit `get` only when it does not.
+        const requestOptions = args.requestOptions ?? (await this.requestPasskeyRequestOptions())
+        const assertion = await this.opts.signAssertion(requestOptions)
+        const ref = await this.requestRef()
+        const companion = await generateCompanionEphemeralIdentity({ ref, deviceType })
+
+        // Attach a pairing handoff proof when a fresh handoff key is held: HMAC
+        // over the prologue payload proves linking continuity and lets the
+        // server skip the code-matching UX.
+        let pairingHandoffProof = args.pairingHandoffProof
+        const handoffKey = this.handoffKey
+        this.handoffKey = null
+        if (
+            pairingHandoffProof === undefined &&
+            handoffKey !== null &&
+            Date.now() - handoffKey.ts < HANDOFF_KEY_TTL_MS
+        ) {
+            pairingHandoffProof = hmacSha256Sign(handoffKey.hmac, companion.prologuePayloadBytes)
+        }
+        const skipHandoffUx = pairingHandoffProof !== undefined
+
+        const response = await this.opts.socket.query(
+            buildSetPasskeyPrologueRequestNode({
+                credentialId: assertion.credentialId,
+                webauthnAssertion: assertion.webauthnAssertion,
+                prologuePayload: companion.prologuePayloadBytes,
+                pairingHandoffProof
+            }),
+            WA_DEFAULTS.IQ_TIMEOUT_MS
+        )
+        assertIqResult(response, 'shortcake set-passkey-prologue')
+
+        this.session = {
+            companion,
+            ref,
+            deviceType,
+            skipHandoffUx,
+            stage: Stage.WaitingForPrimaryIdentity,
+            encryptionKey: null,
+            verificationCode: null
+        }
+        this.opts.logger.debug('shortcake prologue sent', { ref, skipHandoffUx })
+        this.opts.callbacks?.emitPrologueSent?.()
+    }
+
+    /**
+     * Routes the two server-pushed Shortcake notifications. Returns `true` when
+     * the notification was a Shortcake one (and was consumed):
+     * - `passkey_prologue_request` kicks the flow off (server forces passkey,
+     *   often right after a pairing-code `companion_finish`); the WebAuthn
+     *   options are usually embedded.
+     * - `crsc_continuation` carries the primary's ephemeral identity.
+     */
+    public async handleIncomingNotification(node: BinaryNode): Promise<boolean> {
+        if (node.attrs.type === PASSKEY_PROLOGUE_REQUEST_TYPE) {
+            return this.handlePasskeyPrologueRequest(node)
+        }
+        if (node.attrs.type === SHORTCAKE_NOTIFICATION_TYPE) {
+            return this.handlePrimaryEphemeralIdentity(node)
+        }
+        return false
+    }
+
+    private async handlePasskeyPrologueRequest(node: BinaryNode): Promise<boolean> {
+        await this.ackNotification(node)
+        await this.stashHandoffKeyAndRotateAdv()
+        const optionsNode = findNodeChild(node, PASSKEY_REQUEST_OPTIONS_TAG)
+        const requestOptions = optionsNode
+            ? decodeNodeContentUtf8OrBytes(optionsNode.content, 'shortcake.passkey_request_options')
+            : undefined
+        this.opts.logger.debug('shortcake prologue requested by server', {
+            embeddedOptions: optionsNode !== undefined
+        })
+        await this.executePrologue({ requestOptions })
+        return true
+    }
+
+    /**
+     * Derives a pairing handoff HMAC key from the current ADV secret and rotates
+     * the ADV secret (matching the official clients). The derived key signs the
+     * next prologue's handoff proof; the rotated secret goes into the eventual
+     * `PairingRequest`.
+     */
+    private async stashHandoffKeyAndRotateAdv(): Promise<void> {
+        const credentials = this.opts.auth.getCredentials()
+        if (!credentials) {
+            return
+        }
+        this.handoffKey = {
+            hmac: hkdf(credentials.advSecretKey, null, HANDOFF_KEY_INFO, 32),
+            ts: Date.now()
+        }
+        await this.opts.auth.updateCredentials({
+            ...credentials,
+            advSecretKey: await randomBytesAsync(32)
+        })
+    }
+
+    private async handlePrimaryEphemeralIdentity(node: BinaryNode): Promise<boolean> {
+        const child = getFirstNodeChild(node)
+        if (!child || child.tag !== PRIMARY_EPHEMERAL_IDENTITY_TAG) {
+            return false
+        }
+        const session = this.session
+        if (!session || session.stage !== Stage.WaitingForPrimaryIdentity) {
+            this.opts.logger.warn('shortcake primary identity ignored: no active prologue')
+            await this.ackNotification(node)
+            return true
+        }
+
+        await this.ackNotification(node)
+
+        const primary = decodePrimaryEphemeralIdentity(
+            decodeNodeContentUtf8OrBytes(child.content, 'shortcake.primary_ephemeral_identity')
+        )
+
+        // Reveal the committed companion nonce.
+        const nonceResponse = await this.opts.socket.query(
+            buildSetCompanionNonceRequestNode(session.companion.companionNonce),
+            WA_DEFAULTS.IQ_TIMEOUT_MS
+        )
+        assertIqResult(nonceResponse, 'shortcake set-companion-nonce')
+
+        const [verificationCode, encryptionKey] = await Promise.all([
+            Promise.resolve(deriveVerificationCode(session.companion.companionNonce, primary)),
+            deriveEncryptionKey({
+                companionPrivKey: session.companion.keyPair.privKey,
+                primaryPublicKey: primary.publicKey,
+                deviceType: session.deviceType,
+                ref: session.ref
+            })
+        ])
+
+        session.encryptionKey = encryptionKey
+        session.verificationCode = verificationCode
+        session.stage = Stage.WaitingForConfirmation
+        this.opts.logger.debug('shortcake verification code ready')
+        this.opts.callbacks?.emitVerificationCode?.(verificationCode)
+        // Headless companion: there is no user to compare the code, so confirm
+        // automatically and finish the handshake.
+        await this.confirmVerificationCode()
+        return true
+    }
+
+    /** Current verification code, once derived. */
+    public getVerificationCode(): string | null {
+        return this.session?.verificationCode ?? null
+    }
+
+    /**
+     * Confirms the verification code: builds + AES-GCM seals the pairing request
+     * and sends the `encrypted_pairing_request` IQ.
+     */
+    public async confirmVerificationCode(): Promise<void> {
+        const session = this.session
+        if (!session || session.stage !== Stage.WaitingForConfirmation || !session.encryptionKey) {
+            throw new Error('shortcake: no verification code awaiting confirmation')
+        }
+        const credentials = this.opts.auth.getCredentials()
+        if (!credentials) {
+            throw new Error('shortcake: credentials are not initialized')
+        }
+        // PairingRequest is the companion's own registration payload (same keys
+        // the QR/pairing-code flow registers), built from credentials – not a
+        // passkey/caller concern.
+        const plaintext = proto.PairingRequest.encode({
+            companionPublicKey: credentials.noiseKeyPair.pubKey,
+            companionIdentityKey: credentials.registrationInfo.identityKeyPair.pubKey,
+            advSecret: credentials.advSecretKey
+        }).finish()
+        const envelope = await encryptPairingRequest(session.encryptionKey, plaintext)
+
+        const response = await this.opts.socket.query(
+            buildSetEncryptedPairingRequestRequestNode(envelope),
+            WA_DEFAULTS.IQ_TIMEOUT_MS
+        )
+        assertIqResult(response, 'shortcake set-encrypted-pairing-request')
+        session.stage = Stage.WaitingForPairing
+        this.opts.logger.debug('shortcake encrypted pairing request sent')
+    }
+
+    private async requestPasskeyRequestOptions(): Promise<Uint8Array> {
+        const response = await this.opts.socket.query(
+            buildGetPasskeyRequestOptionsRequestNode(),
+            WA_DEFAULTS.IQ_TIMEOUT_MS
+        )
+        assertIqResult(response, 'shortcake get-passkey-request-options')
+        const optionsNode = findNodeChild(response, 'passkey_request_options')
+        if (!optionsNode) {
+            throw new Error('shortcake: get-passkey-request-options response missing options')
+        }
+        return decodeNodeContentUtf8OrBytes(
+            optionsNode.content,
+            'shortcake.passkey_request_options'
+        )
+    }
+
+    private async requestRef(): Promise<string> {
+        const response = await this.opts.socket.query(
+            buildShortcakeGetRefRequestNode(),
+            WA_DEFAULTS.IQ_TIMEOUT_MS
+        )
+        assertIqResult(response, 'shortcake get-ref')
+        const refNode = findNodeChild(response, 'ref')
+        if (!refNode) {
+            throw new Error('shortcake: get-ref response missing ref')
+        }
+        return TEXT_DECODER.decode(decodeNodeContentUtf8OrBytes(refNode.content, 'shortcake.ref'))
+    }
+
+    private async ackNotification(node: BinaryNode): Promise<void> {
+        await this.opts.socket.sendNode(buildAckNode({ kind: 'notification', node }))
+    }
+}

--- a/src/auth/pairing/WaShortcakeFlow.ts
+++ b/src/auth/pairing/WaShortcakeFlow.ts
@@ -19,11 +19,7 @@ import {
     buildSetPasskeyPrologueRequestNode,
     buildShortcakeGetRefRequestNode
 } from '@transport/node/builders/shortcake'
-import {
-    decodeNodeContentUtf8OrBytes,
-    findNodeChild,
-    getFirstNodeChild
-} from '@transport/node/helpers'
+import { decodeNodeContentUtf8OrBytes, findNodeChild } from '@transport/node/helpers'
 import { assertIqResult } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 import { TEXT_DECODER, TEXT_ENCODER } from '@util/bytes'
@@ -52,12 +48,13 @@ interface PasskeyHandoffKey {
     readonly ts: number
 }
 
-const enum Stage {
-    Idle = 'idle',
-    WaitingForPrimaryIdentity = 'waiting_for_primary_identity',
-    WaitingForConfirmation = 'waiting_for_confirmation',
-    WaitingForPairing = 'waiting_for_pairing'
-}
+const Stage = Object.freeze({
+    Idle: 'idle',
+    WaitingForPrimaryIdentity: 'waiting_for_primary_identity',
+    WaitingForConfirmation: 'waiting_for_confirmation',
+    WaitingForPairing: 'waiting_for_pairing'
+} as const)
+type Stage = (typeof Stage)[keyof typeof Stage]
 
 interface ShortcakeSession {
     readonly companion: ShortcakeCompanionEphemeralIdentity
@@ -122,6 +119,7 @@ export class WaShortcakeFlow {
 
     public clearSession(): void {
         this.session = null
+        this.handoffKey = null
     }
 
     /**
@@ -232,8 +230,8 @@ export class WaShortcakeFlow {
     }
 
     private async handlePrimaryEphemeralIdentity(node: BinaryNode): Promise<boolean> {
-        const child = getFirstNodeChild(node)
-        if (!child || child.tag !== PRIMARY_EPHEMERAL_IDENTITY_TAG) {
+        const child = findNodeChild(node, PRIMARY_EPHEMERAL_IDENTITY_TAG)
+        if (!child) {
             return false
         }
         const session = this.session

--- a/src/auth/pairing/WaShortcakeFlow.ts
+++ b/src/auth/pairing/WaShortcakeFlow.ts
@@ -10,7 +10,7 @@ import type { WaAuthCredentials } from '@auth/types'
 import { hkdf, hmacSha256Sign, randomBytesAsync } from '@crypto'
 import type { Logger } from '@infra/log/types'
 import { proto } from '@proto'
-import { WA_DEFAULTS } from '@protocol/constants'
+import { WA_DEFAULTS, WA_NODE_TAGS, WA_NOTIFICATION_TYPES } from '@protocol/constants'
 import { buildAckNode } from '@transport/node/builders/global'
 import {
     buildGetPasskeyRequestOptionsRequestNode,
@@ -33,11 +33,6 @@ import { TEXT_DECODER, TEXT_ENCODER } from '@util/bytes'
 export type WaShortcakeAssertionSigner = (
     requestOptions: Uint8Array
 ) => Promise<{ readonly credentialId: Uint8Array; readonly webauthnAssertion: Uint8Array }>
-
-const PASSKEY_PROLOGUE_REQUEST_TYPE = 'passkey_prologue_request'
-const PASSKEY_REQUEST_OPTIONS_TAG = 'passkey_request_options'
-const SHORTCAKE_NOTIFICATION_TYPE = 'crsc_continuation'
-const PRIMARY_EPHEMERAL_IDENTITY_TAG = 'primary_ephemeral_identity'
 
 /** HKDF info for the pairing handoff HMAC key (derived from the ADV secret). */
 const HANDOFF_KEY_INFO = TEXT_ENCODER.encode('shortcake-passkey-handoff-v1')
@@ -185,10 +180,10 @@ export class WaShortcakeFlow {
      * - `crsc_continuation` carries the primary's ephemeral identity.
      */
     public async handleIncomingNotification(node: BinaryNode): Promise<boolean> {
-        if (node.attrs.type === PASSKEY_PROLOGUE_REQUEST_TYPE) {
+        if (node.attrs.type === WA_NOTIFICATION_TYPES.PASSKEY_PROLOGUE_REQUEST) {
             return this.handlePasskeyPrologueRequest(node)
         }
-        if (node.attrs.type === SHORTCAKE_NOTIFICATION_TYPE) {
+        if (node.attrs.type === WA_NOTIFICATION_TYPES.CRSC_CONTINUATION) {
             return this.handlePrimaryEphemeralIdentity(node)
         }
         return false
@@ -197,7 +192,7 @@ export class WaShortcakeFlow {
     private async handlePasskeyPrologueRequest(node: BinaryNode): Promise<boolean> {
         await this.ackNotification(node)
         await this.stashHandoffKeyAndRotateAdv()
-        const optionsNode = findNodeChild(node, PASSKEY_REQUEST_OPTIONS_TAG)
+        const optionsNode = findNodeChild(node, WA_NODE_TAGS.PASSKEY_REQUEST_OPTIONS)
         const requestOptions = optionsNode
             ? decodeNodeContentUtf8OrBytes(optionsNode.content, 'shortcake.passkey_request_options')
             : undefined
@@ -230,7 +225,7 @@ export class WaShortcakeFlow {
     }
 
     private async handlePrimaryEphemeralIdentity(node: BinaryNode): Promise<boolean> {
-        const child = findNodeChild(node, PRIMARY_EPHEMERAL_IDENTITY_TAG)
+        const child = findNodeChild(node, WA_NODE_TAGS.PRIMARY_EPHEMERAL_IDENTITY)
         if (!child) {
             return false
         }
@@ -253,15 +248,13 @@ export class WaShortcakeFlow {
         )
         assertIqResult(nonceResponse, 'shortcake set-companion-nonce')
 
-        const [verificationCode, encryptionKey] = await Promise.all([
-            Promise.resolve(deriveVerificationCode(session.companion.companionNonce, primary)),
-            deriveEncryptionKey({
-                companionPrivKey: session.companion.keyPair.privKey,
-                primaryPublicKey: primary.publicKey,
-                deviceType: session.deviceType,
-                ref: session.ref
-            })
-        ])
+        const verificationCode = deriveVerificationCode(session.companion.companionNonce, primary)
+        const encryptionKey = await deriveEncryptionKey({
+            companionPrivKey: session.companion.keyPair.privKey,
+            primaryPublicKey: primary.publicKey,
+            deviceType: session.deviceType,
+            ref: session.ref
+        })
 
         session.encryptionKey = encryptionKey
         session.verificationCode = verificationCode
@@ -312,7 +305,7 @@ export class WaShortcakeFlow {
             WA_DEFAULTS.IQ_TIMEOUT_MS
         )
         assertIqResult(response, 'shortcake get-passkey-request-options')
-        const optionsNode = findNodeChild(response, 'passkey_request_options')
+        const optionsNode = findNodeChild(response, WA_NODE_TAGS.PASSKEY_REQUEST_OPTIONS)
         if (!optionsNode) {
             throw new Error('shortcake: get-passkey-request-options response missing options')
         }
@@ -328,7 +321,7 @@ export class WaShortcakeFlow {
             WA_DEFAULTS.IQ_TIMEOUT_MS
         )
         assertIqResult(response, 'shortcake get-ref')
-        const refNode = findNodeChild(response, 'ref')
+        const refNode = findNodeChild(response, WA_NODE_TAGS.REF)
         if (!refNode) {
             throw new Error('shortcake: get-ref response missing ref')
         }

--- a/src/auth/pairing/WaShortcakeFlow.ts
+++ b/src/auth/pairing/WaShortcakeFlow.ts
@@ -137,16 +137,11 @@ export class WaShortcakeFlow {
     ): Promise<void> {
         const deviceType = this.opts.deviceType ?? proto.DeviceProps.PlatformType.CHROME
 
-        // The server usually embeds the WebAuthn options in the prologue-request
-        // notification; fall back to an explicit `get` only when it does not.
         const requestOptions = args.requestOptions ?? (await this.requestPasskeyRequestOptions())
         const assertion = await this.opts.signAssertion(requestOptions)
         const ref = await this.requestRef()
         const companion = await generateCompanionEphemeralIdentity({ ref, deviceType })
 
-        // Attach a pairing handoff proof when a fresh handoff key is held: HMAC
-        // over the prologue payload proves linking continuity and lets the
-        // server skip the code-matching UX.
         let pairingHandoffProof = args.pairingHandoffProof
         const handoffKey = this.handoffKey
         this.handoffKey = null
@@ -254,7 +249,6 @@ export class WaShortcakeFlow {
             decodeNodeContentUtf8OrBytes(child.content, 'shortcake.primary_ephemeral_identity')
         )
 
-        // Reveal the committed companion nonce.
         const nonceResponse = await this.opts.socket.query(
             buildSetCompanionNonceRequestNode(session.companion.companionNonce),
             WA_DEFAULTS.IQ_TIMEOUT_MS
@@ -276,8 +270,6 @@ export class WaShortcakeFlow {
         session.stage = Stage.WaitingForConfirmation
         this.opts.logger.debug('shortcake verification code ready')
         this.opts.callbacks?.emitVerificationCode?.(verificationCode)
-        // Headless companion: there is no user to compare the code, so confirm
-        // automatically and finish the handshake.
         await this.confirmVerificationCode()
         return true
     }
@@ -300,9 +292,6 @@ export class WaShortcakeFlow {
         if (!credentials) {
             throw new Error('shortcake: credentials are not initialized')
         }
-        // PairingRequest is the companion's own registration payload (same keys
-        // the QR/pairing-code flow registers), built from credentials – not a
-        // passkey/caller concern.
         const plaintext = proto.PairingRequest.encode({
             companionPublicKey: credentials.noiseKeyPair.pubKey,
             companionIdentityKey: credentials.registrationInfo.identityKeyPair.pubKey,

--- a/src/auth/pairing/__tests__/shortcake-crypto.test.ts
+++ b/src/auth/pairing/__tests__/shortcake-crypto.test.ts
@@ -6,8 +6,7 @@ import {
     deriveEncryptionKey,
     deriveVerificationCode,
     encryptPairingRequest,
-    generateCompanionEphemeralIdentity,
-    verifyCommitment
+    generateCompanionEphemeralIdentity
 } from '@auth/pairing/shortcake-crypto'
 import { aesGcmDecrypt, hkdf, randomBytesAsync, sha256 } from '@crypto'
 import { X25519 } from '@crypto/curves/X25519'
@@ -27,7 +26,6 @@ test('companion ephemeral identity carries a verifiable commitment', async () =>
     assert.equal(companion.commitmentHash.length, 32)
     assert.ok(companion.prologuePayloadBytes.length > 0)
 
-    // the prologue decodes back to the same identity + commitment
     const prologue = proto.ProloguePayload.decode(companion.prologuePayloadBytes)
     assert.deepEqual(
         new Uint8Array(prologue.companionEphemeralIdentity!),
@@ -38,23 +36,13 @@ test('companion ephemeral identity carries a verifiable commitment', async () =>
         new Uint8Array(companion.commitmentHash)
     )
 
-    // commitment validates, and a swapped nonce is rejected
-    assert.equal(
-        verifyCommitment(
-            companion.companionEphemeralIdentityBytes,
-            companion.companionNonce,
-            companion.commitmentHash
+    assert.deepEqual(
+        new Uint8Array(
+            sha256(
+                concatBytes([companion.companionEphemeralIdentityBytes, companion.companionNonce])
+            )
         ),
-        true
-    )
-    const tampered = await randomBytesAsync(32)
-    assert.equal(
-        verifyCommitment(
-            companion.companionEphemeralIdentityBytes,
-            tampered,
-            companion.commitmentHash
-        ),
-        false
+        new Uint8Array(companion.commitmentHash)
     )
 })
 
@@ -69,11 +57,9 @@ test('verification code is deterministic and matches the independent derivation'
 
     const primary = decodePrimaryEphemeralIdentity(primaryBytes)
     const code = deriveVerificationCode(companionNonce, primary)
-    // 5 bytes -> 8 Crockford chars, deterministic
     assert.equal(code.length, 8)
     assert.equal(deriveVerificationCode(companionNonce, primary), code)
 
-    // re-derive the way the primary does it
     const digest = sha256(concatBytes([companionNonce, primaryPub]))
     const expected = new Uint8Array(5)
     for (let i = 0; i < 5; i += 1) expected[i] = primaryNonce[i] ^ digest[i]
@@ -105,7 +91,6 @@ test('encryption key agrees with the primary side (ECDH symmetry)', async () => 
         ref
     })
 
-    // primary derives from the mirrored shared secret with identical salt/info
     const sharedFromPrimary = await X25519.scalarMult(primaryKp.privKey, companionKp.pubKey)
     const salt = TEXT_ENCODER.encode(`Companion Pairing ${String(DEVICE_TYPE)} with ref ${ref}`)
     const info = TEXT_ENCODER.encode('Pairing Information Encryption Key')

--- a/src/auth/pairing/__tests__/shortcake-crypto.test.ts
+++ b/src/auth/pairing/__tests__/shortcake-crypto.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    decodePrimaryEphemeralIdentity,
+    deriveEncryptionKey,
+    deriveVerificationCode,
+    encryptPairingRequest,
+    generateCompanionEphemeralIdentity,
+    verifyCommitment
+} from '@auth/pairing/shortcake-crypto'
+import { aesGcmDecrypt, hkdf, randomBytesAsync, sha256 } from '@crypto'
+import { X25519 } from '@crypto/curves/X25519'
+import { proto } from '@proto'
+import { concatBytes, TEXT_ENCODER } from '@util/bytes'
+
+const DEVICE_TYPE = proto.DeviceProps.PlatformType.CHROME
+
+test('companion ephemeral identity carries a verifiable commitment', async () => {
+    const companion = await generateCompanionEphemeralIdentity({
+        ref: 'test-ref',
+        deviceType: DEVICE_TYPE
+    })
+
+    assert.equal(companion.keyPair.pubKey.length, 32)
+    assert.equal(companion.companionNonce.length, 32)
+    assert.equal(companion.commitmentHash.length, 32)
+    assert.ok(companion.prologuePayloadBytes.length > 0)
+
+    // the prologue decodes back to the same identity + commitment
+    const prologue = proto.ProloguePayload.decode(companion.prologuePayloadBytes)
+    assert.deepEqual(
+        new Uint8Array(prologue.companionEphemeralIdentity!),
+        new Uint8Array(companion.companionEphemeralIdentityBytes)
+    )
+    assert.deepEqual(
+        new Uint8Array(prologue.commitment!.hash!),
+        new Uint8Array(companion.commitmentHash)
+    )
+
+    // commitment validates, and a swapped nonce is rejected
+    assert.equal(
+        verifyCommitment(
+            companion.companionEphemeralIdentityBytes,
+            companion.companionNonce,
+            companion.commitmentHash
+        ),
+        true
+    )
+    const tampered = await randomBytesAsync(32)
+    assert.equal(
+        verifyCommitment(
+            companion.companionEphemeralIdentityBytes,
+            tampered,
+            companion.commitmentHash
+        ),
+        false
+    )
+})
+
+test('verification code is deterministic and matches the independent derivation', async () => {
+    const companionNonce = await randomBytesAsync(32)
+    const primaryPub = (await X25519.generateKeyPair()).pubKey
+    const primaryNonce = await randomBytesAsync(32)
+    const primaryBytes = proto.PrimaryEphemeralIdentity.encode({
+        publicKey: primaryPub,
+        nonce: primaryNonce
+    }).finish()
+
+    const primary = decodePrimaryEphemeralIdentity(primaryBytes)
+    const code = deriveVerificationCode(companionNonce, primary)
+    // 5 bytes -> 8 Crockford chars, deterministic
+    assert.equal(code.length, 8)
+    assert.equal(deriveVerificationCode(companionNonce, primary), code)
+
+    // re-derive the way the primary does it
+    const digest = sha256(concatBytes([companionNonce, primaryPub]))
+    const expected = new Uint8Array(5)
+    for (let i = 0; i < 5; i += 1) expected[i] = primaryNonce[i] ^ digest[i]
+    const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTVWXYZ'
+    let bitCount = 0
+    let value = 0
+    let manual = ''
+    for (let i = 0; i < expected.length; i += 1) {
+        value = (value << 8) | expected[i]
+        bitCount += 8
+        while (bitCount >= 5) {
+            manual += ALPHABET[(value >>> (bitCount - 5)) & 31]
+            bitCount -= 5
+        }
+    }
+    if (bitCount > 0) manual += ALPHABET[(value << (5 - bitCount)) & 31]
+    assert.equal(code, manual)
+})
+
+test('encryption key agrees with the primary side (ECDH symmetry)', async () => {
+    const companionKp = await X25519.generateKeyPair()
+    const primaryKp = await X25519.generateKeyPair()
+    const ref = 'ecdh-ref'
+
+    const companionKey = await deriveEncryptionKey({
+        companionPrivKey: companionKp.privKey,
+        primaryPublicKey: primaryKp.pubKey,
+        deviceType: DEVICE_TYPE,
+        ref
+    })
+
+    // primary derives from the mirrored shared secret with identical salt/info
+    const sharedFromPrimary = await X25519.scalarMult(primaryKp.privKey, companionKp.pubKey)
+    const salt = TEXT_ENCODER.encode(`Companion Pairing ${String(DEVICE_TYPE)} with ref ${ref}`)
+    const info = TEXT_ENCODER.encode('Pairing Information Encryption Key')
+    const primaryKey = hkdf(sharedFromPrimary, salt, info, 32)
+
+    assert.equal(companionKey.length, 32)
+    assert.deepEqual(companionKey, primaryKey)
+})
+
+test('pairing request envelope round-trips under the derived key', async () => {
+    const key = await randomBytesAsync(32)
+    const plaintext = TEXT_ENCODER.encode('pairing-data')
+
+    const envelopeBytes = await encryptPairingRequest(key, plaintext)
+    const envelope = proto.EncryptedPairingRequest.decode(envelopeBytes)
+    assert.equal(new Uint8Array(envelope.iv!).length, 12)
+    assert.ok(new Uint8Array(envelope.encryptedPayload!).length >= plaintext.length)
+
+    const decrypted = aesGcmDecrypt(
+        key,
+        new Uint8Array(envelope.iv!),
+        new Uint8Array(envelope.encryptedPayload!)
+    )
+    assert.deepEqual(decrypted, plaintext)
+})
+
+test('decode rejects malformed primary identity', () => {
+    const badPublic = proto.PrimaryEphemeralIdentity.encode({
+        publicKey: new Uint8Array(8),
+        nonce: new Uint8Array(32)
+    }).finish()
+    assert.throws(() => decodePrimaryEphemeralIdentity(badPublic), /publicKey must be 32 bytes/)
+})

--- a/src/auth/pairing/__tests__/shortcake-flow.test.ts
+++ b/src/auth/pairing/__tests__/shortcake-flow.test.ts
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { WaShortcakeFlow } from '@auth/pairing/WaShortcakeFlow'
+import type { WaAuthCredentials } from '@auth/types'
+import { hkdf, randomBytesAsync } from '@crypto'
+import { X25519 } from '@crypto/curves/X25519'
+import { createNoopLogger } from '@infra/log/types'
+import { proto } from '@proto'
+import type { BinaryNode } from '@transport/types'
+import { TEXT_DECODER, TEXT_ENCODER } from '@util/bytes'
+
+// Real `passkey_request_options` content captured from a client the server
+// forced into the passkey flow right after a pairing-code `companion_finish`.
+const REAL_OPTIONS_B64 =
+    'eyJjaGFsbGVuZ2UiOiJGQzZ2Y0pnUC1Pdl82NnlmV2dvaDF3OG1fdHJSOTJCbkZEaGctZTVKRXdrIiwidGltZW91dCI6NjAwMDAwLCJycElkIjoid2hhdHNhcHAuY29tIiwiYWxsb3dDcmVkZW50aWFscyI6W10sInVzZXJWZXJpZmljYXRpb24iOiJyZXF1aXJlZCIsImV4dGVuc2lvbnMiOnsidXZtIjp0cnVlfX0='
+const REAL_OPTIONS = new Uint8Array(Buffer.from(REAL_OPTIONS_B64, 'base64'))
+
+const fakeCredentials = {
+    noiseKeyPair: { pubKey: new Uint8Array(32).fill(7), privKey: new Uint8Array(32) },
+    registrationInfo: {
+        identityKeyPair: { pubKey: new Uint8Array(32).fill(8), privKey: new Uint8Array(32) }
+    },
+    advSecretKey: new Uint8Array(32).fill(9)
+} as unknown as WaAuthCredentials
+
+function iqResult(content?: BinaryNode['content']): BinaryNode {
+    return { tag: 'iq', attrs: { type: 'result', id: 'x' }, content }
+}
+
+function firstChildTag(node: BinaryNode): string | undefined {
+    return Array.isArray(node.content) ? node.content[0]?.tag : undefined
+}
+
+function leaf(node: BinaryNode, tag: string): Uint8Array {
+    const child = (node.content as BinaryNode[]).find((c) => c.tag === tag)
+    return child!.content as Uint8Array
+}
+
+test('shortcake flow completes the handshake driven by the real server notification', async () => {
+    const sent: BinaryNode[] = []
+    const acks: BinaryNode[] = []
+    let capturedOptions: Uint8Array | null = null
+    let prologue: BinaryNode | null = null
+    let companionNonce: Uint8Array | null = null
+    let envelope: Uint8Array | null = null
+
+    const socket = {
+        sendNode: async (node: BinaryNode) => {
+            if (node.tag === 'ack') acks.push(node)
+        },
+        query: async (node: BinaryNode): Promise<BinaryNode> => {
+            sent.push(node)
+            switch (firstChildTag(node)) {
+                case 'passkey_request_options':
+                    throw new Error('should not fetch options: they were embedded')
+                case 'ref':
+                    return iqResult([
+                        { tag: 'ref', attrs: {}, content: TEXT_ENCODER.encode('the-ref') }
+                    ])
+                case 'passkey_prologue':
+                    prologue = (node.content as BinaryNode[])[0]
+                    return iqResult()
+                case 'companion_nonce':
+                    companionNonce = (node.content as BinaryNode[])[0].content as Uint8Array
+                    return iqResult()
+                case 'encrypted_pairing_request':
+                    envelope = (node.content as BinaryNode[])[0].content as Uint8Array
+                    return iqResult()
+                default:
+                    return iqResult()
+            }
+        }
+    }
+
+    let emittedCode: string | null = null
+    let creds = fakeCredentials
+    const flow = new WaShortcakeFlow({
+        logger: createNoopLogger(),
+        socket,
+        deviceType: proto.DeviceProps.PlatformType.CHROME,
+        signAssertion: async (options) => {
+            capturedOptions = options
+            return {
+                credentialId: TEXT_ENCODER.encode('cred-id'),
+                webauthnAssertion: TEXT_ENCODER.encode('assertion-json')
+            }
+        },
+        auth: {
+            getCredentials: () => creds,
+            updateCredentials: async (c) => {
+                creds = c
+            }
+        },
+        callbacks: { emitVerificationCode: (code) => (emittedCode = code) }
+    })
+
+    // 1) server pushes the prologue request with embedded options (the real one)
+    const prologueRequest: BinaryNode = {
+        tag: 'notification',
+        attrs: { from: 's.whatsapp.net', type: 'passkey_prologue_request', id: '169361451' },
+        content: [{ tag: 'passkey_request_options', attrs: {}, content: REAL_OPTIONS }]
+    }
+    assert.equal(await flow.handleIncomingNotification(prologueRequest), true)
+
+    // the embedded options reached the signer, and the prologue IQ went out
+    assert.ok(capturedOptions)
+    const parsedOptions = JSON.parse(TEXT_DECODER.decode(capturedOptions))
+    assert.equal(parsedOptions.rpId, 'whatsapp.com')
+    assert.deepEqual(parsedOptions.allowCredentials, [])
+    assert.equal(acks.length, 1)
+    assert.ok(prologue, 'passkey_prologue IQ sent')
+    const prologueNode: BinaryNode = prologue
+    assert.deepEqual(leaf(prologueNode, 'credential_id'), TEXT_ENCODER.encode('cred-id'))
+
+    // a handoff proof is attached (ADV-derived HMAC over the prologue payload)
+    const handoffProof = (prologueNode.content as BinaryNode[]).find(
+        (c) => c.tag === 'pairing_handoff_proof'
+    )
+    assert.ok(handoffProof, 'pairing_handoff_proof attached')
+    // and the ADV secret was rotated away from the original
+    assert.notDeepEqual(new Uint8Array(creds.advSecretKey), new Uint8Array(32).fill(9))
+
+    // 2) act as the primary: read the companion identity from the prologue
+    const prologuePayload = proto.ProloguePayload.decode(leaf(prologue, 'prologue_payload'))
+    const companionIdentity = proto.CompanionEphemeralIdentity.decode(
+        prologuePayload.companionEphemeralIdentity!
+    )
+    const companionPub = new Uint8Array(companionIdentity.publicKey!)
+    assert.equal(companionIdentity.ref, 'the-ref')
+
+    const primaryKp = await X25519.generateKeyPair()
+    const primaryNonce = await randomBytesAsync(32)
+    const primaryBytes = proto.PrimaryEphemeralIdentity.encode({
+        publicKey: primaryKp.pubKey,
+        nonce: primaryNonce
+    }).finish()
+
+    // 3) server relays primary identity as crsc_continuation
+    const continuation: BinaryNode = {
+        tag: 'notification',
+        attrs: { from: 's.whatsapp.net', type: 'crsc_continuation', id: '2' },
+        content: [{ tag: 'primary_ephemeral_identity', attrs: {}, content: primaryBytes }]
+    }
+    assert.equal(await flow.handleIncomingNotification(continuation), true)
+
+    // companion revealed its nonce + emitted a verification code
+    assert.ok(companionNonce, 'companion_nonce IQ sent')
+    assert.ok(emittedCode, 'verification code emitted')
+    assert.equal(emittedCode, flow.getVerificationCode())
+
+    // primary derives the same code (commit-reveal agreement)
+    const digest = (await import('@crypto')).sha256(
+        new Uint8Array([...companionNonce, ...primaryKp.pubKey])
+    )
+    const codeBytes = new Uint8Array(5)
+    for (let i = 0; i < 5; i += 1) codeBytes[i] = primaryNonce[i] ^ digest[i]
+    const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTVWXYZ'
+    let bits = 0
+    let val = 0
+    let primaryCode = ''
+    for (const b of codeBytes) {
+        val = (val << 8) | b
+        bits += 8
+        while (bits >= 5) {
+            primaryCode += ALPHABET[(val >>> (bits - 5)) & 31]
+            bits -= 5
+        }
+    }
+    if (bits > 0) primaryCode += ALPHABET[(val << (5 - bits)) & 31]
+    assert.equal(emittedCode, primaryCode)
+
+    // 4) the flow auto-confirmed -> encrypted pairing request already sent;
+    //    the primary decrypts it under the agreed key
+    assert.ok(envelope, 'encrypted_pairing_request IQ sent')
+    const env = proto.EncryptedPairingRequest.decode(envelope)
+    const sharedFromPrimary = await X25519.scalarMult(primaryKp.privKey, companionPub)
+    const salt = TEXT_ENCODER.encode(
+        `Companion Pairing ${String(proto.DeviceProps.PlatformType.CHROME)} with ref the-ref`
+    )
+    const key = hkdf(
+        sharedFromPrimary,
+        salt,
+        TEXT_ENCODER.encode('Pairing Information Encryption Key'),
+        32
+    )
+    const { aesGcmDecrypt } = await import('@crypto')
+    const decrypted = aesGcmDecrypt(
+        key,
+        new Uint8Array(env.iv!),
+        new Uint8Array(env.encryptedPayload!)
+    )
+    // the sealed payload is the companion's PairingRequest, built from credentials
+    const pairingRequest = proto.PairingRequest.decode(decrypted)
+    assert.deepEqual(new Uint8Array(pairingRequest.companionPublicKey!), new Uint8Array(32).fill(7))
+    assert.deepEqual(
+        new Uint8Array(pairingRequest.companionIdentityKey!),
+        new Uint8Array(32).fill(8)
+    )
+    // advSecret is the ROTATED secret (whatsmeow/web rotate on the prologue)
+    assert.deepEqual(new Uint8Array(pairingRequest.advSecret!), new Uint8Array(creds.advSecretKey))
+})

--- a/src/auth/pairing/__tests__/shortcake-flow.test.ts
+++ b/src/auth/pairing/__tests__/shortcake-flow.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test'
 
 import { WaShortcakeFlow } from '@auth/pairing/WaShortcakeFlow'
 import type { WaAuthCredentials } from '@auth/types'
-import { hkdf, randomBytesAsync } from '@crypto'
+import { aesGcmDecrypt, hkdf, randomBytesAsync, sha256 } from '@crypto'
 import { X25519 } from '@crypto/curves/X25519'
 import { createNoopLogger } from '@infra/log/types'
 import { proto } from '@proto'
@@ -140,9 +140,7 @@ test('shortcake flow completes the handshake driven by the real server notificat
     assert.ok(emittedCode, 'verification code emitted')
     assert.equal(emittedCode, flow.getVerificationCode())
 
-    const digest = (await import('@crypto')).sha256(
-        new Uint8Array([...companionNonce, ...primaryKp.pubKey])
-    )
+    const digest = sha256(new Uint8Array([...companionNonce, ...primaryKp.pubKey]))
     const codeBytes = new Uint8Array(5)
     for (let i = 0; i < 5; i += 1) codeBytes[i] = primaryNonce[i] ^ digest[i]
     const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTVWXYZ'
@@ -172,7 +170,6 @@ test('shortcake flow completes the handshake driven by the real server notificat
         TEXT_ENCODER.encode('Pairing Information Encryption Key'),
         32
     )
-    const { aesGcmDecrypt } = await import('@crypto')
     const decrypted = aesGcmDecrypt(
         key,
         new Uint8Array(env.iv!),

--- a/src/auth/pairing/__tests__/shortcake-flow.test.ts
+++ b/src/auth/pairing/__tests__/shortcake-flow.test.ts
@@ -10,8 +10,6 @@ import { proto } from '@proto'
 import type { BinaryNode } from '@transport/types'
 import { TEXT_DECODER, TEXT_ENCODER } from '@util/bytes'
 
-// Real `passkey_request_options` content captured from a client the server
-// forced into the passkey flow right after a pairing-code `companion_finish`.
 const REAL_OPTIONS_B64 =
     'eyJjaGFsbGVuZ2UiOiJGQzZ2Y0pnUC1Pdl82NnlmV2dvaDF3OG1fdHJSOTJCbkZEaGctZTVKRXdrIiwidGltZW91dCI6NjAwMDAwLCJycElkIjoid2hhdHNhcHAuY29tIiwiYWxsb3dDcmVkZW50aWFscyI6W10sInVzZXJWZXJpZmljYXRpb24iOiJyZXF1aXJlZCIsImV4dGVuc2lvbnMiOnsidXZtIjp0cnVlfX0='
 const REAL_OPTIONS = new Uint8Array(Buffer.from(REAL_OPTIONS_B64, 'base64'))
@@ -95,7 +93,6 @@ test('shortcake flow completes the handshake driven by the real server notificat
         callbacks: { emitVerificationCode: (code) => (emittedCode = code) }
     })
 
-    // 1) server pushes the prologue request with embedded options (the real one)
     const prologueRequest: BinaryNode = {
         tag: 'notification',
         attrs: { from: 's.whatsapp.net', type: 'passkey_prologue_request', id: '169361451' },
@@ -103,7 +100,6 @@ test('shortcake flow completes the handshake driven by the real server notificat
     }
     assert.equal(await flow.handleIncomingNotification(prologueRequest), true)
 
-    // the embedded options reached the signer, and the prologue IQ went out
     assert.ok(capturedOptions)
     const parsedOptions = JSON.parse(TEXT_DECODER.decode(capturedOptions))
     assert.equal(parsedOptions.rpId, 'whatsapp.com')
@@ -113,15 +109,12 @@ test('shortcake flow completes the handshake driven by the real server notificat
     const prologueNode: BinaryNode = prologue
     assert.deepEqual(leaf(prologueNode, 'credential_id'), TEXT_ENCODER.encode('cred-id'))
 
-    // a handoff proof is attached (ADV-derived HMAC over the prologue payload)
     const handoffProof = (prologueNode.content as BinaryNode[]).find(
         (c) => c.tag === 'pairing_handoff_proof'
     )
     assert.ok(handoffProof, 'pairing_handoff_proof attached')
-    // and the ADV secret was rotated away from the original
     assert.notDeepEqual(new Uint8Array(creds.advSecretKey), new Uint8Array(32).fill(9))
 
-    // 2) act as the primary: read the companion identity from the prologue
     const prologuePayload = proto.ProloguePayload.decode(leaf(prologue, 'prologue_payload'))
     const companionIdentity = proto.CompanionEphemeralIdentity.decode(
         prologuePayload.companionEphemeralIdentity!
@@ -136,7 +129,6 @@ test('shortcake flow completes the handshake driven by the real server notificat
         nonce: primaryNonce
     }).finish()
 
-    // 3) server relays primary identity as crsc_continuation
     const continuation: BinaryNode = {
         tag: 'notification',
         attrs: { from: 's.whatsapp.net', type: 'crsc_continuation', id: '2' },
@@ -144,12 +136,10 @@ test('shortcake flow completes the handshake driven by the real server notificat
     }
     assert.equal(await flow.handleIncomingNotification(continuation), true)
 
-    // companion revealed its nonce + emitted a verification code
     assert.ok(companionNonce, 'companion_nonce IQ sent')
     assert.ok(emittedCode, 'verification code emitted')
     assert.equal(emittedCode, flow.getVerificationCode())
 
-    // primary derives the same code (commit-reveal agreement)
     const digest = (await import('@crypto')).sha256(
         new Uint8Array([...companionNonce, ...primaryKp.pubKey])
     )
@@ -170,8 +160,6 @@ test('shortcake flow completes the handshake driven by the real server notificat
     if (bits > 0) primaryCode += ALPHABET[(val << (5 - bits)) & 31]
     assert.equal(emittedCode, primaryCode)
 
-    // 4) the flow auto-confirmed -> encrypted pairing request already sent;
-    //    the primary decrypts it under the agreed key
     assert.ok(envelope, 'encrypted_pairing_request IQ sent')
     const env = proto.EncryptedPairingRequest.decode(envelope)
     const sharedFromPrimary = await X25519.scalarMult(primaryKp.privKey, companionPub)
@@ -190,13 +178,11 @@ test('shortcake flow completes the handshake driven by the real server notificat
         new Uint8Array(env.iv!),
         new Uint8Array(env.encryptedPayload!)
     )
-    // the sealed payload is the companion's PairingRequest, built from credentials
     const pairingRequest = proto.PairingRequest.decode(decrypted)
     assert.deepEqual(new Uint8Array(pairingRequest.companionPublicKey!), new Uint8Array(32).fill(7))
     assert.deepEqual(
         new Uint8Array(pairingRequest.companionIdentityKey!),
         new Uint8Array(32).fill(8)
     )
-    // advSecret is the ROTATED secret (whatsmeow/web rotate on the prologue)
     assert.deepEqual(new Uint8Array(pairingRequest.advSecret!), new Uint8Array(creds.advSecretKey))
 })

--- a/src/auth/pairing/pairing-code-crypto.ts
+++ b/src/auth/pairing/pairing-code-crypto.ts
@@ -15,7 +15,7 @@ const CROCKFORD_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTVWXYZ'
 export const PBKDF2_ITERATIONS = 2 << 16
 const PAIRING_AES_KEY_BYTES = 32
 
-export function bytesToCrockford(bytes: Uint8Array): string {
+export function encodeBytesToCrockford(bytes: Uint8Array): string {
     let bitCount = 0
     let value = 0
     let out = ''
@@ -65,7 +65,7 @@ export async function createCompanionHello(
         randomBytesAsync(16),
         normalizedCustomCode !== null ? Promise.resolve(null) : randomBytesAsync(5)
     ])
-    const pairingCode = normalizedCustomCode ?? bytesToCrockford(codeBytes!)
+    const pairingCode = normalizedCustomCode ?? encodeBytesToCrockford(codeBytes!)
     const cipherKey = await pbkdf2Sha256(
         TEXT_ENCODER.encode(pairingCode),
         salt,

--- a/src/auth/pairing/pairing-code-crypto.ts
+++ b/src/auth/pairing/pairing-code-crypto.ts
@@ -15,7 +15,7 @@ const CROCKFORD_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTVWXYZ'
 export const PBKDF2_ITERATIONS = 2 << 16
 const PAIRING_AES_KEY_BYTES = 32
 
-function bytesToCrockford(bytes: Uint8Array): string {
+export function bytesToCrockford(bytes: Uint8Array): string {
     let bitCount = 0
     let value = 0
     let out = ''

--- a/src/auth/pairing/shortcake-crypto.ts
+++ b/src/auth/pairing/shortcake-crypto.ts
@@ -3,7 +3,7 @@ import { aesGcmEncrypt, hkdf, randomBytesAsync, sha256 } from '@crypto'
 import type { SignalKeyPair } from '@crypto/curves/types'
 import { X25519 } from '@crypto/curves/X25519'
 import { proto } from '@proto'
-import { concatBytes, TEXT_ENCODER, uint8Equal } from '@util/bytes'
+import { concatBytes, TEXT_ENCODER } from '@util/bytes'
 
 /**
  * Cryptographic core of the WhatsApp "Shortcake" companion-linking protocol
@@ -149,18 +149,4 @@ export async function encryptPairingRequest(
     const iv = await randomBytesAsync(GCM_IV_BYTES)
     const encryptedPayload = aesGcmEncrypt(encryptionKey, iv, plaintext)
     return proto.EncryptedPairingRequest.encode({ encryptedPayload, iv }).finish()
-}
-
-/**
- * Verifies that a revealed companion nonce matches a previously sent commitment
- * hash (defends the primary against a swapped nonce). Mirrors the check the
- * primary performs before honoring a prologue.
- */
-export function verifyCommitment(
-    companionEphemeralIdentityBytes: Uint8Array,
-    companionNonce: Uint8Array,
-    commitmentHash: Uint8Array
-): boolean {
-    const expected = sha256(concatBytes([companionEphemeralIdentityBytes, companionNonce]))
-    return uint8Equal(expected, commitmentHash)
 }

--- a/src/auth/pairing/shortcake-crypto.ts
+++ b/src/auth/pairing/shortcake-crypto.ts
@@ -1,0 +1,166 @@
+import { bytesToCrockford } from '@auth/pairing/pairing-code-crypto'
+import { aesGcmEncrypt, hkdf, randomBytesAsync, sha256 } from '@crypto'
+import type { SignalKeyPair } from '@crypto/curves/types'
+import { X25519 } from '@crypto/curves/X25519'
+import { proto } from '@proto'
+import { concatBytes, TEXT_ENCODER, uint8Equal } from '@util/bytes'
+
+/**
+ * Cryptographic core of the WhatsApp "Shortcake" companion-linking protocol
+ * (the device-link flow the official clients call CRSC / Shortcake).
+ *
+ * This module implements ONLY the wire/crypto half: ephemeral X25519 key
+ * exchange, the commit-reveal nonce, the verification code, and the AES-GCM
+ * pairing envelope. The WebAuthn/passkey assertion that gates the prologue is
+ * NOT produced here – it is an opaque input supplied by the caller (so the
+ * credential source stays out of the protocol layer).
+ *
+ * Mirrors `WAWebShortcakeLinkingAlgorithm` from the web client.
+ */
+
+const NONCE_BYTES = 32
+const VERIFICATION_CODE_BYTES = 5
+const GCM_IV_BYTES = 12
+const ENCRYPTION_KEY_BYTES = 32
+const EPHEMERAL_PUBLIC_KEY_BYTES = 32
+
+/** HKDF `info` for the pairing-request encryption key. */
+const ENCRYPTION_KEY_INFO = TEXT_ENCODER.encode('Pairing Information Encryption Key')
+
+/**
+ * Decoded `PrimaryEphemeralIdentity` the primary device returns: its ephemeral
+ * X25519 public key (32B) and a 32B nonce used to derive the verification code.
+ */
+export interface ShortcakePrimaryEphemeralIdentity {
+    readonly publicKey: Uint8Array
+    readonly nonce: Uint8Array
+}
+
+export interface ShortcakeCompanionEphemeralIdentity {
+    /** Companion ephemeral X25519 keypair (private half kept for the ECDH). */
+    readonly keyPair: SignalKeyPair
+    /** 32 random bytes committed up-front, revealed only after the primary replies. */
+    readonly companionNonce: Uint8Array
+    /** Encoded `CompanionEphemeralIdentity` proto (committed + sent in the prologue). */
+    readonly companionEphemeralIdentityBytes: Uint8Array
+    /** `SHA-256(companionEphemeralIdentity ‖ companionNonce)` – the commitment hash. */
+    readonly commitmentHash: Uint8Array
+    /** Encoded `ProloguePayload` proto ready for the `SetPasskeyPrologue` IQ. */
+    readonly prologuePayloadBytes: Uint8Array
+}
+
+/**
+ * Generates the companion's ephemeral identity + commitment for a Shortcake
+ * prologue. The companion publishes a commitment to its nonce now and reveals
+ * the nonce later (after the primary's identity arrives) so the primary cannot
+ * grind the verification code.
+ */
+export async function generateCompanionEphemeralIdentity(args: {
+    readonly ref: string
+    readonly deviceType: proto.DeviceProps.PlatformType
+}): Promise<ShortcakeCompanionEphemeralIdentity> {
+    const [keyPair, companionNonce] = await Promise.all([
+        X25519.generateKeyPair(),
+        randomBytesAsync(NONCE_BYTES)
+    ])
+
+    const companionEphemeralIdentityBytes = proto.CompanionEphemeralIdentity.encode({
+        publicKey: keyPair.pubKey,
+        deviceType: args.deviceType,
+        ref: args.ref
+    }).finish()
+
+    const commitmentHash = sha256(concatBytes([companionEphemeralIdentityBytes, companionNonce]))
+
+    const prologuePayloadBytes = proto.ProloguePayload.encode({
+        companionEphemeralIdentity: companionEphemeralIdentityBytes,
+        commitment: { hash: commitmentHash }
+    }).finish()
+
+    return {
+        keyPair,
+        companionNonce,
+        companionEphemeralIdentityBytes,
+        commitmentHash,
+        prologuePayloadBytes
+    }
+}
+
+/** Parses + validates a `PrimaryEphemeralIdentity` proto from the primary. */
+export function decodePrimaryEphemeralIdentity(
+    bytes: Uint8Array
+): ShortcakePrimaryEphemeralIdentity {
+    const decoded = proto.PrimaryEphemeralIdentity.decode(bytes)
+    const publicKey = decoded.publicKey
+    const nonce = decoded.nonce
+    if (!publicKey || publicKey.length !== EPHEMERAL_PUBLIC_KEY_BYTES) {
+        throw new Error('shortcake: PrimaryEphemeralIdentity.publicKey must be 32 bytes')
+    }
+    if (!nonce || nonce.length !== NONCE_BYTES) {
+        throw new Error('shortcake: PrimaryEphemeralIdentity.nonce must be 32 bytes')
+    }
+    return { publicKey, nonce }
+}
+
+/**
+ * Derives the short verification code shown on both devices:
+ * `Crockford32( primaryNonce[0..5] XOR SHA-256(companionNonce ‖ primaryPubKey)[0..5] )`.
+ */
+export function deriveVerificationCode(
+    companionNonce: Uint8Array,
+    primary: ShortcakePrimaryEphemeralIdentity
+): string {
+    const digest = sha256(concatBytes([companionNonce, primary.publicKey]))
+    const code = new Uint8Array(VERIFICATION_CODE_BYTES)
+    for (let i = 0; i < VERIFICATION_CODE_BYTES; i += 1) {
+        code[i] = primary.nonce[i] ^ digest[i]
+    }
+    return bytesToCrockford(code)
+}
+
+/**
+ * Derives the AES-GCM key that protects the pairing request:
+ * `HKDF( X25519(companionPriv, primaryPub), salt="Companion Pairing <deviceType> with ref <ref>", info="Pairing Information Encryption Key" )`.
+ */
+export async function deriveEncryptionKey(args: {
+    readonly companionPrivKey: Uint8Array
+    readonly primaryPublicKey: Uint8Array
+    readonly deviceType: proto.DeviceProps.PlatformType
+    readonly ref: string
+}): Promise<Uint8Array> {
+    const shared = await X25519.scalarMult(args.companionPrivKey, args.primaryPublicKey)
+    const salt = TEXT_ENCODER.encode(
+        `Companion Pairing ${String(args.deviceType)} with ref ${args.ref}`
+    )
+    return hkdf(shared, salt, ENCRYPTION_KEY_INFO, ENCRYPTION_KEY_BYTES)
+}
+
+/**
+ * Encrypts the pairing request plaintext under the derived key and returns the
+ * encoded `EncryptedPairingRequest` proto (random 12-byte IV).
+ */
+export async function encryptPairingRequest(
+    encryptionKey: Uint8Array,
+    plaintext: Uint8Array
+): Promise<Uint8Array> {
+    if (encryptionKey.length !== ENCRYPTION_KEY_BYTES) {
+        throw new Error('shortcake: encryption key must be 32 bytes')
+    }
+    const iv = await randomBytesAsync(GCM_IV_BYTES)
+    const encryptedPayload = aesGcmEncrypt(encryptionKey, iv, plaintext)
+    return proto.EncryptedPairingRequest.encode({ encryptedPayload, iv }).finish()
+}
+
+/**
+ * Verifies that a revealed companion nonce matches a previously sent commitment
+ * hash (defends the primary against a swapped nonce). Mirrors the check the
+ * primary performs before honoring a prologue.
+ */
+export function verifyCommitment(
+    companionEphemeralIdentityBytes: Uint8Array,
+    companionNonce: Uint8Array,
+    commitmentHash: Uint8Array
+): boolean {
+    const expected = sha256(concatBytes([companionEphemeralIdentityBytes, companionNonce]))
+    return uint8Equal(expected, commitmentHash)
+}

--- a/src/auth/pairing/shortcake-crypto.ts
+++ b/src/auth/pairing/shortcake-crypto.ts
@@ -1,4 +1,4 @@
-import { bytesToCrockford } from '@auth/pairing/pairing-code-crypto'
+import { encodeBytesToCrockford } from '@auth/pairing/pairing-code-crypto'
 import { aesGcmEncrypt, hkdf, randomBytesAsync, sha256 } from '@crypto'
 import type { SignalKeyPair } from '@crypto/curves/types'
 import { X25519 } from '@crypto/curves/X25519'
@@ -36,6 +36,11 @@ export interface ShortcakePrimaryEphemeralIdentity {
     readonly nonce: Uint8Array
 }
 
+/**
+ * @sensitive Carries the companion's ephemeral X25519 private key
+ * (`keyPair.privKey`) and the pre-image `companionNonce`. Hold these in memory
+ * for the handshake only; never log or `JSON.stringify` an instance.
+ */
 export interface ShortcakeCompanionEphemeralIdentity {
     /** Companion ephemeral X25519 keypair (private half kept for the ECDH). */
     readonly keyPair: SignalKeyPair
@@ -115,7 +120,7 @@ export function deriveVerificationCode(
     for (let i = 0; i < VERIFICATION_CODE_BYTES; i += 1) {
         code[i] = primary.nonce[i] ^ digest[i]
     }
-    return bytesToCrockford(code)
+    return encodeBytesToCrockford(code)
 }
 
 /**

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -621,7 +621,8 @@ export function buildWaClientDependencies(input: {
                     runtime.emitEvent('auth_paired', { credentials })
                     scheduleReconnectAfterPairing()
                 },
-                onError: (error) => runtime.handleError(error)
+                onError: (error) => runtime.handleError(error),
+                signPasskeyAssertion: options.signPasskeyAssertion
             }
         }
     )

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -622,6 +622,8 @@ export function buildWaClientDependencies(input: {
                     scheduleReconnectAfterPairing()
                 },
                 onError: (error) => runtime.handleError(error),
+                onPasskeyRequired: (hasSigner) =>
+                    runtime.emitEvent('auth_passkey_required', { hasSigner }),
                 signPasskeyAssertion: options.signPasskeyAssertion
             }
         }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1290,6 +1290,14 @@ export interface WaClientEventMap {
      */
     readonly auth_paired: (event: { readonly credentials: WaAuthCredentials }) => void
     /**
+     * The server is forcing a passkey (Shortcake) to link this device – emitted
+     * when the server pushes the prologue request. `hasSigner` is `true` when a
+     * `signPasskeyAssertion` is configured (the handshake proceeds) and `false`
+     * when none is set (the request is acked but the link cannot complete
+     * headless, so the user should be told a passkey is required).
+     */
+    readonly auth_passkey_required: (event: { readonly hasSigner: boolean }) => void
+    /**
      * Connection-state transitions: `'open'` (handshake + auth complete),
      * `'connecting'`, or `'close'` (with a `reason` and optional `code`). The
      * client does **not** auto-reconnect on close – call {@link WaClient.connect} again.

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,5 +1,6 @@
 import type { AppStateCollectionName } from '@appstate/types'
 import type { DataForKey, WaAppstateActionKey, WaAppstateIndexArgs } from '@appstate-spec'
+import type { WaShortcakeAssertionSigner } from '@auth/pairing/WaShortcakeFlow'
 import type {
     WaAuthClientOptions,
     WaAuthCredentials,
@@ -206,6 +207,14 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
      * disables a security check the production code path enforces.
      */
     readonly dangerous?: WaClientDangerousOptions
+    /**
+     * External WebAuthn signer. Configuring it enables handling a server-forced
+     * passkey ("Shortcake") prologue – e.g. when the server demands a passkey
+     * right after a successful pairing-code `companion_finish`. Called with the
+     * server's request options; returns the assertion + credential id. The
+     * credential source (real/virtual authenticator) stays outside the library.
+     */
+    readonly signPasskeyAssertion?: WaShortcakeAssertionSigner
 }
 
 export interface WaClientDangerousOptions extends WaAuthDangerousOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,6 +233,7 @@ export type {
 } from '@message/addons/link-preview/types'
 export type { SignalLidSyncResult } from '@signal/api/SignalDeviceSyncApi'
 export type { WaAuthCredentials, WaVersionResolver } from '@auth/types'
+export type { WaShortcakeAssertionSigner } from '@auth/pairing/WaShortcakeFlow'
 export type { BinaryNode } from '@transport/types'
 export { fetchLatestWaWebVersion } from '@transport/wa-web-version-fetcher'
 export type {

--- a/src/protocol/nodes.ts
+++ b/src/protocol/nodes.ts
@@ -50,6 +50,8 @@ export const WA_NODE_TAGS = Object.freeze({
     COUNTRY_CODE: 'country_code',
     DEVICE_IDENTITY: 'device-identity',
     PLATFORM: 'platform',
+    PASSKEY_REQUEST_OPTIONS: 'passkey_request_options',
+    PRIMARY_EPHEMERAL_IDENTITY: 'primary_ephemeral_identity',
     SUBJECT: 'subject',
     BODY: 'body',
     PARTICIPANT: 'participant',

--- a/src/protocol/notification.ts
+++ b/src/protocol/notification.ts
@@ -6,7 +6,9 @@ export const WA_NOTIFICATION_TYPES = Object.freeze({
     REGISTRATION: 'registration',
     NEWSLETTER: 'newsletter',
     BUSINESS: 'business',
-    PICTURE: 'picture'
+    PICTURE: 'picture',
+    PASSKEY_PROLOGUE_REQUEST: 'passkey_prologue_request',
+    CRSC_CONTINUATION: 'crsc_continuation'
 } as const)
 
 export const WA_BUSINESS_NOTIFICATION_TAGS = Object.freeze({

--- a/src/transport/node/builders/shortcake.ts
+++ b/src/transport/node/builders/shortcake.ts
@@ -1,0 +1,72 @@
+import { WA_DEFAULTS, WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
+import type { BinaryNode } from '@transport/types'
+
+/**
+ * IQ builders for the WhatsApp "Shortcake" companion-linking protocol
+ * (`xmlns="md"`). Wire shapes mirror the official client's
+ * `WASmaxOutMd…Request` builders. The stanza `id` is assigned by the socket
+ * query layer, matching the other pairing builders.
+ */
+
+function mdIq(type: string, content: BinaryNode['content']): BinaryNode {
+    return {
+        tag: WA_NODE_TAGS.IQ,
+        attrs: {
+            to: WA_DEFAULTS.HOST_DOMAIN,
+            type,
+            xmlns: WA_XMLNS.MD
+        },
+        content
+    }
+}
+
+/** `<iq type="get" xmlns="md"><passkey_request_options/></iq>` */
+export function buildGetPasskeyRequestOptionsRequestNode(): BinaryNode {
+    return mdIq(WA_IQ_TYPES.GET, [
+        { tag: 'passkey_request_options', attrs: {}, content: undefined }
+    ])
+}
+
+/** `<iq type="get" xmlns="md"><ref/></iq>` */
+export function buildShortcakeGetRefRequestNode(): BinaryNode {
+    return mdIq(WA_IQ_TYPES.GET, [{ tag: 'ref', attrs: {}, content: undefined }])
+}
+
+/**
+ * `<iq type="set" xmlns="md"><passkey_prologue><credential_id/><webauthn_assertion/>`
+ * `<prologue_payload/>[<pairing_handoff_proof/>]</passkey_prologue></iq>`
+ */
+export function buildSetPasskeyPrologueRequestNode(args: {
+    readonly credentialId: Uint8Array
+    readonly webauthnAssertion: Uint8Array
+    readonly prologuePayload: Uint8Array
+    readonly pairingHandoffProof?: Uint8Array
+}): BinaryNode {
+    const children: BinaryNode[] = [
+        { tag: 'credential_id', attrs: {}, content: args.credentialId },
+        { tag: 'webauthn_assertion', attrs: {}, content: args.webauthnAssertion },
+        { tag: 'prologue_payload', attrs: {}, content: args.prologuePayload }
+    ]
+    if (args.pairingHandoffProof) {
+        children.push({
+            tag: 'pairing_handoff_proof',
+            attrs: {},
+            content: args.pairingHandoffProof
+        })
+    }
+    return mdIq(WA_IQ_TYPES.SET, [{ tag: 'passkey_prologue', attrs: {}, content: children }])
+}
+
+/** `<iq type="set" xmlns="md"><companion_nonce/></iq>` */
+export function buildSetCompanionNonceRequestNode(companionNonce: Uint8Array): BinaryNode {
+    return mdIq(WA_IQ_TYPES.SET, [{ tag: 'companion_nonce', attrs: {}, content: companionNonce }])
+}
+
+/** `<iq type="set" xmlns="md"><encrypted_pairing_request/></iq>` */
+export function buildSetEncryptedPairingRequestRequestNode(
+    encryptedPairingRequest: Uint8Array
+): BinaryNode {
+    return mdIq(WA_IQ_TYPES.SET, [
+        { tag: 'encrypted_pairing_request', attrs: {}, content: encryptedPairingRequest }
+    ])
+}

--- a/src/transport/node/builders/shortcake.ts
+++ b/src/transport/node/builders/shortcake.ts
@@ -1,4 +1,5 @@
 import { WA_DEFAULTS, WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
+import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
 /**
@@ -8,28 +9,23 @@ import type { BinaryNode } from '@transport/types'
  * query layer, matching the other pairing builders.
  */
 
-function mdIq(type: string, content: BinaryNode['content']): BinaryNode {
-    return {
-        tag: WA_NODE_TAGS.IQ,
-        attrs: {
-            to: WA_DEFAULTS.HOST_DOMAIN,
-            type,
-            xmlns: WA_XMLNS.MD
-        },
-        content
-    }
+function mdIq(
+    type: typeof WA_IQ_TYPES.GET | typeof WA_IQ_TYPES.SET,
+    content: BinaryNode['content']
+): BinaryNode {
+    return buildIqNode(type, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.MD, content)
 }
 
 /** `<iq type="get" xmlns="md"><passkey_request_options/></iq>` */
 export function buildGetPasskeyRequestOptionsRequestNode(): BinaryNode {
     return mdIq(WA_IQ_TYPES.GET, [
-        { tag: 'passkey_request_options', attrs: {}, content: undefined }
+        { tag: WA_NODE_TAGS.PASSKEY_REQUEST_OPTIONS, attrs: {}, content: undefined }
     ])
 }
 
 /** `<iq type="get" xmlns="md"><ref/></iq>` */
 export function buildShortcakeGetRefRequestNode(): BinaryNode {
-    return mdIq(WA_IQ_TYPES.GET, [{ tag: 'ref', attrs: {}, content: undefined }])
+    return mdIq(WA_IQ_TYPES.GET, [{ tag: WA_NODE_TAGS.REF, attrs: {}, content: undefined }])
 }
 
 /**

--- a/src/transport/noise/WaClientPayload.ts
+++ b/src/transport/noise/WaClientPayload.ts
@@ -49,7 +49,9 @@ function defaultWebSubPlatform(): number {
     return proto.ClientPayload.WebInfo.WebSubPlatform.WEB_BROWSER
 }
 
-function resolveDevicePropsPlatformType(deviceBrowser?: string): number {
+export function resolveDevicePropsPlatformType(
+    deviceBrowser?: string
+): proto.DeviceProps.PlatformType {
     const normalized = deviceBrowser?.trim().toLowerCase()
     switch (normalized) {
         case 'chrome':


### PR DESCRIPTION
Implements the companion side of WhatsApp's "Shortcake" (CRSC) passkey device-linking handshake, which the server can force right after a successful pairing-code companion_finish. Previously such a passkey_prologue_request fell through the link-code handler, got acked and ignored, stalling the link with everything else correct.

- shortcake-crypto: X25519 ephemeral key exchange, commit/reveal nonce, Crockford verification code, HKDF session key and AES-GCM pairing envelope (PairingRequest built internally from credentials).
- builders/shortcake: xmlns="md" IQ builders (passkey_request_options, ref, passkey_prologue, companion_nonce, encrypted_pairing_request).
- WaShortcakeFlow: handles passkey_prologue_request + crsc_continuation, drives the handshake and auto-confirms (headless). The WebAuthn assertion is the only external input (signPasskeyAssertion); identity, ADV and the pairing request stay internal.
- Wire into WaAuthClient/options so the prologue is handled instead of stalling; ack + warn when no signer is configured.

Tests cover the crypto agreement and the full handshake driven by a real captured passkey_prologue_request notification.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-triggered Shortcake passkey linking during companion setup, including the prologue/verification/secure pairing-request sequence.
  * Exposed an `auth_passkey_required` client event indicating whether a passkey signer is available, and updated top-level exports to support external WebAuthn signing.
* **Bug Fixes**
  * Improved cleanup by clearing Shortcake session state when transient auth state is reset.
* **Tests**
  * Added crypto and end-to-end flow coverage for Shortcake pairing, including verification code generation and encrypted pairing request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->