### PR TITLE
feat(mobile): host companion devices from a mobile-primary session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9507,7 +9507,7 @@
         },
         "packages/store-mongo": {
             "name": "@zapo-js/store-mongo",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "license": "MIT",
             "devDependencies": {
                 "mongodb": "^6.16.0",
@@ -9523,7 +9523,7 @@
         },
         "packages/store-mysql": {
             "name": "@zapo-js/store-mysql",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "license": "MIT",
             "devDependencies": {
                 "mysql2": "^3.14.0",
@@ -9539,7 +9539,7 @@
         },
         "packages/store-postgres": {
             "name": "@zapo-js/store-postgres",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "license": "MIT",
             "devDependencies": {
                 "@types/pg": "^8.11.0",
@@ -9556,7 +9556,7 @@
         },
         "packages/store-redis": {
             "name": "@zapo-js/store-redis",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "license": "MIT",
             "devDependencies": {
                 "ioredis": "^5.6.1",
@@ -9572,7 +9572,7 @@
         },
         "packages/store-sqlite": {
             "name": "@zapo-js/store-sqlite",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "license": "MIT",
             "devDependencies": {
                 "better-sqlite3": "^12.6.2",

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -3,6 +3,7 @@ import { mkdir } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
 import {
+    createFileCompanionHostPersistence,
     createStore,
     type Logger,
     type LogLevel,
@@ -702,6 +703,14 @@ export class McpRuntime {
             {
                 store,
                 sessionId: state.sessionId,
+                companionHost: {
+                    persistence: createFileCompanionHostPersistence(
+                        resolve(
+                            dirname(this.config.authPath),
+                            `companion-host-${state.sessionId.replace(/[^a-zA-Z0-9_-]/g, '_')}.json`
+                        )
+                    )
+                },
                 ...(mobileTransport ? { mobileTransport } : {}),
                 connectTimeoutMs: 60_000,
                 deviceBrowser: this.config.deviceBrowser ?? 'Chrome',

--- a/src/auth/pairing/__tests__/companion-host.test.ts
+++ b/src/auth/pairing/__tests__/companion-host.test.ts
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    buildSignedCompanionIdentity,
+    completePrimaryHandshake,
+    parseCompanionQr,
+    preparePrimaryHello
+} from '@auth/pairing/companion-host'
+import {
+    aesCtrDecrypt,
+    aesCtrEncrypt,
+    aesGcmEncrypt,
+    hkdf,
+    pbkdf2Sha256,
+    randomBytesAsync,
+    toRawPubKey,
+    toSerializedPubKey,
+    X25519
+} from '@crypto'
+import { proto } from '@proto'
+import { WA_PAIRING_KDF_INFO } from '@protocol'
+import {
+    computeAdvIdentityHmac,
+    verifyDeviceIdentityAccountSignature,
+    verifyKeyIndexListSignature
+} from '@signal'
+import { bytesToBase64UrlSafe, concatBytes, TEXT_ENCODER, uint8Equal } from '@util/bytes'
+
+const PBKDF2_ITERATIONS = 131_072
+
+test('parseCompanionQr splits trailing fields and preserves a comma-bearing ref', () => {
+    const noise = new Uint8Array([1, 2, 3])
+    const identity = new Uint8Array([4, 5, 6])
+    const adv = new Uint8Array([7, 8, 9])
+    const ref = 'ref,with,commas'
+    const qr = [
+        ref,
+        bytesToBase64UrlSafe(noise),
+        bytesToBase64UrlSafe(identity),
+        bytesToBase64UrlSafe(adv),
+        'CHROME'
+    ].join(',')
+
+    const parsed = parseCompanionQr(qr)
+    assert.equal(parsed.ref, ref)
+    assert.equal(parsed.platform, 'CHROME')
+    assert.deepEqual([...parsed.noisePublicKey], [1, 2, 3])
+    assert.deepEqual([...parsed.identityPublicKey], [4, 5, 6])
+    assert.deepEqual([...parsed.advSecretKey], [7, 8, 9])
+})
+
+test('parseCompanionQr rejects too-few fields', () => {
+    assert.throws(() => parseCompanionQr('a,b,c'), /at least 5/)
+})
+
+test('signed companion identity verifies with the companion-side account check', async () => {
+    const accountIdentityKeyPair = await X25519.generateKeyPair()
+    const companionIdentityKeyPair = await X25519.generateKeyPair()
+    // Any 32 secret bytes stand in for the companion's advSecret from its QR.
+    const advSecretKey = (await X25519.generateKeyPair()).privKey
+    const companionIdentityPublicKey = companionIdentityKeyPair.pubKey
+
+    const { deviceIdentityBytes, keyIndexListBytes } = await buildSignedCompanionIdentity({
+        accountIdentityKeyPair,
+        companionIdentityPublicKey,
+        advSecretKey,
+        rawId: 12_345,
+        keyIndex: 1,
+        timestampSeconds: 1_700_000_000,
+        validIndexes: [0, 1]
+    })
+
+    const wrapped = proto.ADVSignedDeviceIdentityHMAC.decode(deviceIdentityBytes)
+    const wrappedDetails = wrapped.details!
+    const expectedHmac = computeAdvIdentityHmac(advSecretKey, wrappedDetails)
+    assert.equal(uint8Equal(expectedHmac, wrapped.hmac!), true)
+
+    const signed = proto.ADVSignedDeviceIdentity.decode(wrappedDetails)
+    assert.equal(
+        await verifyDeviceIdentityAccountSignature(
+            signed.details!,
+            signed.accountSignature!,
+            companionIdentityPublicKey,
+            signed.accountSignatureKey!
+        ),
+        true
+    )
+
+    const signedList = proto.ADVSignedKeyIndexList.decode(keyIndexListBytes)
+    assert.equal(
+        await verifyKeyIndexListSignature(
+            signedList.details!,
+            signedList.accountSignature!,
+            toSerializedPubKey(accountIdentityKeyPair.pubKey)
+        ),
+        true
+    )
+})
+
+// Wraps an ephemeral public key the way a companion's createCompanionHello does.
+async function wrapEphemeral(code: string, ephemeralPub: Uint8Array): Promise<Uint8Array> {
+    const salt = await randomBytesAsync(32)
+    const counter = await randomBytesAsync(16)
+    const key = await pbkdf2Sha256(TEXT_ENCODER.encode(code), salt, PBKDF2_ITERATIONS, 32)
+    return concatBytes([salt, counter, aesCtrEncrypt(key, counter, ephemeralPub)])
+}
+
+test('link-code primary handshake derives the same advSecret as the companion', async () => {
+    const code = 'ABCD2345'
+    const companionEphemeral = await X25519.generateKeyPair()
+    const companionIdentity = await X25519.generateKeyPair()
+    const primaryIdentity = await X25519.generateKeyPair()
+
+    const wrappedCompanionEphemeralPub = await wrapEphemeral(code, companionEphemeral.pubKey)
+
+    // Primary step 1.
+    const prepared = await preparePrimaryHello({ pairingCode: code, wrappedCompanionEphemeralPub })
+
+    // Companion's completeCompanionFinish: unwrap the primary ephemeral, build bundle.
+    const pKey = await pbkdf2Sha256(
+        TEXT_ENCODER.encode(code),
+        prepared.wrappedPrimaryEphemeralPub.subarray(0, 32),
+        PBKDF2_ITERATIONS,
+        32
+    )
+    const primaryEphemeralPub = aesCtrDecrypt(
+        pKey,
+        prepared.wrappedPrimaryEphemeralPub.subarray(32, 48),
+        prepared.wrappedPrimaryEphemeralPub.subarray(48)
+    )
+    const sharedEphemeralCompanion = await X25519.scalarMult(
+        companionEphemeral.privKey,
+        primaryEphemeralPub
+    )
+    const sharedIdentityCompanion = await X25519.scalarMult(
+        companionIdentity.privKey,
+        toRawPubKey(primaryIdentity.pubKey)
+    )
+    const bundleSalt = await randomBytesAsync(32)
+    const bundleIv = await randomBytesAsync(12)
+    const bundleSecret = await randomBytesAsync(32)
+    const bundleKey = hkdf(
+        sharedEphemeralCompanion,
+        bundleSalt,
+        WA_PAIRING_KDF_INFO.LINK_CODE_BUNDLE,
+        32
+    )
+    const plaintextBundle = concatBytes([
+        companionIdentity.pubKey,
+        toRawPubKey(primaryIdentity.pubKey),
+        bundleSecret
+    ])
+    const wrappedKeyBundle = concatBytes([
+        bundleSalt,
+        bundleIv,
+        aesGcmEncrypt(bundleKey, bundleIv, plaintextBundle)
+    ])
+    const advSecretCompanion = hkdf(
+        concatBytes([sharedEphemeralCompanion, sharedIdentityCompanion, bundleSecret]),
+        null,
+        WA_PAIRING_KDF_INFO.ADV_SECRET,
+        32
+    )
+
+    // The shared ephemeral must match on both sides.
+    assert.equal(uint8Equal(prepared.sharedEphemeral, sharedEphemeralCompanion), true)
+
+    // Primary step 2 -> advSecret must equal what the companion derived.
+    const advSecretPrimary = await completePrimaryHandshake({
+        sharedEphemeral: prepared.sharedEphemeral,
+        wrappedKeyBundle,
+        companionIdentityPub: companionIdentity.pubKey,
+        primaryIdentityKeyPair: primaryIdentity
+    })
+    assert.equal(uint8Equal(advSecretPrimary, advSecretCompanion), true)
+})
+
+test('completePrimaryHandshake rejects a bundle bound to a different primary identity', async () => {
+    const code = 'WXYZ6789'
+    const companionEphemeral = await X25519.generateKeyPair()
+    const companionIdentity = await X25519.generateKeyPair()
+    const primaryIdentity = await X25519.generateKeyPair()
+    const wrongPrimary = await X25519.generateKeyPair()
+
+    const wrappedCompanionEphemeralPub = await wrapEphemeral(code, companionEphemeral.pubKey)
+    const prepared = await preparePrimaryHello({ pairingCode: code, wrappedCompanionEphemeralPub })
+
+    const bundleSalt = await randomBytesAsync(32)
+    const bundleIv = await randomBytesAsync(12)
+    const bundleKey = hkdf(
+        prepared.sharedEphemeral,
+        bundleSalt,
+        WA_PAIRING_KDF_INFO.LINK_CODE_BUNDLE,
+        32
+    )
+    const plaintextBundle = concatBytes([
+        companionIdentity.pubKey,
+        toRawPubKey(wrongPrimary.pubKey),
+        await randomBytesAsync(32)
+    ])
+    const wrappedKeyBundle = concatBytes([
+        bundleSalt,
+        bundleIv,
+        aesGcmEncrypt(bundleKey, bundleIv, plaintextBundle)
+    ])
+
+    await assert.rejects(
+        () =>
+            completePrimaryHandshake({
+                sharedEphemeral: prepared.sharedEphemeral,
+                wrappedKeyBundle,
+                companionIdentityPub: companionIdentity.pubKey,
+                primaryIdentityKeyPair: primaryIdentity
+            }),
+        /primary identity mismatch/
+    )
+})

--- a/src/auth/pairing/companion-host.ts
+++ b/src/auth/pairing/companion-host.ts
@@ -1,0 +1,287 @@
+import {
+    aesCtrDecrypt,
+    aesCtrEncrypt,
+    aesGcmDecrypt,
+    hkdf,
+    pbkdf2Sha256,
+    randomBytesAsync,
+    type SignalKeyPair,
+    toRawPubKey,
+    X25519
+} from '@crypto'
+import { proto } from '@proto'
+import { WA_PAIRING_KDF_INFO } from '@protocol'
+import {
+    computeAdvIdentityHmac,
+    generateDeviceIdentityAccountSignature,
+    signKeyIndexList
+} from '@signal'
+import { concatBytes, decodeBase64Url, TEXT_ENCODER, uint8Equal } from '@util/bytes'
+
+const PEM_HKDF_INFO = TEXT_ENCODER.encode('Canonical Ent Companion Nonce Encrypt')
+
+const PBKDF2_ITERATIONS = 131_072
+const PAIRING_AES_KEY_BYTES = 32
+
+/**
+ * `@sensitive` `advSecretKey` is companion secret material; consumers must not
+ * persist it without encryption at rest.
+ *
+ * Fields decoded from a companion pairing QR string. The companion (the device
+ * being linked) generates these; the primary consumes them to sign the device
+ * identity. `advSecretKey` is the companion's secret, not the primary's.
+ */
+export interface ParsedCompanionQr {
+    readonly ref: string
+    readonly noisePublicKey: Uint8Array
+    readonly identityPublicKey: Uint8Array
+    readonly advSecretKey: Uint8Array
+    readonly platform: string
+}
+
+/**
+ * Parses a companion pairing QR of the form
+ * `ref,noisePubB64,identityPubB64,advSecretB64,platform`. The `ref` may itself
+ * contain commas, so the four trailing fields are taken from the end.
+ *
+ * @throws when fewer than 5 comma-separated fields are present.
+ */
+export function parseCompanionQr(qr: string): ParsedCompanionQr {
+    const parts = qr.split(',')
+    if (parts.length < 5) {
+        throw new Error(
+            `companion qr must have at least 5 comma-separated parts, got ${parts.length}`
+        )
+    }
+    const platform = parts[parts.length - 1]
+    const advSecretB64 = parts[parts.length - 2]
+    const identityPubB64 = parts[parts.length - 3]
+    const noisePubB64 = parts[parts.length - 4]
+    const ref = parts.slice(0, parts.length - 4).join(',')
+    return {
+        ref,
+        noisePublicKey: decodeBase64Url(noisePubB64, 'companionQr.noisePublicKey'),
+        identityPublicKey: decodeBase64Url(identityPubB64, 'companionQr.identityPublicKey'),
+        advSecretKey: decodeBase64Url(advSecretB64, 'companionQr.advSecretKey'),
+        platform
+    }
+}
+
+/** `@sensitive` Carries the primary's `accountIdentityKeyPair` private key. */
+export interface BuildSignedKeyIndexListInput {
+    readonly accountIdentityKeyPair: SignalKeyPair
+    readonly rawId: number
+    readonly currentIndex: number
+    readonly timestampSeconds: number
+    readonly validIndexes: readonly number[]
+}
+
+/**
+ * Builds the account-signed `ADVSignedKeyIndexList` bytes for the current device
+ * set. The zero-valued `accountType` enum is omitted to match the phone's byte
+ * layout.
+ */
+export async function buildSignedKeyIndexList(
+    input: BuildSignedKeyIndexListInput
+): Promise<Uint8Array> {
+    const details = proto.ADVKeyIndexList.encode({
+        rawId: input.rawId,
+        timestamp: input.timestampSeconds,
+        currentIndex: input.currentIndex,
+        validIndexes: [...input.validIndexes]
+    }).finish()
+    const accountSignature = await signKeyIndexList(details, input.accountIdentityKeyPair)
+    return proto.ADVSignedKeyIndexList.encode({ details, accountSignature }).finish()
+}
+
+/**
+ * `@sensitive` Carries the primary's `accountIdentityKeyPair` private key and the
+ * companion's `advSecretKey`; do not persist unencrypted.
+ */
+export interface BuildSignedCompanionIdentityInput {
+    readonly accountIdentityKeyPair: SignalKeyPair
+    readonly companionIdentityPublicKey: Uint8Array
+    readonly advSecretKey: Uint8Array
+    readonly rawId: number
+    readonly keyIndex: number
+    readonly timestampSeconds: number
+    readonly validIndexes: readonly number[]
+}
+
+export interface SignedCompanionIdentity {
+    /** `ADVSignedDeviceIdentityHMAC` bytes for the `<device-identity>` node. */
+    readonly deviceIdentityBytes: Uint8Array
+    /** `ADVSignedKeyIndexList` bytes for the `<key-index-list>` node. */
+    readonly keyIndexListBytes: Uint8Array
+}
+
+/**
+ * Builds the signed device identity and key-index list for a linking companion.
+ * The byte layout mirrors WhatsApp's phone (and the in-repo fake-server
+ * reference): the zero-valued `accountType`/`deviceType` enum fields are omitted
+ * so the signed `details` match what the companion verifies.
+ */
+export async function buildSignedCompanionIdentity(
+    input: BuildSignedCompanionIdentityInput
+): Promise<SignedCompanionIdentity> {
+    const accountSignatureKey = toRawPubKey(input.accountIdentityKeyPair.pubKey)
+
+    const details = proto.ADVDeviceIdentity.encode({
+        rawId: input.rawId,
+        timestamp: input.timestampSeconds,
+        keyIndex: input.keyIndex
+    }).finish()
+
+    const accountSignature = await generateDeviceIdentityAccountSignature(
+        details,
+        input.companionIdentityPublicKey,
+        input.accountIdentityKeyPair
+    )
+
+    const signedIdentity = proto.ADVSignedDeviceIdentity.encode({
+        details,
+        accountSignatureKey,
+        accountSignature
+    }).finish()
+
+    const hmac = computeAdvIdentityHmac(input.advSecretKey, signedIdentity)
+    const deviceIdentityBytes = proto.ADVSignedDeviceIdentityHMAC.encode({
+        details: signedIdentity,
+        hmac
+    }).finish()
+
+    const keyIndexListBytes = await buildSignedKeyIndexList({
+        accountIdentityKeyPair: input.accountIdentityKeyPair,
+        rawId: input.rawId,
+        currentIndex: input.keyIndex,
+        timestampSeconds: input.timestampSeconds,
+        validIndexes: input.validIndexes
+    })
+
+    return { deviceIdentityBytes, keyIndexListBytes }
+}
+
+/**
+ * Derives the `<pem>` AES-GCM key the phone ships in the pair-device upload:
+ * `HKDF-SHA256(ikm = advSecret, salt = companionNoisePublicKey, info)`. Not yet
+ * verified against a live server from this implementation; see
+ * `CompanionHostOptions.includePem`.
+ */
+export function derivePemKey(
+    advSecretKey: Uint8Array,
+    companionNoisePublicKey: Uint8Array
+): Uint8Array {
+    return hkdf(advSecretKey, companionNoisePublicKey, PEM_HKDF_INFO, 32)
+}
+
+/**
+ * `@sensitive` Holds the `primaryEphemeralKeyPair` private key and the derived
+ * `sharedEphemeral`; keep in memory only, never persist unencrypted.
+ */
+export interface LinkCodePrimaryHello {
+    readonly primaryEphemeralKeyPair: SignalKeyPair
+    /** `salt(32) || counter(16) || AES-CTR(primaryEphemeralPub)` for `primary_hello`. */
+    readonly wrappedPrimaryEphemeralPub: Uint8Array
+    /** ECDH(primaryEphemeralPriv, companionEphemeralPub); stashed for the finish step. */
+    readonly sharedEphemeral: Uint8Array
+}
+
+/**
+ * Link-code handshake, primary step 1: unwrap the companion ephemeral with the
+ * pairing code, generate the primary ephemeral, compute the shared ECDH secret,
+ * and wrap the primary ephemeral for the `primary_hello` stanza. Mirror of the
+ * companion's `createCompanionHello` + primary-ephemeral unwrap.
+ */
+export async function preparePrimaryHello(args: {
+    readonly pairingCode: string
+    readonly wrappedCompanionEphemeralPub: Uint8Array
+}): Promise<LinkCodePrimaryHello> {
+    if (args.wrappedCompanionEphemeralPub.length < 48) {
+        throw new Error(
+            `wrapped companion ephemeral pub too short: ${args.wrappedCompanionEphemeralPub.length} bytes (need >= 48)`
+        )
+    }
+    const codeBytes = TEXT_ENCODER.encode(args.pairingCode)
+    const companionCipherKey = await pbkdf2Sha256(
+        codeBytes,
+        args.wrappedCompanionEphemeralPub.subarray(0, 32),
+        PBKDF2_ITERATIONS,
+        PAIRING_AES_KEY_BYTES
+    )
+    const companionEphemeralPub = aesCtrDecrypt(
+        companionCipherKey,
+        args.wrappedCompanionEphemeralPub.subarray(32, 48),
+        args.wrappedCompanionEphemeralPub.subarray(48)
+    )
+
+    const [primaryEphemeralKeyPair, salt, counter] = await Promise.all([
+        X25519.generateKeyPair(),
+        randomBytesAsync(32),
+        randomBytesAsync(16)
+    ])
+    const primaryCipherKey = await pbkdf2Sha256(
+        codeBytes,
+        salt,
+        PBKDF2_ITERATIONS,
+        PAIRING_AES_KEY_BYTES
+    )
+    const encrypted = aesCtrEncrypt(primaryCipherKey, counter, primaryEphemeralKeyPair.pubKey)
+    const sharedEphemeral = await X25519.scalarMult(
+        primaryEphemeralKeyPair.privKey,
+        companionEphemeralPub
+    )
+
+    return {
+        primaryEphemeralKeyPair,
+        wrappedPrimaryEphemeralPub: concatBytes([salt, counter, encrypted]),
+        sharedEphemeral
+    }
+}
+
+/**
+ * Link-code handshake, primary step 2: decrypt the `companion_finish` key bundle
+ * and derive the shared `advSecret` (byte-identical to what the companion
+ * derives). Validates that the bundle binds both identities.
+ *
+ * @throws when the bundle's embedded identities do not match.
+ */
+export async function completePrimaryHandshake(args: {
+    readonly sharedEphemeral: Uint8Array
+    readonly wrappedKeyBundle: Uint8Array
+    readonly companionIdentityPub: Uint8Array
+    readonly primaryIdentityKeyPair: SignalKeyPair
+}): Promise<Uint8Array> {
+    const bundleEncryptionKey = hkdf(
+        args.sharedEphemeral,
+        args.wrappedKeyBundle.subarray(0, 32),
+        WA_PAIRING_KDF_INFO.LINK_CODE_BUNDLE,
+        32
+    )
+    const plaintextBundle = aesGcmDecrypt(
+        bundleEncryptionKey,
+        args.wrappedKeyBundle.subarray(32, 44),
+        args.wrappedKeyBundle.subarray(44)
+    )
+    const bundleCompanionIdentity = plaintextBundle.subarray(0, 32)
+    const bundlePrimaryIdentity = plaintextBundle.subarray(32, 64)
+    const bundleSecret = plaintextBundle.subarray(64)
+
+    const rawCompanionIdentity = toRawPubKey(args.companionIdentityPub)
+    if (!uint8Equal(bundlePrimaryIdentity, toRawPubKey(args.primaryIdentityKeyPair.pubKey))) {
+        throw new Error('link-code bundle primary identity mismatch')
+    }
+    if (!uint8Equal(bundleCompanionIdentity, rawCompanionIdentity)) {
+        throw new Error('link-code bundle companion identity mismatch')
+    }
+
+    const sharedIdentity = await X25519.scalarMult(
+        args.primaryIdentityKeyPair.privKey,
+        rawCompanionIdentity
+    )
+    return hkdf(
+        concatBytes([args.sharedEphemeral, sharedIdentity, bundleSecret]),
+        null,
+        WA_PAIRING_KDF_INFO.ADV_SECRET,
+        32
+    )
+}

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -10,6 +10,7 @@ import type { WaEmailCoordinator } from '@client/coordinators/WaEmailCoordinator
 import type { WaGroupCoordinator } from '@client/coordinators/WaGroupCoordinator'
 import type { WaLowLevelCoordinator } from '@client/coordinators/WaLowLevelCoordinator'
 import type { WaMessageCoordinator } from '@client/coordinators/WaMessageCoordinator'
+import type { WaMobileCoordinator } from '@client/coordinators/WaMobileCoordinator'
 import type { WaNewsletterCoordinator } from '@client/coordinators/WaNewsletterCoordinator'
 import type { WaPresenceCoordinator } from '@client/coordinators/WaPresenceCoordinator'
 import type { WaPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordinator'
@@ -149,6 +150,14 @@ class WaClientImpl extends EventEmitter {
                     'please upgrade zapo so the shipped default catches up.'
             )
             void this.runClientTooOldRecover()
+        })
+        this.on('connection', (event) => {
+            if (event.status !== 'open') return
+            void this.deps.mobileCoordinator.reconcileCompanions().catch((error) => {
+                this.logger.debug('companion reconcile on connect failed', {
+                    message: toError(error).message
+                })
+            })
         })
     }
 
@@ -579,6 +588,14 @@ class WaClientImpl extends EventEmitter {
      */
     public get email(): WaEmailCoordinator {
         return this.deps.emailCoordinator
+    }
+    /**
+     * Mobile coordinator: host and manage companion devices linked to this
+     * mobile-primary account (link via QR or pairing code, list, revoke).
+     * Requires a registered primary session. See {@link WaMobileCoordinator}.
+     */
+    public get mobile(): WaMobileCoordinator {
+        return this.deps.mobileCoordinator
     }
 
     /**

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -30,6 +30,7 @@ import {
 } from '@client/coordinators/WaLowLevelCoordinator'
 import { WaMessageCoordinator } from '@client/coordinators/WaMessageCoordinator'
 import { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
+import { WaMobileCoordinator } from '@client/coordinators/WaMobileCoordinator'
 import {
     createNewsletterCoordinator,
     type WaNewsletterCoordinator
@@ -223,6 +224,7 @@ export interface WaClientDependencies {
     readonly trustedContactToken: WaTrustedContactTokenCoordinator
     readonly abPropsCoordinator: WaAbPropsCoordinator
     readonly peerDataOperation: PeerDataOperationRequester
+    readonly mobileCoordinator: WaMobileCoordinator
 }
 
 function assertProxyTransport(value: unknown, path: string): void {
@@ -1387,6 +1389,22 @@ export function buildWaClientDependencies(input: {
         defaultIqTimeoutMs: options.iqTimeoutMs
     })
 
+    const mobileCoordinator = new WaMobileCoordinator({
+        logger,
+        authClient,
+        messageDispatch,
+        chatCoordinator: appStateMutations,
+        deviceSync: signalDeviceSync,
+        appStateStore: sessionStore.appState,
+        queryWithContext: runtime.queryWithContext,
+        emitEvent: runtime.emitEvent,
+        registerIncomingHandler: (registration) =>
+            incomingNode.registerIncomingHandler(registration),
+        isMobilePrimary,
+        persistence: options.companionHost?.persistence,
+        includePem: options.companionHost?.includePem
+    })
+
     return {
         nodeTransport,
         nodeOrchestrator,
@@ -1427,6 +1445,7 @@ export function buildWaClientDependencies(input: {
         connectionManager,
         trustedContactToken,
         abPropsCoordinator,
-        peerDataOperation
+        peerDataOperation,
+        mobileCoordinator
     }
 }

--- a/src/client/coordinators/WaMobileCoordinator.ts
+++ b/src/client/coordinators/WaMobileCoordinator.ts
@@ -1,0 +1,816 @@
+import {
+    buildSignedCompanionIdentity,
+    buildSignedKeyIndexList,
+    completePrimaryHandshake,
+    derivePemKey,
+    parseCompanionQr,
+    preparePrimaryHello
+} from '@auth/pairing/companion-host'
+import {
+    buildHistorySyncBootstrapMessage,
+    type PhoneNumberToLidMapping
+} from '@client/messaging/companion-host'
+import type {
+    CompanionHostEpochState,
+    CompanionHostPersistence,
+    CompanionRecord
+} from '@client/persistence/companion-host'
+import type { WaClientPluginContext } from '@client/plugins/types'
+import type { WaClientEventMap } from '@client/types'
+import type { WaClientDependencies } from '@client/WaClientFactory'
+import { randomIntAsync, toRawPubKey } from '@crypto'
+import type { Logger } from '@infra/log/types'
+import { parseSignalAddressFromJid } from '@protocol/jid'
+import { WA_NODE_TAGS } from '@protocol/nodes'
+import {
+    assertIqResult,
+    type BinaryNode,
+    findNodeChild,
+    getFirstNodeChild,
+    getNodeChildren,
+    getNodeTextContent
+} from '@transport'
+import {
+    buildKeyIndexListPublishIq,
+    buildPairDeviceIq,
+    buildPrimaryHelloIq,
+    buildRemoveAllCompanionDevicesIq,
+    buildRemoveCompanionDeviceIq,
+    type ClientPairingProps
+} from '@transport/node/builders/mobile'
+import { delay } from '@util/async'
+import { toError } from '@util/primitives'
+
+const PAIR_DEVICE_TIMEOUT_MS = 32_000
+const KEY_INDEX_TIMEOUT_MS = 32_000
+const REMOVE_DEVICE_TIMEOUT_MS = 32_000
+const PRIMARY_HELLO_TIMEOUT_MS = 120_000
+const LINK_CODE_FINISH_TIMEOUT_MS = 120_000
+const PEM_TTL_SECONDS = 5 * 24 * 60 * 60
+const COMPANION_PROVISION_ATTEMPTS = 8
+const COMPANION_PROVISION_RETRY_MS = 1500
+
+interface CompanionFinishData {
+    readonly companionIdentityPub: Uint8Array
+    readonly wrappedKeyBundle: Uint8Array
+}
+
+interface CompleteLinkInput {
+    readonly ref: string
+    readonly companionIdentityPublicKey: Uint8Array
+    readonly companionNoisePublicKey: Uint8Array
+    readonly advSecretKey: Uint8Array
+    readonly platform: string
+}
+
+type WaMobileEmit = <K extends keyof WaClientEventMap>(
+    event: K,
+    ...args: Parameters<WaClientEventMap[K]>
+) => void
+
+/** Result of a successful {@link WaMobileCoordinator.linkCompanion}. */
+export interface LinkCompanionResult {
+    readonly deviceJid: string
+    readonly keyIndex: number
+}
+
+/** Dependencies for {@link WaMobileCoordinator}, injected by the client factory. */
+export interface WaMobileCoordinatorDeps {
+    readonly logger: Logger
+    readonly authClient: WaClientDependencies['authClient']
+    readonly messageDispatch: WaClientDependencies['messageDispatch']
+    readonly chatCoordinator: WaClientDependencies['chatCoordinator']
+    readonly deviceSync: WaClientDependencies['signalDeviceSync']
+    readonly appStateStore: WaClientPluginContext['stores']['appState']
+    readonly queryWithContext: WaClientPluginContext['queryWithContext']
+    readonly emitEvent: WaMobileEmit
+    readonly registerIncomingHandler: WaClientPluginContext['registerIncomingHandler']
+    readonly isMobilePrimary: () => boolean
+    readonly persistence?: CompanionHostPersistence
+    readonly includePem?: boolean
+}
+
+/**
+ * Hosts companion devices from a mobile-primary session: signs a companion's
+ * device identity, uploads `pair-device`, tracks the linked set, and can revoke
+ * a device. Exposed at `client.mobile`; requires a registered primary session.
+ * Supports the QR ({@link linkCompanion}) and pairing-code
+ * ({@link linkCompanionByCode}) flows.
+ */
+export class WaMobileCoordinator {
+    private readonly authClient: WaMobileCoordinatorDeps['authClient']
+    private readonly messageDispatch: WaMobileCoordinatorDeps['messageDispatch']
+    private readonly chatCoordinator: WaMobileCoordinatorDeps['chatCoordinator']
+    private readonly deviceSync: WaMobileCoordinatorDeps['deviceSync']
+    private readonly appStateStore: WaMobileCoordinatorDeps['appStateStore']
+    private readonly queryWithContext: WaMobileCoordinatorDeps['queryWithContext']
+    private readonly emitEvent: WaMobileEmit
+    private readonly isMobilePrimary: () => boolean
+    private readonly logger: Logger
+    private readonly persistence?: CompanionHostPersistence
+    private readonly includePem: boolean
+    private epoch: CompanionHostEpochState | null = null
+    private pendingCompanionHello: {
+        readonly ref: string
+        readonly wrappedCompanionEphemeralPub: Uint8Array
+        readonly companionServerAuthKeyPub: Uint8Array
+    } | null = null
+    private pendingFinish: {
+        readonly ref: string
+        readonly resolve: (data: CompanionFinishData) => void
+    } | null = null
+    private accountKeyIndexes: ReadonlySet<number> = new Set([0])
+    private pushNameSeeded = false
+
+    constructor(deps: WaMobileCoordinatorDeps) {
+        this.authClient = deps.authClient
+        this.messageDispatch = deps.messageDispatch
+        this.chatCoordinator = deps.chatCoordinator
+        this.deviceSync = deps.deviceSync
+        this.appStateStore = deps.appStateStore
+        this.queryWithContext = deps.queryWithContext
+        this.emitEvent = deps.emitEvent
+        this.isMobilePrimary = deps.isMobilePrimary
+        this.logger = deps.logger.child({ scope: 'mobile' })
+        this.persistence = deps.persistence
+        this.includePem = deps.includePem ?? false
+        deps.registerIncomingHandler({
+            tag: WA_NODE_TAGS.NOTIFICATION,
+            prepend: true,
+            handler: (node) => this.handleNotification(node)
+        })
+    }
+
+    /**
+     * Links the companion from its pairing QR: signs the device identity, uploads
+     * `pair-device`, and returns the server-assigned device jid.
+     *
+     * @throws when there is no primary session or the server rejects the upload
+     * (e.g. the linked-device cap is reached).
+     */
+    async linkCompanion(qr: string): Promise<LinkCompanionResult> {
+        try {
+            const parsed = parseCompanionQr(qr)
+            return await this.completeLink({
+                ref: parsed.ref,
+                companionIdentityPublicKey: parsed.identityPublicKey,
+                companionNoisePublicKey: parsed.noisePublicKey,
+                advSecretKey: parsed.advSecretKey,
+                platform: parsed.platform
+            })
+        } catch (error) {
+            const normalized = toError(error)
+            this.logger.warn('companion link failed', { message: normalized.message })
+            this.emitEvent('companion_host_error', normalized)
+            throw normalized
+        }
+    }
+
+    /**
+     * Links a companion via its 8-character pairing code (the "link with phone
+     * number" flow). The companion must have requested a code for this account
+     * first (its `companion_hello` is recorded); this drives `primary_hello`,
+     * awaits `companion_finish`, and completes the same `pair-device` upload as
+     * the QR path.
+     *
+     * @throws when there is no primary session, no companion is pending, the code
+     * is wrong, or the handshake times out.
+     */
+    async linkCompanionByCode(pairingCode: string): Promise<LinkCompanionResult> {
+        try {
+            const accountIdentityKeyPair = this.requirePrimaryIdentityKeyPair()
+            const hello = this.pendingCompanionHello
+            if (!hello) {
+                throw new Error(
+                    'no pending companion; a companion must request a pairing code for this account first'
+                )
+            }
+            const prepared = await preparePrimaryHello({
+                pairingCode: pairingCode.replace(/[^0-9A-Za-z]/g, '').toUpperCase(),
+                wrappedCompanionEphemeralPub: hello.wrappedCompanionEphemeralPub
+            })
+            let finishTimeout: ReturnType<typeof setTimeout> | undefined
+            const finishPromise = new Promise<CompanionFinishData>((resolve, reject) => {
+                this.pendingFinish = { ref: hello.ref, resolve }
+                finishTimeout = setTimeout(() => {
+                    if (this.pendingFinish?.ref === hello.ref) {
+                        this.pendingFinish = null
+                        reject(new Error('link-code companion_finish timed out'))
+                    }
+                }, LINK_CODE_FINISH_TIMEOUT_MS)
+            })
+            finishPromise.catch(() => undefined)
+            let finish: CompanionFinishData
+            try {
+                const helloResult = await this.queryWithContext(
+                    'companion-host.primary-hello',
+                    buildPrimaryHelloIq({
+                        ref: hello.ref,
+                        wrappedPrimaryEphemeralPub: prepared.wrappedPrimaryEphemeralPub,
+                        primaryIdentityPub: toRawPubKey(accountIdentityKeyPair.pubKey)
+                    }),
+                    PRIMARY_HELLO_TIMEOUT_MS
+                )
+                assertIqResult(helloResult, 'companion-host.primary-hello')
+                finish = await finishPromise
+            } finally {
+                clearTimeout(finishTimeout)
+                if (this.pendingFinish?.ref === hello.ref) {
+                    this.pendingFinish = null
+                }
+            }
+            const advSecretKey = await completePrimaryHandshake({
+                sharedEphemeral: prepared.sharedEphemeral,
+                wrappedKeyBundle: finish.wrappedKeyBundle,
+                companionIdentityPub: finish.companionIdentityPub,
+                primaryIdentityKeyPair: accountIdentityKeyPair
+            })
+            this.pendingCompanionHello = null
+            return await this.completeLink({
+                ref: hello.ref,
+                companionIdentityPublicKey: toRawPubKey(finish.companionIdentityPub),
+                companionNoisePublicKey: hello.companionServerAuthKeyPub,
+                advSecretKey,
+                platform: 'link-code'
+            })
+        } catch (error) {
+            const normalized = toError(error)
+            this.logger.warn('companion link-by-code failed', { message: normalized.message })
+            this.emitEvent('companion_host_error', normalized)
+            throw normalized
+        }
+    }
+
+    /** Re-signs and republishes the key-index list for the current device set. */
+    async publishKeyIndexList(): Promise<void> {
+        const accountIdentityKeyPair = this.requirePrimaryIdentityKeyPair()
+        const epoch = await this.ensureEpoch()
+        const timestampSeconds = Math.floor(Date.now() / 1000)
+        const validIndexes = this.validKeyIndexes(epoch)
+        const currentIndex = validIndexes[validIndexes.length - 1]
+        const keyIndexListBytes = await buildSignedKeyIndexList({
+            accountIdentityKeyPair,
+            rawId: epoch.rawId,
+            currentIndex,
+            timestampSeconds,
+            validIndexes
+        })
+        const iq = buildKeyIndexListPublishIq({ keyIndexListBytes, timestampSeconds })
+        const result = await this.queryWithContext(
+            'companion-host.key-index-list',
+            iq,
+            KEY_INDEX_TIMEOUT_MS
+        )
+        assertIqResult(result, 'companion-host.key-index-list')
+        this.logger.debug('key-index list published', { currentIndex, validIndexes })
+    }
+
+    /**
+     * Unlinks a companion this primary linked: sends the `remove-companion-device`
+     * IQ, drops it from the tracked set, and republishes the key-index list for
+     * the reduced device set.
+     *
+     * @throws when there is no registered primary session, the companion is not
+     * tracked, or the server rejects the removal.
+     */
+    async revokeCompanion(companionDeviceJid: string, reason = 'user_initiated'): Promise<void> {
+        this.requirePrimaryIdentityKeyPair()
+        const epoch = await this.ensureEpoch()
+        if (!epoch.companions.some((companion) => companion.deviceJid === companionDeviceJid)) {
+            throw new Error(`companion ${companionDeviceJid} is not tracked by this primary`)
+        }
+        const result = await this.queryWithContext(
+            'companion-host.remove-device',
+            buildRemoveCompanionDeviceIq({ deviceJid: companionDeviceJid, reason }),
+            REMOVE_DEVICE_TIMEOUT_MS
+        )
+        assertIqResult(result, 'companion-host.remove-device')
+        this.epoch = {
+            rawId: epoch.rawId,
+            currentKeyIndex: epoch.currentKeyIndex,
+            companions: epoch.companions.filter(
+                (companion) => companion.deviceJid !== companionDeviceJid
+            )
+        }
+        this.forgetAccountKeyIndex(parseSignalAddressFromJid(companionDeviceJid).device)
+        await this.persist(this.epoch)
+        await this.publishKeyIndexList().catch((error) => {
+            this.logger.warn('key-index list republish failed after companion revoke', {
+                deviceJid: companionDeviceJid,
+                message: toError(error).message
+            })
+        })
+        this.logger.info('companion revoked', { deviceJid: companionDeviceJid, reason })
+        this.emitEvent('companion_host_revoked', { deviceJid: companionDeviceJid })
+    }
+
+    /**
+     * Unlinks EVERY companion from the account in a single `remove-companion-device`
+     * `all="true"` stanza (the phone's "log out all companion devices"), clears the
+     * tracked set, and republishes the key-index list for the primary alone.
+     * `excludeHostedCompanion` spares companions this account itself hosts.
+     *
+     * @throws when there is no registered primary session or the server rejects
+     * the removal.
+     */
+    async revokeAllCompanions(
+        reason = 'user_initiated',
+        options: { readonly excludeHostedCompanion?: boolean } = {}
+    ): Promise<void> {
+        this.requirePrimaryIdentityKeyPair()
+        const epoch = await this.ensureEpoch()
+        const result = await this.queryWithContext(
+            'companion-host.remove-all-devices',
+            buildRemoveAllCompanionDevicesIq({
+                reason,
+                excludeHostedCompanion: options.excludeHostedCompanion
+            }),
+            REMOVE_DEVICE_TIMEOUT_MS
+        )
+        assertIqResult(result, 'companion-host.remove-all-devices')
+        if (options.excludeHostedCompanion) {
+            this.logger.info('revoked non-hosted companions; hosted set kept', {
+                kept: epoch.companions.length,
+                reason
+            })
+            return
+        }
+        const removed = epoch.companions.map((companion) => companion.deviceJid)
+        this.epoch = { rawId: epoch.rawId, currentKeyIndex: epoch.currentKeyIndex, companions: [] }
+        this.accountKeyIndexes = new Set([0])
+        await this.persist(this.epoch)
+        await this.publishKeyIndexList().catch((error) => {
+            this.logger.warn('key-index list republish failed after revoke-all', {
+                message: toError(error).message
+            })
+        })
+        this.logger.info('all companions revoked', { count: removed.length, reason })
+        for (const deviceJid of removed) {
+            this.emitEvent('companion_host_revoked', { deviceJid })
+        }
+    }
+
+    /** Returns the companions this primary has linked in the current epoch. */
+    async listCompanions(): Promise<readonly CompanionRecord[]> {
+        const epoch = await this.ensureEpoch()
+        return epoch.companions
+    }
+
+    /**
+     * Reconciles the tracked companion set against the account's live device list
+     * on the server (`usync`). Drops companions the server no longer lists - one
+     * the user unlinked, or one that self-removed while the primary was offline -
+     * then persists and emits `companion_host_revoked` for each. Runs on connect
+     * and on `account_sync`; safe to call manually. A no-op (no server query, no
+     * epoch created) when no companions are tracked. Returns the removed jids.
+     */
+    async reconcileCompanions(): Promise<readonly string[]> {
+        if (!this.isMobilePrimary()) {
+            return []
+        }
+        const meJid = this.authClient.getCurrentCredentials()?.meJid
+        if (!meJid) {
+            return []
+        }
+        const epoch = this.epoch ?? (this.persistence ? await this.persistence.load() : null)
+        if (!epoch || epoch.companions.length === 0) {
+            return []
+        }
+        this.epoch = epoch
+        const [synced] = await this.deviceSync.syncDeviceList([meJid])
+        const serverJids = synced?.deviceJids
+        if (!serverJids || serverJids.length === 0) {
+            return []
+        }
+        return this.pruneCompanionsToDevices(
+            epoch,
+            new Set(serverJids.map((jid) => parseSignalAddressFromJid(jid).device))
+        )
+    }
+
+    /**
+     * Prunes tracked companions to those whose device slot is still in
+     * `serverDeviceIndexes`, persisting + emitting `companion_host_revoked` for
+     * each drop. Shared by the connect-time (`usync`) and `account_sync` paths.
+     */
+    private async pruneCompanionsToDevices(
+        epoch: CompanionHostEpochState,
+        serverDeviceIndexes: ReadonlySet<number>
+    ): Promise<readonly string[]> {
+        const kept = epoch.companions.filter((companion) =>
+            serverDeviceIndexes.has(parseSignalAddressFromJid(companion.deviceJid).device)
+        )
+        if (kept.length === epoch.companions.length) {
+            return []
+        }
+        const removed = epoch.companions
+            .filter(
+                (companion) =>
+                    !serverDeviceIndexes.has(parseSignalAddressFromJid(companion.deviceJid).device)
+            )
+            .map((companion) => companion.deviceJid)
+        this.epoch = {
+            rawId: epoch.rawId,
+            currentKeyIndex: epoch.currentKeyIndex,
+            companions: kept
+        }
+        await this.persist(this.epoch)
+        this.logger.info('reconciled companions with server device list', {
+            kept: kept.length,
+            removed: removed.length
+        })
+        for (const deviceJid of removed) {
+            this.emitEvent('companion_host_revoked', { deviceJid })
+        }
+        return removed
+    }
+
+    /**
+     * Reconciles from an `account_sync` notification's `<devices>` payload - the
+     * fresh, authoritative device set - so a companion the user just unlinked is
+     * pruned immediately (no `usync` round-trip, which would read a stale cache).
+     */
+    private async reconcileFromAccountSync(node: BinaryNode): Promise<void> {
+        if (!this.isMobilePrimary()) {
+            return
+        }
+        const devices = findNodeChild(node, WA_NODE_TAGS.DEVICES)
+        if (!devices) {
+            return
+        }
+        const epoch = this.epoch ?? (this.persistence ? await this.persistence.load() : null)
+        if (!epoch || epoch.companions.length === 0) {
+            return
+        }
+        this.epoch = epoch
+        const serverDeviceIndexes = new Set<number>([0])
+        for (const child of getNodeChildren(devices)) {
+            if (child.tag !== WA_NODE_TAGS.DEVICE) {
+                continue
+            }
+            const jid = child.attrs.jid
+            if (jid) {
+                serverDeviceIndexes.add(parseSignalAddressFromJid(jid).device)
+            }
+        }
+        await this.pruneCompanionsToDevices(epoch, serverDeviceIndexes)
+    }
+
+    /**
+     * Shares the primary's active app-state sync key with a linked companion via
+     * an `APP_STATE_SYNC_KEY_SHARE` peer message so it can decrypt app-state.
+     * Establishes the outbound Signal session on demand, so call it once the
+     * companion is online (prekeys uploaded), not at link time.
+     *
+     * @throws when there is no primary session or no active sync key.
+     */
+    async shareAppStateSyncKeys(companionDeviceJid: string): Promise<void> {
+        this.requirePrimaryIdentityKeyPair()
+        const activeKey = await this.appStateStore.getActiveSyncKey()
+        if (!activeKey) {
+            throw new Error(
+                'no active app-state sync key to share; the primary session is not initialized'
+            )
+        }
+        await this.messageDispatch.sendAppStateSyncKeyShare(companionDeviceJid, [activeKey])
+        this.logger.info('shared app-state sync key with companion', {
+            deviceJid: companionDeviceJid
+        })
+    }
+
+    /**
+     * Pushes the `INITIAL_BOOTSTRAP` history sync to a linked companion as a
+     * `HISTORY_SYNC_NOTIFICATION` peer message. Flips the companion's
+     * `initialChatHistory` bootstrap flag; without it the companion self-removes
+     * with `HistorySyncTimeout`. Requires the companion online with prekeys.
+     *
+     * @throws when there is no registered primary session.
+     */
+    async sendHistorySyncBootstrap(
+        companionDeviceJid: string,
+        options: { readonly phoneNumberToLidMappings?: readonly PhoneNumberToLidMapping[] } = {}
+    ): Promise<void> {
+        this.requirePrimaryIdentityKeyPair()
+        const { message, payloadBytes } = await buildHistorySyncBootstrapMessage({
+            phoneNumberToLidMappings: options.phoneNumberToLidMappings
+        })
+        await this.messageDispatch.publishProtocolMessageToDevice(companionDeviceJid, message)
+        this.logger.info('companion-host history sync bootstrap sent', {
+            deviceJid: companionDeviceJid,
+            mappings: options.phoneNumberToLidMappings?.length ?? 0,
+            payloadBytes
+        })
+    }
+
+    /**
+     * `ClientPairingProps` for the `<client-props>` pair-device element. A
+     * LID-native primary declares the chat DB LID-migrated + pure-LID session so
+     * the companion runs `setIsLidMigrated` at pair time and does not self-remove
+     * on its LID-addressed blocklist.
+     */
+    private buildClientPairingProps(): ClientPairingProps {
+        const meLid = this.authClient.getCurrentCredentials()?.meLid
+        const lidNative = typeof meLid === 'string' && meLid.length > 0
+        return {
+            isChatDbLidMigrated: lidNative,
+            isSyncdPureLidSession: lidNative,
+            isSyncdSnapshotRecoveryEnabled: false
+        }
+    }
+
+    /**
+     * Seeds the primary's own `setting_pushName` into the `critical_block`
+     * app-state collection, once per session. The companion's critical bootstrap
+     * completes only when it finds an applied `SettingPushName` action; without
+     * one it self-removes with `syncd_timeout`. Falls back to the account phone
+     * number when no push name is set. Idempotent and best-effort.
+     */
+    private async ensureAccountPushNameAppState(): Promise<void> {
+        if (this.pushNameSeeded) {
+            return
+        }
+        const credentials = this.authClient.getCurrentCredentials()
+        const meJidUser = credentials?.meJid?.split('@')[0]?.split(':')[0]
+        const name = credentials?.pushName?.trim() || meJidUser
+        if (!name) {
+            throw new Error('cannot seed setting_pushName: primary has no pushName or meJid')
+        }
+        await this.chatCoordinator.set({ schema: 'SettingPushName', name })
+        this.pushNameSeeded = true
+        this.logger.info('seeded primary setting_pushName into critical_block app-state', {
+            name
+        })
+    }
+
+    private async completeLink(input: CompleteLinkInput): Promise<LinkCompanionResult> {
+        const accountIdentityKeyPair = this.requirePrimaryIdentityKeyPair()
+        await this.ensureAccountPushNameAppState().catch((error) => {
+            this.logger.warn('failed to seed primary setting_pushName app-state', {
+                message: toError(error).message
+            })
+        })
+        const epoch = await this.ensureEpoch()
+        const keyIndex = this.nextKeyIndex(epoch)
+        const validIndexes = [...this.validKeyIndexes(epoch), keyIndex].sort((a, b) => a - b)
+        const timestampSeconds = Math.floor(Date.now() / 1000)
+        const record: CompanionRecord = {
+            deviceJid: '',
+            keyIndex,
+            companionIdentityPublicKey: input.companionIdentityPublicKey,
+            addedAtSeconds: timestampSeconds
+        }
+        const signed = await buildSignedCompanionIdentity({
+            accountIdentityKeyPair,
+            companionIdentityPublicKey: input.companionIdentityPublicKey,
+            advSecretKey: input.advSecretKey,
+            rawId: epoch.rawId,
+            keyIndex,
+            timestampSeconds,
+            validIndexes
+        })
+        const iq = buildPairDeviceIq({
+            ref: input.ref,
+            companionNoisePublicKey: input.companionNoisePublicKey,
+            deviceIdentityBytes: signed.deviceIdentityBytes,
+            keyIndexListBytes: signed.keyIndexListBytes,
+            keyIndexListTimestampSeconds: timestampSeconds,
+            clientProps: this.buildClientPairingProps(),
+            pem: this.includePem
+                ? {
+                      aesGcmKeyBytes: derivePemKey(
+                          input.advSecretKey,
+                          input.companionNoisePublicKey
+                      ),
+                      ttlSeconds: PEM_TTL_SECONDS
+                  }
+                : undefined
+        })
+        this.logger.info('linking companion', { platform: input.platform, keyIndex })
+        const result = await this.queryWithContext(
+            'companion-host.pair-device',
+            iq,
+            PAIR_DEVICE_TIMEOUT_MS
+        )
+        assertIqResult(result, 'companion-host.pair-device')
+        const wrapper = getFirstNodeChild(result)
+        const deviceNode =
+            findNodeChild(result, WA_NODE_TAGS.DEVICE) ??
+            (wrapper ? findNodeChild(wrapper, WA_NODE_TAGS.DEVICE) : undefined)
+        const deviceJid = deviceNode?.attrs.jid
+        if (!deviceJid) {
+            throw new Error('pair-device result missing <device jid>')
+        }
+        this.epoch = {
+            rawId: epoch.rawId,
+            currentKeyIndex: keyIndex,
+            companions: [...epoch.companions, { ...record, deviceJid }]
+        }
+        await this.persist(this.epoch)
+        const linked: LinkCompanionResult = { deviceJid, keyIndex }
+        this.logger.info('companion linked', { deviceJid, keyIndex })
+        this.emitEvent('companion_host_linked', linked)
+        this.provisionLinkedCompanion(deviceJid)
+        return linked
+    }
+
+    /**
+     * Best-effort background provisioning after a companion links: pushes the
+     * history-sync bootstrap and shares the app-state sync key. Fire-and-forget
+     * and retried, because the companion needs a moment to upload prekeys before
+     * the outbound Signal session these peer messages ride on can be established.
+     */
+    private provisionLinkedCompanion(deviceJid: string): void {
+        void this.provisionLinkedCompanionWithRetry(deviceJid).catch((error) => {
+            const normalized = toError(error)
+            this.logger.warn('companion provisioning failed', {
+                deviceJid,
+                message: normalized.message
+            })
+            this.emitEvent('companion_host_error', normalized)
+        })
+    }
+
+    private async provisionLinkedCompanionWithRetry(deviceJid: string): Promise<void> {
+        let lastError: unknown
+        for (let attempt = 1; attempt <= COMPANION_PROVISION_ATTEMPTS; attempt += 1) {
+            if (attempt > 1) {
+                await delay(COMPANION_PROVISION_RETRY_MS)
+            }
+            try {
+                await this.sendHistorySyncBootstrap(deviceJid)
+                await this.shareAppStateSyncKeys(deviceJid).catch((error) => {
+                    this.logger.debug('companion app-state key share (best-effort) failed', {
+                        deviceJid,
+                        message: toError(error).message
+                    })
+                })
+                this.logger.info('companion provisioned', { deviceJid, attempts: attempt })
+                return
+            } catch (error) {
+                lastError = error
+                this.logger.debug('companion provisioning attempt failed', {
+                    deviceJid,
+                    attempt,
+                    message: toError(error).message
+                })
+            }
+        }
+        throw toError(lastError)
+    }
+
+    private handleNotification(node: BinaryNode): Promise<boolean> {
+        if (node.attrs.type === 'account_sync') {
+            this.updateAccountKeyIndexes(node)
+            void this.reconcileFromAccountSync(node).catch((error) => {
+                this.logger.debug('companion reconcile on account_sync failed', {
+                    message: toError(error).message
+                })
+            })
+            return Promise.resolve(false)
+        }
+        const linkCode = findNodeChild(node, WA_NODE_TAGS.LINK_CODE_COMPANION_REG)
+        if (linkCode) {
+            const stage = linkCode.attrs.stage
+            if (stage === 'companion_hello') {
+                this.storeCompanionHello(linkCode)
+            } else if (stage === 'companion_finish') {
+                this.resolveCompanionFinish(linkCode)
+            }
+        }
+        return Promise.resolve(false)
+    }
+
+    /**
+     * Tracks the account's live device key-indexes from an `account_sync`
+     * notification so a new companion gets a non-colliding key index and the
+     * published key-index list keeps every existing device valid.
+     */
+    private updateAccountKeyIndexes(node: BinaryNode): void {
+        const devices = findNodeChild(node, WA_NODE_TAGS.DEVICES)
+        if (!devices) {
+            return
+        }
+        const indexes = new Set<number>([0])
+        for (const child of getNodeChildren(devices)) {
+            if (child.tag !== WA_NODE_TAGS.DEVICE) {
+                continue
+            }
+            const rawIndex = child.attrs['key-index']
+            const parsed = rawIndex ? Number.parseInt(rawIndex, 10) : Number.NaN
+            if (Number.isInteger(parsed) && parsed >= 0) {
+                indexes.add(parsed)
+            }
+        }
+        this.accountKeyIndexes = indexes
+        this.logger.debug('account device key-indexes updated', { indexes: [...indexes] })
+    }
+
+    private forgetAccountKeyIndex(index: number): void {
+        if (!this.accountKeyIndexes.has(index)) {
+            return
+        }
+        const next = new Set(this.accountKeyIndexes)
+        next.delete(index)
+        this.accountKeyIndexes = next
+    }
+
+    /**
+     * The key indexes currently valid for this account - index 0 (the primary),
+     * the account's own live devices, and every tracked companion. Sorted
+     * ascending. Deliberately excludes `epoch.currentKeyIndex`, which is an
+     * allocation high-water mark, not proof a device still exists: after revoking
+     * the last-linked companion its index must drop out of the published list.
+     */
+    private validKeyIndexes(epoch: CompanionHostEpochState): number[] {
+        const indexes = new Set<number>([0, ...this.accountKeyIndexes])
+        for (const companion of epoch.companions) {
+            indexes.add(companion.keyIndex)
+        }
+        return [...indexes].sort((a, b) => a - b)
+    }
+
+    /**
+     * Allocates the next companion key index, advancing strictly past both the
+     * epoch's monotonic high-water mark and every currently-valid index so a
+     * revoked index is never reused (reuse breaks previously linked devices).
+     */
+    private nextKeyIndex(epoch: CompanionHostEpochState): number {
+        return Math.max(epoch.currentKeyIndex, ...this.validKeyIndexes(epoch)) + 1
+    }
+
+    private storeCompanionHello(linkCode: BinaryNode): void {
+        const ref = getNodeTextContent(findNodeChild(linkCode, WA_NODE_TAGS.LINK_CODE_PAIRING_REF))
+        const wrapped = this.nodeBytes(
+            linkCode,
+            WA_NODE_TAGS.LINK_CODE_PAIRING_WRAPPED_COMPANION_EPHEMERAL_PUB
+        )
+        const authKey = this.nodeBytes(linkCode, WA_NODE_TAGS.COMPANION_SERVER_AUTH_KEY_PUB)
+        if (!ref || !wrapped || !authKey) {
+            return
+        }
+        this.pendingCompanionHello = {
+            ref,
+            wrappedCompanionEphemeralPub: wrapped,
+            companionServerAuthKeyPub: authKey
+        }
+        this.logger.debug('recorded link-code companion_hello', { ref })
+    }
+
+    private resolveCompanionFinish(linkCode: BinaryNode): void {
+        const ref = getNodeTextContent(findNodeChild(linkCode, WA_NODE_TAGS.LINK_CODE_PAIRING_REF))
+        const wrappedKeyBundle = this.nodeBytes(
+            linkCode,
+            WA_NODE_TAGS.LINK_CODE_PAIRING_WRAPPED_KEY_BUNDLE
+        )
+        const companionIdentityPub = this.nodeBytes(
+            linkCode,
+            WA_NODE_TAGS.COMPANION_IDENTITY_PUBLIC
+        )
+        if (ref && wrappedKeyBundle && companionIdentityPub && this.pendingFinish?.ref === ref) {
+            this.pendingFinish.resolve({ companionIdentityPub, wrappedKeyBundle })
+            this.pendingFinish = null
+        }
+    }
+
+    private nodeBytes(parent: BinaryNode, tag: string): Uint8Array | null {
+        const content = findNodeChild(parent, tag)?.content
+        return content instanceof Uint8Array ? content : null
+    }
+
+    private requirePrimaryIdentityKeyPair() {
+        if (!this.isMobilePrimary()) {
+            throw new Error(
+                'client.mobile requires a mobile-primary session (connect via mobileTransport / a registered phone identity)'
+            )
+        }
+        const credentials = this.authClient.getCurrentCredentials()
+        if (!credentials?.meJid) {
+            throw new Error('companion-host requires a registered primary session (no meJid)')
+        }
+        return credentials.registrationInfo.identityKeyPair
+    }
+
+    private async ensureEpoch(): Promise<CompanionHostEpochState> {
+        if (this.epoch) {
+            return this.epoch
+        }
+        const loaded = this.persistence ? await this.persistence.load() : null
+        if (loaded) {
+            this.epoch = loaded
+            return loaded
+        }
+        this.epoch = { rawId: await this.generateRawId(), currentKeyIndex: 0, companions: [] }
+        await this.persist(this.epoch)
+        return this.epoch
+    }
+
+    private async generateRawId(): Promise<number> {
+        return randomIntAsync(1, 0x7fff_ffff)
+    }
+
+    private async persist(state: CompanionHostEpochState): Promise<void> {
+        if (this.persistence) {
+            await this.persistence.save(state)
+        }
+    }
+}

--- a/src/client/coordinators/__tests__/mobile.test.ts
+++ b/src/client/coordinators/__tests__/mobile.test.ts
@@ -1,0 +1,729 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { inflateSync } from 'node:zlib'
+
+import type { WaAppStateSyncKey } from '@appstate/types'
+import {
+    WaMobileCoordinator,
+    type WaMobileCoordinatorDeps
+} from '@client/coordinators/WaMobileCoordinator'
+import type { CompanionHostEpochState } from '@client/persistence/companion-host'
+import { type SignalKeyPair, X25519 } from '@crypto'
+import { createNoopLogger } from '@infra/log/types'
+import { type Proto, proto } from '@proto'
+import { WA_NODE_TAGS } from '@protocol/nodes'
+import { computeAdvIdentityHmac, verifyDeviceIdentityAccountSignature } from '@signal'
+import { type BinaryNode, findNodeChild, getFirstNodeChild, getNodeChildren } from '@transport'
+import { bytesToBase64UrlSafe, uint8Equal } from '@util/bytes'
+
+const DEVICE_JID = '5511999999999:12@s.whatsapp.net'
+
+async function makeCompanionQr() {
+    const identity = await X25519.generateKeyPair()
+    const noise = await X25519.generateKeyPair()
+    const advSecret = (await X25519.generateKeyPair()).privKey
+    const qr = [
+        'REF123',
+        bytesToBase64UrlSafe(noise.pubKey),
+        bytesToBase64UrlSafe(identity.pubKey),
+        bytesToBase64UrlSafe(advSecret),
+        'CHROME'
+    ].join(',')
+    return { qr, identity, noise, advSecret }
+}
+
+function pairDeviceResult(deviceJid: string): BinaryNode {
+    return {
+        tag: 'iq',
+        attrs: { type: 'result' },
+        content: [
+            {
+                tag: 'pair-device',
+                attrs: {},
+                content: [{ tag: 'device', attrs: { jid: deviceJid } }]
+            }
+        ]
+    }
+}
+
+function mockDeps(config: {
+    readonly meJid: string | undefined
+    readonly meLid?: string
+    readonly pushName?: string
+    readonly primaryIdentity: SignalKeyPair
+    readonly result?: BinaryNode
+    readonly activeSyncKey?: WaAppStateSyncKey | null
+    readonly serverDeviceJids?: readonly string[]
+    readonly isMobilePrimary?: boolean
+}) {
+    const queries: Array<{ context: string; node: BinaryNode }> = []
+    const emitted: Array<[string, unknown[]]> = []
+    const keyShares: Array<{ deviceJid: string; keys: readonly WaAppStateSyncKey[] }> = []
+    const protocolMessages: Array<{ deviceJid: string; protocolMessage: unknown }> = []
+    const appStateMutations: Array<Record<string, unknown>> = []
+    const deviceSyncCalls = { count: 0 }
+    const incomingHandlers: Array<(node: BinaryNode) => Promise<boolean>> = []
+    const credentials = config.meJid
+        ? {
+              meJid: config.meJid,
+              meLid: config.meLid,
+              pushName: config.pushName,
+              registrationInfo: { identityKeyPair: config.primaryIdentity }
+          }
+        : null
+    const deps = {
+        logger: createNoopLogger(),
+        authClient: { getCurrentCredentials: () => credentials },
+        messageDispatch: {
+            sendAppStateSyncKeyShare: (deviceJid: string, keys: readonly WaAppStateSyncKey[]) => {
+                keyShares.push({ deviceJid, keys })
+                return Promise.resolve()
+            },
+            publishProtocolMessageToDevice: (deviceJid: string, protocolMessage: unknown) => {
+                protocolMessages.push({ deviceJid, protocolMessage })
+                return Promise.resolve({})
+            }
+        },
+        chatCoordinator: {
+            set: (input: Record<string, unknown>) => {
+                appStateMutations.push(input)
+                return Promise.resolve()
+            }
+        },
+        deviceSync: {
+            syncDeviceList: () => {
+                deviceSyncCalls.count += 1
+                return Promise.resolve([{ deviceJids: [...(config.serverDeviceJids ?? [])] }])
+            }
+        },
+        appStateStore: {
+            getActiveSyncKey: () => Promise.resolve(config.activeSyncKey ?? null)
+        },
+        queryWithContext: (context: string, node: BinaryNode) => {
+            queries.push({ context, node })
+            return Promise.resolve(config.result ?? { tag: 'iq', attrs: { type: 'result' } })
+        },
+        emitEvent: (event: string, ...args: unknown[]) => {
+            emitted.push([event, args])
+        },
+        isMobilePrimary: () => config.isMobilePrimary ?? true,
+        registerIncomingHandler: (registration: {
+            handler: (node: BinaryNode) => Promise<boolean>
+        }) => {
+            incomingHandlers.push(registration.handler)
+            return () => undefined
+        }
+    } as unknown as WaMobileCoordinatorDeps
+    return {
+        deps,
+        queries,
+        emitted,
+        keyShares,
+        protocolMessages,
+        appStateMutations,
+        deviceSyncCalls,
+        incomingHandlers
+    }
+}
+
+test('linkCompanion signs a companion-verifiable pair-device upload and records the device', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { qr, identity, noise, advSecret } = await makeCompanionQr()
+    const { deps, queries, emitted } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity,
+        result: pairDeviceResult(DEVICE_JID)
+    })
+    const saved: CompanionHostEpochState[] = []
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: { load: () => null, save: (state) => void saved.push(state) }
+    })
+
+    const linked = await coordinator.linkCompanion(qr)
+    assert.equal(linked.deviceJid, DEVICE_JID)
+    assert.equal(linked.keyIndex, 1)
+
+    const pairDeviceQuery = queries.find((query) => query.context === 'companion-host.pair-device')
+    assert.ok(pairDeviceQuery)
+    const iq = pairDeviceQuery.node
+    assert.equal(iq.attrs.to, 's.whatsapp.net')
+    assert.equal(iq.attrs.type, 'set')
+    assert.equal(iq.attrs.xmlns, 'md')
+
+    const pairDevice = getFirstNodeChild(iq)
+    assert.ok(pairDevice)
+    assert.equal(pairDevice.tag, 'pair-device')
+    assert.deepEqual(
+        getNodeChildren(pairDevice).map((child) => child.tag),
+        ['ref', 'pub-key', 'device-identity', 'key-index-list', 'client-props']
+    )
+
+    const pubKey = findNodeChild(pairDevice, 'pub-key')?.content
+    assert.ok(pubKey instanceof Uint8Array)
+    assert.equal(uint8Equal(pubKey, noise.pubKey), true)
+
+    const deviceIdentity = findNodeChild(pairDevice, 'device-identity')?.content
+    assert.ok(deviceIdentity instanceof Uint8Array)
+    const wrapped = proto.ADVSignedDeviceIdentityHMAC.decode(deviceIdentity)
+    assert.equal(
+        uint8Equal(computeAdvIdentityHmac(advSecret, wrapped.details!), wrapped.hmac!),
+        true
+    )
+    const signed = proto.ADVSignedDeviceIdentity.decode(wrapped.details!)
+    assert.equal(
+        await verifyDeviceIdentityAccountSignature(
+            signed.details!,
+            signed.accountSignature!,
+            identity.pubKey,
+            signed.accountSignatureKey!
+        ),
+        true
+    )
+
+    const linkedEvent = emitted.find(([event]) => event === 'companion_host_linked')
+    assert.ok(linkedEvent)
+    assert.deepEqual(linkedEvent[1][0], { deviceJid: DEVICE_JID, keyIndex: 1 })
+
+    const lastSave = saved.at(-1)
+    assert.ok(lastSave)
+    assert.equal(lastSave.currentKeyIndex, 1)
+    assert.equal(lastSave.companions.length, 1)
+    assert.equal(lastSave.companions[0].deviceJid, DEVICE_JID)
+})
+
+test('linkCompanion auto-provisions the companion with an INITIAL_BOOTSTRAP history sync', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { qr } = await makeCompanionQr()
+    const { deps, protocolMessages } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity,
+        result: pairDeviceResult(DEVICE_JID)
+    })
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: { load: () => null, save: () => undefined }
+    })
+
+    await coordinator.linkCompanion(qr)
+    await new Promise((resolve) => setTimeout(resolve, 150))
+
+    const historyMsg = protocolMessages.find(
+        (entry) =>
+            (entry.protocolMessage as Proto.Message.IProtocolMessage).type ===
+            proto.Message.ProtocolMessage.Type.HISTORY_SYNC_NOTIFICATION
+    )
+    assert.ok(historyMsg, 'a history-sync notification is pushed on link')
+    assert.equal(historyMsg.deviceJid, DEVICE_JID)
+    const inline = (historyMsg.protocolMessage as Proto.Message.IProtocolMessage)
+        .historySyncNotification?.initialHistBootstrapInlinePayload
+    assert.ok(inline instanceof Uint8Array)
+    const historySync = proto.HistorySync.decode(inflateSync(inline))
+    assert.equal(historySync.syncType, proto.HistorySync.HistorySyncType.INITIAL_BOOTSTRAP)
+})
+
+test('linkCompanion seeds the primary setting_pushName into critical_block app-state', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { qr } = await makeCompanionQr()
+    const { deps, appStateMutations } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        pushName: 'Alice',
+        primaryIdentity,
+        result: pairDeviceResult(DEVICE_JID)
+    })
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: { load: () => null, save: () => undefined }
+    })
+
+    await coordinator.linkCompanion(qr)
+
+    const pushNameMutation = appStateMutations.find((m) => m.schema === 'SettingPushName')
+    assert.ok(pushNameMutation, 'a SettingPushName app-state mutation is seeded on link')
+    assert.equal(pushNameMutation.name, 'Alice')
+})
+
+test('linkCompanion falls back to the meJid user for setting_pushName when no push name', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { qr } = await makeCompanionQr()
+    const { deps, appStateMutations } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity,
+        result: pairDeviceResult(DEVICE_JID)
+    })
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: { load: () => null, save: () => undefined }
+    })
+
+    await coordinator.linkCompanion(qr)
+
+    const pushNameMutation = appStateMutations.find((m) => m.schema === 'SettingPushName')
+    assert.ok(pushNameMutation)
+    assert.equal(pushNameMutation.name, '5511999999999')
+})
+
+test('linkCompanion declares LID chat-db migration in <client-props> for a LID-native account', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { qr } = await makeCompanionQr()
+    const { deps, queries } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        meLid: '226951105134689@lid',
+        primaryIdentity,
+        result: pairDeviceResult(DEVICE_JID)
+    })
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: { load: () => null, save: () => undefined }
+    })
+
+    await coordinator.linkCompanion(qr)
+
+    const pairDeviceQuery = queries.find((query) => query.context === 'companion-host.pair-device')
+    assert.ok(pairDeviceQuery)
+    const pairDevice = getFirstNodeChild(pairDeviceQuery.node)
+    assert.ok(pairDevice)
+    const clientPropsNode = findNodeChild(pairDevice, 'client-props')
+    assert.ok(clientPropsNode?.content instanceof Uint8Array)
+    const clientProps = proto.ClientPairingProps.decode(clientPropsNode.content)
+    assert.equal(clientProps.isChatDbLidMigrated, true)
+    assert.equal(clientProps.isSyncdPureLidSession, true)
+    assert.equal(clientProps.isSyncdSnapshotRecoveryEnabled, false)
+})
+
+test('linkCompanion rejects and emits an error without a registered primary session', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { qr } = await makeCompanionQr()
+    const { deps, emitted } = mockDeps({ meJid: undefined, primaryIdentity })
+    const coordinator = new WaMobileCoordinator(deps)
+
+    await assert.rejects(() => coordinator.linkCompanion(qr), /registered primary session/)
+    assert.ok(emitted.find(([event]) => event === 'companion_host_error'))
+})
+
+test('shareAppStateSyncKeys pushes the primary active key to the companion', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const activeSyncKey: WaAppStateSyncKey = {
+        keyId: new Uint8Array([1, 2, 3]),
+        keyData: new Uint8Array(32),
+        timestamp: 1
+    }
+    const { deps, keyShares } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity,
+        activeSyncKey
+    })
+    const coordinator = new WaMobileCoordinator(deps)
+
+    await coordinator.shareAppStateSyncKeys(DEVICE_JID)
+    assert.equal(keyShares.length, 1)
+    assert.equal(keyShares[0].deviceJid, DEVICE_JID)
+    assert.deepEqual(keyShares[0].keys, [activeSyncKey])
+})
+
+test('shareAppStateSyncKeys throws when the primary has no active app-state key', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { deps, keyShares } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity,
+        activeSyncKey: null
+    })
+    const coordinator = new WaMobileCoordinator(deps)
+
+    await assert.rejects(
+        () => coordinator.shareAppStateSyncKeys(DEVICE_JID),
+        /no active app-state sync key/
+    )
+    assert.equal(keyShares.length, 0)
+})
+
+test('revokeCompanion removes the device, drops it from the epoch, and republishes', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { deps, queries } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity,
+        result: { tag: 'iq', attrs: { type: 'result' } }
+    })
+    const saved: CompanionHostEpochState[] = []
+    const seeded: CompanionHostEpochState = {
+        rawId: 123,
+        currentKeyIndex: 1,
+        companions: [
+            {
+                deviceJid: DEVICE_JID,
+                keyIndex: 1,
+                companionIdentityPublicKey: new Uint8Array([1, 2, 3]),
+                addedAtSeconds: 1
+            }
+        ]
+    }
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: { load: () => seeded, save: (state) => void saved.push(state) }
+    })
+
+    await coordinator.revokeCompanion(DEVICE_JID)
+
+    const removeQuery = queries.find((query) => query.context === 'companion-host.remove-device')
+    assert.ok(removeQuery)
+    const removeNode = getFirstNodeChild(removeQuery.node)
+    assert.equal(removeNode?.tag, 'remove-companion-device')
+    assert.equal(removeNode?.attrs.jid, DEVICE_JID)
+    assert.ok(queries.find((query) => query.context === 'companion-host.key-index-list'))
+    assert.deepEqual(await coordinator.listCompanions(), [])
+    assert.equal(saved.at(-1)?.companions.length, 0)
+})
+
+test('revokeCompanion throws for an untracked companion', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { deps } = mockDeps({ meJid: '5511999999999@s.whatsapp.net', primaryIdentity })
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: {
+            load: () => ({ rawId: 1, currentKeyIndex: 0, companions: [] }),
+            save: () => undefined
+        }
+    })
+
+    await assert.rejects(
+        () => coordinator.revokeCompanion('639079515517:9@s.whatsapp.net'),
+        /not tracked/
+    )
+})
+
+test('revokeAllCompanions removes every device with all="true" and clears the epoch', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { deps, queries, emitted } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity,
+        result: { tag: 'iq', attrs: { type: 'result' } }
+    })
+    const seeded: CompanionHostEpochState = {
+        rawId: 123,
+        currentKeyIndex: 2,
+        companions: [
+            {
+                deviceJid: '5511999999999:8@s.whatsapp.net',
+                keyIndex: 1,
+                companionIdentityPublicKey: new Uint8Array([1]),
+                addedAtSeconds: 1
+            },
+            {
+                deviceJid: '5511999999999:9@s.whatsapp.net',
+                keyIndex: 2,
+                companionIdentityPublicKey: new Uint8Array([2]),
+                addedAtSeconds: 2
+            }
+        ]
+    }
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: { load: () => seeded, save: () => undefined }
+    })
+
+    await coordinator.revokeAllCompanions()
+
+    const removeQuery = queries.find(
+        (query) => query.context === 'companion-host.remove-all-devices'
+    )
+    assert.ok(removeQuery)
+    const removeNode = getFirstNodeChild(removeQuery.node)
+    assert.equal(removeNode?.tag, 'remove-companion-device')
+    assert.equal(removeNode?.attrs.all, 'true')
+    assert.equal(removeNode?.attrs.jid, undefined)
+    assert.equal(removeNode?.attrs.reason, 'user_initiated')
+    assert.ok(queries.find((query) => query.context === 'companion-host.key-index-list'))
+    assert.deepEqual(await coordinator.listCompanions(), [])
+
+    const revoked = emitted.filter(([event]) => event === 'companion_host_revoked')
+    assert.equal(revoked.length, 2)
+})
+
+test('reconcileCompanions drops companions the server no longer lists', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const KEEP = '5511999999999:9@s.whatsapp.net'
+    const GONE = '5511999999999:8@s.whatsapp.net'
+    const { deps, emitted } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity,
+        serverDeviceJids: ['5511999999999@s.whatsapp.net', KEEP]
+    })
+    const saved: CompanionHostEpochState[] = []
+    const seeded: CompanionHostEpochState = {
+        rawId: 1,
+        currentKeyIndex: 9,
+        companions: [
+            {
+                deviceJid: GONE,
+                keyIndex: 8,
+                companionIdentityPublicKey: new Uint8Array([1]),
+                addedAtSeconds: 1
+            },
+            {
+                deviceJid: KEEP,
+                keyIndex: 9,
+                companionIdentityPublicKey: new Uint8Array([2]),
+                addedAtSeconds: 2
+            }
+        ]
+    }
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: { load: () => seeded, save: (state) => void saved.push(state) }
+    })
+
+    const removed = await coordinator.reconcileCompanions()
+    assert.deepEqual(removed, [GONE])
+    assert.deepEqual(
+        (await coordinator.listCompanions()).map((companion) => companion.deviceJid),
+        [KEEP]
+    )
+    assert.equal(saved.at(-1)?.companions.length, 1)
+    const revoked = emitted.filter(([event]) => event === 'companion_host_revoked')
+    assert.equal(revoked.length, 1)
+    assert.deepEqual(revoked[0][1][0], { deviceJid: GONE })
+})
+
+test('reconcileCompanions skips the server query when the tracked set is empty', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { deps, deviceSyncCalls } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity,
+        serverDeviceJids: ['5511999999999@s.whatsapp.net']
+    })
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: {
+            load: () => ({ rawId: 1, currentKeyIndex: 0, companions: [] }),
+            save: () => undefined
+        }
+    })
+    assert.deepEqual(await coordinator.reconcileCompanions(), [])
+    assert.equal(deviceSyncCalls.count, 0)
+})
+
+test('reconcileCompanions never queries the server without a companion store', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { deps, deviceSyncCalls } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity
+    })
+    const coordinator = new WaMobileCoordinator({ ...deps })
+    assert.deepEqual(await coordinator.reconcileCompanions(), [])
+    assert.equal(deviceSyncCalls.count, 0)
+})
+
+test('account_sync prunes companions from the notification payload (LID devices, PN epoch)', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const KEEP = '639094882867:10@s.whatsapp.net'
+    const { deps, emitted, incomingHandlers, deviceSyncCalls } = mockDeps({
+        meJid: '639094882867@s.whatsapp.net',
+        meLid: '226951105134689@lid',
+        primaryIdentity
+    })
+    const seeded: CompanionHostEpochState = {
+        rawId: 1,
+        currentKeyIndex: 10,
+        companions: [
+            {
+                deviceJid: KEEP,
+                keyIndex: 10,
+                companionIdentityPublicKey: new Uint8Array([1]),
+                addedAtSeconds: 1
+            }
+        ]
+    }
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: { load: () => seeded, save: () => undefined }
+    })
+
+    const node: BinaryNode = {
+        tag: 'notification',
+        attrs: { type: 'account_sync' },
+        content: [
+            {
+                tag: 'devices',
+                attrs: {},
+                content: [{ tag: 'device', attrs: { jid: '226951105134689@lid' } }]
+            }
+        ]
+    }
+    await incomingHandlers[0](node)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    assert.deepEqual(await coordinator.listCompanions(), [])
+    assert.equal(deviceSyncCalls.count, 0)
+    const revoked = emitted.filter(([event]) => event === 'companion_host_revoked')
+    assert.equal(revoked.length, 1)
+    assert.deepEqual(revoked[0][1][0], { deviceJid: KEEP })
+})
+
+test('mobile operations are gated to mobile-primary sessions', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { deps, deviceSyncCalls } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity,
+        isMobilePrimary: false
+    })
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: {
+            load: () => ({
+                rawId: 1,
+                currentKeyIndex: 1,
+                companions: [
+                    {
+                        deviceJid: '5511999999999:1@s.whatsapp.net',
+                        keyIndex: 1,
+                        companionIdentityPublicKey: new Uint8Array([1]),
+                        addedAtSeconds: 1
+                    }
+                ]
+            }),
+            save: () => undefined
+        }
+    })
+
+    await assert.rejects(() => coordinator.linkCompanionByCode('12345678'), /mobile-primary/)
+    await assert.rejects(() => coordinator.revokeAllCompanions(), /mobile-primary/)
+    assert.deepEqual(await coordinator.reconcileCompanions(), [])
+    assert.equal(deviceSyncCalls.count, 0)
+})
+
+test('linkCompanionByCode rejects when no companion is pending', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { deps, emitted } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity
+    })
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: { load: () => null, save: () => undefined }
+    })
+
+    await assert.rejects(() => coordinator.linkCompanionByCode('12345678'), /no pending companion/)
+    assert.ok(emitted.some(([event]) => event === 'companion_host_error'))
+})
+
+test('linkCompanionByCode rejects cleanly when primary_hello fails', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const { deps, emitted, incomingHandlers } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity
+    })
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: { load: () => null, save: () => undefined },
+        queryWithContext: (context: string) =>
+            context === 'companion-host.primary-hello'
+                ? Promise.reject(new Error('primary-hello boom'))
+                : Promise.resolve({ tag: 'iq', attrs: { type: 'result' } })
+    })
+
+    const authKey = (await X25519.generateKeyPair()).pubKey
+    const helloNode: BinaryNode = {
+        tag: 'notification',
+        attrs: {},
+        content: [
+            {
+                tag: WA_NODE_TAGS.LINK_CODE_COMPANION_REG,
+                attrs: { stage: 'companion_hello' },
+                content: [
+                    { tag: WA_NODE_TAGS.LINK_CODE_PAIRING_REF, attrs: {}, content: 'REFCODE' },
+                    {
+                        tag: WA_NODE_TAGS.LINK_CODE_PAIRING_WRAPPED_COMPANION_EPHEMERAL_PUB,
+                        attrs: {},
+                        content: new Uint8Array(80)
+                    },
+                    {
+                        tag: WA_NODE_TAGS.COMPANION_SERVER_AUTH_KEY_PUB,
+                        attrs: {},
+                        content: authKey
+                    }
+                ]
+            }
+        ]
+    }
+    await incomingHandlers[0](helloNode)
+
+    await assert.rejects(() => coordinator.linkCompanionByCode('12345678'), /primary-hello boom/)
+    assert.ok(emitted.some(([event]) => event === 'companion_host_error'))
+
+    const finishNode: BinaryNode = {
+        tag: 'notification',
+        attrs: {},
+        content: [
+            {
+                tag: WA_NODE_TAGS.LINK_CODE_COMPANION_REG,
+                attrs: { stage: 'companion_finish' },
+                content: [
+                    { tag: WA_NODE_TAGS.LINK_CODE_PAIRING_REF, attrs: {}, content: 'REFCODE' },
+                    {
+                        tag: WA_NODE_TAGS.LINK_CODE_PAIRING_WRAPPED_KEY_BUNDLE,
+                        attrs: {},
+                        content: new Uint8Array(64)
+                    },
+                    {
+                        tag: WA_NODE_TAGS.COMPANION_IDENTITY_PUBLIC,
+                        attrs: {},
+                        content: new Uint8Array(32)
+                    }
+                ]
+            }
+        ]
+    }
+    await assert.doesNotReject(() => incomingHandlers[0](finishNode))
+})
+
+test('revoking the last companion drops its key index from the republished list', async () => {
+    const primaryIdentity = await X25519.generateKeyPair()
+    const REVOKED = '5511999999999:2@s.whatsapp.net'
+    const { deps, queries, incomingHandlers } = mockDeps({
+        meJid: '5511999999999@s.whatsapp.net',
+        primaryIdentity,
+        result: { tag: 'iq', attrs: { type: 'result' } }
+    })
+    const coordinator = new WaMobileCoordinator({
+        ...deps,
+        persistence: {
+            load: () => ({
+                rawId: 1,
+                currentKeyIndex: 2,
+                companions: [
+                    {
+                        deviceJid: REVOKED,
+                        keyIndex: 2,
+                        companionIdentityPublicKey: new Uint8Array([1]),
+                        addedAtSeconds: 1
+                    }
+                ]
+            }),
+            save: () => undefined
+        }
+    })
+
+    await incomingHandlers[0]({
+        tag: 'notification',
+        attrs: { type: 'account_sync' },
+        content: [
+            {
+                tag: 'devices',
+                attrs: {},
+                content: [{ tag: 'device', attrs: { jid: REVOKED, 'key-index': '2' } }]
+            }
+        ]
+    })
+
+    await coordinator.revokeCompanion(REVOKED)
+
+    const publish = queries.find((query) => query.context === 'companion-host.key-index-list')
+    assert.ok(publish)
+    const content = findNodeChild(publish.node, 'key-index-list')?.content
+    assert.ok(content instanceof Uint8Array)
+    const signed = proto.ADVSignedKeyIndexList.decode(content)
+    assert.ok(signed.details)
+    const details = proto.ADVKeyIndexList.decode(signed.details)
+    assert.deepEqual([...details.validIndexes], [0])
+    assert.equal(details.currentIndex, 0)
+})

