### PR TITLE
fix(retry): resend group pkmsg retry without device-identity on mobile primary

### DIFF
--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -180,6 +180,7 @@ export class WaRetryCoordinator {
             signalProtocol: options.signalProtocol,
             sessionResolver: options.sessionResolver,
             getCurrentCredentials: options.getCurrentCredentials,
+            isMobilePrimary: options.isMobilePrimary,
             resolveUserIcdc: options.resolveUserIcdc,
             resolvePrivacyTokenNode: options.resolvePrivacyTokenNode
         })

--- a/src/retry/__tests__/retry.test.ts
+++ b/src/retry/__tests__/retry.test.ts
@@ -316,7 +316,7 @@ test('retry replay service returns ineligible on plaintext destination mismatch'
     assert.equal(result, 'ineligible')
 })
 
-test('retry replay service handles group plaintext retries and pkmsg identity guard', async () => {
+test('retry replay service handles group plaintext retries and omits device-identity when unsigned', async () => {
     const sendNodeCalls: BinaryNode[] = []
     const warnings: string[] = []
     let encType: 'msg' | 'pkmsg' = 'pkmsg'
@@ -349,10 +349,16 @@ test('retry replay service handles group plaintext retries and pkmsg identity gu
         '5511999999999:2@s.whatsapp.net',
         1
     )
-    assert.equal(pkmsgResult, 'ineligible')
+    assert.equal(pkmsgResult, 'resent')
     assert.ok(warnings.some((message) => message.includes('missing signed identity')))
-    assert.equal(sendNodeCalls.length, 0)
+    assert.equal(sendNodeCalls.length, 1)
+    assert.ok(Array.isArray(sendNodeCalls[0].content))
+    assert.equal(
+        (sendNodeCalls[0].content as BinaryNode[]).some((child) => child.tag === 'device-identity'),
+        false
+    )
 
+    sendNodeCalls.length = 0
     encType = 'msg'
     const msgResult = await service.resendOutboundMessage(
         outbound,
@@ -368,6 +374,51 @@ test('retry replay service handles group plaintext retries and pkmsg identity gu
     assert.equal(sendNodeCalls[0].content[0].tag, 'enc')
     assert.equal(sendNodeCalls[0].content[0].attrs.type, 'msg')
     assert.equal(sendNodeCalls[0].content[0].attrs.count, '1')
+})
+
+test('retry replay service resends group pkmsg without device-identity for mobile primary', async () => {
+    const sendNodeCalls: BinaryNode[] = []
+    const warnings: string[] = []
+    const service = new WaRetryReplayService({
+        logger: createLogger(warnings),
+        messageClient: {
+            sendEncrypted: async () => undefined,
+            sendMessageNode: async (node: BinaryNode) => {
+                sendNodeCalls.push(node)
+            }
+        } as unknown as WaMessageClient,
+        signalProtocol: {
+            encryptMessage: async () => ({
+                type: 'pkmsg' as const,
+                ciphertext: new Uint8Array([5, 6, 7])
+            })
+        } as unknown as SignalProtocol,
+        getCurrentCredentials: () => null,
+        isMobilePrimary: () => true,
+        sessionResolver: NOOP_SESSION_RESOLVER
+    })
+
+    const outbound = buildOutboundRecord('m-group-mobile', {
+        mode: 'plaintext',
+        to: '123456@g.us',
+        type: 'text',
+        plaintext: new Uint8Array([1, 2, 3, 4])
+    })
+    const result = await service.resendOutboundMessage(
+        outbound,
+        '5511999999999:2@s.whatsapp.net',
+        1
+    )
+    assert.equal(result, 'resent')
+    assert.equal(sendNodeCalls.length, 1)
+    assert.equal(
+        (sendNodeCalls[0].content as BinaryNode[]).some((child) => child.tag === 'device-identity'),
+        false
+    )
+    assert.equal(
+        warnings.some((message) => message.includes('missing signed identity')),
+        false
+    )
 })
 
 test('retry replay service emits status@broadcast retry with meta and no addressing_mode', async () => {

--- a/src/retry/replay.ts
+++ b/src/retry/replay.ts
@@ -36,6 +36,7 @@ export interface WaRetryReplayServiceOptions {
     readonly signalProtocol: SignalProtocol
     readonly sessionResolver: SignalSessionResolver
     readonly getCurrentCredentials: () => WaAuthCredentials | null
+    readonly isMobilePrimary?: () => boolean
     readonly resolveUserIcdc?: (userJid: string) => Promise<IcdcMeta | null>
     /**
      * Resolves the trusted-contact (privacy) token node for a recipient user
@@ -164,9 +165,12 @@ export class WaRetryReplayService {
     private resolveSignedDeviceIdentity(context: string): Uint8Array | undefined {
         const signedIdentity = this.options.getCurrentCredentials()?.signedIdentity
         if (!signedIdentity) {
-            this.options.logger.warn('retry request missing signed identity for pkmsg envelope', {
-                context
-            })
+            if (!this.options.isMobilePrimary?.()) {
+                this.options.logger.warn(
+                    'retry request missing signed identity for pkmsg envelope',
+                    { context }
+                )
+            }
             return undefined
         }
         return proto.ADVSignedDeviceIdentity.encode(signedIdentity).finish()
@@ -277,18 +281,8 @@ export class WaRetryReplayService {
             requesterAddress,
             plaintext
         )
-        let deviceIdentity: Uint8Array | undefined
-
-        if (encrypted.type === 'pkmsg') {
-            const signedIdentity = this.options.getCurrentCredentials()?.signedIdentity
-            if (!signedIdentity) {
-                this.options.logger.warn(
-                    'retry request rejected: missing signed identity for pkmsg group retry'
-                )
-                return 'ineligible'
-            }
-            deviceIdentity = proto.ADVSignedDeviceIdentity.encode(signedIdentity).finish()
-        }
+        const deviceIdentity =
+            encrypted.type === 'pkmsg' ? this.resolveSignedDeviceIdentity('group') : undefined
 
         const isStatus = isStatusBroadcastJid(payload.to)
         const metaAttrs: Record<string, string> = {}


### PR DESCRIPTION
A mobile primary (device 0) has no self-signed device-identity, so the group retry resend path dropped every pkmsg resend as ineligible. Reuse resolveSignedDeviceIdentity so the resend goes out without the node, matching the direct and encrypted paths, and scope the missing-identity warn to companion sessions where the absence is actually anomalous.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for group plaintext messages so they are less likely to fail as ineligible when identity details are missing.
  * Reduced unnecessary warning logs in mobile-primary scenarios while preserving retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->