--- a/src/client/messaging/companion-host.ts
+++ b/src/client/messaging/companion-host.ts
@@ -1,0 +1,88 @@
+import { promisify } from 'node:util'
+import { deflate } from 'node:zlib'
+
+import { type Proto, proto } from '@proto'
+
+const deflateAsync = promisify(deflate)
+
+/** A PN→LID mapping carried inside a history sync (one per chat peer with a LID). */
+export interface PhoneNumberToLidMapping {
+    readonly pnJid: string
+    readonly lidJid: string
+}
+
+export interface HistorySyncBootstrapInput {
+    /**
+     * Chat-peer PN→LID pairs (the primary's own account excluded, only peers
+     * resolving to a LID). A fresh account with no chats yields an empty list.
+     */
+    readonly phoneNumberToLidMappings?: readonly PhoneNumberToLidMapping[]
+    readonly conversations?: readonly Proto.IConversation[]
+    readonly pushnames?: readonly Proto.IPushname[]
+    /** The companion pairing session id, echoed so the companion can bind it. */
+    readonly companionMetaNonce?: string
+}
+
+/**
+ * Serializes a `HistorySync` and zlib-deflates it. The phone uses DEFLATE
+ * level 1; any zlib-framed level inflates identically, so it is only a
+ * size/speed tradeoff.
+ */
+export async function encodeHistorySync(content: Proto.IHistorySync): Promise<Uint8Array> {
+    const serialized = proto.HistorySync.encode(content).finish()
+    const compressed = await deflateAsync(serialized, { level: 1 })
+    return new Uint8Array(compressed)
+}
+
+/**
+ * Wraps a deflated `HistorySync` inline in a `HISTORY_SYNC_NOTIFICATION` protocol
+ * message. Only small syncs are inlined; larger ones ride an external
+ * `md-msg-hist` MMS blob referenced by the same notification.
+ */
+export function buildInlineHistorySyncNotification(
+    syncType: Proto.Message.HistorySyncType,
+    deflatedPayload: Uint8Array,
+    options: { readonly chunkOrder?: number; readonly progress?: number } = {}
+): Proto.Message.IProtocolMessage {
+    return {
+        type: proto.Message.ProtocolMessage.Type.HISTORY_SYNC_NOTIFICATION,
+        historySyncNotification: {
+            syncType,
+            chunkOrder: options.chunkOrder ?? 0,
+            progress: options.progress ?? 100,
+            initialHistBootstrapInlinePayload: deflatedPayload
+        }
+    }
+}
+
+/**
+ * Builds the `INITIAL_BOOTSTRAP` `HISTORY_SYNC_NOTIFICATION` a mobile-primary
+ * pushes to a freshly-linked companion: a deflated `HistorySync` wrapped in a
+ * protocol message for delivery as an encrypted peer message. Note
+ * `HistorySync.syncType` and `HistorySyncNotification.syncType` are distinct
+ * enum types with shared values, so each field uses its own.
+ */
+export async function buildHistorySyncBootstrapMessage(
+    input: HistorySyncBootstrapInput = {}
+): Promise<{ readonly message: Proto.Message.IProtocolMessage; readonly payloadBytes: number }> {
+    const historySync: Proto.IHistorySync = {
+        syncType: proto.HistorySync.HistorySyncType.INITIAL_BOOTSTRAP,
+        chunkOrder: 0,
+        progress: 100,
+        conversations: input.conversations ? [...input.conversations] : [],
+        pushnames: input.pushnames ? [...input.pushnames] : [],
+        phoneNumberToLidMappings: (input.phoneNumberToLidMappings ?? []).map((mapping) => ({
+            pnJid: mapping.pnJid,
+            lidJid: mapping.lidJid
+        })),
+        ...(input.companionMetaNonce !== undefined
+            ? { companionMetaNonce: input.companionMetaNonce }
+            : {})
+    }
+    const payload = await encodeHistorySync(historySync)
+    const message = buildInlineHistorySyncNotification(
+        proto.Message.HistorySyncType.INITIAL_BOOTSTRAP,
+        payload
+    )
+    return { message, payloadBytes: payload.byteLength }
+}

--- a/src/client/messaging/key-protocol.ts
+++ b/src/client/messaging/key-protocol.ts
@@ -7,6 +7,16 @@ import { type Proto, proto } from '@proto'
 import { normalizeDeviceJid } from '@protocol/jid'
 import { bytesToHex } from '@util/bytes'
 
+/**
+ * Valid app-state sync key ids are exactly 6 bytes: a 2-byte device id followed
+ * by a 4-byte big-endian epoch (matching the phone primary's `crypto_info`
+ * (device_id, epoch) schema and WhatsApp Web's `handleAppStateSyncKeyShare`,
+ * which fatally rejects any share whose keyId byte length is not 6). A primary
+ * must never emit a malformed key, so legacy/short key ids are dropped from
+ * outgoing shares rather than poisoning the peer's syncd engine.
+ */
+const APP_STATE_SYNC_KEY_ID_LENGTH = 6
+
 export type PublishProtocolMessageToDeviceFn = (
     deviceJid: string,
     protocolMessage: Proto.Message.IProtocolMessage,
@@ -111,7 +121,12 @@ export function createAppStateSyncKeyProtocol(options: {
         const seenKeyIds = new Set<string>()
         const keyShareEntries: Proto.Message.IAppStateSyncKey[] = []
         let sharedKeyCount = 0
+        const droppedKeyIds: string[] = []
         for (const key of keys) {
+            if (key.keyId.byteLength !== APP_STATE_SYNC_KEY_ID_LENGTH) {
+                droppedKeyIds.push(bytesToHex(key.keyId))
+                continue
+            }
             const keyHex = bytesToHex(key.keyId)
             if (seenKeyIds.has(keyHex)) {
                 continue
@@ -128,7 +143,10 @@ export function createAppStateSyncKeyProtocol(options: {
             })
         }
         for (const keyId of missingKeyIds) {
-            if (keyId.byteLength === 0) {
+            if (keyId.byteLength !== APP_STATE_SYNC_KEY_ID_LENGTH) {
+                if (keyId.byteLength > 0) {
+                    droppedKeyIds.push(bytesToHex(keyId))
+                }
                 continue
             }
             const keyHex = bytesToHex(keyId)
@@ -139,6 +157,16 @@ export function createAppStateSyncKeyProtocol(options: {
             keyShareEntries.push({
                 keyId: { keyId }
             })
+        }
+        if (droppedKeyIds.length > 0) {
+            logger.warn(
+                'app-state refusing to share malformed sync keys: keyId byte length must be 6',
+                {
+                    droppedCount: droppedKeyIds.length,
+                    totalExpected: keys.length + missingKeyIds.length,
+                    sample: droppedKeyIds.slice(0, 5)
+                }
+            )
         }
 
         const protocolMessage: proto.Message.IProtocolMessage = {

--- a/src/client/persistence/__tests__/companion-host.test.ts
+++ b/src/client/persistence/__tests__/companion-host.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+
+import { createFileCompanionHostPersistence } from '@client/persistence/companion-host'
+
+test('file persistence round-trips the epoch including companion key bytes', async () => {
+    const path = join(tmpdir(), 'zapo-companion-host-persistence.test.json')
+    await rm(path, { force: true })
+    const persistence = createFileCompanionHostPersistence(path)
+
+    assert.equal(await persistence.load(), null)
+
+    await persistence.save({
+        rawId: 8_675_309,
+        currentKeyIndex: 2,
+        companions: [
+            {
+                deviceJid: 'x:1@s.whatsapp.net',
+                keyIndex: 1,
+                companionIdentityPublicKey: new Uint8Array([1, 2, 3]),
+                addedAtSeconds: 100
+            },
+            {
+                deviceJid: 'x:2@s.whatsapp.net',
+                keyIndex: 2,
+                companionIdentityPublicKey: new Uint8Array([4, 5, 6]),
+                addedAtSeconds: 200
+            }
+        ]
+    })
+
+    const loaded = await persistence.load()
+    assert.ok(loaded)
+    assert.equal(loaded.rawId, 8_675_309)
+    assert.equal(loaded.currentKeyIndex, 2)
+    assert.equal(loaded.companions.length, 2)
+    assert.deepEqual([...loaded.companions[0].companionIdentityPublicKey], [1, 2, 3])
+    assert.deepEqual([...loaded.companions[1].companionIdentityPublicKey], [4, 5, 6])
+    assert.equal(loaded.companions[1].deviceJid, 'x:2@s.whatsapp.net')
+
+    await rm(path, { force: true })
+})

--- a/src/client/persistence/companion-host.ts
+++ b/src/client/persistence/companion-host.ts
@@ -1,0 +1,98 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+import { base64ToBytes, bytesToBase64 } from '@util/bytes'
+
+/** A companion device this primary has linked. */
+export interface CompanionRecord {
+    readonly deviceJid: string
+    readonly keyIndex: number
+    readonly companionIdentityPublicKey: Uint8Array
+    readonly addedAtSeconds: number
+}
+
+/**
+ * The primary's ADV epoch state. `rawId` is the account's stable ADV identity
+ * id; `currentKeyIndex` is the last-issued companion key index (companions get
+ * `currentKeyIndex + 1`). This MUST persist across restarts, otherwise reissuing
+ * an already-used key index breaks previously linked devices.
+ */
+export interface CompanionHostEpochState {
+    readonly rawId: number
+    readonly currentKeyIndex: number
+    readonly companions: readonly CompanionRecord[]
+}
+
+/**
+ * Persistence hook for {@link CompanionHostEpochState}. Supply one via plugin
+ * options to survive restarts; without it the epoch is in-memory only (fine for
+ * a single-session smoke test, unsafe for production relinking).
+ */
+export interface CompanionHostPersistence {
+    readonly load: () => Promise<CompanionHostEpochState | null> | CompanionHostEpochState | null
+    readonly save: (state: CompanionHostEpochState) => Promise<void> | void
+}
+
+interface SerializedCompanion {
+    readonly deviceJid: string
+    readonly keyIndex: number
+    readonly companionIdentityPublicKey: string
+    readonly addedAtSeconds: number
+}
+
+interface SerializedEpoch {
+    readonly rawId: number
+    readonly currentKeyIndex: number
+    readonly companions: readonly SerializedCompanion[]
+}
+
+/**
+ * File-backed {@link CompanionHostPersistence}: stores the ADV epoch as JSON at
+ * `filePath` (the companion identity keys are base64-encoded). Zero native
+ * dependencies - the state is tiny (the epoch header plus the linked-companion
+ * list). For a database-backed store, implement the two-method
+ * `CompanionHostPersistence` contract directly against your DB; there is no need
+ * for a dedicated core store domain.
+ */
+export function createFileCompanionHostPersistence(filePath: string): CompanionHostPersistence {
+    return {
+        async load(): Promise<CompanionHostEpochState | null> {
+            let raw: string
+            try {
+                raw = await readFile(filePath, 'utf8')
+            } catch (error) {
+                if ((error as { code?: unknown }).code === 'ENOENT') {
+                    return null
+                }
+                throw error
+            }
+            const parsed = JSON.parse(raw) as SerializedEpoch
+            return {
+                rawId: parsed.rawId,
+                currentKeyIndex: parsed.currentKeyIndex,
+                companions: parsed.companions.map((companion) => ({
+                    deviceJid: companion.deviceJid,
+                    keyIndex: companion.keyIndex,
+                    companionIdentityPublicKey: base64ToBytes(companion.companionIdentityPublicKey),
+                    addedAtSeconds: companion.addedAtSeconds
+                }))
+            }
+        },
+        async save(state: CompanionHostEpochState): Promise<void> {
+            const serialized: SerializedEpoch = {
+                rawId: state.rawId,
+                currentKeyIndex: state.currentKeyIndex,
+                companions: state.companions.map((companion) => ({
+                    deviceJid: companion.deviceJid,
+                    keyIndex: companion.keyIndex,
+                    companionIdentityPublicKey: bytesToBase64(companion.companionIdentityPublicKey),
+                    addedAtSeconds: companion.addedAtSeconds
+                }))
+            }
+            await mkdir(dirname(filePath), { recursive: true })
+            const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}`
+            await writeFile(tempPath, JSON.stringify(serialized), 'utf8')
+            await rename(tempPath, filePath)
+        }
+    }
+}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -9,6 +9,7 @@ import type {
 } from '@auth/types'
 import type { WaCallGroupParticipant, WaCallType } from '@client/events/call'
 import type { IncomingPresenceType, PresenceLastSeen } from '@client/events/presence'
+import type { CompanionHostPersistence } from '@client/persistence/companion-host'
 import type { WaClientPluginDefinition } from '@client/plugins/types'
 import type { WaMediaProcessor } from '@media/processor'
 import type { WaLinkPreviewOptions } from '@message/addons/link-preview/types'
@@ -96,6 +97,16 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
      * tests or pinning a specific edge.
      */
     readonly chatSocketUrls?: readonly string[]
+    /**
+     * Companion-hosting config for a mobile-primary session (see
+     * {@link WaClient.mobile}). `persistence` survives the ADV epoch across
+     * restarts (without it, relinking breaks previously linked devices);
+     * `includePem` adds the experimental `<pem>` node to the pair-device upload.
+     */
+    readonly companionHost?: {
+        readonly persistence?: CompanionHostPersistence
+        readonly includePem?: boolean
+    }
     /** Default timeout (ms) for IQ queries. Defaults to `WA_DEFAULTS.IQ_TIMEOUT_MS` (60s). */
     readonly iqTimeoutMs?: number
     /** Default timeout (ms) for raw node `query()` calls when none is passed. */
@@ -1412,6 +1423,16 @@ export interface WaClientEventMap {
      * `mobileTransport`.
      */
     readonly mobile_account_takeover_notice: (event: WaAccountTakeoverNoticeEvent) => void
+
+    /** A companion device was linked from this mobile-primary account. */
+    readonly companion_host_linked: (result: {
+        readonly deviceJid: string
+        readonly keyIndex: number
+    }) => void
+    /** A hosted companion device was revoked / unlinked. */
+    readonly companion_host_revoked: (payload: { readonly deviceJid: string }) => void
+    /** A companion-host link or provisioning operation failed. */
+    readonly companion_host_error: (error: Error) => void
 
     /** **debug** – the success node closing the noise handshake; emitted before `connection: { status: 'open' }`. */
     readonly debug_connection_success: (event: { readonly node: BinaryNode }) => void

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,16 @@ export type {
     WaUnlinkSubGroupsResult
 } from '@client/coordinators/WaGroupCoordinator'
 export type {
+    LinkCompanionResult,
+    WaMobileCoordinator
+} from '@client/coordinators/WaMobileCoordinator'
+export { createFileCompanionHostPersistence } from '@client/persistence/companion-host'
+export type {
+    CompanionHostEpochState,
+    CompanionHostPersistence,
+    CompanionRecord
+} from '@client/persistence/companion-host'
+export type {
     WaNewsletterAdminInfo,
     WaNewsletterAdminInviteInput,
     WaNewsletterAdminInviteResult,
@@ -350,3 +360,4 @@ export type {
     WaStreamErrorCode
 } from '@protocol'
 export { proto } from '@proto'
+export type { Proto } from '@proto'

--- a/src/protocol/nodes.ts
+++ b/src/protocol/nodes.ts
@@ -80,7 +80,22 @@ export const WA_NODE_TAGS = Object.freeze({
     USERNAME: 'username',
     TEXT_STATUS: 'text_status',
     DISAPPEARING_MODE: 'disappearing_mode',
-    BUSINESS: 'business'
+    BUSINESS: 'business',
+    PUB_KEY: 'pub-key',
+    KEY_INDEX_LIST: 'key-index-list',
+    CLIENT_PROPS: 'client-props',
+    PEM: 'pem',
+    TTL: 'ttl',
+    KEY_ID: 'key_id',
+    REMOVE_COMPANION_DEVICE: 'remove-companion-device',
+    PRIMARY_IDENTITY_PUB: 'primary_identity_pub',
+    COMPANION_IDENTITY_PUBLIC: 'companion_identity_public',
+    COMPANION_SERVER_AUTH_KEY_PUB: 'companion_server_auth_key_pub',
+    LINK_CODE_PAIRING_WRAPPED_PRIMARY_EPHEMERAL_PUB:
+        'link_code_pairing_wrapped_primary_ephemeral_pub',
+    LINK_CODE_PAIRING_WRAPPED_COMPANION_EPHEMERAL_PUB:
+        'link_code_pairing_wrapped_companion_ephemeral_pub',
+    LINK_CODE_PAIRING_WRAPPED_KEY_BUNDLE: 'link_code_pairing_wrapped_key_bundle'
 } as const)
 
 export const WA_IQ_TYPES = Object.freeze({

--- a/src/signal/attestation/WaAdvSignature.ts
+++ b/src/signal/attestation/WaAdvSignature.ts
@@ -1,19 +1,28 @@
 import { hmacSha256Sign, toRawPubKey, xeddsaSign, xeddsaVerify } from '@crypto'
 import type { SignalKeyPair } from '@crypto/curves/types'
 import {
+    ADV_PREFIX_ACCOUNT_KEY_INDEX,
     ADV_PREFIX_ACCOUNT_SIGNATURE,
     ADV_PREFIX_DEVICE_SIGNATURE,
+    ADV_PREFIX_HOSTED_ACCOUNT_KEY_INDEX,
     ADV_PREFIX_HOSTED_ACCOUNT_SIGNATURE,
     ADV_PREFIX_HOSTED_DEVICE_SIGNATURE
 } from '@signal/attestation/constants'
 import { concatBytes } from '@util/bytes'
 
 export {
+    ADV_PREFIX_ACCOUNT_KEY_INDEX,
     ADV_PREFIX_ACCOUNT_SIGNATURE,
     ADV_PREFIX_DEVICE_SIGNATURE,
     ADV_PREFIX_HOSTED_ACCOUNT_SIGNATURE
 } from '@signal/attestation/constants'
 
+/**
+ * Companion-side check that the primary's account key signed a device identity.
+ * Verifies `accountSignature` over `prefix || details || identityPublicKey`
+ * against the account signature public key. Inverse of
+ * {@link generateDeviceIdentityAccountSignature}.
+ */
 export async function verifyDeviceIdentityAccountSignature(
     details: Uint8Array,
     accountSignature: Uint8Array,
@@ -26,6 +35,12 @@ export async function verifyDeviceIdentityAccountSignature(
     return xeddsaVerify(toRawPubKey(accountSignatureKey), message, accountSignature)
 }
 
+/**
+ * Companion-side signature proving possession of the identity private key after
+ * adopting a primary-signed identity. Signs
+ * `prefix || details || identityKeyPair.pubKey || accountSignatureKey`, and is
+ * verified by the primary via {@link verifyDeviceSignature}.
+ */
 export async function generateDeviceSignature(
     details: Uint8Array,
     identityKeyPair: SignalKeyPair,
@@ -37,6 +52,83 @@ export async function generateDeviceSignature(
     return xeddsaSign(identityKeyPair.privKey, message)
 }
 
+/**
+ * HMAC-SHA256 over an `ADVSignedDeviceIdentity` (or hosted-prefixed variant)
+ * keyed by the shared ADV secret, binding the signed identity to the pairing
+ * secret inside `ADVSignedDeviceIdentityHMAC`.
+ */
 export function computeAdvIdentityHmac(secretKey: Uint8Array, details: Uint8Array): Uint8Array {
     return hmacSha256Sign(secretKey, details)
+}
+
+/**
+ * Primary-side counterpart to {@link verifyDeviceIdentityAccountSignature}.
+ * Signs a companion's `ADVDeviceIdentity` details with the account (primary)
+ * identity key so a linking companion can prove the primary authorized this
+ * device. The signed message is `prefix || details || companionIdentityPublicKey`.
+ *
+ * `accountIdentityKeyPair` is the primary's own Signal identity key pair; its
+ * public half is what ships as `ADVSignedDeviceIdentity.accountSignatureKey`.
+ * Pass `companionIdentityPublicKey` in the exact byte form the companion will
+ * present at verification (the value carried in its pairing QR / key bundle).
+ */
+export async function generateDeviceIdentityAccountSignature(
+    details: Uint8Array,
+    companionIdentityPublicKey: Uint8Array,
+    accountIdentityKeyPair: SignalKeyPair,
+    isHosted = false
+): Promise<Uint8Array> {
+    const prefix = isHosted ? ADV_PREFIX_HOSTED_ACCOUNT_SIGNATURE : ADV_PREFIX_ACCOUNT_SIGNATURE
+    const message = concatBytes([prefix, details, companionIdentityPublicKey])
+    return xeddsaSign(accountIdentityKeyPair.privKey, message)
+}
+
+/**
+ * Primary-side counterpart to {@link generateDeviceSignature}. Verifies the
+ * device signature a companion returns after adopting a signed identity, which
+ * proves the companion holds the identity private key it registered. The signed
+ * message is `prefix || details || companionIdentityPublicKey || accountSignatureKey`.
+ */
+export async function verifyDeviceSignature(
+    details: Uint8Array,
+    deviceSignature: Uint8Array,
+    companionIdentityPublicKey: Uint8Array,
+    accountSignatureKey: Uint8Array,
+    isHosted = false
+): Promise<boolean> {
+    const prefix = isHosted ? ADV_PREFIX_HOSTED_DEVICE_SIGNATURE : ADV_PREFIX_DEVICE_SIGNATURE
+    const message = concatBytes([prefix, details, companionIdentityPublicKey, accountSignatureKey])
+    return xeddsaVerify(toRawPubKey(companionIdentityPublicKey), message, deviceSignature)
+}
+
+/**
+ * Signs an `ADVKeyIndexList` details blob with the account (primary) identity
+ * key. A primary republishes this list whenever its companion set changes so
+ * every device can validate the current set of key indexes. The signed message
+ * is `prefix || keyIndexListDetails`.
+ */
+export async function signKeyIndexList(
+    keyIndexListDetails: Uint8Array,
+    accountIdentityKeyPair: SignalKeyPair,
+    isHosted = false
+): Promise<Uint8Array> {
+    const prefix = isHosted ? ADV_PREFIX_HOSTED_ACCOUNT_KEY_INDEX : ADV_PREFIX_ACCOUNT_KEY_INDEX
+    const message = concatBytes([prefix, keyIndexListDetails])
+    return xeddsaSign(accountIdentityKeyPair.privKey, message)
+}
+
+/**
+ * Verifies an `ADVSignedKeyIndexList` account signature against the primary's
+ * account signature key. Inverse of {@link signKeyIndexList}; used by a device
+ * to validate a key-index list published by the primary.
+ */
+export async function verifyKeyIndexListSignature(
+    keyIndexListDetails: Uint8Array,
+    accountSignature: Uint8Array,
+    accountSignatureKey: Uint8Array,
+    isHosted = false
+): Promise<boolean> {
+    const prefix = isHosted ? ADV_PREFIX_HOSTED_ACCOUNT_KEY_INDEX : ADV_PREFIX_ACCOUNT_KEY_INDEX
+    const message = concatBytes([prefix, keyIndexListDetails])
+    return xeddsaVerify(toRawPubKey(accountSignatureKey), message, accountSignature)
 }

--- a/src/signal/attestation/__tests__/adv-signature.test.ts
+++ b/src/signal/attestation/__tests__/adv-signature.test.ts
@@ -6,8 +6,12 @@ import {
     ADV_PREFIX_ACCOUNT_SIGNATURE,
     ADV_PREFIX_DEVICE_SIGNATURE,
     computeAdvIdentityHmac,
+    generateDeviceIdentityAccountSignature,
     generateDeviceSignature,
-    verifyDeviceIdentityAccountSignature
+    signKeyIndexList,
+    verifyDeviceIdentityAccountSignature,
+    verifyDeviceSignature,
+    verifyKeyIndexListSignature
 } from '@signal/attestation/WaAdvSignature'
 import { concatBytes, uint8Equal } from '@util/bytes'
 
@@ -98,4 +102,71 @@ test('adv identity hmac is deterministic for same key and details', async () => 
 
     assert.equal(left.length, right.length)
     assert.equal(uint8Equal(left, right), true)
+})
+
+test('primary account-signature generation verifies with the companion verifier', async () => {
+    const accountKeyPair = await X25519.generateKeyPair()
+    const companionKeyPair = await X25519.generateKeyPair()
+    const details = makeBytes(24, 5)
+    const companionPub = toSerializedPubKey(companionKeyPair.pubKey)
+    const accountPub = toSerializedPubKey(accountKeyPair.pubKey)
+
+    const accountSignature = await generateDeviceIdentityAccountSignature(
+        details,
+        companionPub,
+        accountKeyPair
+    )
+    assert.equal(
+        await verifyDeviceIdentityAccountSignature(
+            details,
+            accountSignature,
+            companionPub,
+            accountPub
+        ),
+        true
+    )
+    // The e2ee signature must not validate under the hosted prefix.
+    assert.equal(
+        await verifyDeviceIdentityAccountSignature(
+            details,
+            accountSignature,
+            companionPub,
+            accountPub,
+            true
+        ),
+        false
+    )
+})
+
+test('primary device-signature verifier accepts the companion device signature', async () => {
+    const companionKeyPair = await X25519.generateKeyPair()
+    const accountKeyPair = await X25519.generateKeyPair()
+    const accountPub = toSerializedPubKey(accountKeyPair.pubKey)
+    const details = makeBytes(24, 7)
+
+    const deviceSignature = await generateDeviceSignature(details, companionKeyPair, accountPub)
+    assert.equal(
+        await verifyDeviceSignature(details, deviceSignature, companionKeyPair.pubKey, accountPub),
+        true
+    )
+
+    const tampered = new Uint8Array(deviceSignature)
+    tampered[0] ^= 0x01
+    assert.equal(
+        await verifyDeviceSignature(details, tampered, companionKeyPair.pubKey, accountPub),
+        false
+    )
+})
+
+test('key-index-list signature signs and verifies with the account key', async () => {
+    const accountKeyPair = await X25519.generateKeyPair()
+    const accountPub = toSerializedPubKey(accountKeyPair.pubKey)
+    const listDetails = makeBytes(40, 13)
+
+    const signature = await signKeyIndexList(listDetails, accountKeyPair)
+    assert.equal(await verifyKeyIndexListSignature(listDetails, signature, accountPub), true)
+
+    const tampered = new Uint8Array(listDetails)
+    tampered[0] ^= 0x01
+    assert.equal(await verifyKeyIndexListSignature(tampered, signature, accountPub), false)
 })

--- a/src/signal/attestation/constants.ts
+++ b/src/signal/attestation/constants.ts
@@ -1,4 +1,6 @@
 export const ADV_PREFIX_ACCOUNT_SIGNATURE: Readonly<Uint8Array> = new Uint8Array([6, 0])
 export const ADV_PREFIX_DEVICE_SIGNATURE: Readonly<Uint8Array> = new Uint8Array([6, 1])
+export const ADV_PREFIX_ACCOUNT_KEY_INDEX: Readonly<Uint8Array> = new Uint8Array([6, 2])
 export const ADV_PREFIX_HOSTED_ACCOUNT_SIGNATURE: Readonly<Uint8Array> = new Uint8Array([6, 5])
 export const ADV_PREFIX_HOSTED_DEVICE_SIGNATURE: Readonly<Uint8Array> = new Uint8Array([6, 6])
+export const ADV_PREFIX_HOSTED_ACCOUNT_KEY_INDEX: Readonly<Uint8Array> = new Uint8Array([6, 7])

--- a/src/signal/index.ts
+++ b/src/signal/index.ts
@@ -54,3 +54,16 @@ export { SenderKeyManager } from '@signal/group/SenderKeyManager'
 export { createAndStoreInitialKeys } from '@signal/registration/utils'
 export { SignalProtocol } from '@signal/session/SignalProtocol'
 export { createSignalSessionResolver, type SignalSessionResolver } from '@signal/session/resolver'
+export {
+    ADV_PREFIX_ACCOUNT_KEY_INDEX,
+    ADV_PREFIX_ACCOUNT_SIGNATURE,
+    ADV_PREFIX_DEVICE_SIGNATURE,
+    ADV_PREFIX_HOSTED_ACCOUNT_SIGNATURE,
+    computeAdvIdentityHmac,
+    generateDeviceIdentityAccountSignature,
+    generateDeviceSignature,
+    signKeyIndexList,
+    verifyDeviceIdentityAccountSignature,
+    verifyDeviceSignature,
+    verifyKeyIndexListSignature
+} from '@signal/attestation/WaAdvSignature'

--- a/src/transport/node/builders/mobile.ts
+++ b/src/transport/node/builders/mobile.ts
@@ -1,0 +1,158 @@
+import { proto } from '@proto'
+import { WA_DEFAULTS } from '@protocol/defaults'
+import { WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
+import { buildIqNode } from '@transport/node/query'
+import type { BinaryNode } from '@transport/types'
+
+/**
+ * `ClientPairingProps` the primary declares in the `<client-props>` pair-device
+ * element. A LID-native account must send `isChatDbLidMigrated: true` (with
+ * `isSyncdPureLidSession`) so the companion runs `setIsLidMigrated` before
+ * fetching its LID-addressed blocklist; without it the companion self-removes
+ * with `lid_blocklist_chat_db_unmigrated`.
+ */
+export interface ClientPairingProps {
+    readonly isChatDbLidMigrated: boolean
+    readonly isSyncdPureLidSession: boolean
+    readonly isSyncdSnapshotRecoveryEnabled: boolean
+}
+
+export interface PairDeviceIqInput {
+    readonly ref: string
+    readonly companionNoisePublicKey: Uint8Array
+    readonly deviceIdentityBytes: Uint8Array
+    readonly keyIndexListBytes: Uint8Array
+    readonly keyIndexListTimestampSeconds: number
+    readonly clientProps?: ClientPairingProps
+    readonly pem?: {
+        readonly aesGcmKeyBytes: Uint8Array
+        readonly ttlSeconds: number
+    }
+}
+
+/**
+ * Builds the primary's `<iq type="set" xmlns="md">` carrying `<pair-device>`
+ * with `ref`, `pub-key`, `device-identity`, `key-index-list`, and optional
+ * `client-props`/`pem` children. The `id` is assigned by the send path.
+ */
+export function buildPairDeviceIq(input: PairDeviceIqInput): BinaryNode {
+    const children: BinaryNode[] = [
+        { tag: WA_NODE_TAGS.REF, attrs: {}, content: input.ref },
+        { tag: WA_NODE_TAGS.PUB_KEY, attrs: {}, content: input.companionNoisePublicKey },
+        { tag: WA_NODE_TAGS.DEVICE_IDENTITY, attrs: {}, content: input.deviceIdentityBytes },
+        {
+            tag: WA_NODE_TAGS.KEY_INDEX_LIST,
+            attrs: { ts: String(input.keyIndexListTimestampSeconds) },
+            content: input.keyIndexListBytes
+        }
+    ]
+    if (input.clientProps) {
+        children.push({
+            tag: WA_NODE_TAGS.CLIENT_PROPS,
+            attrs: {},
+            content: proto.ClientPairingProps.encode({
+                isChatDbLidMigrated: input.clientProps.isChatDbLidMigrated,
+                isSyncdPureLidSession: input.clientProps.isSyncdPureLidSession,
+                isSyncdSnapshotRecoveryEnabled: input.clientProps.isSyncdSnapshotRecoveryEnabled
+            }).finish()
+        })
+    }
+    if (input.pem) {
+        children.push({
+            tag: WA_NODE_TAGS.PEM,
+            attrs: { version: '1', algorithm: 'rsa2048' },
+            content: [
+                { tag: WA_NODE_TAGS.PEM, attrs: {}, content: input.pem.aesGcmKeyBytes },
+                { tag: WA_NODE_TAGS.TTL, attrs: { ts_s: String(input.pem.ttlSeconds) } },
+                { tag: WA_NODE_TAGS.KEY_ID, attrs: {}, content: '1' }
+            ]
+        })
+    }
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.MD, [
+        { tag: WA_NODE_TAGS.PAIR_DEVICE, attrs: {}, content: children }
+    ])
+}
+
+/**
+ * Builds the standalone key-index-list publish `<iq>` the primary sends when its
+ * companion set changes.
+ */
+export function buildKeyIndexListPublishIq(input: {
+    readonly keyIndexListBytes: Uint8Array
+    readonly timestampSeconds: number
+}): BinaryNode {
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.MD, [
+        {
+            tag: WA_NODE_TAGS.KEY_INDEX_LIST,
+            attrs: { ts: String(input.timestampSeconds) },
+            content: input.keyIndexListBytes
+        }
+    ])
+}
+
+/**
+ * Builds the `remove-companion-device` IQ that unlinks a companion from the
+ * account. The device is identified by its full device jid; `reason` is a
+ * free-form label the server records.
+ */
+export function buildRemoveCompanionDeviceIq(input: {
+    readonly deviceJid: string
+    readonly reason: string
+}): BinaryNode {
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.MD, [
+        {
+            tag: WA_NODE_TAGS.REMOVE_COMPANION_DEVICE,
+            attrs: { jid: input.deviceJid, reason: input.reason }
+        }
+    ])
+}
+
+/**
+ * Builds the `remove-companion-device` IQ that unlinks EVERY companion in one
+ * stanza: `all="true"` (no `jid`), mirroring the phone's "log out all companion
+ * devices". `excludeHostedCompanion` adds `exclude_hosted_companion="true"` to
+ * spare companions this account itself hosts.
+ */
+export function buildRemoveAllCompanionDevicesIq(input: {
+    readonly reason: string
+    readonly excludeHostedCompanion?: boolean
+}): BinaryNode {
+    const attrs: Record<string, string> = { all: 'true', reason: input.reason }
+    if (input.excludeHostedCompanion) {
+        attrs.exclude_hosted_companion = 'true'
+    }
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.MD, [
+        { tag: WA_NODE_TAGS.REMOVE_COMPANION_DEVICE, attrs }
+    ])
+}
+
+/**
+ * Builds the `primary_hello` IQ the primary sends to drive a link-code (pairing
+ * code) handshake: the code-wrapped primary ephemeral, the primary ADV identity
+ * public key, and the companion's pairing ref.
+ */
+export function buildPrimaryHelloIq(input: {
+    readonly ref: string
+    readonly wrappedPrimaryEphemeralPub: Uint8Array
+    readonly primaryIdentityPub: Uint8Array
+}): BinaryNode {
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.MD, [
+        {
+            tag: WA_NODE_TAGS.LINK_CODE_COMPANION_REG,
+            attrs: { stage: 'primary_hello' },
+            content: [
+                {
+                    tag: WA_NODE_TAGS.LINK_CODE_PAIRING_WRAPPED_PRIMARY_EPHEMERAL_PUB,
+                    attrs: {},
+                    content: input.wrappedPrimaryEphemeralPub
+                },
+                {
+                    tag: WA_NODE_TAGS.PRIMARY_IDENTITY_PUB,
+                    attrs: {},
+                    content: input.primaryIdentityPub
+                },
+                { tag: WA_NODE_TAGS.LINK_CODE_PAIRING_REF, attrs: {}, content: input.ref }
+            ]
+        }
+    ])
+}


### PR DESCRIPTION
Add client.mobile (WaMobileCoordinator): a mobile-primary session can link, host, and revoke its own companion devices - the inverse of zapo's usual companion role.

- Link a companion by QR or 8-char pairing code, signing its ADVSignedDeviceIdentity + key-index-list and uploading pair-device.
- Keep companions past the ~180s critical bootstrap by satisfying its three gates: client-props LID migration, an INITIAL_BOOTSTRAP history-sync notification, and a seeded setting_pushName app-state.
- Revoke one device or every companion in a single remove-companion-device stanza, republishing the key-index list for the reduced set.
- Reconcile the tracked set against the server device list on connect and on account_sync, pruning companions unlinked while offline.
- Share app-state sync keys and persist the companion epoch across restarts.

Guarded to mobile-primary sessions (mobileTransport / a registered phone identity); companion sessions get a clear error from client.mobile.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile-primary companion-device linking with QR and pairing-code handshakes.
  * Added companion management: list, reconcile, revoke one/all, and publish updated key-index lists.
  * Added automatic history sync bootstrap and best-effort app-state key sharing when linking.
  * Added file-backed companion-host persistence for per-session reconnects and new companion-host event reporting.
* **Bug Fixes**
  * Hardened app-state sync key sharing by rejecting malformed key IDs and aggregating warnings.
* **Tests**
  * Added companion-host and mobile coordinator test coverage for success and failure flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->