### PR TITLE
feat(wam): add @zapo-js/wam analytics/telemetry plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,21 @@ jobs:
             - run: npx turbo run build --filter=@zapo-js/voip
             - run: npm test -w packages/voip
 
+    test-wam:
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        needs: build-core
+
+        steps:
+            - uses: actions/checkout@v4
+            - uses: ./.github/actions/setup-node
+            - uses: actions/download-artifact@v4
+              with:
+                  name: core-build
+                  path: dist/
+            - run: npx turbo run build --filter=@zapo-js/wam
+            - run: npm test -w packages/wam
+
     test-mysql:
         runs-on: ubuntu-latest
         timeout-minutes: 15
@@ -305,6 +320,7 @@ jobs:
             - test-sqlite
             - test-mcp-server
             - test-voip
+            - test-wam
             - test-mysql
             - test-postgres
             - test-redis

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,7 +53,8 @@ module.exports = [
                     './packages/media-utils/tsconfig.json',
                     './packages/voip/tsconfig.json',
                     './packages/fake-server/tsconfig.json',
-                    './packages/mcp-server/tsconfig.json'
+                    './packages/mcp-server/tsconfig.json',
+                    './packages/wam/tsconfig.json'
                 ]
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2618,6 +2618,21 @@
                 "typescript-eslint": "^8.12.2"
             }
         },
+        "node_modules/@vinikjkkj/wa-wam": {
+            "version": "2.3000.1041713829-1ec0d3b",
+            "resolved": "https://registry.npmjs.org/@vinikjkkj/wa-wam/-/wa-wam-2.3000.1041713829-1ec0d3b.tgz",
+            "integrity": "sha512-u0/ODuwN3nBTumlqLh3+sb2r4DPNnF0SecN2OcC3nBAhHm/xVQjEXUGLsvKCP/vTLw0TcJRDMYQY8jGqt9kQrw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/vinikjkkj"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.9.0"
+            }
+        },
         "node_modules/@zapo-js/fake-server": {
             "resolved": "packages/fake-server",
             "link": true
@@ -2652,6 +2667,10 @@
         },
         "node_modules/@zapo-js/voip": {
             "resolved": "packages/voip",
+            "link": true
+        },
+        "node_modules/@zapo-js/wam": {
+            "resolved": "packages/wam",
             "link": true
         },
         "node_modules/accepts": {
@@ -9601,6 +9620,23 @@
             "peerDependencies": {
                 "@roamhq/wrtc": ">=0.10.0",
                 "libmlow-wasm": "^0.1.1",
+                "zapo-js": "^1.0.0"
+            }
+        },
+        "packages/wam": {
+            "name": "@zapo-js/wam",
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "@vinikjkkj/wa-wam": "2.3000.1041713829-1ec0d3b"
+            },
+            "devDependencies": {
+                "zapo-js": "file:../.."
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "peerDependencies": {
                 "zapo-js": "^1.0.0"
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9484,7 +9484,7 @@
                 "@modelcontextprotocol/sdk": "^1.29.0",
                 "@zapo-js/media-utils": "^1.0.0",
                 "@zapo-js/store-sqlite": "^1.0.1",
-                "@zapo-js/wam": "^1.0.0",
+                "@zapo-js/wam": "^0.1.0",
                 "better-sqlite3": "^12.6.2"
             },
             "bin": {
@@ -9626,7 +9626,7 @@
         },
         "packages/wam": {
             "name": "@zapo-js/wam",
-            "version": "1.0.0",
+            "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
                 "@vinikjkkj/wa-wam": "2.3000.1041713829-1ec0d3b"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9484,6 +9484,7 @@
                 "@modelcontextprotocol/sdk": "^1.29.0",
                 "@zapo-js/media-utils": "^1.0.0",
                 "@zapo-js/store-sqlite": "^1.0.1",
+                "@zapo-js/wam": "^1.0.0",
                 "better-sqlite3": "^12.6.2"
             },
             "bin": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -40,7 +40,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@zapo-js/media-utils": "^1.0.0",
         "@zapo-js/store-sqlite": "^1.0.1",
-        "@zapo-js/wam": "^1.0.0",
+        "@zapo-js/wam": "^0.1.0",
         "better-sqlite3": "^12.6.2"
     },
     "peerDependencies": {

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -15,6 +15,7 @@ import { hexToBytes, resolvePositive, toError } from 'zapo-js/util'
 
 import { createMediaProcessor } from '@zapo-js/media-utils'
 import { createSqliteStore } from '@zapo-js/store-sqlite'
+import { wamPlugin } from '@zapo-js/wam'
 
 import { encodeForJson } from './serializer'
 
@@ -711,6 +712,7 @@ export class McpRuntime {
                         )
                     )
                 },
+                plugins: [wamPlugin()],
                 ...(mobileTransport ? { mobileTransport } : {}),
                 connectTimeoutMs: 60_000,
                 deviceBrowser: this.config.deviceBrowser ?? 'Chrome',

--- a/packages/wam/README.md
+++ b/packages/wam/README.md
@@ -44,49 +44,67 @@ plugins: [wamPlugin({ syntheticUi: false })]
 
 ## Events emitted
 
-**39** of the registry's **426** events. They come from two independently toggled
+**131** of the registry's **426** events. They come from two independently toggled
 sources:
 
 | Source             | Flag          | Default | Count |
 | ------------------ | ------------- | ------- | ----- |
-| Protocol lifecycle | `autoEmit`    | on      | 17    |
-| Integrator actions | `autoEmit`    | on      | 13    |
-| Synthetic UI       | `syntheticUi` | on      | 9     |
+| Protocol lifecycle | `autoEmit`    | on      | 19    |
+| Integrator actions | `autoEmit`    | on      | 18    |
+| Synthetic UI       | `syntheticUi` | on      | 94    |
 
 <details>
 <summary>Full list</summary>
 
-**Protocol lifecycle (17)** - derived from real inbound/outbound stanzas:
+**Protocol lifecycle (19)** - derived from real inbound/outbound stanzas:
 `E2eMessageSend`, `E2eMessageRecv`, `MessageSend`, `MessageReceive`,
 `WebcMessageSend`, `ReceiptStanzaReceive`, `MessageHighRetryCount`,
 `EditMessageSend`, `ClockSkewDifferenceT`, `GroupJoinC`, `WaOldCode`,
 `WebcSocketConnect`, `WebcStreamModeChange`, `WebcPageResume`,
-`WebcRawPlatforms`, `MdBootstrapHistoryDataReceived`, `UnknownStanza`
+`WebcRawPlatforms`, `MdBootstrapHistoryDataReceived`, `UnknownStanza`,
+`OfflineCountTooHigh`, `WebWamForceFlush`
 
-**Integrator actions (13)** - the client's own sends and app-state mutations:
+**Integrator actions (18)** - the client's own sends and app-state mutations:
 `ForwardSend`, `ReactionActions`, `PollsActions`, `SendDocument`, `StickerSend`,
-`PinInChatMessageSend`, `RevokeMessageSend`, `MessageDeleteActions`,
-`WaFsGroupJoinRequestAction`, `ChatMute`, `ChatAction`, `StatusMute`,
-`MdSyncdDogfoodingFeatureUsage`
+`PinInChatMessageSend`, `RevokeMessageSend`, `SendRevokeMessage`,
+`MessageDeleteActions`, `WaFsGroupJoinRequestAction`, `GroupCreate`,
+`GroupCreateC`, `EphemeralSettingChange`, `DisappearingModeSettingChange`,
+`ChatMute`, `ChatAction`, `StatusMute`, `MdSyncdDogfoodingFeatureUsage`
 
-**Synthetic UI (9)** - fabricated plausible ambient activity:
-`UiAction`, `AboutConsumption`, `AttachmentTrayActions`,
-`ContactSearchExperience`, `MemoryStat`, `UserActivity`, `WebcChatOpen`,
-`WebcEmojiOpen`, `WebcMediaLoad`
+**Synthetic UI (94)** - plausible activity, every event grounded in WA Web's own
+emit (only the field subset WA sets, with plausible values). The base stream —
+`UiAction` (chat/image/info opens), `WebcChatOpen`, `AttachmentTrayActions`,
+`ContactSearchExperience`, `MemoryStat`, `UserActivity`/`TsBitArray`,
+`WebcEmojiOpen`, `StickerPickerOpened`, `AboutConsumption`/`AboutInteraction`,
+`WebcMediaLoad` — plus a weighted ambient table of ~70 more UI events and 9
+message-anchored ones (media playback/compose, mention picker, group catch-up, …).
+The table lives in
+[`src/synthetic/fabrications.ts`](src/synthetic/fabrications.ts).
+
+**9 events are capability-gated** (default **off**) — firing them on an account that
+lacks the surface is itself a tell: `ChannelOpen` needs `channels`; the `Community*`
+events and `GroupJourney` need `communities`; the business/SMB events
+(`WaShopsManagement`, `MdChatAssignmentSecondaryAction`,
+`StructuredMessageBuyerInteraction`) need `business`.
 
 </details>
 
 ## Coverage
 
-**35 / 426** registry events (~8%). The low figure is **by design**: the
-remaining ~390 events are dominated by data a headless client does not have and
-cannot truthfully synthesize (browser/runtime internals, device and OS state,
-mobile-app-only flows, UI-render interactions, crypto internals, ads, and
-server-side aggregates).
+**131 / 426** registry events (~31%). The rest are dominated by data a headless
+client cannot produce or plausibly fake — browser/runtime internals, device and OS
+state, mobile-app-only flows, crypto internals, ads, server-side aggregates — plus
+events carried on the private (non-`w:stats`) channels.
 
-The plugin only emits an event when **every field it sets is honestly derivable**.
-A partial or fabricated ("skeleton") event is a _worse_ fingerprint than silence,
-so those are deliberately left unimplemented rather than filled with placeholders.
+Two disciplines keep the emitted set a faithful fingerprint:
+
+- **Auto-emitted** protocol and integrator events are sent only when **every field
+  is honestly derivable** from real client activity.
+- **Synthetic UI** events are **fabricated**, but each replicates WA Web's actual
+  emit — only the field subset WA sets, with plausible values — verified against the
+  deobfuscated web bundle. They are jittered, rate-limited, and confined to
+  configurable active hours; a badly-timed or skeleton event is a worse tell than
+  none, so events WA Web itself never fires are left out.
 
 ## Options
 
@@ -102,6 +120,11 @@ so those are deliberately left unimplemented rather than filled with placeholder
 | `maxBufferSize`            | `50000`       | Byte size that forces an immediate flush                                 |
 | `logLevel`                 | host client's | Minimum log level for the plugin                                         |
 
+`syntheticUi` also accepts an options object. Besides jitter/interval and
+`activeHoursStartHour`/`activeHoursEndHour` tuning, `channels`, `communities`, and
+`business` (all default `false`) enable the capability-gated ambient events for
+accounts that actually have those surfaces.
+
 ## How it works
 
 1. **Accumulate**: committed events buffer into a per-channel batch whose globals
@@ -114,5 +137,6 @@ so those are deliberately left unimplemented rather than filled with placeholder
    failing batch is dropped, never surfaced.
 
 `autoEmit` observes the client's typed events and raw stanzas and maps each to the
-WAM event WA Web fires at the same point. `syntheticUi` fabricates ambient
-`UiAction`/activity telemetry within configurable active hours.
+WAM event WA Web fires at the same point. `syntheticUi` fabricates UI telemetry — a
+weighted table of wa-web-grounded ambient events plus message-anchored ones —
+jittered and confined to configurable active hours.

--- a/packages/wam/README.md
+++ b/packages/wam/README.md
@@ -7,7 +7,7 @@ the client-side `w:stats` metrics batches WA Web sends, for **wire parity** and
 WA Web continuously uploads WAM (Falco) telemetry: message send/receive metrics,
 connection lifecycle, sync progress, UI interactions, and more. A headless client
 that uploads **none** of these has a conspicuous gap in its event profile. This
-plugin closes that gap by emitting the events a headless client can *truthfully*
+plugin closes that gap by emitting the events a headless client can _truthfully_
 produce, and (opt-in) by fabricating plausible ambient UI activity.
 
 ## Install
@@ -27,9 +27,9 @@ import { WaClient } from 'zapo-js'
 import { wamPlugin } from '@zapo-js/wam'
 
 const client = new WaClient({
-  store,
-  sessionId: 'main',
-  plugins: [wamPlugin()]
+    store,
+    sessionId: 'main',
+    plugins: [wamPlugin()]
 })
 
 // Protocol events auto-emit as the client runs. You can also commit your own:
@@ -47,11 +47,11 @@ plugins: [wamPlugin({ syntheticUi: true })]
 **35** of the registry's **426** events. They come from two independently toggled
 sources:
 
-| Source | Flag | Default | Count |
-| --- | --- | --- | --- |
-| Protocol lifecycle | `autoEmit` | on | 17 |
-| Integrator actions | `autoEmit` | on | 9 |
-| Synthetic UI | `syntheticUi` | off | 9 |
+| Source             | Flag          | Default | Count |
+| ------------------ | ------------- | ------- | ----- |
+| Protocol lifecycle | `autoEmit`    | on      | 17    |
+| Integrator actions | `autoEmit`    | on      | 9     |
+| Synthetic UI       | `syntheticUi` | off     | 9     |
 
 <details>
 <summary>Full list</summary>
@@ -84,22 +84,22 @@ mobile-app-only flows, UI-render interactions, crypto internals, ads, and
 server-side aggregates).
 
 The plugin only emits an event when **every field it sets is honestly derivable**.
-A partial or fabricated ("skeleton") event is a *worse* fingerprint than silence,
+A partial or fabricated ("skeleton") event is a _worse_ fingerprint than silence,
 so those are deliberately left unimplemented rather than filled with placeholders.
 
 ## Options
 
 `wamPlugin(options)`, all optional:
 
-| Option | Default | Description |
-| --- | --- | --- |
-| `autoEmit` | `true` | Emit protocol + integrator-action events by observing the client |
-| `syntheticUi` | `false` | Fabricate plausible UI telemetry (`true` or an options object) |
-| `serviceImprovementOptOut` | `false` | `service_improvement_opt_out` consent bit |
-| `appVersion` | `WA_VERSION` | Override the advertised app version |
-| `flushIntervalMs` | `5000` | Coalesce window before a non-empty batch flushes |
-| `maxBufferSize` | `50000` | Byte size that forces an immediate flush |
-| `logLevel` | host client's | Minimum log level for the plugin |
+| Option                     | Default       | Description                                                      |
+| -------------------------- | ------------- | ---------------------------------------------------------------- |
+| `autoEmit`                 | `true`        | Emit protocol + integrator-action events by observing the client |
+| `syntheticUi`              | `false`       | Fabricate plausible UI telemetry (`true` or an options object)   |
+| `serviceImprovementOptOut` | `false`       | `service_improvement_opt_out` consent bit                        |
+| `appVersion`               | `WA_VERSION`  | Override the advertised app version                              |
+| `flushIntervalMs`          | `5000`        | Coalesce window before a non-empty batch flushes                 |
+| `maxBufferSize`            | `50000`       | Byte size that forces an immediate flush                         |
+| `logLevel`                 | host client's | Minimum log level for the plugin                                 |
 
 ## How it works
 

--- a/packages/wam/README.md
+++ b/packages/wam/README.md
@@ -8,7 +8,7 @@ WA Web continuously uploads WAM (Falco) telemetry: message send/receive metrics,
 connection lifecycle, sync progress, UI interactions, and more. A headless client
 that uploads **none** of these has a conspicuous gap in its event profile. This
 plugin closes that gap by emitting the events a headless client can _truthfully_
-produce, and (opt-in) by fabricating plausible ambient UI activity.
+produce, and by fabricating plausible ambient UI activity (on by default).
 
 ## Install
 
@@ -36,22 +36,22 @@ const client = new WaClient({
 client.wam.commit('UiAction', { uiActionType: 'CHAT_OPEN' })
 ```
 
-Opt into synthetic UI telemetry (off by default):
+Synthetic UI telemetry is on by default. Disable it (or tune it) with:
 
 ```ts
-plugins: [wamPlugin({ syntheticUi: true })]
+plugins: [wamPlugin({ syntheticUi: false })]
 ```
 
 ## Events emitted
 
-**35** of the registry's **426** events. They come from two independently toggled
+**39** of the registry's **426** events. They come from two independently toggled
 sources:
 
 | Source             | Flag          | Default | Count |
 | ------------------ | ------------- | ------- | ----- |
 | Protocol lifecycle | `autoEmit`    | on      | 17    |
-| Integrator actions | `autoEmit`    | on      | 9     |
-| Synthetic UI       | `syntheticUi` | off     | 9     |
+| Integrator actions | `autoEmit`    | on      | 13    |
+| Synthetic UI       | `syntheticUi` | on      | 9     |
 
 <details>
 <summary>Full list</summary>
@@ -63,9 +63,10 @@ sources:
 `WebcSocketConnect`, `WebcStreamModeChange`, `WebcPageResume`,
 `WebcRawPlatforms`, `MdBootstrapHistoryDataReceived`, `UnknownStanza`
 
-**Integrator actions (9)** - the client's own sends and app-state mutations:
-`ForwardSend`, `ReactionActions`, `PollsActions`, `SendDocument`,
-`RevokeMessageSend`, `WaFsGroupJoinRequestAction`, `ChatMute`, `ChatAction`,
+**Integrator actions (13)** - the client's own sends and app-state mutations:
+`ForwardSend`, `ReactionActions`, `PollsActions`, `SendDocument`, `StickerSend`,
+`PinInChatMessageSend`, `RevokeMessageSend`, `MessageDeleteActions`,
+`WaFsGroupJoinRequestAction`, `ChatMute`, `ChatAction`, `StatusMute`,
 `MdSyncdDogfoodingFeatureUsage`
 
 **Synthetic UI (9)** - fabricated plausible ambient activity:
@@ -91,15 +92,15 @@ so those are deliberately left unimplemented rather than filled with placeholder
 
 `wamPlugin(options)`, all optional:
 
-| Option                     | Default       | Description                                                      |
-| -------------------------- | ------------- | ---------------------------------------------------------------- |
-| `autoEmit`                 | `true`        | Emit protocol + integrator-action events by observing the client |
-| `syntheticUi`              | `false`       | Fabricate plausible UI telemetry (`true` or an options object)   |
-| `serviceImprovementOptOut` | `false`       | `service_improvement_opt_out` consent bit                        |
-| `appVersion`               | `WA_VERSION`  | Override the advertised app version                              |
-| `flushIntervalMs`          | `5000`        | Coalesce window before a non-empty batch flushes                 |
-| `maxBufferSize`            | `50000`       | Byte size that forces an immediate flush                         |
-| `logLevel`                 | host client's | Minimum log level for the plugin                                 |
+| Option                     | Default       | Description                                                              |
+| -------------------------- | ------------- | ------------------------------------------------------------------------ |
+| `autoEmit`                 | `true`        | Emit protocol + integrator-action events by observing the client         |
+| `syntheticUi`              | `true`        | Fabricate plausible UI telemetry (`false` to disable, or options object) |
+| `serviceImprovementOptOut` | `false`       | `service_improvement_opt_out` consent bit                                |
+| `appVersion`               | `WA_VERSION`  | Override the advertised app version                                      |
+| `flushIntervalMs`          | `5000`        | Coalesce window before a non-empty batch flushes                         |
+| `maxBufferSize`            | `50000`       | Byte size that forces an immediate flush                                 |
+| `logLevel`                 | host client's | Minimum log level for the plugin                                         |
 
 ## How it works
 

--- a/packages/wam/README.md
+++ b/packages/wam/README.md
@@ -1,0 +1,117 @@
+# @zapo-js/wam
+
+WhatsApp Web **WAM** (analytics/telemetry) plugin for [zapo-js](../../). It emits
+the client-side `w:stats` metrics batches WA Web sends, for **wire parity** and
+**anti-fingerprinting**.
+
+WA Web continuously uploads WAM (Falco) telemetry: message send/receive metrics,
+connection lifecycle, sync progress, UI interactions, and more. A headless client
+that uploads **none** of these has a conspicuous gap in its event profile. This
+plugin closes that gap by emitting the events a headless client can *truthfully*
+produce, and (opt-in) by fabricating plausible ambient UI activity.
+
+## Install
+
+```sh
+npm install @zapo-js/wam
+```
+
+`zapo-js` is a peer dependency. The WAM event registry
+([`@vinikjkkj/wa-wam`](https://www.npmjs.com/package/@vinikjkkj/wa-wam)) is
+bundled.
+
+## Usage
+
+```ts
+import { WaClient } from 'zapo-js'
+import { wamPlugin } from '@zapo-js/wam'
+
+const client = new WaClient({
+  store,
+  sessionId: 'main',
+  plugins: [wamPlugin()]
+})
+
+// Protocol events auto-emit as the client runs. You can also commit your own:
+client.wam.commit('UiAction', { uiActionType: 'CHAT_OPEN' })
+```
+
+Opt into synthetic UI telemetry (off by default):
+
+```ts
+plugins: [wamPlugin({ syntheticUi: true })]
+```
+
+## Events emitted
+
+**35** of the registry's **426** events. They come from two independently toggled
+sources:
+
+| Source | Flag | Default | Count |
+| --- | --- | --- | --- |
+| Protocol lifecycle | `autoEmit` | on | 17 |
+| Integrator actions | `autoEmit` | on | 9 |
+| Synthetic UI | `syntheticUi` | off | 9 |
+
+<details>
+<summary>Full list</summary>
+
+**Protocol lifecycle (17)** - derived from real inbound/outbound stanzas:
+`E2eMessageSend`, `E2eMessageRecv`, `MessageSend`, `MessageReceive`,
+`WebcMessageSend`, `ReceiptStanzaReceive`, `MessageHighRetryCount`,
+`EditMessageSend`, `ClockSkewDifferenceT`, `GroupJoinC`, `WaOldCode`,
+`WebcSocketConnect`, `WebcStreamModeChange`, `WebcPageResume`,
+`WebcRawPlatforms`, `MdBootstrapHistoryDataReceived`, `UnknownStanza`
+
+**Integrator actions (9)** - the client's own sends and app-state mutations:
+`ForwardSend`, `ReactionActions`, `PollsActions`, `SendDocument`,
+`RevokeMessageSend`, `WaFsGroupJoinRequestAction`, `ChatMute`, `ChatAction`,
+`MdSyncdDogfoodingFeatureUsage`
+
+**Synthetic UI (9)** - fabricated plausible ambient activity:
+`UiAction`, `AboutConsumption`, `AttachmentTrayActions`,
+`ContactSearchExperience`, `MemoryStat`, `UserActivity`, `WebcChatOpen`,
+`WebcEmojiOpen`, `WebcMediaLoad`
+
+</details>
+
+## Coverage
+
+**35 / 426** registry events (~8%). The low figure is **by design**: the
+remaining ~390 events are dominated by data a headless client does not have and
+cannot truthfully synthesize (browser/runtime internals, device and OS state,
+mobile-app-only flows, UI-render interactions, crypto internals, ads, and
+server-side aggregates).
+
+The plugin only emits an event when **every field it sets is honestly derivable**.
+A partial or fabricated ("skeleton") event is a *worse* fingerprint than silence,
+so those are deliberately left unimplemented rather than filled with placeholders.
+
+## Options
+
+`wamPlugin(options)`, all optional:
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `autoEmit` | `true` | Emit protocol + integrator-action events by observing the client |
+| `syntheticUi` | `false` | Fabricate plausible UI telemetry (`true` or an options object) |
+| `serviceImprovementOptOut` | `false` | `service_improvement_opt_out` consent bit |
+| `appVersion` | `WA_VERSION` | Override the advertised app version |
+| `flushIntervalMs` | `5000` | Coalesce window before a non-empty batch flushes |
+| `maxBufferSize` | `50000` | Byte size that forces an immediate flush |
+| `logLevel` | host client's | Minimum log level for the plugin |
+
+## How it works
+
+1. **Accumulate**: committed events buffer into a per-channel batch whose globals
+   derive from the client's own device identity, so they agree with the pairing
+   `ClientPayload`.
+2. **Flush**: on the coalesce interval, on reaching `maxBufferSize`, or on
+   dispose.
+3. **Upload**: as the `<iq type="set" xmlns="w:stats"><add t>` stanza WA Web
+   sends. Best-effort; transient failures retry with backoff, and a permanently
+   failing batch is dropped, never surfaced.
+
+`autoEmit` observes the client's typed events and raw stanzas and maps each to the
+WAM event WA Web fires at the same point. `syntheticUi` fabricates ambient
+`UiAction`/activity telemetry within configurable active hours.

--- a/packages/wam/package.json
+++ b/packages/wam/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zapo-js/wam",
-    "version": "1.0.0",
+    "version": "0.1.0",
     "description": "WhatsApp Web WAM (analytics/telemetry) plugin for zapo-js — emits the client-side metrics batches WA Web sends, for wire parity and anti-fingerprinting",
     "license": "MIT",
     "author": "vinikjkkj <contact@vinicius.email> (https://github.com/vinikjkkj)",

--- a/packages/wam/package.json
+++ b/packages/wam/package.json
@@ -1,20 +1,17 @@
 {
-    "name": "@zapo-js/mcp-server",
-    "version": "1.0.3",
-    "description": "MCP server exposing zapo-js WaClient as dynamic tools for end-to-end testing",
+    "name": "@zapo-js/wam",
+    "version": "1.0.0",
+    "description": "WhatsApp Web WAM (analytics/telemetry) plugin for zapo-js — emits the client-side metrics batches WA Web sends, for wire parity and anti-fingerprinting",
     "license": "MIT",
     "author": "vinikjkkj <contact@vinicius.email> (https://github.com/vinikjkkj)",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/vinikjkkj/zapo.git",
-        "directory": "packages/mcp-server"
+        "directory": "packages/wam"
     },
     "main": "dist/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/index.d.ts",
-    "bin": {
-        "zapo-mcp-server": "./dist/bin.js"
-    },
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -24,7 +21,8 @@
         }
     },
     "files": [
-        "dist"
+        "dist",
+        "README.md"
     ],
     "publishConfig": {
         "access": "public"
@@ -32,23 +30,15 @@
     "scripts": {
         "build": "tsc -p tsconfig.build.cjs.json && tsc -p tsconfig.build.esm.json && node ../../scripts/finalize-esm-build.cjs",
         "typecheck": "tsc --noEmit",
-        "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\"",
-        "start": "node --import tsx src/bin.ts",
-        "dev": "cross-env MCP_TRANSPORT=http MCP_EVAL_ENABLED=1 MCP_LOG_LEVEL=trace MCP_AUTH_PATH=../../.auth/state.sqlite node --watch --import tsx src/bin.ts"
+        "test": "node --import tsx --test \"src/**/__tests__/**/*.test.ts\""
     },
     "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
-        "@zapo-js/media-utils": "^1.0.0",
-        "@zapo-js/store-sqlite": "^1.0.1",
-        "@zapo-js/wam": "^1.0.0",
-        "better-sqlite3": "^12.6.2"
+        "@vinikjkkj/wa-wam": "2.3000.1041713829-1ec0d3b"
     },
     "peerDependencies": {
         "zapo-js": "^1.0.0"
     },
     "devDependencies": {
-        "@zapo-js/fake-server": "file:../fake-server",
-        "cross-env": "^7.0.3",
         "zapo-js": "file:../.."
     },
     "engines": {

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -126,7 +126,7 @@ export class WaWamAutoEmitter {
         this.client = ctx.client
         const onConnection = (event: WaConnectionEvent): void => this.onConnection(event)
         const onGroup = (event: WaGroupEvent): void => this.onGroup(event)
-        const onMutation = (event: WaAppStateMutationEvent): void => this.onMutation(event)
+        const onMutationSend = (event: WaAppStateMutationEvent): void => this.onMutationSend(event)
         const onMessageSend = (event: WaOutgoingMessageEvent): void => this.onMessageSend(event)
         const onMessage = (event: WaIncomingMessageEvent): void => this.onMessage(event)
         const onReceipt = (event: WaIncomingReceiptEvent): void => this.onReceipt(event)
@@ -137,7 +137,7 @@ export class WaWamAutoEmitter {
         const onHistory = (event: WaHistorySyncChunkEvent): void => this.onHistorySyncChunk(event)
         ctx.on('connection', onConnection)
         ctx.on('group', onGroup)
-        ctx.on('mutation', onMutation)
+        ctx.on('mutation_send', onMutationSend)
         ctx.on('message_send', onMessageSend)
         ctx.on('message', onMessage)
         ctx.on('receipt', onReceipt)
@@ -148,7 +148,7 @@ export class WaWamAutoEmitter {
         this.unsubscribes.push(
             () => ctx.off('connection', onConnection),
             () => ctx.off('group', onGroup),
-            () => ctx.off('mutation', onMutation),
+            () => ctx.off('mutation_send', onMutationSend),
             () => ctx.off('message_send', onMessageSend),
             () => ctx.off('message', onMessage),
             () => ctx.off('receipt', onReceipt),
@@ -201,8 +201,8 @@ export class WaWamAutoEmitter {
         this.coordinator.commit('GroupJoinC', {})
     }
 
-    private onMutation(event: WaAppStateMutationEvent): void {
-        if (event.source !== 'local') return
+    /** `mutation_send` is this client's own outbound app-state action, mirroring where WA Web fires these. */
+    private onMutationSend(event: WaAppStateMutationEvent): void {
         if (event.schema === 'Mute') {
             const muted = event.operation === 'set' && event.muted === true
             const actionConducted = muted ? 'MUTE' : 'UNMUTE'

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -284,7 +284,11 @@ export class WaWamAutoEmitter {
             return
         }
 
-        const poll = msg.pollCreationMessage
+        const poll =
+            msg.pollCreationMessage ??
+            msg.pollCreationMessageV2 ??
+            msg.pollCreationMessageV3 ??
+            msg.pollCreationMessageV5
         if (poll) {
             this.coordinator.commit('PollsActions', {
                 pollAction: 'CREATE_POLL',

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -339,16 +339,8 @@ export class WaWamAutoEmitter {
         const sticker = msg.stickerMessage
         if (sticker) {
             this.coordinator.commit('StickerSend', {
-                stickerSendMessageType: 'REGULAR',
-                ...(typeof sticker.isAnimated === 'boolean'
-                    ? { stickerIsAnimated: sticker.isAnimated }
-                    : {}),
-                ...(typeof sticker.isAvatar === 'boolean'
-                    ? { stickerIsAvatar: sticker.isAvatar }
-                    : {}),
-                ...(typeof sticker.isAiSticker === 'boolean'
-                    ? { stickerIsAi: sticker.isAiSticker }
-                    : {})
+                stickerIsAnimated: sticker.isAnimated === true,
+                stickerIsLottie: sticker.isLottie === true
             })
             return
         }
@@ -437,15 +429,18 @@ export class WaWamAutoEmitter {
         const media = mediaTypeKey(enc.attrs.mediatype)
         const version = enc.attrs.v
         const count = enc.attrs.count
+        const editType = editTypeKey(node.attrs.edit)
 
         this.coordinator.commit('E2eMessageSend', {
             e2eSuccessful: true,
             e2eDestination: destination,
             isLid,
+            botType: 'UNKNOWN',
+            editType: editType ?? 'NOT_EDITED',
+            retryCount: count !== undefined ? Number(count) : 0,
             ...(ciphertextType !== null ? { e2eCiphertextType: ciphertextType } : {}),
             ...(version !== undefined ? { e2eCiphertextVersion: Number(version) } : {}),
             ...(media !== null ? { messageMediaType: media } : {}),
-            ...(count !== undefined ? { retryCount: Number(count) } : {}),
             ...(isGroup ? { typeOfGroup: 'GROUP' as const } : {})
         })
 
@@ -456,7 +451,6 @@ export class WaWamAutoEmitter {
 
         const id = node.attrs.id
         if (id !== undefined) {
-            const editType = editTypeKey(node.attrs.edit)
             this.trackSend(id, {
                 destination,
                 isLid,
@@ -524,8 +518,14 @@ export class WaWamAutoEmitter {
             this.sentMessages.delete(id)
             this.coordinator.commit('MessageSend', {
                 messageSendResult: 'OK',
+                messageSendResultIsTerminal: false,
                 messageType: info.destination,
                 isLid: info.isLid,
+                botType: 'UNKNOWN',
+                editType: info.editType ?? 'NOT_EDITED',
+                messageIsRevoke:
+                    info.editType === 'SENDER_REVOKE' || info.editType === 'ADMIN_REVOKE',
+                e2eBackfill: false,
                 ...(info.ciphertextType !== null ? { e2eCiphertextType: info.ciphertextType } : {}),
                 ...(info.mediaType !== null ? { messageMediaType: info.mediaType } : {}),
                 ...(info.isGroup ? { typeOfGroup: 'GROUP' as const } : {})
@@ -534,6 +534,7 @@ export class WaWamAutoEmitter {
                 this.coordinator.commit('EditMessageSend', {
                     editType: info.editType,
                     messageType: info.destination,
+                    messageSendResultIsTerminal: false,
                     ...(info.mediaType !== null ? { mediaType: info.mediaType } : {}),
                     ...(info.isGroup ? { typeOfGroup: 'GROUP' as const } : {})
                 })
@@ -542,7 +543,7 @@ export class WaWamAutoEmitter {
                 this.coordinator.commit('RevokeMessageSend', {
                     revokeType: info.editType === 'ADMIN_REVOKE' ? 'ADMIN' : 'SENDER',
                     messageType: info.destination,
-                    messageSendResultIsTerminal: true
+                    messageSendResultIsTerminal: false
                 })
                 this.coordinator.commit('MessageDeleteActions', {
                     deleteActionType: 'DELETE_FOR_EVERYONE',

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -312,9 +312,7 @@ export class WaWamAutoEmitter {
                 documentType: documentTypeFor(doc.mimetype),
                 ...(ext !== undefined ? { documentExt: ext } : {}),
                 ...(typeof doc.pageCount === 'number' ? { documentPageSize: doc.pageCount } : {}),
-                ...(typeof doc.fileLength === 'number'
-                    ? { documentSize: doc.fileLength }
-                    : {})
+                ...(typeof doc.fileLength === 'number' ? { documentSize: doc.fileLength } : {})
             })
             return
         }
@@ -399,7 +397,14 @@ export class WaWamAutoEmitter {
         const id = node.attrs.id
         if (id !== undefined) {
             const editType = editTypeKey(node.attrs.edit)
-            this.trackSend(id, { destination, isLid, isGroup, ciphertextType, mediaType: media, editType })
+            this.trackSend(id, {
+                destination,
+                isLid,
+                isGroup,
+                ciphertextType,
+                mediaType: media,
+                editType
+            })
         }
     }
 
@@ -409,7 +414,10 @@ export class WaWamAutoEmitter {
             return
         }
         if (node.tag === WA_NODE_TAGS.NOTIFICATION) {
-            const oldReg = findNodeChild(node, WA_REGISTRATION_NOTIFICATION_TAGS.WA_OLD_REGISTRATION)
+            const oldReg = findNodeChild(
+                node,
+                WA_REGISTRATION_NOTIFICATION_TAGS.WA_OLD_REGISTRATION
+            )
             if (oldReg !== undefined && oldReg.attrs.device_id !== undefined) {
                 this.coordinator.commit('WaOldCode', { deviceId: oldReg.attrs.device_id })
             }
@@ -430,7 +438,10 @@ export class WaWamAutoEmitter {
             }
             return
         }
-        if (node.tag === WA_MESSAGE_TAGS.RECEIPT && node.attrs.type === WA_MESSAGE_TYPES.RECEIPT_TYPE_RETRY) {
+        if (
+            node.tag === WA_MESSAGE_TAGS.RECEIPT &&
+            node.attrs.type === WA_MESSAGE_TYPES.RECEIPT_TYPE_RETRY
+        ) {
             const retry = findNodeChild(node, WA_MESSAGE_TYPES.RECEIPT_TYPE_RETRY)
             const count = retry?.attrs.count !== undefined ? Number(retry.attrs.count) : 0
             if (count >= HIGH_RETRY_THRESHOLD) {
@@ -442,7 +453,10 @@ export class WaWamAutoEmitter {
             }
             return
         }
-        if (node.tag === WA_MESSAGE_TAGS.ACK && node.attrs.class === WA_MESSAGE_TYPES.ACK_CLASS_MESSAGE) {
+        if (
+            node.tag === WA_MESSAGE_TAGS.ACK &&
+            node.attrs.class === WA_MESSAGE_TYPES.ACK_CLASS_MESSAGE
+        ) {
             const id = node.attrs.id
             if (id === undefined) return
             const info = this.sentMessages.get(id)

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -37,6 +37,7 @@ import {
     fileExtension,
     findFirstEncNode,
     mediaTypeKey,
+    pinInChatTypeKey,
     type WamCiphertextTypeKey,
     type WamE2eDestinationKey,
     type WamEditTypeKey,
@@ -245,6 +246,12 @@ export class WaWamAutoEmitter {
                         : 'CLEAR_CHAT_KEEP_STARRED_MUTATION'
             })
         }
+        if (event.schema === 'UserStatusMute') {
+            this.coordinator.commit('StatusMute', {
+                muteAction: event.operation === 'set' && event.muted === true ? 'MUTE' : 'UNMUTE',
+                statusCategory: 'REGULAR_STATUS'
+            })
+        }
     }
 
     private commitChatAction(
@@ -317,6 +324,37 @@ export class WaWamAutoEmitter {
                 ...(ext !== undefined ? { documentExt: ext } : {}),
                 ...(typeof doc.pageCount === 'number' ? { documentPageSize: doc.pageCount } : {}),
                 ...(typeof doc.fileLength === 'number' ? { documentSize: doc.fileLength } : {})
+            })
+            return
+        }
+
+        const sticker = msg.stickerMessage
+        if (sticker) {
+            this.coordinator.commit('StickerSend', {
+                stickerSendMessageType: 'REGULAR',
+                ...(typeof sticker.isAnimated === 'boolean'
+                    ? { stickerIsAnimated: sticker.isAnimated }
+                    : {}),
+                ...(typeof sticker.isAvatar === 'boolean'
+                    ? { stickerIsAvatar: sticker.isAvatar }
+                    : {}),
+                ...(typeof sticker.isAiSticker === 'boolean'
+                    ? { stickerIsAi: sticker.isAiSticker }
+                    : {})
+            })
+            return
+        }
+
+        const pin = msg.pinInChatMessage
+        if (pin) {
+            const pinType = pinInChatTypeKey(pin.type)
+            this.coordinator.commit('PinInChatMessageSend', {
+                ...(pinType !== null ? { pinInChatType: pinType } : {}),
+                isAGroup: isGroup,
+                isSelfPin: true,
+                ...(typeof pin.key?.fromMe === 'boolean'
+                    ? { isSelfParentMessage: pin.key.fromMe }
+                    : {})
             })
             return
         }
@@ -487,6 +525,11 @@ export class WaWamAutoEmitter {
                     revokeType: info.editType === 'ADMIN_REVOKE' ? 'ADMIN' : 'SENDER',
                     messageType: info.destination,
                     messageSendResultIsTerminal: true
+                })
+                this.coordinator.commit('MessageDeleteActions', {
+                    deleteActionType: 'DELETE_FOR_EVERYONE',
+                    isAGroup: info.isGroup,
+                    messagesDeleted: 1
                 })
             }
         }

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -262,6 +262,19 @@ export class WaWamAutoEmitter {
         const destination = e2eDestinationKey(event.to)
         const isGroup = isGroupJid(event.to)
 
+        const ctx = getContextInfo(msg)
+        if (ctx?.isForwarded) {
+            const media = mediaTypeKey(resolveEncMediaType(msg) ?? undefined)
+            const score = ctx.forwardingScore ?? 0
+            this.coordinator.commit('ForwardSend', {
+                messageType: destination,
+                isFrequentlyForwarded: score >= 4,
+                isForwardedForward: score > 1,
+                ...(media !== null ? { messageMediaType: media } : {}),
+                ...(isGroup ? { typeOfGroup: 'GROUP' as const } : {})
+            })
+        }
+
         const reaction = msg.reactionMessage
         if (reaction) {
             this.coordinator.commit('ReactionActions', {
@@ -304,19 +317,6 @@ export class WaWamAutoEmitter {
                     : {})
             })
             return
-        }
-
-        const ctx = getContextInfo(msg)
-        if (ctx?.isForwarded) {
-            const media = mediaTypeKey(resolveEncMediaType(msg) ?? undefined)
-            const score = ctx.forwardingScore ?? 0
-            this.coordinator.commit('ForwardSend', {
-                messageType: destination,
-                isFrequentlyForwarded: score >= 4,
-                isForwardedForward: score > 1,
-                ...(media !== null ? { messageMediaType: media } : {}),
-                ...(isGroup ? { typeOfGroup: 'GROUP' as const } : {})
-            })
         }
     }
 

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -57,17 +57,25 @@ interface SentMessageInfo {
 
 type WamGroupJoinRequestAction = 'MEMBERSHIP_REQUEST_APPROVE' | 'MEMBERSHIP_REQUEST_REJECT'
 
-interface PendingIq {
-    readonly startMs: number
-    readonly groupJid: string
-    readonly joinRequestAction: WamGroupJoinRequestAction
-}
+type PendingIq =
+    | {
+          readonly kind: 'joinRequest'
+          readonly startMs: number
+          readonly groupJid: string
+          readonly joinRequestAction: WamGroupJoinRequestAction
+      }
+    | { readonly kind: 'groupCreate'; readonly hasGroupName: boolean }
+    | { readonly kind: 'ephemeral'; readonly duration: number }
+    | { readonly kind: 'disappearingMode'; readonly duration: number }
 
 const MAX_TRACKED_SENDS = 256
 const MAX_TRACKED_IQS = 64
 
 /** A retry receipt at or above this count fires MessageHighRetryCount (WA's threshold). */
 const HIGH_RETRY_THRESHOLD = 5
+
+/** A message whose offline-queue position reaches this fires OfflineCountTooHigh (WA's `s=11`). */
+const OFFLINE_COUNT_TOO_HIGH_THRESHOLD = 11
 
 const SECONDS_PER_HOUR = 3600
 
@@ -372,9 +380,9 @@ export class WaWamAutoEmitter {
         const isLid = isLidJid(key.participant ?? key.remoteJid ?? '')
 
         const enc = findFirstEncNode(event.rawNode)
+        const media = enc !== null ? mediaTypeKey(enc.attrs.mediatype) : null
         if (enc !== null) {
             const ciphertextType = ciphertextTypeKey(enc.attrs.type)
-            const media = mediaTypeKey(enc.attrs.mediatype)
             this.coordinator.commit('E2eMessageRecv', {
                 e2eSuccessful: true,
                 e2eDestination: e2eDestinationKey(key.remoteJid ?? ''),
@@ -394,6 +402,16 @@ export class WaWamAutoEmitter {
             messageIsOffline: event.offline ?? false,
             ...(key.isGroup ? { typeOfGroup: 'GROUP' as const } : {})
         })
+
+        const offlineCount = Number(event.rawNode.attrs.offline)
+        if (Number.isFinite(offlineCount) && offlineCount >= OFFLINE_COUNT_TOO_HIGH_THRESHOLD) {
+            this.coordinator.commit('OfflineCountTooHigh', {
+                offlineCount,
+                stanzaType: 'MESSAGE',
+                messageType: messageTypeKey(key),
+                mediaType: media ?? 'NONE'
+            })
+        }
     }
 
     private onReceipt(event: WaIncomingReceiptEvent): void {
@@ -531,6 +549,7 @@ export class WaWamAutoEmitter {
                     isAGroup: info.isGroup,
                     messagesDeleted: 1
                 })
+                this.coordinator.commit('SendRevokeMessage', { messageType: info.destination })
             }
         }
     }
@@ -546,19 +565,51 @@ export class WaWamAutoEmitter {
     /** Tracks a membership-request approve/reject IQ so its response can emit round-trip time + result. */
     private trackOutgoingIq(node: BinaryNode): void {
         const id = node.attrs.id
-        const groupJid = node.attrs.to
-        if (id === undefined || groupJid === undefined) return
-        if (node.attrs.type !== WA_IQ_TYPES.SET || node.attrs.xmlns !== WA_XMLNS.GROUPS) return
-        const membership = findNodeChild(node, WA_GROUP_MEMBERSHIP_ACTION_TAGS.REQUESTS_ACTION)
-        if (membership === undefined) return
-        const joinRequestAction: WamGroupJoinRequestAction | null =
-            findNodeChild(membership, WA_GROUP_MEMBERSHIP_ACTION_TAGS.APPROVE) !== undefined
-                ? 'MEMBERSHIP_REQUEST_APPROVE'
-                : findNodeChild(membership, WA_GROUP_MEMBERSHIP_ACTION_TAGS.REJECT) !== undefined
-                  ? 'MEMBERSHIP_REQUEST_REJECT'
-                  : null
-        if (joinRequestAction === null) return
-        this.trackIq(id, { startMs: Date.now(), groupJid, joinRequestAction })
+        if (id === undefined || node.attrs.type !== WA_IQ_TYPES.SET) return
+        if (node.attrs.xmlns === WA_XMLNS.GROUPS) {
+            const membership = findNodeChild(node, WA_GROUP_MEMBERSHIP_ACTION_TAGS.REQUESTS_ACTION)
+            if (membership !== undefined) {
+                const groupJid = node.attrs.to
+                const joinRequestAction: WamGroupJoinRequestAction | null =
+                    findNodeChild(membership, WA_GROUP_MEMBERSHIP_ACTION_TAGS.APPROVE) !== undefined
+                        ? 'MEMBERSHIP_REQUEST_APPROVE'
+                        : findNodeChild(membership, WA_GROUP_MEMBERSHIP_ACTION_TAGS.REJECT) !==
+                            undefined
+                          ? 'MEMBERSHIP_REQUEST_REJECT'
+                          : null
+                if (groupJid !== undefined && joinRequestAction !== null) {
+                    this.trackIq(id, {
+                        kind: 'joinRequest',
+                        startMs: Date.now(),
+                        groupJid,
+                        joinRequestAction
+                    })
+                }
+                return
+            }
+            const create = findNodeChild(node, 'create')
+            if (create !== undefined) {
+                this.trackIq(id, {
+                    kind: 'groupCreate',
+                    hasGroupName: create.attrs.subject !== undefined
+                })
+                return
+            }
+            const ephemeral = findNodeChild(node, WA_NODE_TAGS.EPHEMERAL)
+            if (ephemeral?.attrs.expiration !== undefined) {
+                this.trackIq(id, {
+                    kind: 'ephemeral',
+                    duration: Number(ephemeral.attrs.expiration)
+                })
+            }
+            return
+        }
+        if (node.attrs.xmlns === WA_XMLNS.DISAPPEARING_MODE) {
+            const dm = findNodeChild(node, WA_NODE_TAGS.DISAPPEARING_MODE)
+            if (dm?.attrs.duration !== undefined) {
+                this.trackIq(id, { kind: 'disappearingMode', duration: Number(dm.attrs.duration) })
+            }
+        }
     }
 
     private resolveOutgoingIq(node: BinaryNode, isSuccessful: boolean): void {
@@ -567,12 +618,32 @@ export class WaWamAutoEmitter {
         const pending = this.pendingIqs.get(id)
         if (pending === undefined) return
         this.pendingIqs.delete(id)
-        this.coordinator.commit('WaFsGroupJoinRequestAction', {
-            groupJid: pending.groupJid,
-            groupJoinRequestAction: pending.joinRequestAction,
-            isSuccessful,
-            serverResponseTime: Math.max(0, Date.now() - pending.startMs)
-        })
+        switch (pending.kind) {
+            case 'joinRequest':
+                this.coordinator.commit('WaFsGroupJoinRequestAction', {
+                    groupJid: pending.groupJid,
+                    groupJoinRequestAction: pending.joinRequestAction,
+                    isSuccessful,
+                    serverResponseTime: Math.max(0, Date.now() - pending.startMs)
+                })
+                return
+            case 'groupCreate':
+                if (!isSuccessful) return
+                this.coordinator.commit('GroupCreate', { hasGroupName: pending.hasGroupName })
+                this.coordinator.commit('GroupCreateC', {})
+                return
+            case 'ephemeral':
+                this.coordinator.commit('EphemeralSettingChange', {
+                    chatEphemeralityDuration: pending.duration,
+                    isSuccess: isSuccessful
+                })
+                return
+            case 'disappearingMode':
+                this.coordinator.commit('DisappearingModeSettingChange', {
+                    newEphemeralityDuration: pending.duration,
+                    isSuccess: isSuccessful
+                })
+        }
     }
 
     private trackIq(id: string, pending: PendingIq): void {

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -2,6 +2,7 @@ import type {
     BinaryNode,
     WaClientPluginContext,
     WaConnectionEvent,
+    WaGroupEvent,
     WaHistorySyncChunkEvent,
     WaIncomingMessageEvent,
     WaIncomingReceiptEvent,
@@ -42,7 +43,12 @@ const HIGH_RETRY_THRESHOLD = 5
 const SECONDS_PER_HOUR = 3600
 
 /** Subset of the plugin context the auto-emitter subscribes through. */
-export type WaWamAutoEmitterContext = Pick<WaClientPluginContext, 'on' | 'off'>
+export type WaWamAutoEmitterContext = Pick<WaClientPluginContext, 'on' | 'off' | 'client'>
+
+/** True when `candidate` addresses this account (either its PN or LID jid). */
+function isSelfJid(candidate: string | undefined, meJid?: string, meLid?: string): boolean {
+    return candidate !== undefined && (candidate === meJid || candidate === meLid)
+}
 
 /** MESSAGE_TYPE enum key for the chat a received message belongs to. */
 function messageTypeKey(
@@ -66,12 +72,16 @@ export class WaWamAutoEmitter {
     private streamMode: 'MAIN' | 'SYNCING' | 'OFFLINE' | null = null
     private connectedOnce = false
     private resumeCount = 0
+    private platformReported = false
+    private readonly client: WaWamAutoEmitterContext['client']
 
     constructor(
         private readonly coordinator: WaWamCoordinator,
         ctx: WaWamAutoEmitterContext
     ) {
+        this.client = ctx.client
         const onConnection = (event: WaConnectionEvent): void => this.onConnection(event)
+        const onGroup = (event: WaGroupEvent): void => this.onGroup(event)
         const onMessage = (event: WaIncomingMessageEvent): void => this.onMessage(event)
         const onReceipt = (event: WaIncomingReceiptEvent): void => this.onReceipt(event)
         const onNodeOut = (event: { readonly node: BinaryNode }): void => this.onNodeOut(event.node)
@@ -80,6 +90,7 @@ export class WaWamAutoEmitter {
             this.onUnhandledStanza(event)
         const onHistory = (event: WaHistorySyncChunkEvent): void => this.onHistorySyncChunk(event)
         ctx.on('connection', onConnection)
+        ctx.on('group', onGroup)
         ctx.on('message', onMessage)
         ctx.on('receipt', onReceipt)
         ctx.on('debug_transport_node_out', onNodeOut)
@@ -88,6 +99,7 @@ export class WaWamAutoEmitter {
         ctx.on('history_sync_chunk', onHistory)
         this.unsubscribes.push(
             () => ctx.off('connection', onConnection),
+            () => ctx.off('group', onGroup),
             () => ctx.off('message', onMessage),
             () => ctx.off('receipt', onReceipt),
             () => ctx.off('debug_transport_node_out', onNodeOut),
@@ -111,6 +123,32 @@ export class WaWamAutoEmitter {
             this.coordinator.commit('WebcPageResume', { webcResumeCount: this.resumeCount })
         }
         this.connectedOnce = true
+        if (!this.platformReported) {
+            const platform = this.client.getCredentials()?.platform
+            if (platform !== undefined) {
+                this.platformReported = true
+                this.coordinator.commit('WebcRawPlatforms', { webcRawPlatform: platform })
+            }
+        }
+    }
+
+    private onGroup(event: WaGroupEvent): void {
+        if (event.action !== 'create' && event.action !== 'add') return
+        const creds = this.client.getCredentials()
+        const meJid = creds?.meJid
+        const meLid = creds?.meLid
+        if (isSelfJid(event.authorJid, meJid, meLid)) return
+        if (event.action === 'add') {
+            const added = event.participants ?? []
+            const meAdded = added.some(
+                (p) =>
+                    isSelfJid(p.jid, meJid, meLid) ||
+                    isSelfJid(p.lidJid, meJid, meLid) ||
+                    isSelfJid(p.phoneJid, meJid, meLid)
+            )
+            if (!meAdded) return
+        }
+        this.coordinator.commit('GroupJoinC', {})
     }
 
     /** Mirrors WA Web's stream model: emit on each real mode transition, deduped. */

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -1,21 +1,40 @@
-import type {
-    BinaryNode,
-    WaAppStateMutationEvent,
-    WaClientPluginContext,
-    WaConnectionEvent,
-    WaGroupEvent,
-    WaHistorySyncChunkEvent,
-    WaIncomingMessageEvent,
-    WaIncomingReceiptEvent,
-    WaIncomingUnhandledStanzaEvent
+import {
+    type BinaryNode,
+    getContextInfo,
+    resolveEncMediaType,
+    unwrapMessage,
+    type WaAppStateMutationEvent,
+    type WaClientPluginContext,
+    type WaConnectionEvent,
+    type WaGroupEvent,
+    type WaHistorySyncChunkEvent,
+    type WaIncomingMessageEvent,
+    type WaIncomingReceiptEvent,
+    type WaIncomingUnhandledStanzaEvent,
+    type WaOutgoingMessageEvent
 } from 'zapo-js'
-import { isGroupJid, isLidJid, isStatusBroadcastJid } from 'zapo-js/protocol'
+import {
+    isGroupJid,
+    isLidJid,
+    isNewsletterJid,
+    isStatusBroadcastJid,
+    WA_ADDRESSING_MODES,
+    WA_GROUP_MEMBERSHIP_ACTION_TAGS,
+    WA_IQ_TYPES,
+    WA_MESSAGE_TAGS,
+    WA_MESSAGE_TYPES,
+    WA_NODE_TAGS,
+    WA_REGISTRATION_NOTIFICATION_TAGS,
+    WA_XMLNS
+} from 'zapo-js/protocol'
 import { findNodeChild } from 'zapo-js/transport'
 
 import {
     ciphertextTypeKey,
+    documentTypeFor,
     e2eDestinationKey,
     editTypeKey,
+    fileExtension,
     findFirstEncNode,
     mediaTypeKey,
     type WamCiphertextTypeKey,
@@ -35,35 +54,46 @@ interface SentMessageInfo {
     readonly editType: WamEditTypeKey | null
 }
 
-/** Cap on tracked in-flight sends; oldest evict first when exceeded. */
+type WamGroupJoinRequestAction = 'MEMBERSHIP_REQUEST_APPROVE' | 'MEMBERSHIP_REQUEST_REJECT'
+
+interface PendingIq {
+    readonly startMs: number
+    readonly groupJid: string
+    readonly joinRequestAction: WamGroupJoinRequestAction
+}
+
 const MAX_TRACKED_SENDS = 256
+const MAX_TRACKED_IQS = 64
 
 /** A retry receipt at or above this count fires MessageHighRetryCount (WA's threshold). */
 const HIGH_RETRY_THRESHOLD = 5
 
 const SECONDS_PER_HOUR = 3600
 
-/** Subset of the plugin context the auto-emitter subscribes through. */
 export type WaWamAutoEmitterContext = Pick<WaClientPluginContext, 'on' | 'off' | 'client'>
 
-/** True when `candidate` addresses this account (either its PN or LID jid). */
 function isSelfJid(candidate: string | undefined, meJid?: string, meLid?: string): boolean {
     return candidate !== undefined && (candidate === meJid || candidate === meLid)
 }
 
-/** MUTE_CHAT_TYPE enum key for a chat jid. */
 function muteChatTypeKey(jid: string): 'ONE_ON_ONE' | 'GROUP' | 'CHANNEL' {
     if (isGroupJid(jid)) return 'GROUP'
-    if (jid.endsWith('@newsletter')) return 'CHANNEL'
+    if (isNewsletterJid(jid)) return 'CHANNEL'
     return 'ONE_ON_ONE'
 }
 
-/** CHAT_ACTION_CHAT_TYPE enum key for a chat jid (business is not derivable here). */
+/** Business chat type is not derivable here, so only GROUP/INDIVIDUAL. */
 function chatActionChatTypeKey(jid: string): 'GROUP' | 'INDIVIDUAL' {
     return isGroupJid(jid) ? 'GROUP' : 'INDIVIDUAL'
 }
 
-/** MESSAGE_TYPE enum key for the chat a received message belongs to. */
+function pollChatTypeKey(jid: string): 'INDIVIDUAL' | 'GROUP' | 'STATUS' | 'CHANNEL' {
+    if (isGroupJid(jid)) return 'GROUP'
+    if (isNewsletterJid(jid)) return 'CHANNEL'
+    if (isStatusBroadcastJid(jid)) return 'STATUS'
+    return 'INDIVIDUAL'
+}
+
 function messageTypeKey(
     key: WaIncomingMessageEvent['key']
 ): 'CHANNEL' | 'STATUS' | 'BROADCAST' | 'GROUP' | 'INDIVIDUAL' {
@@ -81,6 +111,7 @@ function messageTypeKey(
 export class WaWamAutoEmitter {
     private readonly unsubscribes: Array<() => void> = []
     private readonly sentMessages = new Map<string, SentMessageInfo>()
+    private readonly pendingIqs = new Map<string, PendingIq>()
     private clockSkewReported = false
     private streamMode: 'MAIN' | 'SYNCING' | 'OFFLINE' | null = null
     private connectedOnce = false
@@ -96,6 +127,7 @@ export class WaWamAutoEmitter {
         const onConnection = (event: WaConnectionEvent): void => this.onConnection(event)
         const onGroup = (event: WaGroupEvent): void => this.onGroup(event)
         const onMutation = (event: WaAppStateMutationEvent): void => this.onMutation(event)
+        const onMessageSend = (event: WaOutgoingMessageEvent): void => this.onMessageSend(event)
         const onMessage = (event: WaIncomingMessageEvent): void => this.onMessage(event)
         const onReceipt = (event: WaIncomingReceiptEvent): void => this.onReceipt(event)
         const onNodeOut = (event: { readonly node: BinaryNode }): void => this.onNodeOut(event.node)
@@ -106,6 +138,7 @@ export class WaWamAutoEmitter {
         ctx.on('connection', onConnection)
         ctx.on('group', onGroup)
         ctx.on('mutation', onMutation)
+        ctx.on('message_send', onMessageSend)
         ctx.on('message', onMessage)
         ctx.on('receipt', onReceipt)
         ctx.on('debug_transport_node_out', onNodeOut)
@@ -116,6 +149,7 @@ export class WaWamAutoEmitter {
             () => ctx.off('connection', onConnection),
             () => ctx.off('group', onGroup),
             () => ctx.off('mutation', onMutation),
+            () => ctx.off('message_send', onMessageSend),
             () => ctx.off('message', onMessage),
             () => ctx.off('receipt', onReceipt),
             () => ctx.off('debug_transport_node_out', onNodeOut),
@@ -223,6 +257,69 @@ export class WaWamAutoEmitter {
         })
     }
 
+    private onMessageSend(event: WaOutgoingMessageEvent): void {
+        const msg = unwrapMessage(event.message)
+        const destination = e2eDestinationKey(event.to)
+        const isGroup = isGroupJid(event.to)
+
+        const reaction = msg.reactionMessage
+        if (reaction) {
+            this.coordinator.commit('ReactionActions', {
+                reactionAction: (reaction.text ?? '').length > 0 ? 'UPDATE' : 'DELETE',
+                messageType: destination
+            })
+            return
+        }
+
+        const poll = msg.pollCreationMessage
+        if (poll) {
+            this.coordinator.commit('PollsActions', {
+                pollAction: 'CREATE_POLL',
+                chatType: pollChatTypeKey(event.to),
+                isAGroup: isGroup,
+                ...(poll.options ? { pollOptionsCount: poll.options.length } : {}),
+                ...(isGroup ? { typeOfGroup: 'GROUP' as const } : {})
+            })
+            return
+        }
+        if (msg.pollUpdateMessage) {
+            this.coordinator.commit('PollsActions', {
+                pollAction: 'VOTE',
+                chatType: pollChatTypeKey(event.to),
+                isAGroup: isGroup,
+                ...(isGroup ? { typeOfGroup: 'GROUP' as const } : {})
+            })
+            return
+        }
+
+        const doc = msg.documentMessage
+        if (doc) {
+            const ext = fileExtension(doc.fileName)
+            this.coordinator.commit('SendDocument', {
+                documentType: documentTypeFor(doc.mimetype),
+                ...(ext !== undefined ? { documentExt: ext } : {}),
+                ...(typeof doc.pageCount === 'number' ? { documentPageSize: doc.pageCount } : {}),
+                ...(typeof doc.fileLength === 'number'
+                    ? { documentSize: doc.fileLength }
+                    : {})
+            })
+            return
+        }
+
+        const ctx = getContextInfo(msg)
+        if (ctx?.isForwarded) {
+            const media = mediaTypeKey(resolveEncMediaType(msg) ?? undefined)
+            const score = ctx.forwardingScore ?? 0
+            this.coordinator.commit('ForwardSend', {
+                messageType: destination,
+                isFrequentlyForwarded: score >= 4,
+                isForwardedForward: score > 1,
+                ...(media !== null ? { messageMediaType: media } : {}),
+                ...(isGroup ? { typeOfGroup: 'GROUP' as const } : {})
+            })
+        }
+    }
+
     /** Mirrors WA Web's stream model: emit on each real mode transition, deduped. */
     private setStreamMode(mode: 'MAIN' | 'SYNCING' | 'OFFLINE'): void {
         if (this.streamMode === mode) return
@@ -267,12 +364,16 @@ export class WaWamAutoEmitter {
     }
 
     private onNodeOut(node: BinaryNode): void {
-        if (node.tag !== 'message') return
+        if (node.tag === WA_NODE_TAGS.IQ) {
+            this.trackOutgoingIq(node)
+            return
+        }
+        if (node.tag !== WA_MESSAGE_TAGS.MESSAGE) return
         const enc = findFirstEncNode(node)
         if (enc === null) return
         const to = node.attrs.to ?? ''
         const destination = e2eDestinationKey(to)
-        const isLid = isLidJid(to) || node.attrs.addressing_mode === 'lid'
+        const isLid = isLidJid(to) || node.attrs.addressing_mode === WA_ADDRESSING_MODES.LID
         const isGroup = isGroupJid(to)
         const ciphertextType = ciphertextTypeKey(enc.attrs.type)
         const media = mediaTypeKey(enc.attrs.mediatype)
@@ -303,12 +404,12 @@ export class WaWamAutoEmitter {
     }
 
     private onNodeIn(node: BinaryNode): void {
-        if (node.tag === 'ib') {
-            if (findNodeChild(node, 'offline') !== null) this.setStreamMode('MAIN')
+        if (node.tag === WA_NODE_TAGS.INFO_BULLETIN) {
+            if (findNodeChild(node, WA_NODE_TAGS.OFFLINE) !== undefined) this.setStreamMode('MAIN')
             return
         }
-        if (node.tag === 'notification') {
-            const oldReg = findNodeChild(node, 'wa_old_registration')
+        if (node.tag === WA_NODE_TAGS.NOTIFICATION) {
+            const oldReg = findNodeChild(node, WA_REGISTRATION_NOTIFICATION_TAGS.WA_OLD_REGISTRATION)
             if (oldReg !== undefined && oldReg.attrs.device_id !== undefined) {
                 this.coordinator.commit('WaOldCode', { deviceId: oldReg.attrs.device_id })
             }
@@ -323,8 +424,14 @@ export class WaWamAutoEmitter {
                 })
             }
         }
-        if (node.tag === 'receipt' && node.attrs.type === 'retry') {
-            const retry = findNodeChild(node, 'retry')
+        if (node.tag === WA_NODE_TAGS.IQ) {
+            if (node.attrs.type === WA_IQ_TYPES.RESULT || node.attrs.type === WA_IQ_TYPES.ERROR) {
+                this.resolveOutgoingIq(node, node.attrs.type === WA_IQ_TYPES.RESULT)
+            }
+            return
+        }
+        if (node.tag === WA_MESSAGE_TAGS.RECEIPT && node.attrs.type === WA_MESSAGE_TYPES.RECEIPT_TYPE_RETRY) {
+            const retry = findNodeChild(node, WA_MESSAGE_TYPES.RECEIPT_TYPE_RETRY)
             const count = retry?.attrs.count !== undefined ? Number(retry.attrs.count) : 0
             if (count >= HIGH_RETRY_THRESHOLD) {
                 this.coordinator.commit('MessageHighRetryCount', {
@@ -335,7 +442,7 @@ export class WaWamAutoEmitter {
             }
             return
         }
-        if (node.tag === 'ack' && node.attrs.class === 'message') {
+        if (node.tag === WA_MESSAGE_TAGS.ACK && node.attrs.class === WA_MESSAGE_TYPES.ACK_CLASS_MESSAGE) {
             const id = node.attrs.id
             if (id === undefined) return
             const info = this.sentMessages.get(id)
@@ -357,6 +464,13 @@ export class WaWamAutoEmitter {
                     ...(info.isGroup ? { typeOfGroup: 'GROUP' as const } : {})
                 })
             }
+            if (info.editType === 'SENDER_REVOKE' || info.editType === 'ADMIN_REVOKE') {
+                this.coordinator.commit('RevokeMessageSend', {
+                    revokeType: info.editType === 'ADMIN_REVOKE' ? 'ADMIN' : 'SENDER',
+                    messageType: info.destination,
+                    messageSendResultIsTerminal: true
+                })
+            }
         }
     }
 
@@ -366,6 +480,46 @@ export class WaWamAutoEmitter {
             if (oldest !== undefined) this.sentMessages.delete(oldest)
         }
         this.sentMessages.set(id, info)
+    }
+
+    /** Tracks a membership-request approve/reject IQ so its response can emit round-trip time + result. */
+    private trackOutgoingIq(node: BinaryNode): void {
+        const id = node.attrs.id
+        const groupJid = node.attrs.to
+        if (id === undefined || groupJid === undefined) return
+        if (node.attrs.type !== WA_IQ_TYPES.SET || node.attrs.xmlns !== WA_XMLNS.GROUPS) return
+        const membership = findNodeChild(node, WA_GROUP_MEMBERSHIP_ACTION_TAGS.REQUESTS_ACTION)
+        if (membership === undefined) return
+        const joinRequestAction: WamGroupJoinRequestAction | null =
+            findNodeChild(membership, WA_GROUP_MEMBERSHIP_ACTION_TAGS.APPROVE) !== undefined
+                ? 'MEMBERSHIP_REQUEST_APPROVE'
+                : findNodeChild(membership, WA_GROUP_MEMBERSHIP_ACTION_TAGS.REJECT) !== undefined
+                  ? 'MEMBERSHIP_REQUEST_REJECT'
+                  : null
+        if (joinRequestAction === null) return
+        this.trackIq(id, { startMs: Date.now(), groupJid, joinRequestAction })
+    }
+
+    private resolveOutgoingIq(node: BinaryNode, isSuccessful: boolean): void {
+        const id = node.attrs.id
+        if (id === undefined) return
+        const pending = this.pendingIqs.get(id)
+        if (pending === undefined) return
+        this.pendingIqs.delete(id)
+        this.coordinator.commit('WaFsGroupJoinRequestAction', {
+            groupJid: pending.groupJid,
+            groupJoinRequestAction: pending.joinRequestAction,
+            isSuccessful,
+            serverResponseTime: Math.max(0, Date.now() - pending.startMs)
+        })
+    }
+
+    private trackIq(id: string, pending: PendingIq): void {
+        if (this.pendingIqs.size >= MAX_TRACKED_IQS) {
+            const oldest = this.pendingIqs.keys().next().value
+            if (oldest !== undefined) this.pendingIqs.delete(oldest)
+        }
+        this.pendingIqs.set(id, pending)
     }
 
     private onUnhandledStanza(event: WaIncomingUnhandledStanzaEvent): void {
@@ -384,7 +538,6 @@ export class WaWamAutoEmitter {
         })
     }
 
-    /** Detaches every event subscription. */
     dispose(): void {
         for (let i = this.unsubscribes.length - 1; i >= 0; i -= 1) this.unsubscribes[i]()
         this.unsubscribes.length = 0

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -13,10 +13,12 @@ import { findNodeChild } from 'zapo-js/transport'
 import {
     ciphertextTypeKey,
     e2eDestinationKey,
+    editTypeKey,
     findFirstEncNode,
     mediaTypeKey,
     type WamCiphertextTypeKey,
     type WamE2eDestinationKey,
+    type WamEditTypeKey,
     type WamMediaTypeKey
 } from './send-parse.js'
 import type { WaWamCoordinator } from './WaWamCoordinator.js'
@@ -28,6 +30,7 @@ interface SentMessageInfo {
     readonly isGroup: boolean
     readonly ciphertextType: WamCiphertextTypeKey | null
     readonly mediaType: WamMediaTypeKey | null
+    readonly editType: WamEditTypeKey | null
 }
 
 /** Cap on tracked in-flight sends; oldest evict first when exceeded. */
@@ -61,6 +64,8 @@ export class WaWamAutoEmitter {
     private readonly sentMessages = new Map<string, SentMessageInfo>()
     private clockSkewReported = false
     private streamMode: 'MAIN' | 'SYNCING' | 'OFFLINE' | null = null
+    private connectedOnce = false
+    private resumeCount = 0
 
     constructor(
         private readonly coordinator: WaWamCoordinator,
@@ -101,6 +106,11 @@ export class WaWamAutoEmitter {
             webcSocketConnectReason: event.isNewLogin ? 'PAGE_LOAD' : 'RECONNECT'
         })
         this.setStreamMode('SYNCING')
+        if (this.connectedOnce) {
+            this.resumeCount += 1
+            this.coordinator.commit('WebcPageResume', { webcResumeCount: this.resumeCount })
+        }
+        this.connectedOnce = true
     }
 
     /** Mirrors WA Web's stream model: emit on each real mode transition, deduped. */
@@ -177,7 +187,8 @@ export class WaWamAutoEmitter {
 
         const id = node.attrs.id
         if (id !== undefined) {
-            this.trackSend(id, { destination, isLid, isGroup, ciphertextType, mediaType: media })
+            const editType = editTypeKey(node.attrs.edit)
+            this.trackSend(id, { destination, isLid, isGroup, ciphertextType, mediaType: media, editType })
         }
     }
 
@@ -185,6 +196,12 @@ export class WaWamAutoEmitter {
         if (node.tag === 'ib') {
             if (findNodeChild(node, 'offline') !== null) this.setStreamMode('MAIN')
             return
+        }
+        if (node.tag === 'notification') {
+            const oldReg = findNodeChild(node, 'wa_old_registration')
+            if (oldReg !== undefined && oldReg.attrs.device_id !== undefined) {
+                this.coordinator.commit('WaOldCode', { deviceId: oldReg.attrs.device_id })
+            }
         }
         if (!this.clockSkewReported && node.attrs.t !== undefined) {
             this.clockSkewReported = true
@@ -222,6 +239,14 @@ export class WaWamAutoEmitter {
                 ...(info.mediaType !== null ? { messageMediaType: info.mediaType } : {}),
                 ...(info.isGroup ? { typeOfGroup: 'GROUP' as const } : {})
             })
+            if (info.editType !== null) {
+                this.coordinator.commit('EditMessageSend', {
+                    editType: info.editType,
+                    messageType: info.destination,
+                    ...(info.mediaType !== null ? { mediaType: info.mediaType } : {}),
+                    ...(info.isGroup ? { typeOfGroup: 'GROUP' as const } : {})
+                })
+            }
         }
     }
 

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -1,5 +1,6 @@
 import type {
     BinaryNode,
+    WaAppStateMutationEvent,
     WaClientPluginContext,
     WaConnectionEvent,
     WaGroupEvent,
@@ -50,6 +51,18 @@ function isSelfJid(candidate: string | undefined, meJid?: string, meLid?: string
     return candidate !== undefined && (candidate === meJid || candidate === meLid)
 }
 
+/** MUTE_CHAT_TYPE enum key for a chat jid. */
+function muteChatTypeKey(jid: string): 'ONE_ON_ONE' | 'GROUP' | 'CHANNEL' {
+    if (isGroupJid(jid)) return 'GROUP'
+    if (jid.endsWith('@newsletter')) return 'CHANNEL'
+    return 'ONE_ON_ONE'
+}
+
+/** CHAT_ACTION_CHAT_TYPE enum key for a chat jid (business is not derivable here). */
+function chatActionChatTypeKey(jid: string): 'GROUP' | 'INDIVIDUAL' {
+    return isGroupJid(jid) ? 'GROUP' : 'INDIVIDUAL'
+}
+
 /** MESSAGE_TYPE enum key for the chat a received message belongs to. */
 function messageTypeKey(
     key: WaIncomingMessageEvent['key']
@@ -82,6 +95,7 @@ export class WaWamAutoEmitter {
         this.client = ctx.client
         const onConnection = (event: WaConnectionEvent): void => this.onConnection(event)
         const onGroup = (event: WaGroupEvent): void => this.onGroup(event)
+        const onMutation = (event: WaAppStateMutationEvent): void => this.onMutation(event)
         const onMessage = (event: WaIncomingMessageEvent): void => this.onMessage(event)
         const onReceipt = (event: WaIncomingReceiptEvent): void => this.onReceipt(event)
         const onNodeOut = (event: { readonly node: BinaryNode }): void => this.onNodeOut(event.node)
@@ -91,6 +105,7 @@ export class WaWamAutoEmitter {
         const onHistory = (event: WaHistorySyncChunkEvent): void => this.onHistorySyncChunk(event)
         ctx.on('connection', onConnection)
         ctx.on('group', onGroup)
+        ctx.on('mutation', onMutation)
         ctx.on('message', onMessage)
         ctx.on('receipt', onReceipt)
         ctx.on('debug_transport_node_out', onNodeOut)
@@ -100,6 +115,7 @@ export class WaWamAutoEmitter {
         this.unsubscribes.push(
             () => ctx.off('connection', onConnection),
             () => ctx.off('group', onGroup),
+            () => ctx.off('mutation', onMutation),
             () => ctx.off('message', onMessage),
             () => ctx.off('receipt', onReceipt),
             () => ctx.off('debug_transport_node_out', onNodeOut),
@@ -149,6 +165,44 @@ export class WaWamAutoEmitter {
             if (!meAdded) return
         }
         this.coordinator.commit('GroupJoinC', {})
+    }
+
+    private onMutation(event: WaAppStateMutationEvent): void {
+        if (event.source !== 'local') return
+        if (event.schema === 'Mute') {
+            const muted = event.operation === 'set' && event.muted === true
+            const actionConducted = muted ? 'MUTE' : 'UNMUTE'
+            this.coordinator.commit('ChatMute', {
+                actionConducted,
+                muteChatType: muteChatTypeKey(event.chatJid),
+                ...(event.operation === 'set' && typeof event.muteEndTimestamp === 'number'
+                    ? { muteDuration: Math.max(0, event.muteEndTimestamp - Date.now()) }
+                    : {})
+            })
+            this.commitChatAction(actionConducted, event.chatJid)
+            return
+        }
+        if (event.schema === 'Pin' && event.operation === 'set' && event.pinned === true) {
+            this.commitChatAction('PIN', event.chatJid)
+            return
+        }
+        if (event.schema === 'Archive' && event.operation === 'set' && event.archived === true) {
+            this.commitChatAction('ARCHIVE', event.chatJid)
+            return
+        }
+        if (event.schema === 'MarkChatAsRead' && event.operation === 'set') {
+            this.commitChatAction(event.read === true ? 'READ' : 'UNREAD', event.chatJid)
+        }
+    }
+
+    private commitChatAction(
+        chatActionType: 'MUTE' | 'UNMUTE' | 'PIN' | 'ARCHIVE' | 'READ' | 'UNREAD',
+        chatJid: string
+    ): void {
+        this.coordinator.commit('ChatAction', {
+            chatActionType,
+            chatActionChatType: chatActionChatTypeKey(chatJid)
+        })
     }
 
     /** Mirrors WA Web's stream model: emit on each real mode transition, deduped. */

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -1,0 +1,241 @@
+import type {
+    BinaryNode,
+    WaClientPluginContext,
+    WaConnectionEvent,
+    WaHistorySyncChunkEvent,
+    WaIncomingMessageEvent,
+    WaIncomingReceiptEvent,
+    WaIncomingUnhandledStanzaEvent
+} from 'zapo-js'
+import { isGroupJid, isLidJid, isStatusBroadcastJid } from 'zapo-js/protocol'
+import { findNodeChild } from 'zapo-js/transport'
+
+import {
+    ciphertextTypeKey,
+    e2eDestinationKey,
+    findFirstEncNode,
+    mediaTypeKey,
+    type WamCiphertextTypeKey,
+    type WamE2eDestinationKey,
+    type WamMediaTypeKey
+} from './send-parse.js'
+import type { WaWamCoordinator } from './WaWamCoordinator.js'
+
+/** Outbound send context retained (bounded) so a later `<ack>` can enrich MessageSend. */
+interface SentMessageInfo {
+    readonly destination: WamE2eDestinationKey
+    readonly isLid: boolean
+    readonly isGroup: boolean
+    readonly ciphertextType: WamCiphertextTypeKey | null
+    readonly mediaType: WamMediaTypeKey | null
+}
+
+/** Cap on tracked in-flight sends; oldest evict first when exceeded. */
+const MAX_TRACKED_SENDS = 256
+
+/** A retry receipt at or above this count fires MessageHighRetryCount (WA's threshold). */
+const HIGH_RETRY_THRESHOLD = 5
+
+const SECONDS_PER_HOUR = 3600
+
+/** Subset of the plugin context the auto-emitter subscribes through. */
+export type WaWamAutoEmitterContext = Pick<WaClientPluginContext, 'on' | 'off'>
+
+/** MESSAGE_TYPE enum key for the chat a received message belongs to. */
+function messageTypeKey(
+    key: WaIncomingMessageEvent['key']
+): 'CHANNEL' | 'STATUS' | 'BROADCAST' | 'GROUP' | 'INDIVIDUAL' {
+    if (key.isNewsletter) return 'CHANNEL'
+    if (key.isBroadcast) return isStatusBroadcastJid(key.remoteJid ?? '') ? 'STATUS' : 'BROADCAST'
+    if (key.isGroup) return 'GROUP'
+    return 'INDIVIDUAL'
+}
+
+/**
+ * Bridges the host client's typed events and raw stanzas to WAM commits,
+ * mirroring where WA Web fires each analytics event. Only sets fields a headless
+ * client can truthfully derive; {@link dispose} detaches all subscriptions.
+ */
+export class WaWamAutoEmitter {
+    private readonly unsubscribes: Array<() => void> = []
+    private readonly sentMessages = new Map<string, SentMessageInfo>()
+    private clockSkewReported = false
+
+    constructor(
+        private readonly coordinator: WaWamCoordinator,
+        ctx: WaWamAutoEmitterContext
+    ) {
+        const onConnection = (event: WaConnectionEvent): void => this.onConnection(event)
+        const onMessage = (event: WaIncomingMessageEvent): void => this.onMessage(event)
+        const onReceipt = (event: WaIncomingReceiptEvent): void => this.onReceipt(event)
+        const onNodeOut = (event: { readonly node: BinaryNode }): void => this.onNodeOut(event.node)
+        const onNodeIn = (event: { readonly node: BinaryNode }): void => this.onNodeIn(event.node)
+        const onUnhandled = (event: WaIncomingUnhandledStanzaEvent): void =>
+            this.onUnhandledStanza(event)
+        const onHistory = (event: WaHistorySyncChunkEvent): void => this.onHistorySyncChunk(event)
+        ctx.on('connection', onConnection)
+        ctx.on('message', onMessage)
+        ctx.on('receipt', onReceipt)
+        ctx.on('debug_transport_node_out', onNodeOut)
+        ctx.on('debug_transport_node_in', onNodeIn)
+        ctx.on('debug_unhandled_stanza', onUnhandled)
+        ctx.on('history_sync_chunk', onHistory)
+        this.unsubscribes.push(
+            () => ctx.off('connection', onConnection),
+            () => ctx.off('message', onMessage),
+            () => ctx.off('receipt', onReceipt),
+            () => ctx.off('debug_transport_node_out', onNodeOut),
+            () => ctx.off('debug_transport_node_in', onNodeIn),
+            () => ctx.off('debug_unhandled_stanza', onUnhandled),
+            () => ctx.off('history_sync_chunk', onHistory)
+        )
+    }
+
+    private onConnection(event: WaConnectionEvent): void {
+        if (event.status !== 'open') return
+        this.coordinator.commit('WebcSocketConnect', {
+            webcSocketConnectReason: event.isNewLogin ? 'PAGE_LOAD' : 'RECONNECT'
+        })
+    }
+
+    private onMessage(event: WaIncomingMessageEvent): void {
+        const key = event.key
+        const isLid = isLidJid(key.participant ?? key.remoteJid ?? '')
+
+        const enc = findFirstEncNode(event.rawNode)
+        if (enc !== null) {
+            const ciphertextType = ciphertextTypeKey(enc.attrs.type)
+            const media = mediaTypeKey(enc.attrs.mediatype)
+            this.coordinator.commit('E2eMessageRecv', {
+                e2eSuccessful: true,
+                e2eDestination: e2eDestinationKey(key.remoteJid ?? ''),
+                isLid,
+                offline: event.offline ?? false,
+                ...(ciphertextType !== null ? { e2eCiphertextType: ciphertextType } : {}),
+                ...(enc.attrs.v !== undefined ? { e2eCiphertextVersion: Number(enc.attrs.v) } : {}),
+                ...(media !== null ? { messageMediaType: media } : {}),
+                ...(enc.attrs.count !== undefined ? { retryCount: Number(enc.attrs.count) } : {}),
+                ...(key.isGroup ? { typeOfGroup: 'GROUP' as const } : {})
+            })
+        }
+
+        this.coordinator.commit('MessageReceive', {
+            messageType: messageTypeKey(key),
+            isLid,
+            messageIsOffline: event.offline ?? false,
+            ...(key.isGroup ? { typeOfGroup: 'GROUP' as const } : {})
+        })
+    }
+
+    private onReceipt(event: WaIncomingReceiptEvent): void {
+        this.coordinator.commit('ReceiptStanzaReceive', {
+            receiptStanzaType: event.status,
+            receiptStanzaTotalCount: event.messageIds.length
+        })
+    }
+
+    private onNodeOut(node: BinaryNode): void {
+        if (node.tag !== 'message') return
+        const enc = findFirstEncNode(node)
+        if (enc === null) return
+        const to = node.attrs.to ?? ''
+        const destination = e2eDestinationKey(to)
+        const isLid = isLidJid(to) || node.attrs.addressing_mode === 'lid'
+        const isGroup = isGroupJid(to)
+        const ciphertextType = ciphertextTypeKey(enc.attrs.type)
+        const media = mediaTypeKey(enc.attrs.mediatype)
+        const version = enc.attrs.v
+        const count = enc.attrs.count
+
+        this.coordinator.commit('E2eMessageSend', {
+            e2eSuccessful: true,
+            e2eDestination: destination,
+            isLid,
+            ...(ciphertextType !== null ? { e2eCiphertextType: ciphertextType } : {}),
+            ...(version !== undefined ? { e2eCiphertextVersion: Number(version) } : {}),
+            ...(media !== null ? { messageMediaType: media } : {}),
+            ...(count !== undefined ? { retryCount: Number(count) } : {}),
+            ...(isGroup ? { typeOfGroup: 'GROUP' as const } : {})
+        })
+
+        this.coordinator.commit('WebcMessageSend', {
+            messageType: destination,
+            ...(media !== null ? { messageMediaType: media } : {})
+        })
+
+        const id = node.attrs.id
+        if (id !== undefined) {
+            this.trackSend(id, { destination, isLid, isGroup, ciphertextType, mediaType: media })
+        }
+    }
+
+    private onNodeIn(node: BinaryNode): void {
+        if (!this.clockSkewReported && node.attrs.t !== undefined) {
+            this.clockSkewReported = true
+            const serverSeconds = Number(node.attrs.t)
+            const skewSeconds = Date.now() / 1000 - serverSeconds
+            if (Number.isFinite(serverSeconds) && Math.abs(skewSeconds) >= SECONDS_PER_HOUR) {
+                this.coordinator.commit('ClockSkewDifferenceT', {
+                    clockSkewHourly: Math.round(skewSeconds / SECONDS_PER_HOUR)
+                })
+            }
+        }
+        if (node.tag === 'receipt' && node.attrs.type === 'retry') {
+            const retry = findNodeChild(node, 'retry')
+            const count = retry?.attrs.count !== undefined ? Number(retry.attrs.count) : 0
+            if (count >= HIGH_RETRY_THRESHOLD) {
+                this.coordinator.commit('MessageHighRetryCount', {
+                    retryCount: count,
+                    messageType: e2eDestinationKey(node.attrs.from ?? ''),
+                    isSenderLidBased: node.attrs.is_lid === 'true'
+                })
+            }
+            return
+        }
+        if (node.tag === 'ack' && node.attrs.class === 'message') {
+            const id = node.attrs.id
+            if (id === undefined) return
+            const info = this.sentMessages.get(id)
+            if (info === undefined) return
+            this.sentMessages.delete(id)
+            this.coordinator.commit('MessageSend', {
+                messageSendResult: 'OK',
+                messageType: info.destination,
+                isLid: info.isLid,
+                ...(info.ciphertextType !== null ? { e2eCiphertextType: info.ciphertextType } : {}),
+                ...(info.mediaType !== null ? { messageMediaType: info.mediaType } : {}),
+                ...(info.isGroup ? { typeOfGroup: 'GROUP' as const } : {})
+            })
+        }
+    }
+
+    private trackSend(id: string, info: SentMessageInfo): void {
+        if (this.sentMessages.size >= MAX_TRACKED_SENDS) {
+            const oldest = this.sentMessages.keys().next().value
+            if (oldest !== undefined) this.sentMessages.delete(oldest)
+        }
+        this.sentMessages.set(id, info)
+    }
+
+    private onUnhandledStanza(event: WaIncomingUnhandledStanzaEvent): void {
+        this.coordinator.commit('UnknownStanza', {
+            unknownStanzaTag: event.rawNode.tag,
+            ...(event.rawNode.attrs.type !== undefined
+                ? { unknownStanzaType: event.rawNode.attrs.type }
+                : {})
+        })
+    }
+
+    private onHistorySyncChunk(event: WaHistorySyncChunkEvent): void {
+        this.coordinator.commit('MdBootstrapHistoryDataReceived', {
+            ...(event.chunkOrder !== undefined ? { historySyncChunkOrder: event.chunkOrder } : {}),
+            ...(event.progress !== undefined ? { historySyncStageProgress: event.progress } : {})
+        })
+    }
+
+    /** Detaches every event subscription. */
+    dispose(): void {
+        for (let i = this.unsubscribes.length - 1; i >= 0; i -= 1) this.unsubscribes[i]()
+        this.unsubscribes.length = 0
+    }
+}

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -184,6 +184,9 @@ export class WaWamAutoEmitter {
         }
         if (event.schema === 'Pin' && event.operation === 'set' && event.pinned === true) {
             this.commitChatAction('PIN', event.chatJid)
+            this.coordinator.commit('MdSyncdDogfoodingFeatureUsage', {
+                mdSyncdDogfoodingFeature: 'PIN_MUTATION'
+            })
             return
         }
         if (event.schema === 'Archive' && event.operation === 'set' && event.archived === true) {
@@ -192,6 +195,21 @@ export class WaWamAutoEmitter {
         }
         if (event.schema === 'MarkChatAsRead' && event.operation === 'set') {
             this.commitChatAction(event.read === true ? 'READ' : 'UNREAD', event.chatJid)
+            return
+        }
+        if (event.schema === 'DeleteChat') {
+            this.coordinator.commit('MdSyncdDogfoodingFeatureUsage', {
+                mdSyncdDogfoodingFeature: 'DELETE_MUTATION'
+            })
+            return
+        }
+        if (event.schema === 'ClearChat') {
+            this.coordinator.commit('MdSyncdDogfoodingFeatureUsage', {
+                mdSyncdDogfoodingFeature:
+                    event.deleteStarred === '1'
+                        ? 'CLEAR_CHAT_REMOVE_STARRED_MUTATION'
+                        : 'CLEAR_CHAT_KEEP_STARRED_MUTATION'
+            })
         }
     }
 

--- a/packages/wam/src/WaWamAutoEmitter.ts
+++ b/packages/wam/src/WaWamAutoEmitter.ts
@@ -60,6 +60,7 @@ export class WaWamAutoEmitter {
     private readonly unsubscribes: Array<() => void> = []
     private readonly sentMessages = new Map<string, SentMessageInfo>()
     private clockSkewReported = false
+    private streamMode: 'MAIN' | 'SYNCING' | 'OFFLINE' | null = null
 
     constructor(
         private readonly coordinator: WaWamCoordinator,
@@ -92,10 +93,21 @@ export class WaWamAutoEmitter {
     }
 
     private onConnection(event: WaConnectionEvent): void {
-        if (event.status !== 'open') return
+        if (event.status === 'close') {
+            if (this.streamMode !== null) this.setStreamMode('OFFLINE')
+            return
+        }
         this.coordinator.commit('WebcSocketConnect', {
             webcSocketConnectReason: event.isNewLogin ? 'PAGE_LOAD' : 'RECONNECT'
         })
+        this.setStreamMode('SYNCING')
+    }
+
+    /** Mirrors WA Web's stream model: emit on each real mode transition, deduped. */
+    private setStreamMode(mode: 'MAIN' | 'SYNCING' | 'OFFLINE'): void {
+        if (this.streamMode === mode) return
+        this.streamMode = mode
+        this.coordinator.commit('WebcStreamModeChange', { webcStreamMode: mode })
     }
 
     private onMessage(event: WaIncomingMessageEvent): void {
@@ -170,6 +182,10 @@ export class WaWamAutoEmitter {
     }
 
     private onNodeIn(node: BinaryNode): void {
+        if (node.tag === 'ib') {
+            if (findNodeChild(node, 'offline') !== null) this.setStreamMode('MAIN')
+            return
+        }
         if (!this.clockSkewReported && node.attrs.t !== undefined) {
             this.clockSkewReported = true
             const serverSeconds = Number(node.attrs.t)

--- a/packages/wam/src/WaWamCoordinator.ts
+++ b/packages/wam/src/WaWamCoordinator.ts
@@ -10,8 +10,8 @@ import { toError } from 'zapo-js/util'
 
 import { resolveWamGlobals, type WamGlobalsInput } from './globals.js'
 import { resolveWamEventFields } from './registry.js'
+import { WaWamSyntheticUi, type WaWamSyntheticUiOptions } from './synthetic/index.js'
 import { WaWamAutoEmitter } from './WaWamAutoEmitter.js'
-import { WaWamSyntheticUi, type WaWamSyntheticUiOptions } from './WaWamSyntheticUi.js'
 import { WaWamUploader } from './WaWamUploader.js'
 import { WamBatch, type WamGlobalValue } from './wire/WamBatch.js'
 
@@ -122,6 +122,7 @@ export class WaWamCoordinator {
 
     /** Flushes remaining batches and stops accepting new events. */
     async dispose(): Promise<void> {
+        this.commit('WebWamForceFlush', {})
         this.disposed = true
         this.autoEmitter?.dispose()
         this.syntheticUi?.dispose()

--- a/packages/wam/src/WaWamCoordinator.ts
+++ b/packages/wam/src/WaWamCoordinator.ts
@@ -32,8 +32,9 @@ export interface WaWamCoordinatorOptions {
     readonly autoEmit?: boolean
     /**
      * Fabricate plausible UI (`UiAction`) telemetry so the event profile mimics a
-     * human WA Web session. Opt-in and off by default: it is best-effort
-     * anti-fingerprinting, and badly-timed fabrication is a worse tell than none.
+     * human WA Web session. On by default; pass `false` to disable, or an options
+     * object to tune it. Best-effort anti-fingerprinting: everything is jittered
+     * and rate-limited, since badly-timed fabrication is a worse tell than none.
      */
     readonly syntheticUi?: boolean | WaWamSyntheticUiOptions
 }
@@ -83,7 +84,7 @@ export class WaWamCoordinator {
         }
         this.autoEmitter = options.autoEmit === false ? null : new WaWamAutoEmitter(this, ctx)
         this.syntheticUi =
-            options.syntheticUi === undefined || options.syntheticUi === false
+            options.syntheticUi === false
                 ? null
                 : new WaWamSyntheticUi(
                       this,

--- a/packages/wam/src/WaWamCoordinator.ts
+++ b/packages/wam/src/WaWamCoordinator.ts
@@ -111,7 +111,6 @@ export class WaWamCoordinator {
         }
     }
 
-    /** Flushes every open channel batch immediately. */
     async flush(): Promise<void> {
         this.clearTimer()
         const channels = [...this.openBatches.keys()]

--- a/packages/wam/src/WaWamCoordinator.ts
+++ b/packages/wam/src/WaWamCoordinator.ts
@@ -1,0 +1,167 @@
+import {
+    WA_WAM_BUFFER_CONSTANTS,
+    WA_WAM_EVENTS,
+    type WaWamChannel,
+    type WaWamEventArgs,
+    type WaWamEventName
+} from '@vinikjkkj/wa-wam'
+import type { Logger, LogLevel, WaClientPluginContext } from 'zapo-js'
+import { toError } from 'zapo-js/util'
+
+import { resolveWamGlobals, type WamGlobalsInput } from './globals.js'
+import { resolveWamEventFields } from './registry.js'
+import { WaWamAutoEmitter } from './WaWamAutoEmitter.js'
+import { WaWamUploader } from './WaWamUploader.js'
+import { WamBatch, type WamGlobalValue } from './wire/WamBatch.js'
+
+const SEQUENCE_MAX = 65_535
+
+export interface WaWamCoordinatorOptions {
+    /** Minimum log level for the plugin (defaults to the host client's). */
+    readonly logLevel?: LogLevel
+    /** Coalesce window before a non-empty buffer flushes (default 5s). */
+    readonly flushIntervalMs?: number
+    /** Byte size that forces an immediate flush (default 50KB). */
+    readonly maxBufferSize?: number
+    /** Overrides the advertised app version (defaults to `WA_VERSION`). */
+    readonly appVersion?: string
+    /** `service_improvement_opt_out` consent bit (default `false`). */
+    readonly serviceImprovementOptOut?: boolean
+    /** Auto-emit protocol events by observing the client (default `true`). */
+    readonly autoEmit?: boolean
+}
+
+/**
+ * Owns the WAM telemetry pipeline for one client: accumulates committed events
+ * into a per-channel {@link WamBatch} and flushes on size/interval/dispose.
+ * Exposed as `client.wam`.
+ *
+ * @example
+ * ```ts
+ * client.wam.commit('UiAction', { uiActionType: 'CHAT_OPEN', uiActionT: 142 })
+ * ```
+ */
+export class WaWamCoordinator {
+    private readonly logger: Logger
+    private readonly uploader: WaWamUploader
+    private readonly globalsInput: WamGlobalsInput
+    private readonly globalsByChannel = new Map<WaWamChannel, ReadonlyMap<number, WamGlobalValue>>()
+    private readonly openBatches = new Map<WaWamChannel, WamBatch>()
+    private readonly sequenceByChannel = new Map<WaWamChannel, number>()
+    private readonly streamId: number
+    private readonly flushIntervalMs: number
+    private readonly maxBufferSize: number
+    private readonly autoEmitter: WaWamAutoEmitter | null
+    private flushTimer: ReturnType<typeof setTimeout> | null = null
+    private disposed = false
+
+    constructor(ctx: WaClientPluginContext, options: WaWamCoordinatorOptions = {}) {
+        this.logger = ctx.logger.child({ scope: '@zapo-js/wam' }, { level: options.logLevel })
+        this.uploader = new WaWamUploader({ query: ctx.queryWithContext, logger: this.logger })
+        this.streamId = 1 + Math.floor(Math.random() * 255)
+        this.flushIntervalMs =
+            options.flushIntervalMs ??
+            (WA_WAM_BUFFER_CONSTANTS.inMemoryBufferingDurationSecs ?? 5) * 1_000
+        this.maxBufferSize =
+            options.maxBufferSize ?? WA_WAM_BUFFER_CONSTANTS.maxBufferSize ?? 50_000
+        this.globalsInput = {
+            deviceBrowser: ctx.options.deviceBrowser,
+            deviceOsDisplayName: ctx.options.deviceOsDisplayName,
+            devicePlatform: ctx.options.devicePlatform,
+            streamId: this.streamId,
+            appVersion: options.appVersion,
+            serviceImprovementOptOut: options.serviceImprovementOptOut
+        }
+        this.autoEmitter = options.autoEmit === false ? null : new WaWamAutoEmitter(this, ctx)
+    }
+
+    /**
+     * Commits one WAM event, buffered until the next flush. Dropped by the same
+     * `Math.random() * weight > 1` sampling gate WA applies (and if unknown).
+     */
+    commit<K extends WaWamEventName>(name: K, payload: WaWamEventArgs<K> = {}): void {
+        if (this.disposed) return
+        const definition = WA_WAM_EVENTS[name]
+        if (definition === undefined) return
+        const weight = definition.weight.default ?? 1
+        if (Math.random() * weight > 1) return
+        const fields = resolveWamEventFields(name, payload)
+        const batch = this.openBatch(definition.channel)
+        batch.writeEvent(Date.now(), definition.id, weight, fields)
+        if (batch.size() >= this.maxBufferSize) {
+            void this.flushChannel(definition.channel)
+        } else {
+            this.scheduleFlush()
+        }
+    }
+
+    /** Flushes every open channel batch immediately. */
+    async flush(): Promise<void> {
+        this.clearTimer()
+        const channels = [...this.openBatches.keys()]
+        for (const channel of channels) await this.flushChannel(channel)
+    }
+
+    /** Flushes remaining batches and stops accepting new events. */
+    async dispose(): Promise<void> {
+        this.disposed = true
+        this.autoEmitter?.dispose()
+        await this.flush()
+    }
+
+    private openBatch(channel: WaWamChannel): WamBatch {
+        let batch = this.openBatches.get(channel)
+        if (batch === undefined) {
+            batch = new WamBatch(
+                channel,
+                this.streamId,
+                this.nextSequence(channel),
+                this.globalsFor(channel)
+            )
+            this.openBatches.set(channel, batch)
+        }
+        return batch
+    }
+
+    private async flushChannel(channel: WaWamChannel): Promise<void> {
+        const batch = this.openBatches.get(channel)
+        if (batch === undefined) return
+        this.openBatches.delete(channel)
+        if (!batch.hasEvents()) return
+        await this.uploader.upload(batch.toBytes())
+    }
+
+    private globalsFor(channel: WaWamChannel): ReadonlyMap<number, WamGlobalValue> {
+        let globals = this.globalsByChannel.get(channel)
+        if (globals === undefined) {
+            globals = resolveWamGlobals(this.globalsInput, channel)
+            this.globalsByChannel.set(channel, globals)
+        }
+        return globals
+    }
+
+    private nextSequence(channel: WaWamChannel): number {
+        const current = this.sequenceByChannel.get(channel)
+        const next = current === undefined || current >= SEQUENCE_MAX ? 1 : current + 1
+        this.sequenceByChannel.set(channel, next)
+        return next
+    }
+
+    private scheduleFlush(): void {
+        if (this.flushTimer !== null) return
+        this.flushTimer = setTimeout(() => {
+            this.flushTimer = null
+            void this.flush().catch((error) => {
+                this.logger.debug('wam flush failed', { message: toError(error).message })
+            })
+        }, this.flushIntervalMs)
+        this.flushTimer.unref?.()
+    }
+
+    private clearTimer(): void {
+        if (this.flushTimer !== null) {
+            clearTimeout(this.flushTimer)
+            this.flushTimer = null
+        }
+    }
+}

--- a/packages/wam/src/WaWamCoordinator.ts
+++ b/packages/wam/src/WaWamCoordinator.ts
@@ -11,6 +11,7 @@ import { toError } from 'zapo-js/util'
 import { resolveWamGlobals, type WamGlobalsInput } from './globals.js'
 import { resolveWamEventFields } from './registry.js'
 import { WaWamAutoEmitter } from './WaWamAutoEmitter.js'
+import { WaWamSyntheticUi, type WaWamSyntheticUiOptions } from './WaWamSyntheticUi.js'
 import { WaWamUploader } from './WaWamUploader.js'
 import { WamBatch, type WamGlobalValue } from './wire/WamBatch.js'
 
@@ -29,6 +30,12 @@ export interface WaWamCoordinatorOptions {
     readonly serviceImprovementOptOut?: boolean
     /** Auto-emit protocol events by observing the client (default `true`). */
     readonly autoEmit?: boolean
+    /**
+     * Fabricate plausible UI (`UiAction`) telemetry so the event profile mimics a
+     * human WA Web session. Opt-in and off by default: it is best-effort
+     * anti-fingerprinting, and badly-timed fabrication is a worse tell than none.
+     */
+    readonly syntheticUi?: boolean | WaWamSyntheticUiOptions
 }
 
 /**
@@ -52,6 +59,7 @@ export class WaWamCoordinator {
     private readonly flushIntervalMs: number
     private readonly maxBufferSize: number
     private readonly autoEmitter: WaWamAutoEmitter | null
+    private readonly syntheticUi: WaWamSyntheticUi | null
     private flushTimer: ReturnType<typeof setTimeout> | null = null
     private disposed = false
 
@@ -73,6 +81,14 @@ export class WaWamCoordinator {
             serviceImprovementOptOut: options.serviceImprovementOptOut
         }
         this.autoEmitter = options.autoEmit === false ? null : new WaWamAutoEmitter(this, ctx)
+        this.syntheticUi =
+            options.syntheticUi === undefined || options.syntheticUi === false
+                ? null
+                : new WaWamSyntheticUi(
+                      this,
+                      ctx,
+                      typeof options.syntheticUi === 'object' ? options.syntheticUi : {}
+                  )
     }
 
     /**
@@ -106,6 +122,7 @@ export class WaWamCoordinator {
     async dispose(): Promise<void> {
         this.disposed = true
         this.autoEmitter?.dispose()
+        this.syntheticUi?.dispose()
         await this.flush()
     }
 

--- a/packages/wam/src/WaWamCoordinator.ts
+++ b/packages/wam/src/WaWamCoordinator.ts
@@ -89,7 +89,9 @@ export class WaWamCoordinator {
                 : new WaWamSyntheticUi(
                       this,
                       ctx,
-                      typeof options.syntheticUi === 'object' ? options.syntheticUi : {}
+                      options.syntheticUi !== null && typeof options.syntheticUi === 'object'
+                          ? options.syntheticUi
+                          : {}
                   )
         this.isConnected = (): boolean => ctx.deps.connectionManager.isConnected()
     }

--- a/packages/wam/src/WaWamCoordinator.ts
+++ b/packages/wam/src/WaWamCoordinator.ts
@@ -62,6 +62,7 @@ export class WaWamCoordinator {
     private readonly syntheticUi: WaWamSyntheticUi | null
     private flushTimer: ReturnType<typeof setTimeout> | null = null
     private disposed = false
+    private readonly isConnected: () => boolean
 
     constructor(ctx: WaClientPluginContext, options: WaWamCoordinatorOptions = {}) {
         this.logger = ctx.logger.child({ scope: '@zapo-js/wam' }, { level: options.logLevel })
@@ -89,6 +90,7 @@ export class WaWamCoordinator {
                       ctx,
                       typeof options.syntheticUi === 'object' ? options.syntheticUi : {}
                   )
+        this.isConnected = (): boolean => ctx.deps.connectionManager.isConnected()
     }
 
     /**
@@ -144,6 +146,13 @@ export class WaWamCoordinator {
         if (batch === undefined) return
         this.openBatches.delete(channel)
         if (!batch.hasEvents()) return
+        if (!this.isConnected()) {
+            this.logger.trace('wam batch dropped: not connected', {
+                channel,
+                size: batch.size()
+            })
+            return
+        }
         await this.uploader.upload(batch.toBytes())
     }
 

--- a/packages/wam/src/WaWamSyntheticUi.ts
+++ b/packages/wam/src/WaWamSyntheticUi.ts
@@ -1,0 +1,254 @@
+import type { WaWamEventArgs } from '@vinikjkkj/wa-wam'
+import type { BinaryNode, WaClientPluginContext, WaIncomingMessageEvent } from 'zapo-js'
+import { isLidJid } from 'zapo-js/protocol'
+
+import type { WaWamCoordinator } from './WaWamCoordinator.js'
+
+type Ctx = Pick<WaClientPluginContext, 'on' | 'off'>
+
+/** Minimum spacing between fabricated chat opens, so inbound bursts don't imply an implausible click rate. */
+const MESSAGE_OPEN_MIN_GAP_MS = 20_000
+/** Info-drawer opens (group/channel/msg info) are rare interactions; keep them well spaced. */
+const INFO_OPEN_MIN_GAP_MS = 180_000
+/** How many recent chats' addressing to keep for the ambient re-open stream. */
+const RECENT_CHATS = 12
+/** Emoji-picker tabs WA Web reports for WebcEmojiOpen. */
+const EMOJI_TABS = ['EMOJI', 'GIF', 'STICKER'] as const
+
+export interface WaWamSyntheticUiOptions {
+    /** Chance a given inbound message fabricates a CHAT_OPEN (default 0.25). */
+    readonly chatOpenProbability?: number
+    /** Chance an inbound image additionally fabricates an IMAGE_OPEN (default 0.3). */
+    readonly imageOpenProbability?: number
+    /** Chance an event fabricates an info-drawer open (group/channel/msg info) (default 0.05). */
+    readonly infoOpenProbability?: number
+    /** Ambient (idle-checking) re-open interval bounds in ms (default 5-25min). */
+    readonly ambientIntervalMinMs?: number
+    readonly ambientIntervalMaxMs?: number
+    /**
+     * Local-time hour window [start, end) outside which nothing is fabricated, so
+     * the profile does not show 4am activity. Both required to take effect; a
+     * start > end spans midnight. Default: unset (fabricate around the clock).
+     */
+    readonly activeHoursStartHour?: number
+    readonly activeHoursEndHour?: number
+}
+
+const rand = (min: number, max: number): number => min + Math.random() * (max - min)
+const randInt = (min: number, max: number): number => Math.floor(rand(min, max))
+
+/**
+ * Fabricates plausible `UiAction` telemetry so the emitted event profile
+ * resembles a human WA Web session rather than a client that only reports
+ * protocol events. Only the UiAction types WA Web actually fires are used, with
+ * the exact fields WA sets (`uiActionPreloaded`, `isLid`, `uiActionT`), anchored
+ * to real activity with human delays: a chat that received a message may "open"
+ * (CHAT_OPEN paired with its WebcChatOpen, plus IMAGE_OPEN); its group/channel or
+ * a sent message's info drawer may be "opened" (GROUP/CHANNEL/MSG_INFO_OPEN); plus a
+ * low-rate jittered re-open of a recent chat. Opt-in and best-effort - badly-timed
+ * fabrication is a worse tell than none, so everything is jittered and rate-limited.
+ */
+export class WaWamSyntheticUi {
+    private readonly timers = new Set<ReturnType<typeof setTimeout>>()
+    private readonly unsubscribes: Array<() => void> = []
+    private readonly recentChatIsLid: boolean[] = []
+    private readonly chatOpenProbability: number
+    private readonly imageOpenProbability: number
+    private readonly infoOpenProbability: number
+    private readonly ambientMinMs: number
+    private readonly ambientMaxMs: number
+    private readonly activeStartHour: number | undefined
+    private readonly activeEndHour: number | undefined
+    private readonly windowHeightFloat = randInt(680, 1040)
+    private lastOpenMs = 0
+    private lastInfoOpenMs = 0
+    private disposed = false
+
+    constructor(
+        private readonly coordinator: WaWamCoordinator,
+        ctx: Ctx,
+        options: WaWamSyntheticUiOptions = {}
+    ) {
+        this.chatOpenProbability = options.chatOpenProbability ?? 0.25
+        this.imageOpenProbability = options.imageOpenProbability ?? 0.3
+        this.infoOpenProbability = options.infoOpenProbability ?? 0.05
+        this.ambientMinMs = options.ambientIntervalMinMs ?? 5 * 60_000
+        this.ambientMaxMs = options.ambientIntervalMaxMs ?? 25 * 60_000
+        this.activeStartHour = options.activeHoursStartHour
+        this.activeEndHour = options.activeHoursEndHour
+        const onMessage = (event: WaIncomingMessageEvent): void => this.onMessage(event)
+        const onNodeOut = (event: { readonly node: BinaryNode }): void => this.onNodeOut(event.node)
+        ctx.on('message', onMessage)
+        ctx.on('debug_transport_node_out', onNodeOut)
+        this.unsubscribes.push(
+            () => ctx.off('message', onMessage),
+            () => ctx.off('debug_transport_node_out', onNodeOut)
+        )
+        this.scheduleAmbient()
+    }
+
+    private onMessage(event: WaIncomingMessageEvent): void {
+        if (this.disposed) return
+        const key = event.key
+        const isLid = isLidJid(key.remoteJid ?? '')
+        this.rememberChat(isLid)
+
+        const now = Date.now()
+        if (
+            Math.random() <= this.chatOpenProbability &&
+            now - this.lastOpenMs >= MESSAGE_OPEN_MIN_GAP_MS
+        ) {
+            this.lastOpenMs = now
+            this.schedule(rand(2000, 60_000), () => this.emitChatOpen(isLid))
+            if (event.message?.imageMessage && Math.random() < this.imageOpenProbability) {
+                this.schedule(rand(4000, 90_000), () => this.emitImageOpen(isLid))
+            }
+        }
+
+        if ((key.isGroup || key.isNewsletter) && this.infoOpenAllowed()) {
+            const payload: WaWamEventArgs<'UiAction'> = key.isNewsletter
+                ? {
+                      uiActionType: 'CHANNEL_INFO_OPEN',
+                      uiActionPreloaded: true,
+                      uiActionT: randInt(40, 400)
+                  }
+                : {
+                      uiActionType: 'GROUP_INFO_OPEN',
+                      uiActionPreloaded: true,
+                      isLid,
+                      uiActionT: randInt(40, 400)
+                  }
+            this.schedule(rand(3000, 120_000), () => this.emit(payload))
+        }
+
+        if (event.message?.audioMessage && Math.random() < this.imageOpenProbability) {
+            this.schedule(rand(1000, 8000), () => this.emitMediaLoad())
+        }
+    }
+
+    private emitMediaLoad(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('WebcMediaLoad', {
+            webcMediaLoadResult: 'SUCCESS',
+            webcMediaLoadT: randInt(30, 800)
+        })
+    }
+
+    private onNodeOut(node: BinaryNode): void {
+        if (this.disposed || node.tag !== 'message') return
+        if (!this.infoOpenAllowed()) return
+        const to = node.attrs.to ?? ''
+        const isLid = isLidJid(to) || node.attrs.addressing_mode === 'lid'
+        this.schedule(rand(3000, 120_000), () =>
+            this.emit({
+                uiActionType: 'MSG_INFO_OPEN',
+                uiActionPreloaded: true,
+                isLid,
+                uiActionT: randInt(40, 400)
+            })
+        )
+    }
+
+    private scheduleAmbient(): void {
+        this.schedule(rand(this.ambientMinMs, this.ambientMaxMs), () => {
+            if (Math.random() < 0.15) {
+                this.emitEmojiOpen()
+            } else {
+                const isLid = this.recentChatIsLid[randInt(0, this.recentChatIsLid.length)]
+                if (isLid !== undefined) this.emitChatOpen(isLid)
+            }
+            this.scheduleAmbient()
+        })
+    }
+
+    private emitEmojiOpen(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('WebcEmojiOpen', {
+            webcEmojiOpenTab: EMOJI_TABS[randInt(0, EMOJI_TABS.length)]
+        })
+    }
+
+    private infoOpenAllowed(): boolean {
+        const now = Date.now()
+        if (
+            Math.random() >= this.infoOpenProbability ||
+            now - this.lastInfoOpenMs < INFO_OPEN_MIN_GAP_MS
+        ) {
+            return false
+        }
+        this.lastInfoOpenMs = now
+        return true
+    }
+
+    private emitChatOpen(isLid: boolean): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('UiAction', {
+            uiActionType: 'CHAT_OPEN',
+            uiActionPreloaded: true,
+            isLid,
+            uiActionT: randInt(40, 400)
+        })
+        const rendered = randInt(8, 30)
+        const beforePaint = randInt(20, 80)
+        const painted = beforePaint + randInt(20, 120)
+        this.coordinator.commit('WebcChatOpen', {
+            webcUnreadCount: randInt(0, 4),
+            webcWindowHeightFloat: this.windowHeightFloat,
+            webcChatOpenBeforePaintT: beforePaint,
+            webcChatOpenPaintedT: painted,
+            webcChatOpenT: painted + randInt(10, 200),
+            webcRenderedMessageCount: rendered,
+            webcFinalRenderedMessageCount: rendered
+        })
+    }
+
+    private emitImageOpen(isLid: boolean): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('UiAction', {
+            uiActionType: 'IMAGE_OPEN',
+            uiActionPreloaded: true,
+            isLid,
+            uiActionT: randInt(60, 600)
+        })
+    }
+
+    private canEmit(): boolean {
+        return !this.disposed && this.withinActiveHours()
+    }
+
+    private withinActiveHours(): boolean {
+        if (this.activeStartHour === undefined || this.activeEndHour === undefined) return true
+        const hour = new Date().getHours()
+        return this.activeStartHour <= this.activeEndHour
+            ? hour >= this.activeStartHour && hour < this.activeEndHour
+            : hour >= this.activeStartHour || hour < this.activeEndHour
+    }
+
+    private rememberChat(isLid: boolean): void {
+        this.recentChatIsLid.push(isLid)
+        if (this.recentChatIsLid.length > RECENT_CHATS) this.recentChatIsLid.shift()
+    }
+
+    private emit(payload: WaWamEventArgs<'UiAction'>): void {
+        if (this.canEmit()) this.coordinator.commit('UiAction', payload)
+    }
+
+    private schedule(delayMs: number, fn: () => void): void {
+        if (this.disposed) return
+        const timer = setTimeout(() => {
+            this.timers.delete(timer)
+            if (!this.disposed) fn()
+        }, delayMs)
+        timer.unref?.()
+        this.timers.add(timer)
+    }
+
+    /** Cancels all pending timers and detaches subscriptions. */
+    dispose(): void {
+        this.disposed = true
+        for (const timer of this.timers) clearTimeout(timer)
+        this.timers.clear()
+        for (let i = this.unsubscribes.length - 1; i >= 0; i -= 1) this.unsubscribes[i]()
+        this.unsubscribes.length = 0
+    }
+}

--- a/packages/wam/src/WaWamSyntheticUi.ts
+++ b/packages/wam/src/WaWamSyntheticUi.ts
@@ -1,6 +1,6 @@
 import type { WaWamEventArgs } from '@vinikjkkj/wa-wam'
 import type { BinaryNode, WaClientPluginContext, WaIncomingMessageEvent } from 'zapo-js'
-import { isGroupJid, isLidJid } from 'zapo-js/protocol'
+import { isGroupJid, isLidJid, WA_ADDRESSING_MODES, WA_MESSAGE_TAGS } from 'zapo-js/protocol'
 
 import { findFirstEncNode, mediaTypeKey, type WamMediaTypeKey } from './send-parse.js'
 import type { WaWamCoordinator } from './WaWamCoordinator.js'
@@ -214,10 +214,10 @@ export class WaWamSyntheticUi {
     }
 
     private onNodeOut(node: BinaryNode): void {
-        if (this.disposed || node.tag !== 'message') return
+        if (this.disposed || node.tag !== WA_MESSAGE_TAGS.MESSAGE) return
         this.markActivity()
         const to = node.attrs.to ?? ''
-        const isLid = isLidJid(to) || node.attrs.addressing_mode === 'lid'
+        const isLid = isLidJid(to) || node.attrs.addressing_mode === WA_ADDRESSING_MODES.LID
 
         const enc = findFirstEncNode(node)
         const media = enc !== null ? mediaTypeKey(enc.attrs.mediatype) : null
@@ -425,7 +425,6 @@ export class WaWamSyntheticUi {
         this.timers.add(timer)
     }
 
-    /** Cancels all pending timers and detaches subscriptions. */
     dispose(): void {
         this.disposed = true
         for (const timer of this.timers) clearTimeout(timer)

--- a/packages/wam/src/WaWamSyntheticUi.ts
+++ b/packages/wam/src/WaWamSyntheticUi.ts
@@ -28,6 +28,8 @@ export interface WaWamSyntheticUiOptions {
     readonly chatOpenProbability?: number
     /** Chance an inbound image additionally fabricates an IMAGE_OPEN (default 0.3). */
     readonly imageOpenProbability?: number
+    /** Chance an inbound audio fabricates a WebcMediaLoad playback load (default 0.3). */
+    readonly audioLoadProbability?: number
     /** Chance an event fabricates an info-drawer open (group/channel/msg info) (default 0.05). */
     readonly infoOpenProbability?: number
     /** Chance an outbound media message fabricates an AttachmentTrayActions send (default 0.4). */
@@ -53,6 +55,12 @@ const rand = (min: number, max: number): number => min + Math.random() * (max - 
 const randInt = (min: number, max: number): number => Math.floor(rand(min, max))
 const randHex = (len: number): string =>
     Array.from({ length: len }, () => Math.floor(Math.random() * 16).toString(16)).join('')
+
+const clampProbability = (value: number | undefined, fallback: number): number =>
+    typeof value === 'number' && Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : fallback
+
+const clampInterval = (value: number | undefined, fallback: number): number =>
+    typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback
 
 type AttachmentTarget = 'GALLERY' | 'DOCUMENT' | 'AUDIO' | 'CONTACT' | 'LOCATION'
 
@@ -93,6 +101,7 @@ export class WaWamSyntheticUi {
     private readonly recentChatIsLid: boolean[] = []
     private readonly chatOpenProbability: number
     private readonly imageOpenProbability: number
+    private readonly audioLoadProbability: number
     private readonly infoOpenProbability: number
     private readonly attachmentTrayProbability: number
     private readonly aboutConsumptionProbability: number
@@ -125,15 +134,19 @@ export class WaWamSyntheticUi {
         ctx: Ctx,
         options: WaWamSyntheticUiOptions = {}
     ) {
-        this.chatOpenProbability = options.chatOpenProbability ?? 0.25
-        this.imageOpenProbability = options.imageOpenProbability ?? 0.3
-        this.infoOpenProbability = options.infoOpenProbability ?? 0.05
-        this.attachmentTrayProbability = options.attachmentTrayProbability ?? 0.4
-        this.aboutConsumptionProbability = options.aboutConsumptionProbability ?? 0.06
-        this.ambientMinMs = options.ambientIntervalMinMs ?? 5 * 60_000
-        this.ambientMaxMs = options.ambientIntervalMaxMs ?? 25 * 60_000
-        this.memoryMinMs = options.memoryIntervalMinMs ?? 2 * 60_000
-        this.memoryMaxMs = options.memoryIntervalMaxMs ?? 5 * 60_000
+        this.chatOpenProbability = clampProbability(options.chatOpenProbability, 0.25)
+        this.imageOpenProbability = clampProbability(options.imageOpenProbability, 0.3)
+        this.audioLoadProbability = clampProbability(options.audioLoadProbability, 0.3)
+        this.infoOpenProbability = clampProbability(options.infoOpenProbability, 0.05)
+        this.attachmentTrayProbability = clampProbability(options.attachmentTrayProbability, 0.4)
+        this.aboutConsumptionProbability = clampProbability(
+            options.aboutConsumptionProbability,
+            0.06
+        )
+        this.ambientMinMs = clampInterval(options.ambientIntervalMinMs, 5 * 60_000)
+        this.ambientMaxMs = clampInterval(options.ambientIntervalMaxMs, 25 * 60_000)
+        this.memoryMinMs = clampInterval(options.memoryIntervalMinMs, 2 * 60_000)
+        this.memoryMaxMs = clampInterval(options.memoryIntervalMaxMs, 5 * 60_000)
         this.activeStartHour = options.activeHoursStartHour
         this.activeEndHour = options.activeHoursEndHour
         const onMessage = (event: WaIncomingMessageEvent): void => this.onMessage(event)
@@ -184,7 +197,7 @@ export class WaWamSyntheticUi {
             this.schedule(rand(3000, 120_000), () => this.emit(payload))
         }
 
-        if (event.message?.audioMessage && Math.random() < this.imageOpenProbability) {
+        if (event.message?.audioMessage && Math.random() < this.audioLoadProbability) {
             this.schedule(rand(1000, 8000), () => this.emitMediaLoad())
         }
 
@@ -256,6 +269,7 @@ export class WaWamSyntheticUi {
     }
 
     private markActivity(): void {
+        if (!this.canEmit()) return
         this.sliceActive = true
         this.messagesSeen += 1
     }

--- a/packages/wam/src/WaWamSyntheticUi.ts
+++ b/packages/wam/src/WaWamSyntheticUi.ts
@@ -1,7 +1,8 @@
 import type { WaWamEventArgs } from '@vinikjkkj/wa-wam'
 import type { BinaryNode, WaClientPluginContext, WaIncomingMessageEvent } from 'zapo-js'
-import { isLidJid } from 'zapo-js/protocol'
+import { isGroupJid, isLidJid } from 'zapo-js/protocol'
 
+import { findFirstEncNode, mediaTypeKey, type WamMediaTypeKey } from './send-parse.js'
 import type { WaWamCoordinator } from './WaWamCoordinator.js'
 
 type Ctx = Pick<WaClientPluginContext, 'on' | 'off'>
@@ -14,6 +15,11 @@ const INFO_OPEN_MIN_GAP_MS = 180_000
 const RECENT_CHATS = 12
 /** Emoji-picker tabs WA Web reports for WebcEmojiOpen. */
 const EMOJI_TABS = ['EMOJI', 'GIF', 'STICKER'] as const
+/** One time-spent activity slice; a bit is set per slice the session saw traffic. */
+const ACTIVITY_SLICE_MS = 60_000
+/** Slices per UserActivity flush, and the cap WA Web's 2x32-bit bitmap holds. */
+const ACTIVITY_FLUSH_SLICES = 5
+const ACTIVITY_MAX_SLICES = 64
 
 export interface WaWamSyntheticUiOptions {
     /** Chance a given inbound message fabricates a CHAT_OPEN (default 0.25). */
@@ -22,9 +28,14 @@ export interface WaWamSyntheticUiOptions {
     readonly imageOpenProbability?: number
     /** Chance an event fabricates an info-drawer open (group/channel/msg info) (default 0.05). */
     readonly infoOpenProbability?: number
+    /** Chance an outbound media message fabricates an AttachmentTrayActions send (default 0.4). */
+    readonly attachmentTrayProbability?: number
     /** Ambient (idle-checking) re-open interval bounds in ms (default 5-25min). */
     readonly ambientIntervalMinMs?: number
     readonly ambientIntervalMaxMs?: number
+    /** MemoryStat sample interval bounds in ms (default 2-5min). */
+    readonly memoryIntervalMinMs?: number
+    readonly memoryIntervalMaxMs?: number
     /**
      * Local-time hour window [start, end) outside which nothing is fabricated, so
      * the profile does not show 4am activity. Both required to take effect; a
@@ -36,6 +47,30 @@ export interface WaWamSyntheticUiOptions {
 
 const rand = (min: number, max: number): number => min + Math.random() * (max - min)
 const randInt = (min: number, max: number): number => Math.floor(rand(min, max))
+const randHex = (len: number): string =>
+    Array.from({ length: len }, () => Math.floor(Math.random() * 16).toString(16)).join('')
+
+type AttachmentTarget = 'GALLERY' | 'DOCUMENT' | 'AUDIO' | 'CONTACT' | 'LOCATION'
+
+/** ATTACHMENT_TRAY_ACTION_TARGET for an outbound media type; null for sticker/gif (emoji panel, not the tray). */
+function attachmentTargetFor(media: WamMediaTypeKey): AttachmentTarget | null {
+    switch (media) {
+        case 'PHOTO':
+        case 'VIDEO':
+            return 'GALLERY'
+        case 'DOCUMENT':
+            return 'DOCUMENT'
+        case 'AUDIO':
+        case 'PTT':
+            return 'AUDIO'
+        case 'CONTACT':
+            return 'CONTACT'
+        case 'LOCATION':
+            return 'LOCATION'
+        default:
+            return null
+    }
+}
 
 /**
  * Fabricates plausible `UiAction` telemetry so the emitted event profile
@@ -55,13 +90,27 @@ export class WaWamSyntheticUi {
     private readonly chatOpenProbability: number
     private readonly imageOpenProbability: number
     private readonly infoOpenProbability: number
+    private readonly attachmentTrayProbability: number
     private readonly ambientMinMs: number
     private readonly ambientMaxMs: number
+    private readonly memoryMinMs: number
+    private readonly memoryMaxMs: number
     private readonly activeStartHour: number | undefined
     private readonly activeEndHour: number | undefined
     private readonly windowHeightFloat = randInt(680, 1040)
+    private readonly sessionStartMs = Date.now()
+    private readonly activitySessionId = randHex(8)
     private lastOpenMs = 0
     private lastInfoOpenMs = 0
+    private memCurrentKb = randInt(50_000, 90_000)
+    private memPeakKb = 0
+    private messagesSeen = 0
+    private activitySlice = 0
+    private activitySeq = 0
+    private activeSliceCount = 0
+    private bitmapLow = 0
+    private bitmapHigh = 0
+    private sliceActive = false
     private disposed = false
 
     constructor(
@@ -72,8 +121,11 @@ export class WaWamSyntheticUi {
         this.chatOpenProbability = options.chatOpenProbability ?? 0.25
         this.imageOpenProbability = options.imageOpenProbability ?? 0.3
         this.infoOpenProbability = options.infoOpenProbability ?? 0.05
+        this.attachmentTrayProbability = options.attachmentTrayProbability ?? 0.4
         this.ambientMinMs = options.ambientIntervalMinMs ?? 5 * 60_000
         this.ambientMaxMs = options.ambientIntervalMaxMs ?? 25 * 60_000
+        this.memoryMinMs = options.memoryIntervalMinMs ?? 2 * 60_000
+        this.memoryMaxMs = options.memoryIntervalMaxMs ?? 5 * 60_000
         this.activeStartHour = options.activeHoursStartHour
         this.activeEndHour = options.activeHoursEndHour
         const onMessage = (event: WaIncomingMessageEvent): void => this.onMessage(event)
@@ -85,10 +137,13 @@ export class WaWamSyntheticUi {
             () => ctx.off('debug_transport_node_out', onNodeOut)
         )
         this.scheduleAmbient()
+        this.scheduleMemory()
+        this.scheduleActivitySlice()
     }
 
     private onMessage(event: WaIncomingMessageEvent): void {
         if (this.disposed) return
+        this.markActivity()
         const key = event.key
         const isLid = isLidJid(key.remoteJid ?? '')
         this.rememberChat(isLid)
@@ -136,17 +191,107 @@ export class WaWamSyntheticUi {
 
     private onNodeOut(node: BinaryNode): void {
         if (this.disposed || node.tag !== 'message') return
-        if (!this.infoOpenAllowed()) return
+        this.markActivity()
         const to = node.attrs.to ?? ''
         const isLid = isLidJid(to) || node.attrs.addressing_mode === 'lid'
-        this.schedule(rand(3000, 120_000), () =>
-            this.emit({
-                uiActionType: 'MSG_INFO_OPEN',
-                uiActionPreloaded: true,
-                isLid,
-                uiActionT: randInt(40, 400)
-            })
+
+        const enc = findFirstEncNode(node)
+        const media = enc !== null ? mediaTypeKey(enc.attrs.mediatype) : null
+        if (media !== null && Math.random() < this.attachmentTrayProbability) {
+            this.schedule(rand(1000, 12_000), () => this.emitAttachmentTray(media, to))
+        }
+
+        if (this.infoOpenAllowed()) {
+            this.schedule(rand(3000, 120_000), () =>
+                this.emit({
+                    uiActionType: 'MSG_INFO_OPEN',
+                    uiActionPreloaded: true,
+                    isLid,
+                    uiActionT: randInt(40, 400)
+                })
+            )
+        }
+    }
+
+    private emitAttachmentTray(media: WamMediaTypeKey, to: string): void {
+        if (!this.canEmit()) return
+        const target = attachmentTargetFor(media)
+        if (target === null) return
+        const isGroup = isGroupJid(to)
+        this.coordinator.commit('AttachmentTrayActions', {
+            attachmentTrayAction: 'SEND',
+            attachmentTrayActionTarget: target,
+            actionThreadType: isGroup ? 'GROUP_CHAT' : 'P2P_THREAD',
+            isAGroup: isGroup,
+            isSuccessful: true,
+            actionDurationMs: randInt(1500, 20_000),
+            sendTime: randInt(200, 4000),
+            ...(media === 'PHOTO' || media === 'VIDEO' ? { sendMediaType: media } : {})
+        })
+    }
+
+    private markActivity(): void {
+        this.sliceActive = true
+        this.messagesSeen += 1
+    }
+
+    private scheduleMemory(): void {
+        this.schedule(rand(this.memoryMinMs, this.memoryMaxMs), () => {
+            this.emitMemoryStat()
+            this.scheduleMemory()
+        })
+    }
+
+    private emitMemoryStat(): void {
+        if (!this.canEmit()) return
+        this.memCurrentKb = Math.max(
+            40_000,
+            Math.min(180_000, this.memCurrentKb + randInt(-4000, 6000))
         )
+        this.memPeakKb = Math.max(this.memPeakKb, this.memCurrentKb)
+        this.coordinator.commit('MemoryStat', {
+            workingSetSize: this.memCurrentKb,
+            workingSetPeakSize: this.memPeakKb,
+            uptime: Math.round((Date.now() - this.sessionStartMs) / 1000),
+            numMessages: this.messagesSeen,
+            processType: 'main'
+        })
+    }
+
+    private scheduleActivitySlice(): void {
+        this.schedule(ACTIVITY_SLICE_MS, () => {
+            this.recordActivitySlice()
+            this.scheduleActivitySlice()
+        })
+    }
+
+    private recordActivitySlice(): void {
+        if (this.activitySlice < ACTIVITY_MAX_SLICES) {
+            if (this.sliceActive) {
+                const i = this.activitySlice
+                if (i < 32) this.bitmapLow = (this.bitmapLow | (1 << i)) >>> 0
+                else this.bitmapHigh = (this.bitmapHigh | (1 << (i - 32))) >>> 0
+                this.activeSliceCount += 1
+            }
+            this.activitySlice += 1
+        }
+        this.sliceActive = false
+        if (this.activitySlice % ACTIVITY_FLUSH_SLICES === 0) this.emitUserActivity()
+    }
+
+    private emitUserActivity(): void {
+        if (!this.canEmit() || this.activitySlice === 0) return
+        this.activitySeq += 1
+        const len = Math.min(this.activitySlice, ACTIVITY_MAX_SLICES)
+        this.coordinator.commit('UserActivity', {
+            userActivitySessionId: this.activitySessionId,
+            userActivityStartTime: Math.floor(this.sessionStartMs / 1000),
+            userActivityBitmapLen: len,
+            userActivityBitmapLow: this.bitmapLow,
+            userActivitySessionSeq: this.activitySeq,
+            userActivitySessionCum: this.activeSliceCount,
+            ...(len > 32 ? { userActivityBitmapHigh: this.bitmapHigh } : {})
+        })
     }
 
     private scheduleAmbient(): void {

--- a/packages/wam/src/WaWamSyntheticUi.ts
+++ b/packages/wam/src/WaWamSyntheticUi.ts
@@ -104,7 +104,8 @@ export class WaWamSyntheticUi {
     private readonly activeEndHour: number | undefined
     private readonly windowHeightFloat = randInt(680, 1040)
     private readonly sessionStartMs = Date.now()
-    private readonly activitySessionId = randHex(8)
+    private activitySessionId = randHex(8)
+    private activityStartMs = Date.now()
     private lastOpenMs = 0
     private lastInfoOpenMs = 0
     private lastAboutMs = 0
@@ -290,17 +291,31 @@ export class WaWamSyntheticUi {
     }
 
     private recordActivitySlice(): void {
-        if (this.activitySlice < ACTIVITY_MAX_SLICES) {
-            if (this.sliceActive) {
-                const i = this.activitySlice
-                if (i < 32) this.bitmapLow = (this.bitmapLow | (1 << i)) >>> 0
-                else this.bitmapHigh = (this.bitmapHigh | (1 << (i - 32))) >>> 0
-                this.activeSliceCount += 1
-            }
-            this.activitySlice += 1
+        if (this.sliceActive) {
+            const i = this.activitySlice
+            if (i < 32) this.bitmapLow = (this.bitmapLow | (1 << i)) >>> 0
+            else this.bitmapHigh = (this.bitmapHigh | (1 << (i - 32))) >>> 0
+            this.activeSliceCount += 1
         }
+        this.activitySlice += 1
         this.sliceActive = false
-        if (this.activitySlice % ACTIVITY_FLUSH_SLICES === 0) this.emitUserActivity()
+        if (this.activitySlice >= ACTIVITY_MAX_SLICES) {
+            this.emitUserActivity()
+            this.resetActivityWindow()
+        } else if (this.activitySlice % ACTIVITY_FLUSH_SLICES === 0) {
+            this.emitUserActivity()
+        }
+    }
+
+    /** Rolls to a fresh activity session once the bitmap fills, mirroring WA Web's per-session time-spent windows instead of going silent at the cap. */
+    private resetActivityWindow(): void {
+        this.bitmapLow = 0
+        this.bitmapHigh = 0
+        this.activitySlice = 0
+        this.activeSliceCount = 0
+        this.activitySeq = 0
+        this.activitySessionId = randHex(8)
+        this.activityStartMs = Date.now()
     }
 
     private emitUserActivity(): void {
@@ -309,7 +324,7 @@ export class WaWamSyntheticUi {
         const len = Math.min(this.activitySlice, ACTIVITY_MAX_SLICES)
         this.coordinator.commit('UserActivity', {
             userActivitySessionId: this.activitySessionId,
-            userActivityStartTime: Math.floor(this.sessionStartMs / 1000),
+            userActivityStartTime: Math.floor(this.activityStartMs / 1000),
             userActivityBitmapLen: len,
             userActivityBitmapLow: this.bitmapLow,
             userActivitySessionSeq: this.activitySeq,

--- a/packages/wam/src/WaWamSyntheticUi.ts
+++ b/packages/wam/src/WaWamSyntheticUi.ts
@@ -11,6 +11,8 @@ type Ctx = Pick<WaClientPluginContext, 'on' | 'off'>
 const MESSAGE_OPEN_MIN_GAP_MS = 20_000
 /** Info-drawer opens (group/channel/msg info) are rare interactions; keep them well spaced. */
 const INFO_OPEN_MIN_GAP_MS = 180_000
+/** Viewing a contact's About is occasional; keep the fabricated views well spaced. */
+const ABOUT_MIN_GAP_MS = 120_000
 /** How many recent chats' addressing to keep for the ambient re-open stream. */
 const RECENT_CHATS = 12
 /** Emoji-picker tabs WA Web reports for WebcEmojiOpen. */
@@ -30,6 +32,8 @@ export interface WaWamSyntheticUiOptions {
     readonly infoOpenProbability?: number
     /** Chance an outbound media message fabricates an AttachmentTrayActions send (default 0.4). */
     readonly attachmentTrayProbability?: number
+    /** Chance a 1:1 inbound message fabricates an AboutConsumption (profile-About view) (default 0.06). */
+    readonly aboutConsumptionProbability?: number
     /** Ambient (idle-checking) re-open interval bounds in ms (default 5-25min). */
     readonly ambientIntervalMinMs?: number
     readonly ambientIntervalMaxMs?: number
@@ -91,6 +95,7 @@ export class WaWamSyntheticUi {
     private readonly imageOpenProbability: number
     private readonly infoOpenProbability: number
     private readonly attachmentTrayProbability: number
+    private readonly aboutConsumptionProbability: number
     private readonly ambientMinMs: number
     private readonly ambientMaxMs: number
     private readonly memoryMinMs: number
@@ -102,6 +107,7 @@ export class WaWamSyntheticUi {
     private readonly activitySessionId = randHex(8)
     private lastOpenMs = 0
     private lastInfoOpenMs = 0
+    private lastAboutMs = 0
     private memCurrentKb = randInt(50_000, 90_000)
     private memPeakKb = 0
     private messagesSeen = 0
@@ -122,6 +128,7 @@ export class WaWamSyntheticUi {
         this.imageOpenProbability = options.imageOpenProbability ?? 0.3
         this.infoOpenProbability = options.infoOpenProbability ?? 0.05
         this.attachmentTrayProbability = options.attachmentTrayProbability ?? 0.4
+        this.aboutConsumptionProbability = options.aboutConsumptionProbability ?? 0.06
         this.ambientMinMs = options.ambientIntervalMinMs ?? 5 * 60_000
         this.ambientMaxMs = options.ambientIntervalMaxMs ?? 25 * 60_000
         this.memoryMinMs = options.memoryIntervalMinMs ?? 2 * 60_000
@@ -179,6 +186,23 @@ export class WaWamSyntheticUi {
         if (event.message?.audioMessage && Math.random() < this.imageOpenProbability) {
             this.schedule(rand(1000, 8000), () => this.emitMediaLoad())
         }
+
+        if (
+            !key.isGroup &&
+            !key.isNewsletter &&
+            Math.random() < this.aboutConsumptionProbability &&
+            now - this.lastAboutMs >= ABOUT_MIN_GAP_MS
+        ) {
+            this.lastAboutMs = now
+            this.schedule(rand(2000, 40_000), () => this.emitAboutConsumption())
+        }
+    }
+
+    private emitAboutConsumption(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('AboutConsumption', {
+            aboutConsumptionSurface: Math.random() < 0.5 ? 'ONE_ON_ONE_CHAT' : 'PROFILE_INFO'
+        })
     }
 
     private emitMediaLoad(): void {
@@ -296,8 +320,11 @@ export class WaWamSyntheticUi {
 
     private scheduleAmbient(): void {
         this.schedule(rand(this.ambientMinMs, this.ambientMaxMs), () => {
-            if (Math.random() < 0.15) {
+            const r = Math.random()
+            if (r < 0.12) {
                 this.emitEmojiOpen()
+            } else if (r < 0.2) {
+                this.emitContactSearch()
             } else {
                 const isLid = this.recentChatIsLid[randInt(0, this.recentChatIsLid.length)]
                 if (isLid !== undefined) this.emitChatOpen(isLid)
@@ -310,6 +337,16 @@ export class WaWamSyntheticUi {
         if (!this.canEmit()) return
         this.coordinator.commit('WebcEmojiOpen', {
             webcEmojiOpenTab: EMOJI_TABS[randInt(0, EMOJI_TABS.length)]
+        })
+    }
+
+    private emitContactSearch(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('ContactSearchExperience', {
+            contactSearchEntrypoint: 'CHATS_LIST_GLOBAL_SEARCH',
+            searchActionName: Math.random() < 0.6 ? 'SEARCH_START' : 'CLICK_ON_CONTACT',
+            isUsernameSearch: false,
+            searchStartsWithAt: false
         })
     }
 

--- a/packages/wam/src/WaWamUploader.ts
+++ b/packages/wam/src/WaWamUploader.ts
@@ -1,0 +1,86 @@
+import type { BinaryNode, Logger, WaClientPluginContext } from 'zapo-js'
+import { WA_DEFAULTS, WA_IQ_TYPES, WA_NODE_TAGS } from 'zapo-js/protocol'
+import { delay, toError } from 'zapo-js/util'
+
+/** Exponential backoff with jitter, matching the WA stats backend shape. */
+function backoffMs(attempt: number): number {
+    const base = Math.min(1_000 * 2 ** attempt, 120_000)
+    return base + Math.floor(base * 0.1 * Math.random())
+}
+
+export interface WaWamUploaderDeps {
+    readonly query: WaClientPluginContext['queryWithContext']
+    readonly logger: Logger
+    /** IQ timeout per attempt. Defaults to 15s. */
+    readonly timeoutMs?: number
+    /** Max send attempts before the batch is dropped. Defaults to 4. */
+    readonly maxAttempts?: number
+}
+
+/**
+ * Ships a finalized WAM batch as the `<iq xmlns="w:stats"><add t>` stanza WA Web
+ * sends. Best-effort: transient failures retry with exponential backoff; a
+ * permanently failing batch is dropped (logged at debug), never surfaced.
+ */
+export class WaWamUploader {
+    private readonly query: WaClientPluginContext['queryWithContext']
+    private readonly logger: Logger
+    private readonly timeoutMs: number
+    private readonly maxAttempts: number
+
+    constructor(deps: WaWamUploaderDeps) {
+        this.query = deps.query
+        this.logger = deps.logger
+        this.timeoutMs = deps.timeoutMs ?? 15_000
+        this.maxAttempts = deps.maxAttempts ?? 4
+    }
+
+    /** Uploads one batch. Resolves `true` on server ack, `false` if dropped. */
+    async upload(batch: Uint8Array): Promise<boolean> {
+        const node: BinaryNode = {
+            tag: WA_NODE_TAGS.IQ,
+            attrs: {
+                to: WA_DEFAULTS.HOST_DOMAIN,
+                type: WA_IQ_TYPES.SET,
+                xmlns: 'w:stats'
+            },
+            content: [
+                {
+                    tag: 'add',
+                    attrs: { t: String(Math.floor(Date.now() / 1000)) },
+                    content: batch
+                }
+            ]
+        }
+
+        for (let attempt = 0; attempt < this.maxAttempts; attempt += 1) {
+            try {
+                const result = await this.query('wam-upload', node, this.timeoutMs)
+                if (result.attrs.type === WA_IQ_TYPES.RESULT) {
+                    this.logger.trace('wam batch uploaded', { size: batch.length })
+                    return true
+                }
+                if (!isRetryable(result)) {
+                    this.logger.debug('wam batch rejected', { type: result.attrs.type })
+                    return false
+                }
+            } catch (error) {
+                this.logger.debug('wam batch upload attempt failed', {
+                    attempt,
+                    message: toError(error).message
+                })
+            }
+            if (attempt < this.maxAttempts - 1) await delay(backoffMs(attempt))
+        }
+        this.logger.debug('wam batch dropped after retries', { size: batch.length })
+        return false
+    }
+}
+
+/** A `<iq type="error">` with a 5xx child code is retryable; anything else is terminal. */
+function isRetryable(result: BinaryNode): boolean {
+    if (!Array.isArray(result.content)) return false
+    const error = result.content.find((child) => child.tag === WA_NODE_TAGS.ERROR)
+    const code = Number.parseInt(error?.attrs.code ?? '', 10)
+    return Number.isFinite(code) && code >= 500
+}

--- a/packages/wam/src/WaWamUploader.ts
+++ b/packages/wam/src/WaWamUploader.ts
@@ -2,6 +2,10 @@ import type { BinaryNode, Logger, WaClientPluginContext } from 'zapo-js'
 import { WA_DEFAULTS, WA_IQ_TYPES, WA_NODE_TAGS } from 'zapo-js/protocol'
 import { delay, toError } from 'zapo-js/util'
 
+/** WAM-telemetry upload stanza namespace + child tag (`<iq xmlns="w:stats"><add t>`). WAM-specific, not a core concept. */
+const WAM_STATS_XMLNS = 'w:stats'
+const WAM_STATS_ADD_TAG = 'add'
+
 /** Exponential backoff with jitter, matching the WA stats backend shape. */
 function backoffMs(attempt: number): number {
     const base = Math.min(1_000 * 2 ** attempt, 120_000)
@@ -42,11 +46,11 @@ export class WaWamUploader {
             attrs: {
                 to: WA_DEFAULTS.HOST_DOMAIN,
                 type: WA_IQ_TYPES.SET,
-                xmlns: 'w:stats'
+                xmlns: WAM_STATS_XMLNS
             },
             content: [
                 {
-                    tag: 'add',
+                    tag: WAM_STATS_ADD_TAG,
                     attrs: { t: String(Math.floor(Date.now() / 1000)) },
                     content: batch
                 }

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -533,6 +533,32 @@ test('auto-emitter maps an outbound poll to PollsActions (CREATE_POLL with optio
     )
 })
 
+test('auto-emitter maps a V3 poll (the version this client sends) to PollsActions', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message_send', {
+        to: '456@s.whatsapp.net',
+        message: {
+            pollCreationMessageV3: {
+                name: 'q',
+                options: [{ optionName: 'a' }, { optionName: 'b' }]
+            }
+        }
+    })
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'PollsActions'),
+        {
+            name: 'PollsActions',
+            payload: {
+                pollAction: 'CREATE_POLL',
+                chatType: 'INDIVIDUAL',
+                isAGroup: false,
+                pollOptionsCount: 2
+            }
+        }
+    )
+})
+
 test('auto-emitter maps an outbound document to SendDocument', () => {
     const h = makeHarness()
     new WaWamAutoEmitter(h.coordinator, h.ctx)

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -483,6 +483,101 @@ test('auto-emitter ignores non-local (synced) app-state mutations', () => {
     assert.equal(h.commits.length, 0)
 })
 
+test('auto-emitter maps an outbound reaction to ReactionActions (UPDATE / DELETE)', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message_send', {
+        to: '456@s.whatsapp.net',
+        message: { reactionMessage: { text: '👍' } }
+    })
+    assert.deepEqual(h.commits.find((c) => c.name === 'ReactionActions'), {
+        name: 'ReactionActions',
+        payload: { reactionAction: 'UPDATE', messageType: 'INDIVIDUAL' }
+    })
+    h.commits.length = 0
+    h.emit('message_send', { to: '456@s.whatsapp.net', message: { reactionMessage: { text: '' } } })
+    assert.equal(
+        (h.commits.find((c) => c.name === 'ReactionActions')?.payload as { reactionAction: string })
+            .reactionAction,
+        'DELETE'
+    )
+})
+
+test('auto-emitter maps an outbound poll to PollsActions (CREATE_POLL with option count)', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message_send', {
+        to: '1@g.us',
+        message: {
+            pollCreationMessage: {
+                name: 'q',
+                options: [{ optionName: 'a' }, { optionName: 'b' }, { optionName: 'c' }]
+            }
+        }
+    })
+    assert.deepEqual(h.commits.find((c) => c.name === 'PollsActions'), {
+        name: 'PollsActions',
+        payload: {
+            pollAction: 'CREATE_POLL',
+            chatType: 'GROUP',
+            isAGroup: true,
+            pollOptionsCount: 3,
+            typeOfGroup: 'GROUP'
+        }
+    })
+})
+
+test('auto-emitter maps an outbound document to SendDocument', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message_send', {
+        to: '456@s.whatsapp.net',
+        message: {
+            documentMessage: {
+                fileName: 'report.pdf',
+                mimetype: 'application/pdf',
+                pageCount: 4,
+                fileLength: 12345
+            }
+        }
+    })
+    assert.deepEqual(h.commits.find((c) => c.name === 'SendDocument'), {
+        name: 'SendDocument',
+        payload: {
+            documentType: 'DOCUMENT',
+            documentExt: 'pdf',
+            documentPageSize: 4,
+            documentSize: 12345
+        }
+    })
+})
+
+test('auto-emitter maps a forwarded outbound message to ForwardSend', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message_send', {
+        to: '1@g.us',
+        message: { imageMessage: { contextInfo: { isForwarded: true, forwardingScore: 5 } } }
+    })
+    assert.deepEqual(h.commits.find((c) => c.name === 'ForwardSend'), {
+        name: 'ForwardSend',
+        payload: {
+            messageType: 'GROUP',
+            isFrequentlyForwarded: true,
+            isForwardedForward: true,
+            messageMediaType: 'PHOTO',
+            typeOfGroup: 'GROUP'
+        }
+    })
+})
+
+test('auto-emitter fires no ForwardSend for a normal (non-forwarded) outbound message', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message_send', { to: '456@s.whatsapp.net', message: { conversation: 'oi' } })
+    assert.equal(h.commits.filter((c) => c.name === 'ForwardSend').length, 0)
+})
+
 test('auto-emitter maps a device-switch notification to WaOldCode', () => {
     const h = makeHarness()
     new WaWamAutoEmitter(h.coordinator, h.ctx)
@@ -532,6 +627,23 @@ test('auto-emitter maps an edit=7 revoke send to a SENDER_REVOKE EditMessageSend
     assert.equal((edit?.payload as { editType: string }).editType, 'SENDER_REVOKE')
 })
 
+test('auto-emitter fires RevokeMessageSend (ADMIN) alongside EditMessageSend for an edit=8 revoke ack', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'message',
+            attrs: { to: '1@g.us', id: 'rv1', edit: '8' },
+            content: [{ tag: 'enc', attrs: { v: '2', type: 'skmsg' } }]
+        }
+    })
+    h.emit('debug_transport_node_in', { node: { tag: 'ack', attrs: { class: 'message', id: 'rv1' } } })
+    assert.deepEqual(h.commits.find((c) => c.name === 'RevokeMessageSend'), {
+        name: 'RevokeMessageSend',
+        payload: { revokeType: 'ADMIN', messageType: 'GROUP', messageSendResultIsTerminal: true }
+    })
+})
+
 test('auto-emitter fires no EditMessageSend for a normal (non-edit) send', () => {
     const h = makeHarness()
     new WaWamAutoEmitter(h.coordinator, h.ctx)
@@ -576,4 +688,77 @@ test('auto-emitter emits no stream mode for a close before any open, and detache
     assert.equal(h.commits.length, 0)
     emitter.dispose()
     assert.equal(h.handlers.size, 0)
+})
+
+const membershipActionIq = (id: string, action: 'approve' | 'reject') => ({
+    node: {
+        tag: 'iq',
+        attrs: { id, to: '123@g.us', type: 'set', xmlns: 'w:g2' },
+        content: [
+            {
+                tag: 'membership_requests_action',
+                attrs: {},
+                content: [
+                    { tag: action, attrs: {}, content: [{ tag: 'participant', attrs: { jid: '5@s.whatsapp.net' } }] }
+                ]
+            }
+        ]
+    }
+})
+
+test('auto-emitter correlates an approved membership-request IQ to WaFsGroupJoinRequestAction', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_out', membershipActionIq('iq1', 'approve'))
+    assert.equal(h.commits.length, 0)
+    h.emit('debug_transport_node_in', { node: { tag: 'iq', attrs: { id: 'iq1', type: 'result' } } })
+    assert.equal(h.commits.length, 1)
+    const commit = h.commits[0]
+    assert.equal(commit?.name, 'WaFsGroupJoinRequestAction')
+    const payload = commit?.payload as Record<string, unknown>
+    assert.equal(payload.groupJid, '123@g.us')
+    assert.equal(payload.groupJoinRequestAction, 'MEMBERSHIP_REQUEST_APPROVE')
+    assert.equal(payload.isSuccessful, true)
+    assert.equal(typeof payload.serverResponseTime, 'number')
+    assert.ok((payload.serverResponseTime as number) >= 0)
+    assert.equal('groupJoinRequestEntrypoint' in payload, false)
+    assert.equal('groupJoinRequestGroupsInCommon' in payload, false)
+})
+
+test('auto-emitter marks a rejected membership-request IQ error as unsuccessful', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_out', membershipActionIq('iq2', 'reject'))
+    h.emit('debug_transport_node_in', { node: { tag: 'iq', attrs: { id: 'iq2', type: 'error' } } })
+    assert.equal(h.commits.length, 1)
+    assert.deepEqual(
+        {
+            name: h.commits[0]?.name,
+            groupJoinRequestAction: (h.commits[0]?.payload as Record<string, unknown>)
+                .groupJoinRequestAction,
+            isSuccessful: (h.commits[0]?.payload as Record<string, unknown>).isSuccessful
+        },
+        {
+            name: 'WaFsGroupJoinRequestAction',
+            groupJoinRequestAction: 'MEMBERSHIP_REQUEST_REJECT',
+            isSuccessful: false
+        }
+    )
+})
+
+test('auto-emitter ignores unrelated IQs and unmatched IQ responses', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    // A w:g2 set without a membership action is not tracked.
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'iq',
+            attrs: { id: 'x1', to: '123@g.us', type: 'set', xmlns: 'w:g2' },
+            content: [{ tag: 'demote', attrs: {}, content: [] }]
+        }
+    })
+    // A result for an untracked id emits nothing.
+    h.emit('debug_transport_node_in', { node: { tag: 'iq', attrs: { id: 'x1', type: 'result' } } })
+    h.emit('debug_transport_node_in', { node: { tag: 'iq', attrs: { id: 'ghost', type: 'result' } } })
+    assert.equal(h.commits.length, 0)
 })

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -571,6 +571,28 @@ test('auto-emitter maps a forwarded outbound message to ForwardSend', () => {
     })
 })
 
+test('auto-emitter emits both ForwardSend and SendDocument for a forwarded document', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message_send', {
+        to: '1@g.us',
+        message: {
+            documentMessage: {
+                fileName: 'report.pdf',
+                mimetype: 'application/pdf',
+                contextInfo: { isForwarded: true, forwardingScore: 2 }
+            }
+        }
+    })
+    assert.equal(h.commits.filter((c) => c.name === 'ForwardSend').length, 1)
+    assert.equal(h.commits.filter((c) => c.name === 'SendDocument').length, 1)
+    assert.equal(
+        (h.commits.find((c) => c.name === 'ForwardSend')?.payload as Record<string, unknown>)
+            .isForwardedForward,
+        true
+    )
+})
+
 test('auto-emitter fires no ForwardSend for a normal (non-forwarded) outbound message', () => {
     const h = makeHarness()
     new WaWamAutoEmitter(h.coordinator, h.ctx)
@@ -642,6 +664,11 @@ test('auto-emitter fires RevokeMessageSend (ADMIN) alongside EditMessageSend for
         name: 'RevokeMessageSend',
         payload: { revokeType: 'ADMIN', messageType: 'GROUP', messageSendResultIsTerminal: true }
     })
+    assert.equal(
+        (h.commits.find((c) => c.name === 'EditMessageSend')?.payload as { editType: string })
+            .editType,
+        'ADMIN_REVOKE'
+    )
 })
 
 test('auto-emitter fires no EditMessageSend for a normal (non-edit) send', () => {

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -14,6 +14,7 @@ interface Commit {
 function makeHarness() {
     const commits: Commit[] = []
     const handlers = new Map<string, (event: unknown) => void>()
+    let creds: Record<string, unknown> | undefined
     const coordinator = {
         commit: (name: string, payload: unknown) => commits.push({ name, payload })
     } as unknown as WaWamCoordinator
@@ -21,10 +22,14 @@ function makeHarness() {
         on: (event: string, handler: (event: unknown) => void) => handlers.set(event, handler),
         off: (event: string, handler: (event: unknown) => void) => {
             if (handlers.get(event) === handler) handlers.delete(event)
-        }
+        },
+        client: { getCredentials: () => creds }
     } as unknown as WaWamAutoEmitterContext
     const emit = (event: string, payload: unknown) => handlers.get(event)?.(payload)
-    return { commits, handlers, coordinator, ctx, emit }
+    const setCreds = (next: Record<string, unknown> | undefined) => {
+        creds = next
+    }
+    return { commits, handlers, coordinator, ctx, emit, setCreds }
 }
 
 const openEvent = (isNewLogin: boolean): WaConnectionEvent =>
@@ -316,6 +321,59 @@ test('auto-emitter emits WebcPageResume with an incrementing count on each recon
         .filter((c) => c.name === 'WebcPageResume')
         .map((c) => (c.payload as { webcResumeCount: number }).webcResumeCount)
     assert.deepEqual(resumes, [1, 2])
+})
+
+test('auto-emitter reports WebcRawPlatforms once from the primary platform on connect', () => {
+    const h = makeHarness()
+    h.setCreds({ platform: 'android' })
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('connection', openEvent(false))
+    h.emit('connection', { status: 'close', reason: 'lost', isNewLogin: false })
+    h.emit('connection', openEvent(false))
+    const raw = h.commits.filter((c) => c.name === 'WebcRawPlatforms')
+    assert.equal(raw.length, 1)
+    assert.deepEqual(raw[0]?.payload, { webcRawPlatform: 'android' })
+})
+
+test('auto-emitter emits no WebcRawPlatforms when the platform is unknown', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('connection', openEvent(false))
+    assert.equal(h.commits.filter((c) => c.name === 'WebcRawPlatforms').length, 0)
+})
+
+test('auto-emitter fires GroupJoinC when added to a group by someone else', () => {
+    const h = makeHarness()
+    h.setCreds({ meJid: 'me@s.whatsapp.net', meLid: 'me@lid' })
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('group', {
+        action: 'add',
+        authorJid: 'admin@s.whatsapp.net',
+        participants: [{ jid: 'other@s.whatsapp.net' }, { jid: 'me@s.whatsapp.net' }]
+    })
+    assert.equal(h.commits.filter((c) => c.name === 'GroupJoinC').length, 1)
+})
+
+test('auto-emitter fires GroupJoinC on a group created by someone else', () => {
+    const h = makeHarness()
+    h.setCreds({ meJid: 'me@s.whatsapp.net', meLid: 'me@lid' })
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('group', { action: 'create', authorJid: 'founder@s.whatsapp.net' })
+    assert.equal(h.commits.filter((c) => c.name === 'GroupJoinC').length, 1)
+})
+
+test('auto-emitter does not fire GroupJoinC for self-authored actions or others being added', () => {
+    const h = makeHarness()
+    h.setCreds({ meJid: 'me@s.whatsapp.net', meLid: 'me@lid' })
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('group', { action: 'create', authorJid: 'me@s.whatsapp.net' })
+    h.emit('group', {
+        action: 'add',
+        authorJid: 'admin@s.whatsapp.net',
+        participants: [{ jid: 'other@s.whatsapp.net' }]
+    })
+    h.emit('group', { action: 'subject', authorJid: 'admin@s.whatsapp.net' })
+    assert.equal(h.commits.filter((c) => c.name === 'GroupJoinC').length, 0)
 })
 
 test('auto-emitter maps a device-switch notification to WaOldCode', () => {

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -428,6 +428,47 @@ test('auto-emitter maps local Pin/Archive/Read mutations to ChatAction', () => {
     assert.deepEqual(types, ['PIN', 'ARCHIVE', 'UNREAD'])
 })
 
+test('auto-emitter maps local Pin/Delete/Clear mutations to MdSyncdDogfoodingFeatureUsage', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('mutation', {
+        schema: 'Pin',
+        operation: 'set',
+        source: 'local',
+        chatJid: 'a@s.whatsapp.net',
+        pinned: true
+    })
+    h.emit('mutation', {
+        schema: 'DeleteChat',
+        operation: 'set',
+        source: 'local',
+        chatJid: 'a@s.whatsapp.net'
+    })
+    h.emit('mutation', {
+        schema: 'ClearChat',
+        operation: 'set',
+        source: 'local',
+        chatJid: 'a@s.whatsapp.net',
+        deleteStarred: '1'
+    })
+    h.emit('mutation', {
+        schema: 'ClearChat',
+        operation: 'set',
+        source: 'local',
+        chatJid: 'b@s.whatsapp.net',
+        deleteStarred: '0'
+    })
+    const feats = h.commits
+        .filter((c) => c.name === 'MdSyncdDogfoodingFeatureUsage')
+        .map((c) => (c.payload as { mdSyncdDogfoodingFeature: string }).mdSyncdDogfoodingFeature)
+    assert.deepEqual(feats, [
+        'PIN_MUTATION',
+        'DELETE_MUTATION',
+        'CLEAR_CHAT_REMOVE_STARRED_MUTATION',
+        'CLEAR_CHAT_KEEP_STARRED_MUTATION'
+    ])
+})
+
 test('auto-emitter ignores non-local (synced) app-state mutations', () => {
     const h = makeHarness()
     new WaWamAutoEmitter(h.coordinator, h.ctx)

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -1,0 +1,288 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import type { WaConnectionEvent } from 'zapo-js'
+
+import { WaWamAutoEmitter, type WaWamAutoEmitterContext } from '../WaWamAutoEmitter.js'
+import type { WaWamCoordinator } from '../WaWamCoordinator.js'
+
+interface Commit {
+    readonly name: string
+    readonly payload: unknown
+}
+
+function makeHarness() {
+    const commits: Commit[] = []
+    const handlers = new Map<string, (event: unknown) => void>()
+    const coordinator = {
+        commit: (name: string, payload: unknown) => commits.push({ name, payload })
+    } as unknown as WaWamCoordinator
+    const ctx = {
+        on: (event: string, handler: (event: unknown) => void) => handlers.set(event, handler),
+        off: (event: string, handler: (event: unknown) => void) => {
+            if (handlers.get(event) === handler) handlers.delete(event)
+        }
+    } as unknown as WaWamAutoEmitterContext
+    const emit = (event: string, payload: unknown) => handlers.get(event)?.(payload)
+    return { commits, handlers, coordinator, ctx, emit }
+}
+
+const openEvent = (isNewLogin: boolean): WaConnectionEvent =>
+    ({ status: 'open', reason: 'connected', isNewLogin }) as WaConnectionEvent
+
+test('auto-emitter maps a group message to MessageReceive (GROUP, isLid, offline)', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message', {
+        key: {
+            remoteJid: '123@g.us',
+            participant: '456@lid',
+            isGroup: true,
+            isBroadcast: false,
+            isNewsletter: false
+        },
+        offline: true,
+        rawNode: { tag: 'message', attrs: {} }
+    })
+    assert.deepEqual(h.commits, [
+        {
+            name: 'MessageReceive',
+            payload: {
+                messageType: 'GROUP',
+                isLid: true,
+                messageIsOffline: true,
+                typeOfGroup: 'GROUP'
+            }
+        }
+    ])
+})
+
+test('auto-emitter maps a 1:1 pn message to INDIVIDUAL without typeOfGroup', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message', {
+        key: {
+            remoteJid: '5511999999999@s.whatsapp.net',
+            isGroup: false,
+            isBroadcast: false,
+            isNewsletter: false
+        },
+        rawNode: { tag: 'message', attrs: {} }
+    })
+    assert.deepEqual(h.commits[0], {
+        name: 'MessageReceive',
+        payload: { messageType: 'INDIVIDUAL', isLid: false, messageIsOffline: false }
+    })
+})
+
+test('auto-emitter derives E2eMessageRecv from the raw inbound stanza before MessageReceive', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message', {
+        key: {
+            remoteJid: '123@g.us',
+            participant: '456@lid',
+            isGroup: true,
+            isBroadcast: false,
+            isNewsletter: false
+        },
+        offline: false,
+        rawNode: {
+            tag: 'message',
+            attrs: { from: '123@g.us' },
+            content: [{ tag: 'enc', attrs: { v: '2', type: 'skmsg' } }]
+        }
+    })
+    assert.deepEqual(h.commits[0], {
+        name: 'E2eMessageRecv',
+        payload: {
+            e2eSuccessful: true,
+            e2eDestination: 'GROUP',
+            isLid: true,
+            offline: false,
+            e2eCiphertextType: 'SENDER_KEY_MESSAGE',
+            e2eCiphertextVersion: 2,
+            typeOfGroup: 'GROUP'
+        }
+    })
+    assert.equal(h.commits[1]?.name, 'MessageReceive')
+})
+
+test('auto-emitter maps a receipt to ReceiptStanzaReceive with type and count', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('receipt', { status: 'read', messageIds: ['a', 'b', 'c'] })
+    assert.deepEqual(h.commits[0], {
+        name: 'ReceiptStanzaReceive',
+        payload: { receiptStanzaType: 'read', receiptStanzaTotalCount: 3 }
+    })
+})
+
+test('auto-emitter derives E2eMessageSend from an outbound group media message', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'message',
+            attrs: { to: '123@g.us', id: 'm1', type: 'media' },
+            content: [{ tag: 'enc', attrs: { v: '2', type: 'skmsg', mediatype: 'image' } }]
+        }
+    })
+    assert.deepEqual(h.commits[0], {
+        name: 'E2eMessageSend',
+        payload: {
+            e2eSuccessful: true,
+            e2eDestination: 'GROUP',
+            isLid: false,
+            e2eCiphertextType: 'SENDER_KEY_MESSAGE',
+            e2eCiphertextVersion: 2,
+            messageMediaType: 'PHOTO',
+            typeOfGroup: 'GROUP'
+        }
+    })
+})
+
+test('auto-emitter derives isLid + retryCount for a lid pkmsg retry, and ignores non-messages', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_out', { node: { tag: 'ack', attrs: {} } })
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'message',
+            attrs: { to: '456@lid', id: 'm2', addressing_mode: 'lid' },
+            content: [{ tag: 'enc', attrs: { v: '2', type: 'pkmsg', count: '2' } }]
+        }
+    })
+    assert.equal(h.commits.length, 2)
+    assert.deepEqual(h.commits[0], {
+        name: 'E2eMessageSend',
+        payload: {
+            e2eSuccessful: true,
+            e2eDestination: 'INDIVIDUAL',
+            isLid: true,
+            e2eCiphertextType: 'PREKEY_MESSAGE',
+            e2eCiphertextVersion: 2,
+            retryCount: 2
+        }
+    })
+    assert.equal(h.commits[1]?.name, 'WebcMessageSend')
+})
+
+test('auto-emitter fires MessageHighRetryCount only for retry receipts at/above the threshold', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    const retryReceipt = (count: string) => ({
+        node: {
+            tag: 'receipt',
+            attrs: { type: 'retry', from: '123@g.us', is_lid: 'false' },
+            content: [{ tag: 'retry', attrs: { count, id: 'm1' } }]
+        }
+    })
+    h.emit('debug_transport_node_in', retryReceipt('3'))
+    assert.equal(h.commits.length, 0)
+    h.emit('debug_transport_node_in', retryReceipt('5'))
+    assert.deepEqual(h.commits[0], {
+        name: 'MessageHighRetryCount',
+        payload: { retryCount: 5, messageType: 'GROUP', isSenderLidBased: false }
+    })
+})
+
+test('auto-emitter fires MessageSend when an ack matches a tracked outbound message', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'message',
+            attrs: { to: '5511999999999@s.whatsapp.net', id: 'sendme' },
+            content: [{ tag: 'enc', attrs: { v: '2', type: 'msg' } }]
+        }
+    })
+    h.commits.length = 0
+    h.emit('debug_transport_node_in', {
+        node: { tag: 'ack', attrs: { class: 'message', id: 'sendme' } }
+    })
+    assert.deepEqual(h.commits[0], {
+        name: 'MessageSend',
+        payload: {
+            messageSendResult: 'OK',
+            messageType: 'INDIVIDUAL',
+            isLid: false,
+            e2eCiphertextType: 'MESSAGE'
+        }
+    })
+    h.commits.length = 0
+    h.emit('debug_transport_node_in', {
+        node: { tag: 'ack', attrs: { class: 'message', id: 'nope' } }
+    })
+    assert.equal(h.commits.length, 0)
+})
+
+test('auto-emitter reports ClockSkewDifferenceT once when a stanza timestamp is far off', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_in', { node: { tag: 'message', attrs: { t: '0' } } })
+    assert.equal(h.commits.length, 1)
+    assert.equal(h.commits[0]?.name, 'ClockSkewDifferenceT')
+    assert.ok((h.commits[0]?.payload as { clockSkewHourly: number }).clockSkewHourly > 0)
+    h.emit('debug_transport_node_in', { node: { tag: 'receipt', attrs: { t: '0' } } })
+    assert.equal(h.commits.length, 1)
+})
+
+test('auto-emitter does not report clock skew for an in-sync timestamp', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    const nowSeconds = String(Math.floor(Date.now() / 1000))
+    h.emit('debug_transport_node_in', { node: { tag: 'message', attrs: { t: nowSeconds } } })
+    assert.equal(h.commits.length, 0)
+})
+
+test('auto-emitter commits WebcSocketConnect with PAGE_LOAD on a fresh login', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('connection', openEvent(true))
+    assert.deepEqual(h.commits, [
+        { name: 'WebcSocketConnect', payload: { webcSocketConnectReason: 'PAGE_LOAD' } }
+    ])
+})
+
+test('auto-emitter uses RECONNECT when it is not a new login', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('connection', openEvent(false))
+    assert.equal(
+        (h.commits[0]?.payload as { webcSocketConnectReason: string }).webcSocketConnectReason,
+        'RECONNECT'
+    )
+})
+
+test('auto-emitter maps an unhandled stanza to UnknownStanza', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_unhandled_stanza', {
+        reason: 'no handler',
+        rawNode: { tag: 'notification', attrs: { type: 'shmex' } }
+    })
+    assert.deepEqual(h.commits[0], {
+        name: 'UnknownStanza',
+        payload: { unknownStanzaTag: 'notification', unknownStanzaType: 'shmex' }
+    })
+})
+
+test('auto-emitter maps a history-sync chunk to MdBootstrapHistoryDataReceived', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('history_sync_chunk', { syncType: 2, messagesCount: 10, chunkOrder: 3, progress: 40 })
+    assert.deepEqual(h.commits[0], {
+        name: 'MdBootstrapHistoryDataReceived',
+        payload: { historySyncChunkOrder: 3, historySyncStageProgress: 40 }
+    })
+})
+
+test('auto-emitter ignores non-open connection events and detaches on dispose', () => {
+    const h = makeHarness()
+    const emitter = new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('connection', { status: 'close', reason: 'lost', isNewLogin: false })
+    assert.equal(h.commits.length, 0)
+    emitter.dispose()
+    assert.equal(h.handlers.size, 0)
+})

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -140,6 +140,9 @@ test('auto-emitter derives E2eMessageSend from an outbound group media message',
             e2eSuccessful: true,
             e2eDestination: 'GROUP',
             isLid: false,
+            botType: 'UNKNOWN',
+            editType: 'NOT_EDITED',
+            retryCount: 0,
             e2eCiphertextType: 'SENDER_KEY_MESSAGE',
             e2eCiphertextVersion: 2,
             messageMediaType: 'PHOTO',
@@ -166,9 +169,11 @@ test('auto-emitter derives isLid + retryCount for a lid pkmsg retry, and ignores
             e2eSuccessful: true,
             e2eDestination: 'INDIVIDUAL',
             isLid: true,
+            botType: 'UNKNOWN',
+            editType: 'NOT_EDITED',
+            retryCount: 2,
             e2eCiphertextType: 'PREKEY_MESSAGE',
-            e2eCiphertextVersion: 2,
-            retryCount: 2
+            e2eCiphertextVersion: 2
         }
     })
     assert.equal(h.commits[1]?.name, 'WebcMessageSend')
@@ -211,8 +216,13 @@ test('auto-emitter fires MessageSend when an ack matches a tracked outbound mess
         name: 'MessageSend',
         payload: {
             messageSendResult: 'OK',
+            messageSendResultIsTerminal: false,
             messageType: 'INDIVIDUAL',
             isLid: false,
+            botType: 'UNKNOWN',
+            editType: 'NOT_EDITED',
+            messageIsRevoke: false,
+            e2eBackfill: false,
             e2eCiphertextType: 'MESSAGE'
         }
     })
@@ -611,17 +621,15 @@ test('auto-emitter maps an outbound sticker to StickerSend', () => {
     new WaWamAutoEmitter(h.coordinator, h.ctx)
     h.emit('message_send', {
         to: '456@s.whatsapp.net',
-        message: { stickerMessage: { isAnimated: true, isAvatar: false, isAiSticker: false } }
+        message: { stickerMessage: { isAnimated: true, isLottie: false } }
     })
     assert.deepEqual(
         h.commits.find((c) => c.name === 'StickerSend'),
         {
             name: 'StickerSend',
             payload: {
-                stickerSendMessageType: 'REGULAR',
                 stickerIsAnimated: true,
-                stickerIsAvatar: false,
-                stickerIsAi: false
+                stickerIsLottie: false
             }
         }
     )
@@ -738,7 +746,12 @@ test('auto-emitter fires EditMessageSend (EDITED) when an edited group message i
         h.commits.find((c) => c.name === 'EditMessageSend'),
         {
             name: 'EditMessageSend',
-            payload: { editType: 'EDITED', messageType: 'GROUP', typeOfGroup: 'GROUP' }
+            payload: {
+                editType: 'EDITED',
+                messageType: 'GROUP',
+                messageSendResultIsTerminal: false,
+                typeOfGroup: 'GROUP'
+            }
         }
     )
 })
@@ -780,7 +793,7 @@ test('auto-emitter fires RevokeMessageSend (ADMIN) alongside EditMessageSend for
             payload: {
                 revokeType: 'ADMIN',
                 messageType: 'GROUP',
-                messageSendResultIsTerminal: true
+                messageSendResultIsTerminal: false
             }
         }
     )

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -376,10 +376,10 @@ test('auto-emitter does not fire GroupJoinC for self-authored actions or others 
     assert.equal(h.commits.filter((c) => c.name === 'GroupJoinC').length, 0)
 })
 
-test('auto-emitter maps a local Mute mutation to ChatMute and ChatAction', () => {
+test('auto-emitter maps an outbound Mute (mutation_send) to ChatMute and ChatAction', () => {
     const h = makeHarness()
     new WaWamAutoEmitter(h.coordinator, h.ctx)
-    h.emit('mutation', {
+    h.emit('mutation_send', {
         schema: 'Mute',
         operation: 'set',
         source: 'local',
@@ -398,24 +398,24 @@ test('auto-emitter maps a local Mute mutation to ChatMute and ChatAction', () =>
     })
 })
 
-test('auto-emitter maps local Pin/Archive/Read mutations to ChatAction', () => {
+test('auto-emitter maps outbound Pin/Archive/Read (mutation_send) to ChatAction', () => {
     const h = makeHarness()
     new WaWamAutoEmitter(h.coordinator, h.ctx)
-    h.emit('mutation', {
+    h.emit('mutation_send', {
         schema: 'Pin',
         operation: 'set',
         source: 'local',
         chatJid: 'a@s.whatsapp.net',
         pinned: true
     })
-    h.emit('mutation', {
+    h.emit('mutation_send', {
         schema: 'Archive',
         operation: 'set',
         source: 'local',
         chatJid: '1@g.us',
         archived: true
     })
-    h.emit('mutation', {
+    h.emit('mutation_send', {
         schema: 'MarkChatAsRead',
         operation: 'set',
         source: 'local',
@@ -428,30 +428,30 @@ test('auto-emitter maps local Pin/Archive/Read mutations to ChatAction', () => {
     assert.deepEqual(types, ['PIN', 'ARCHIVE', 'UNREAD'])
 })
 
-test('auto-emitter maps local Pin/Delete/Clear mutations to MdSyncdDogfoodingFeatureUsage', () => {
+test('auto-emitter maps outbound Pin/Delete/Clear (mutation_send) to MdSyncdDogfoodingFeatureUsage', () => {
     const h = makeHarness()
     new WaWamAutoEmitter(h.coordinator, h.ctx)
-    h.emit('mutation', {
+    h.emit('mutation_send', {
         schema: 'Pin',
         operation: 'set',
         source: 'local',
         chatJid: 'a@s.whatsapp.net',
         pinned: true
     })
-    h.emit('mutation', {
+    h.emit('mutation_send', {
         schema: 'DeleteChat',
         operation: 'set',
         source: 'local',
         chatJid: 'a@s.whatsapp.net'
     })
-    h.emit('mutation', {
+    h.emit('mutation_send', {
         schema: 'ClearChat',
         operation: 'set',
         source: 'local',
         chatJid: 'a@s.whatsapp.net',
         deleteStarred: '1'
     })
-    h.emit('mutation', {
+    h.emit('mutation_send', {
         schema: 'ClearChat',
         operation: 'set',
         source: 'local',
@@ -469,7 +469,7 @@ test('auto-emitter maps local Pin/Delete/Clear mutations to MdSyncdDogfoodingFea
     ])
 })
 
-test('auto-emitter ignores non-local (synced) app-state mutations', () => {
+test('auto-emitter ignores the inbound mutation stream (reacts only to mutation_send)', () => {
     const h = makeHarness()
     new WaWamAutoEmitter(h.coordinator, h.ctx)
     h.emit('mutation', {

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -800,6 +800,58 @@ test('auto-emitter fires RevokeMessageSend (ADMIN) alongside EditMessageSend for
             }
         }
     )
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'SendRevokeMessage'),
+        {
+            name: 'SendRevokeMessage',
+            payload: { messageType: 'GROUP' }
+        }
+    )
+})
+
+test('auto-emitter fires OfflineCountTooHigh once a message offline position hits 11', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message', {
+        key: {
+            remoteJid: '1@s.whatsapp.net',
+            isGroup: false,
+            isBroadcast: false,
+            isNewsletter: false
+        },
+        offline: true,
+        rawNode: { tag: 'message', attrs: { offline: '11' } }
+    })
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'OfflineCountTooHigh'),
+        {
+            name: 'OfflineCountTooHigh',
+            payload: {
+                offlineCount: 11,
+                stanzaType: 'MESSAGE',
+                messageType: 'INDIVIDUAL',
+                mediaType: 'NONE'
+            }
+        }
+    )
+})
+
+test('auto-emitter does not fire OfflineCountTooHigh below the threshold', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message', {
+        key: {
+            remoteJid: '1@s.whatsapp.net',
+            isGroup: false,
+            isBroadcast: false,
+            isNewsletter: false
+        },
+        rawNode: { tag: 'message', attrs: { offline: '10' } }
+    })
+    assert.equal(
+        h.commits.find((c) => c.name === 'OfflineCountTooHigh'),
+        undefined
+    )
 })
 
 test('auto-emitter fires no EditMessageSend for a normal (non-edit) send', () => {
@@ -927,4 +979,86 @@ test('auto-emitter ignores unrelated IQs and unmatched IQ responses', () => {
         node: { tag: 'iq', attrs: { id: 'ghost', type: 'result' } }
     })
     assert.equal(h.commits.length, 0)
+})
+
+test('auto-emitter fires GroupCreate + GroupCreateC on a successful create IQ', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'iq',
+            attrs: { id: 'gc1', to: '@g.us', type: 'set', xmlns: 'w:g2' },
+            content: [{ tag: 'create', attrs: { subject: 'My Group' }, content: [] }]
+        }
+    })
+    assert.equal(h.commits.length, 0)
+    h.emit('debug_transport_node_in', { node: { tag: 'iq', attrs: { id: 'gc1', type: 'result' } } })
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'GroupCreate'),
+        {
+            name: 'GroupCreate',
+            payload: { hasGroupName: true }
+        }
+    )
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'GroupCreateC'),
+        {
+            name: 'GroupCreateC',
+            payload: {}
+        }
+    )
+})
+
+test('auto-emitter does not fire GroupCreate when the create IQ errors', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'iq',
+            attrs: { id: 'gc2', to: '@g.us', type: 'set', xmlns: 'w:g2' },
+            content: [{ tag: 'create', attrs: { subject: 'X' }, content: [] }]
+        }
+    })
+    h.emit('debug_transport_node_in', { node: { tag: 'iq', attrs: { id: 'gc2', type: 'error' } } })
+    assert.equal(h.commits.length, 0)
+})
+
+test('auto-emitter fires EphemeralSettingChange from a group ephemeral IQ', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'iq',
+            attrs: { id: 'ep1', to: '123@g.us', type: 'set', xmlns: 'w:g2' },
+            content: [{ tag: 'ephemeral', attrs: { expiration: '604800' } }]
+        }
+    })
+    h.emit('debug_transport_node_in', { node: { tag: 'iq', attrs: { id: 'ep1', type: 'result' } } })
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'EphemeralSettingChange'),
+        {
+            name: 'EphemeralSettingChange',
+            payload: { chatEphemeralityDuration: 604800, isSuccess: true }
+        }
+    )
+})
+
+test('auto-emitter fires DisappearingModeSettingChange (isSuccess reflects the ack) from a disappearing_mode IQ', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'iq',
+            attrs: { id: 'dm1', to: '@s.whatsapp.net', type: 'set', xmlns: 'disappearing_mode' },
+            content: [{ tag: 'disappearing_mode', attrs: { duration: '86400' } }]
+        }
+    })
+    h.emit('debug_transport_node_in', { node: { tag: 'iq', attrs: { id: 'dm1', type: 'error' } } })
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'DisappearingModeSettingChange'),
+        {
+            name: 'DisappearingModeSettingChange',
+            payload: { newEphemeralityDuration: 86400, isSuccess: false }
+        }
+    )
 })

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -302,6 +302,85 @@ test('auto-emitter uses RECONNECT when it is not a new login', () => {
     )
 })
 
+test('auto-emitter emits WebcPageResume with an incrementing count on each reconnect', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    const close = { status: 'close', reason: 'lost', isNewLogin: false }
+    h.emit('connection', openEvent(false))
+    assert.equal(h.commits.filter((c) => c.name === 'WebcPageResume').length, 0)
+    h.emit('connection', close)
+    h.emit('connection', openEvent(false))
+    h.emit('connection', close)
+    h.emit('connection', openEvent(false))
+    const resumes = h.commits
+        .filter((c) => c.name === 'WebcPageResume')
+        .map((c) => (c.payload as { webcResumeCount: number }).webcResumeCount)
+    assert.deepEqual(resumes, [1, 2])
+})
+
+test('auto-emitter maps a device-switch notification to WaOldCode', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_in', {
+        node: {
+            tag: 'notification',
+            attrs: { from: 's.whatsapp.net', type: 'w:old' },
+            content: [{ tag: 'wa_old_registration', attrs: { device_id: 'ABC123', code: '000' } }]
+        }
+    })
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'WaOldCode'),
+        { name: 'WaOldCode', payload: { deviceId: 'ABC123' } }
+    )
+})
+
+test('auto-emitter fires EditMessageSend (EDITED) when an edited group message is acked', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'message',
+            attrs: { to: '123@g.us', id: 'e1', edit: '1' },
+            content: [{ tag: 'enc', attrs: { v: '2', type: 'skmsg' } }]
+        }
+    })
+    h.commits.length = 0
+    h.emit('debug_transport_node_in', { node: { tag: 'ack', attrs: { class: 'message', id: 'e1' } } })
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'EditMessageSend'),
+        { name: 'EditMessageSend', payload: { editType: 'EDITED', messageType: 'GROUP', typeOfGroup: 'GROUP' } }
+    )
+})
+
+test('auto-emitter maps an edit=7 revoke send to a SENDER_REVOKE EditMessageSend', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'message',
+            attrs: { to: '5511999999999@s.whatsapp.net', id: 'r1', edit: '7' },
+            content: [{ tag: 'enc', attrs: { v: '2', type: 'msg' } }]
+        }
+    })
+    h.emit('debug_transport_node_in', { node: { tag: 'ack', attrs: { class: 'message', id: 'r1' } } })
+    const edit = h.commits.find((c) => c.name === 'EditMessageSend')
+    assert.equal((edit?.payload as { editType: string }).editType, 'SENDER_REVOKE')
+})
+
+test('auto-emitter fires no EditMessageSend for a normal (non-edit) send', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'message',
+            attrs: { to: '5511999999999@s.whatsapp.net', id: 'n1' },
+            content: [{ tag: 'enc', attrs: { v: '2', type: 'msg' } }]
+        }
+    })
+    h.emit('debug_transport_node_in', { node: { tag: 'ack', attrs: { class: 'message', id: 'n1' } } })
+    assert.equal(h.commits.filter((c) => c.name === 'EditMessageSend').length, 0)
+})
+
 test('auto-emitter maps an unhandled stanza to UnknownStanza', () => {
     const h = makeHarness()
     new WaWamAutoEmitter(h.coordinator, h.ctx)

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -376,6 +376,72 @@ test('auto-emitter does not fire GroupJoinC for self-authored actions or others 
     assert.equal(h.commits.filter((c) => c.name === 'GroupJoinC').length, 0)
 })
 
+test('auto-emitter maps a local Mute mutation to ChatMute and ChatAction', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('mutation', {
+        schema: 'Mute',
+        operation: 'set',
+        source: 'local',
+        chatJid: '1@g.us',
+        muted: true,
+        muteEndTimestamp: Date.now() + 60_000
+    })
+    const mute = h.commits.find((c) => c.name === 'ChatMute')
+    assert.ok(mute)
+    assert.equal((mute?.payload as { actionConducted: string }).actionConducted, 'MUTE')
+    assert.equal((mute?.payload as { muteChatType: string }).muteChatType, 'GROUP')
+    assert.equal(typeof (mute?.payload as { muteDuration: number }).muteDuration, 'number')
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'ChatAction')?.payload,
+        { chatActionType: 'MUTE', chatActionChatType: 'GROUP' }
+    )
+})
+
+test('auto-emitter maps local Pin/Archive/Read mutations to ChatAction', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('mutation', {
+        schema: 'Pin',
+        operation: 'set',
+        source: 'local',
+        chatJid: 'a@s.whatsapp.net',
+        pinned: true
+    })
+    h.emit('mutation', {
+        schema: 'Archive',
+        operation: 'set',
+        source: 'local',
+        chatJid: '1@g.us',
+        archived: true
+    })
+    h.emit('mutation', {
+        schema: 'MarkChatAsRead',
+        operation: 'set',
+        source: 'local',
+        chatJid: 'a@s.whatsapp.net',
+        read: false
+    })
+    const types = h.commits
+        .filter((c) => c.name === 'ChatAction')
+        .map((c) => (c.payload as { chatActionType: string }).chatActionType)
+    assert.deepEqual(types, ['PIN', 'ARCHIVE', 'UNREAD'])
+})
+
+test('auto-emitter ignores non-local (synced) app-state mutations', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('mutation', {
+        schema: 'Mute',
+        operation: 'set',
+        source: 'patch',
+        chatJid: '1@g.us',
+        muted: true,
+        muteEndTimestamp: 0
+    })
+    assert.equal(h.commits.length, 0)
+})
+
 test('auto-emitter maps a device-switch notification to WaOldCode', () => {
     const h = makeHarness()
     new WaWamAutoEmitter(h.coordinator, h.ctx)

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -392,10 +392,10 @@ test('auto-emitter maps a local Mute mutation to ChatMute and ChatAction', () =>
     assert.equal((mute?.payload as { actionConducted: string }).actionConducted, 'MUTE')
     assert.equal((mute?.payload as { muteChatType: string }).muteChatType, 'GROUP')
     assert.equal(typeof (mute?.payload as { muteDuration: number }).muteDuration, 'number')
-    assert.deepEqual(
-        h.commits.find((c) => c.name === 'ChatAction')?.payload,
-        { chatActionType: 'MUTE', chatActionChatType: 'GROUP' }
-    )
+    assert.deepEqual(h.commits.find((c) => c.name === 'ChatAction')?.payload, {
+        chatActionType: 'MUTE',
+        chatActionChatType: 'GROUP'
+    })
 })
 
 test('auto-emitter maps local Pin/Archive/Read mutations to ChatAction', () => {
@@ -490,10 +490,13 @@ test('auto-emitter maps an outbound reaction to ReactionActions (UPDATE / DELETE
         to: '456@s.whatsapp.net',
         message: { reactionMessage: { text: '👍' } }
     })
-    assert.deepEqual(h.commits.find((c) => c.name === 'ReactionActions'), {
-        name: 'ReactionActions',
-        payload: { reactionAction: 'UPDATE', messageType: 'INDIVIDUAL' }
-    })
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'ReactionActions'),
+        {
+            name: 'ReactionActions',
+            payload: { reactionAction: 'UPDATE', messageType: 'INDIVIDUAL' }
+        }
+    )
     h.commits.length = 0
     h.emit('message_send', { to: '456@s.whatsapp.net', message: { reactionMessage: { text: '' } } })
     assert.equal(
@@ -515,16 +518,19 @@ test('auto-emitter maps an outbound poll to PollsActions (CREATE_POLL with optio
             }
         }
     })
-    assert.deepEqual(h.commits.find((c) => c.name === 'PollsActions'), {
-        name: 'PollsActions',
-        payload: {
-            pollAction: 'CREATE_POLL',
-            chatType: 'GROUP',
-            isAGroup: true,
-            pollOptionsCount: 3,
-            typeOfGroup: 'GROUP'
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'PollsActions'),
+        {
+            name: 'PollsActions',
+            payload: {
+                pollAction: 'CREATE_POLL',
+                chatType: 'GROUP',
+                isAGroup: true,
+                pollOptionsCount: 3,
+                typeOfGroup: 'GROUP'
+            }
         }
-    })
+    )
 })
 
 test('auto-emitter maps an outbound document to SendDocument', () => {
@@ -541,15 +547,18 @@ test('auto-emitter maps an outbound document to SendDocument', () => {
             }
         }
     })
-    assert.deepEqual(h.commits.find((c) => c.name === 'SendDocument'), {
-        name: 'SendDocument',
-        payload: {
-            documentType: 'DOCUMENT',
-            documentExt: 'pdf',
-            documentPageSize: 4,
-            documentSize: 12345
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'SendDocument'),
+        {
+            name: 'SendDocument',
+            payload: {
+                documentType: 'DOCUMENT',
+                documentExt: 'pdf',
+                documentPageSize: 4,
+                documentSize: 12345
+            }
         }
-    })
+    )
 })
 
 test('auto-emitter maps a forwarded outbound message to ForwardSend', () => {
@@ -559,16 +568,19 @@ test('auto-emitter maps a forwarded outbound message to ForwardSend', () => {
         to: '1@g.us',
         message: { imageMessage: { contextInfo: { isForwarded: true, forwardingScore: 5 } } }
     })
-    assert.deepEqual(h.commits.find((c) => c.name === 'ForwardSend'), {
-        name: 'ForwardSend',
-        payload: {
-            messageType: 'GROUP',
-            isFrequentlyForwarded: true,
-            isForwardedForward: true,
-            messageMediaType: 'PHOTO',
-            typeOfGroup: 'GROUP'
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'ForwardSend'),
+        {
+            name: 'ForwardSend',
+            payload: {
+                messageType: 'GROUP',
+                isFrequentlyForwarded: true,
+                isForwardedForward: true,
+                messageMediaType: 'PHOTO',
+                typeOfGroup: 'GROUP'
+            }
         }
-    })
+    )
 })
 
 test('auto-emitter emits both ForwardSend and SendDocument for a forwarded document', () => {
@@ -627,10 +639,15 @@ test('auto-emitter fires EditMessageSend (EDITED) when an edited group message i
         }
     })
     h.commits.length = 0
-    h.emit('debug_transport_node_in', { node: { tag: 'ack', attrs: { class: 'message', id: 'e1' } } })
+    h.emit('debug_transport_node_in', {
+        node: { tag: 'ack', attrs: { class: 'message', id: 'e1' } }
+    })
     assert.deepEqual(
         h.commits.find((c) => c.name === 'EditMessageSend'),
-        { name: 'EditMessageSend', payload: { editType: 'EDITED', messageType: 'GROUP', typeOfGroup: 'GROUP' } }
+        {
+            name: 'EditMessageSend',
+            payload: { editType: 'EDITED', messageType: 'GROUP', typeOfGroup: 'GROUP' }
+        }
     )
 })
 
@@ -644,7 +661,9 @@ test('auto-emitter maps an edit=7 revoke send to a SENDER_REVOKE EditMessageSend
             content: [{ tag: 'enc', attrs: { v: '2', type: 'msg' } }]
         }
     })
-    h.emit('debug_transport_node_in', { node: { tag: 'ack', attrs: { class: 'message', id: 'r1' } } })
+    h.emit('debug_transport_node_in', {
+        node: { tag: 'ack', attrs: { class: 'message', id: 'r1' } }
+    })
     const edit = h.commits.find((c) => c.name === 'EditMessageSend')
     assert.equal((edit?.payload as { editType: string }).editType, 'SENDER_REVOKE')
 })
@@ -659,11 +678,20 @@ test('auto-emitter fires RevokeMessageSend (ADMIN) alongside EditMessageSend for
             content: [{ tag: 'enc', attrs: { v: '2', type: 'skmsg' } }]
         }
     })
-    h.emit('debug_transport_node_in', { node: { tag: 'ack', attrs: { class: 'message', id: 'rv1' } } })
-    assert.deepEqual(h.commits.find((c) => c.name === 'RevokeMessageSend'), {
-        name: 'RevokeMessageSend',
-        payload: { revokeType: 'ADMIN', messageType: 'GROUP', messageSendResultIsTerminal: true }
+    h.emit('debug_transport_node_in', {
+        node: { tag: 'ack', attrs: { class: 'message', id: 'rv1' } }
     })
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'RevokeMessageSend'),
+        {
+            name: 'RevokeMessageSend',
+            payload: {
+                revokeType: 'ADMIN',
+                messageType: 'GROUP',
+                messageSendResultIsTerminal: true
+            }
+        }
+    )
     assert.equal(
         (h.commits.find((c) => c.name === 'EditMessageSend')?.payload as { editType: string })
             .editType,
@@ -681,7 +709,9 @@ test('auto-emitter fires no EditMessageSend for a normal (non-edit) send', () =>
             content: [{ tag: 'enc', attrs: { v: '2', type: 'msg' } }]
         }
     })
-    h.emit('debug_transport_node_in', { node: { tag: 'ack', attrs: { class: 'message', id: 'n1' } } })
+    h.emit('debug_transport_node_in', {
+        node: { tag: 'ack', attrs: { class: 'message', id: 'n1' } }
+    })
     assert.equal(h.commits.filter((c) => c.name === 'EditMessageSend').length, 0)
 })
 
@@ -726,7 +756,11 @@ const membershipActionIq = (id: string, action: 'approve' | 'reject') => ({
                 tag: 'membership_requests_action',
                 attrs: {},
                 content: [
-                    { tag: action, attrs: {}, content: [{ tag: 'participant', attrs: { jid: '5@s.whatsapp.net' } }] }
+                    {
+                        tag: action,
+                        attrs: {},
+                        content: [{ tag: 'participant', attrs: { jid: '5@s.whatsapp.net' } }]
+                    }
                 ]
             }
         ]
@@ -786,6 +820,8 @@ test('auto-emitter ignores unrelated IQs and unmatched IQ responses', () => {
     })
     // A result for an untracked id emits nothing.
     h.emit('debug_transport_node_in', { node: { tag: 'iq', attrs: { id: 'x1', type: 'result' } } })
-    h.emit('debug_transport_node_in', { node: { tag: 'iq', attrs: { id: 'ghost', type: 'result' } } })
+    h.emit('debug_transport_node_in', {
+        node: { tag: 'iq', attrs: { id: 'ghost', type: 'result' } }
+    })
     assert.equal(h.commits.length, 0)
 })

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
 import type { WaConnectionEvent } from 'zapo-js'
+import { proto } from 'zapo-js/proto'
 
 import { WaWamAutoEmitter, type WaWamAutoEmitterContext } from '../WaWamAutoEmitter.js'
 import type { WaWamCoordinator } from '../WaWamCoordinator.js'
@@ -483,6 +484,24 @@ test('auto-emitter ignores the inbound mutation stream (reacts only to mutation_
     assert.equal(h.commits.length, 0)
 })
 
+test('auto-emitter maps an outbound UserStatusMute to StatusMute', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('mutation_send', {
+        schema: 'UserStatusMute',
+        operation: 'set',
+        source: 'local',
+        muted: true
+    })
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'StatusMute'),
+        {
+            name: 'StatusMute',
+            payload: { muteAction: 'MUTE', statusCategory: 'REGULAR_STATUS' }
+        }
+    )
+})
+
 test('auto-emitter maps an outbound reaction to ReactionActions (UPDATE / DELETE)', () => {
     const h = makeHarness()
     new WaWamAutoEmitter(h.coordinator, h.ctx)
@@ -582,6 +601,53 @@ test('auto-emitter maps an outbound document to SendDocument', () => {
                 documentExt: 'pdf',
                 documentPageSize: 4,
                 documentSize: 12345
+            }
+        }
+    )
+})
+
+test('auto-emitter maps an outbound sticker to StickerSend', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message_send', {
+        to: '456@s.whatsapp.net',
+        message: { stickerMessage: { isAnimated: true, isAvatar: false, isAiSticker: false } }
+    })
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'StickerSend'),
+        {
+            name: 'StickerSend',
+            payload: {
+                stickerSendMessageType: 'REGULAR',
+                stickerIsAnimated: true,
+                stickerIsAvatar: false,
+                stickerIsAi: false
+            }
+        }
+    )
+})
+
+test('auto-emitter maps an outbound pin-in-chat to PinInChatMessageSend', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('message_send', {
+        to: '1@g.us',
+        message: {
+            pinInChatMessage: {
+                type: proto.Message.PinInChatMessage.Type.PIN_FOR_ALL,
+                key: { fromMe: true }
+            }
+        }
+    })
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'PinInChatMessageSend'),
+        {
+            name: 'PinInChatMessageSend',
+            payload: {
+                pinInChatType: 'PIN_FOR_ALL',
+                isAGroup: true,
+                isSelfPin: true,
+                isSelfParentMessage: true
             }
         }
     )
@@ -722,6 +788,17 @@ test('auto-emitter fires RevokeMessageSend (ADMIN) alongside EditMessageSend for
         (h.commits.find((c) => c.name === 'EditMessageSend')?.payload as { editType: string })
             .editType,
         'ADMIN_REVOKE'
+    )
+    assert.deepEqual(
+        h.commits.find((c) => c.name === 'MessageDeleteActions'),
+        {
+            name: 'MessageDeleteActions',
+            payload: {
+                deleteActionType: 'DELETE_FOR_EVERYONE',
+                isAGroup: true,
+                messagesDeleted: 1
+            }
+        }
     )
 })
 

--- a/packages/wam/src/__tests__/auto-emitter.test.ts
+++ b/packages/wam/src/__tests__/auto-emitter.test.ts
@@ -236,13 +236,60 @@ test('auto-emitter does not report clock skew for an in-sync timestamp', () => {
     assert.equal(h.commits.length, 0)
 })
 
-test('auto-emitter commits WebcSocketConnect with PAGE_LOAD on a fresh login', () => {
+test('auto-emitter commits WebcSocketConnect with PAGE_LOAD then SYNCING on a fresh login', () => {
     const h = makeHarness()
     new WaWamAutoEmitter(h.coordinator, h.ctx)
     h.emit('connection', openEvent(true))
     assert.deepEqual(h.commits, [
-        { name: 'WebcSocketConnect', payload: { webcSocketConnectReason: 'PAGE_LOAD' } }
+        { name: 'WebcSocketConnect', payload: { webcSocketConnectReason: 'PAGE_LOAD' } },
+        { name: 'WebcStreamModeChange', payload: { webcStreamMode: 'SYNCING' } }
     ])
+})
+
+const offlineIb = () => ({
+    node: {
+        tag: 'ib',
+        attrs: { from: 's.whatsapp.net' },
+        content: [{ tag: 'offline', attrs: { count: '0' } }]
+    }
+})
+
+test('auto-emitter walks the stream mode SYNCING -> MAIN -> OFFLINE across a session', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('connection', openEvent(false))
+    h.emit('debug_transport_node_in', offlineIb())
+    h.emit('connection', { status: 'close', reason: 'lost', isNewLogin: false })
+    const modes = h.commits
+        .filter((c) => c.name === 'WebcStreamModeChange')
+        .map((c) => (c.payload as { webcStreamMode: string }).webcStreamMode)
+    assert.deepEqual(modes, ['SYNCING', 'MAIN', 'OFFLINE'])
+})
+
+test('auto-emitter reaches MAIN on the offline ib even with an empty queue (no preview)', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('connection', openEvent(false))
+    h.emit('debug_transport_node_in', offlineIb())
+    const main = h.commits.find(
+        (c) =>
+            c.name === 'WebcStreamModeChange' &&
+            (c.payload as { webcStreamMode: string }).webcStreamMode === 'MAIN'
+    )
+    assert.ok(main)
+})
+
+test('auto-emitter emits MAIN once and ignores ibs without an offline child', () => {
+    const h = makeHarness()
+    new WaWamAutoEmitter(h.coordinator, h.ctx)
+    h.emit('connection', openEvent(false))
+    h.emit('debug_transport_node_in', offlineIb())
+    h.commits.length = 0
+    h.emit('debug_transport_node_in', {
+        node: { tag: 'ib', attrs: {}, content: [{ tag: 'notice', attrs: { id: '1' } }] }
+    })
+    h.emit('debug_transport_node_in', offlineIb())
+    assert.equal(h.commits.length, 0)
 })
 
 test('auto-emitter uses RECONNECT when it is not a new login', () => {
@@ -278,7 +325,7 @@ test('auto-emitter maps a history-sync chunk to MdBootstrapHistoryDataReceived',
     })
 })
 
-test('auto-emitter ignores non-open connection events and detaches on dispose', () => {
+test('auto-emitter emits no stream mode for a close before any open, and detaches on dispose', () => {
     const h = makeHarness()
     const emitter = new WaWamAutoEmitter(h.coordinator, h.ctx)
     h.emit('connection', { status: 'close', reason: 'lost', isNewLogin: false })

--- a/packages/wam/src/__tests__/coordinator.test.ts
+++ b/packages/wam/src/__tests__/coordinator.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import type { BinaryNode, WaClientPluginContext } from 'zapo-js'
+
+import { WaWamCoordinator } from '../WaWamCoordinator.js'
+
+const noopLogger = {
+    trace() {},
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+    child() {
+        return noopLogger
+    }
+}
+
+function makeCoordinator(connectedInitially: boolean) {
+    const uploads: BinaryNode[] = []
+    let connected = connectedInitially
+    const ctx = {
+        logger: noopLogger,
+        queryWithContext: async (_context: string, node: BinaryNode) => {
+            uploads.push(node)
+            return { tag: 'iq', attrs: { type: 'result' }, content: [] } as BinaryNode
+        },
+        deps: { connectionManager: { isConnected: () => connected } },
+        options: { deviceBrowser: 'Chrome', deviceOsDisplayName: 'Windows' }
+    } as unknown as WaClientPluginContext
+    const coordinator = new WaWamCoordinator(ctx, { autoEmit: false })
+    return { coordinator, uploads, setConnected: (value: boolean) => (connected = value) }
+}
+
+test('WaWamCoordinator drops the batch while disconnected instead of buffering or uploading', async () => {
+    const { coordinator, uploads, setConnected } = makeCoordinator(false)
+    coordinator.commit('UiAction', { uiActionType: 'CHAT_OPEN' })
+    await coordinator.flush()
+    assert.equal(uploads.length, 0)
+    setConnected(true)
+    await coordinator.flush()
+    assert.equal(uploads.length, 0)
+    await coordinator.dispose()
+})
+
+test('WaWamCoordinator uploads the batch as a w:stats iq when connected', async () => {
+    const { coordinator, uploads } = makeCoordinator(true)
+    coordinator.commit('UiAction', { uiActionType: 'CHAT_OPEN' })
+    await coordinator.flush()
+    assert.equal(uploads.length, 1)
+    assert.equal(uploads[0]?.attrs.xmlns, 'w:stats')
+    await coordinator.dispose()
+})

--- a/packages/wam/src/__tests__/coordinator.test.ts
+++ b/packages/wam/src/__tests__/coordinator.test.ts
@@ -51,3 +51,16 @@ test('WaWamCoordinator uploads the batch as a w:stats iq when connected', async 
     assert.equal(uploads[0]?.attrs.xmlns, 'w:stats')
     await coordinator.dispose()
 })
+
+test('WaWamCoordinator commits WebWamForceFlush on dispose (WA Web force-flush parity)', async () => {
+    const origRandom = Math.random
+    Math.random = () => 0 // ensure the commit sampling gate passes
+    try {
+        const { coordinator, uploads } = makeCoordinator(true)
+        await coordinator.dispose()
+        assert.equal(uploads.length, 1)
+        assert.equal(uploads[0]?.attrs.xmlns, 'w:stats')
+    } finally {
+        Math.random = origRandom
+    }
+})

--- a/packages/wam/src/__tests__/coordinator.test.ts
+++ b/packages/wam/src/__tests__/coordinator.test.ts
@@ -28,7 +28,7 @@ function makeCoordinator(connectedInitially: boolean) {
         deps: { connectionManager: { isConnected: () => connected } },
         options: { deviceBrowser: 'Chrome', deviceOsDisplayName: 'Windows' }
     } as unknown as WaClientPluginContext
-    const coordinator = new WaWamCoordinator(ctx, { autoEmit: false })
+    const coordinator = new WaWamCoordinator(ctx, { autoEmit: false, syntheticUi: false })
     return { coordinator, uploads, setConnected: (value: boolean) => (connected = value) }
 }
 

--- a/packages/wam/src/__tests__/globals.test.ts
+++ b/packages/wam/src/__tests__/globals.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { resolveWamGlobals } from '../globals.js'
+
+test('resolveWamGlobals derives identity-consistent regular-channel globals', () => {
+    const globals = resolveWamGlobals(
+        { deviceBrowser: 'chrome', deviceOsDisplayName: 'Windows', streamId: 7 },
+        'regular'
+    )
+    assert.equal(globals.get(11), 8)
+    assert.equal(globals.get(15), 'Windows')
+    assert.equal(globals.get(779), 'Chrome')
+    assert.equal(globals.get(899), 2)
+    assert.equal(globals.get(3543), 7)
+    assert.equal(globals.get(5), 0)
+    assert.equal(globals.get(3), 0)
+    assert.equal(typeof globals.get(17), 'string')
+})
+
+test('resolveWamGlobals maps macOS to the DARWIN web platform', () => {
+    const globals = resolveWamGlobals(
+        { deviceBrowser: 'safari', deviceOsDisplayName: 'Mac OS', streamId: 1 },
+        'regular'
+    )
+    assert.equal(globals.get(899), 3)
+})
+
+test('resolveWamGlobals filters globals by channel', () => {
+    const priv = resolveWamGlobals({ streamId: 1 }, 'private')
+    assert.equal(priv.has(779), false)
+    assert.equal(priv.has(11), true)
+})

--- a/packages/wam/src/__tests__/registry.test.ts
+++ b/packages/wam/src/__tests__/registry.test.ts
@@ -35,3 +35,12 @@ test('resolveWamEventFields skips absent fields and unresolvable enum keys', () 
     assert.deepEqual(resolveWamEventFields('UiAction', {}), [])
     assert.deepEqual(resolveWamEventFields('UiAction', { uiActionType: 'NOPE' }), [])
 })
+
+test('resolveWamEventFields drops non-integer / non-finite int fields', () => {
+    assert.deepEqual(resolveWamEventFields('UiAction', { uiActionT: 3.14 }), [])
+    assert.deepEqual(resolveWamEventFields('UiAction', { uiActionT: Number.NaN }), [])
+    assert.deepEqual(resolveWamEventFields('UiAction', { uiActionT: Number.POSITIVE_INFINITY }), [])
+    assert.deepEqual(resolveWamEventFields('UiAction', { uiActionT: 142 }), [
+        { id: 3, kind: 'int', value: 142 }
+    ])
+})

--- a/packages/wam/src/__tests__/registry.test.ts
+++ b/packages/wam/src/__tests__/registry.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { resolveWamEnumValue, resolveWamEventFields, wamValueKind } from '../registry.js'
+
+test('wamValueKind maps registry types to wire kinds', () => {
+    assert.equal(wamValueKind('boolean'), 'bool')
+    assert.equal(wamValueKind('integer'), 'int')
+    assert.equal(wamValueKind('timer'), 'int')
+    assert.equal(wamValueKind('enum'), 'int')
+    assert.equal(wamValueKind('number'), 'float')
+    assert.equal(wamValueKind('string'), 'string')
+    assert.equal(wamValueKind('unknown'), null)
+})
+
+test('resolveWamEnumValue converts value keys to numeric ids', () => {
+    assert.equal(resolveWamEnumValue('UI_ACTION_TYPE', 'CHAT_OPEN'), 3)
+    assert.equal(resolveWamEnumValue('UI_ACTION_TYPE', 'NONEXISTENT'), null)
+})
+
+test('resolveWamEventFields resolves enums and types (registry field order)', () => {
+    const fields = resolveWamEventFields('UiAction', {
+        uiActionType: 'CHAT_OPEN',
+        uiActionPreloaded: true,
+        uiActionT: 142
+    })
+    assert.deepEqual(fields, [
+        { id: 2, kind: 'bool', value: true },
+        { id: 3, kind: 'int', value: 142 },
+        { id: 1, kind: 'int', value: 3 }
+    ])
+})
+
+test('resolveWamEventFields skips absent fields and unresolvable enum keys', () => {
+    assert.deepEqual(resolveWamEventFields('UiAction', {}), [])
+    assert.deepEqual(resolveWamEventFields('UiAction', { uiActionType: 'NOPE' }), [])
+})

--- a/packages/wam/src/__tests__/send-parse.test.ts
+++ b/packages/wam/src/__tests__/send-parse.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import type { BinaryNode } from 'zapo-js'
+
+import {
+    ciphertextTypeKey,
+    e2eDestinationKey,
+    findFirstEncNode,
+    mediaTypeKey
+} from '../send-parse.js'
+
+const enc = (attrs: Record<string, string>): BinaryNode => ({ tag: 'enc', attrs })
+
+test('findFirstEncNode finds direct, group and participant-nested enc nodes', () => {
+    const direct: BinaryNode = { tag: 'message', attrs: {}, content: [enc({ type: 'msg' })] }
+    assert.equal(findFirstEncNode(direct)?.attrs.type, 'msg')
+
+    const nested: BinaryNode = {
+        tag: 'message',
+        attrs: {},
+        content: [
+            {
+                tag: 'participants',
+                attrs: {},
+                content: [{ tag: 'to', attrs: {}, content: [enc({ type: 'pkmsg' })] }]
+            }
+        ]
+    }
+    assert.equal(findFirstEncNode(nested)?.attrs.type, 'pkmsg')
+
+    const none: BinaryNode = { tag: 'message', attrs: {}, content: [{ tag: 'x', attrs: {} }] }
+    assert.equal(findFirstEncNode(none), null)
+    assert.equal(findFirstEncNode({ tag: 'message', attrs: {} }), null)
+})
+
+test('ciphertextTypeKey maps enc type attr to the E2E_CIPHERTEXT_TYPE key', () => {
+    assert.equal(ciphertextTypeKey('msg'), 'MESSAGE')
+    assert.equal(ciphertextTypeKey('pkmsg'), 'PREKEY_MESSAGE')
+    assert.equal(ciphertextTypeKey('skmsg'), 'SENDER_KEY_MESSAGE')
+    assert.equal(ciphertextTypeKey('msmsg'), 'MESSAGE_SECRET_MESSAGE')
+    assert.equal(ciphertextTypeKey('nope'), null)
+    assert.equal(ciphertextTypeKey(undefined), null)
+})
+
+test('e2eDestinationKey maps the recipient jid to the destination', () => {
+    assert.equal(e2eDestinationKey('123@g.us'), 'GROUP')
+    assert.equal(e2eDestinationKey('status@broadcast'), 'STATUS')
+    assert.equal(e2eDestinationKey('abc@newsletter'), 'CHANNEL')
+    assert.equal(e2eDestinationKey('5511999999999@s.whatsapp.net'), 'INDIVIDUAL')
+    assert.equal(e2eDestinationKey('456@lid'), 'INDIVIDUAL')
+})
+
+test('mediaTypeKey maps the enc mediatype attr to the MEDIA_TYPE key', () => {
+    assert.equal(mediaTypeKey('image'), 'PHOTO')
+    assert.equal(mediaTypeKey('ptt'), 'PTT')
+    assert.equal(mediaTypeKey('document'), 'DOCUMENT')
+    assert.equal(mediaTypeKey('carrier-pigeon'), null)
+    assert.equal(mediaTypeKey(undefined), null)
+})

--- a/packages/wam/src/__tests__/synthetic-ui.test.ts
+++ b/packages/wam/src/__tests__/synthetic-ui.test.ts
@@ -55,7 +55,8 @@ test('synthetic UI fabricates CHAT_OPEN with WA Web fields (preloaded + isLid, n
     assert.ok(webc)
     assert.equal(typeof webc?.payload.webcWindowHeightFloat, 'number')
     assert.equal(typeof webc?.payload.webcUnreadCount, 'number')
-    ui.dispose()})
+    ui.dispose()
+})
 
 test('synthetic UI fabricates IMAGE_OPEN for an image message and only uses web-real types', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -70,7 +71,8 @@ test('synthetic UI fabricates IMAGE_OPEN for an image message and only uses web-
     assert.ok(types.includes('CHAT_OPEN'))
     assert.ok(types.includes('IMAGE_OPEN'))
     assert.ok(types.every((t) => t === 'CHAT_OPEN' || t === 'IMAGE_OPEN'))
-    ui.dispose()})
+    ui.dispose()
+})
 
 test('synthetic UI fabricates GROUP_INFO_OPEN (preloaded + isLid) for a group message', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -88,7 +90,8 @@ test('synthetic UI fabricates GROUP_INFO_OPEN (preloaded + isLid) for a group me
     assert.ok(info)
     assert.equal(info?.payload.uiActionPreloaded, true)
     assert.equal(info?.payload.isLid, false)
-    ui.dispose()})
+    ui.dispose()
+})
 
 test('synthetic UI fabricates CHANNEL_INFO_OPEN without isLid for a newsletter message', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -107,7 +110,8 @@ test('synthetic UI fabricates CHANNEL_INFO_OPEN without isLid for a newsletter m
     assert.equal(info?.payload.uiActionPreloaded, true)
     // WA Web's CHANNEL_INFO_OPEN does not set isLid
     assert.equal(info?.payload.isLid, undefined)
-    ui.dispose()})
+    ui.dispose()
+})
 
 test('synthetic UI fabricates MSG_INFO_OPEN after an outbound message', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -121,14 +125,15 @@ test('synthetic UI fabricates MSG_INFO_OPEN after an outbound message', () => {
     assert.ok(info)
     assert.equal(info?.payload.uiActionPreloaded, true)
     assert.equal(info?.payload.isLid, true)
-    ui.dispose()})
+    ui.dispose()
+})
 
 test('synthetic UI fabricates WebcMediaLoad (SUCCESS) for an inbound audio message', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
     const h = makeHarness()
     const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
         chatOpenProbability: 0,
-        imageOpenProbability: 1
+        audioLoadProbability: 1
     })
     h.emit('message', lidMessage({ message: { audioMessage: {} } }))
     mock.timers.tick(10_000)
@@ -136,7 +141,8 @@ test('synthetic UI fabricates WebcMediaLoad (SUCCESS) for an inbound audio messa
     assert.ok(media)
     assert.equal(media?.payload.webcMediaLoadResult, 'SUCCESS')
     assert.equal(typeof media?.payload.webcMediaLoadT, 'number')
-    ui.dispose()})
+    ui.dispose()
+})
 
 test('synthetic UI fabricates nothing outside the configured active hours', () => {
     mock.timers.enable({ apis: ['setTimeout', 'Date'] })
@@ -150,7 +156,37 @@ test('synthetic UI fabricates nothing outside the configured active hours', () =
     h.emit('message', lidMessage())
     mock.timers.tick(61_000)
     assert.equal(h.commits.length, 0)
-    ui.dispose()})
+    ui.dispose()
+})
+
+test('synthetic UI falls back to the default interval for a non-positive option (no tight loop)', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        chatOpenProbability: 0,
+        ambientIntervalMinMs: 10 * 60_000,
+        ambientIntervalMaxMs: 10 * 60_000,
+        memoryIntervalMinMs: 0,
+        memoryIntervalMaxMs: -1
+    })
+    mock.timers.tick(5_000)
+    assert.equal(h.commits.filter((c) => c.name === 'MemoryStat').length, 0)
+    ui.dispose()
+})
+
+test('synthetic UI gates audio WebcMediaLoad on audioLoadProbability, not imageOpenProbability', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        chatOpenProbability: 0,
+        imageOpenProbability: 1,
+        audioLoadProbability: 0
+    })
+    h.emit('message', lidMessage({ message: { audioMessage: {} } }))
+    mock.timers.tick(10_000)
+    assert.equal(h.commits.filter((c) => c.name === 'WebcMediaLoad').length, 0)
+    ui.dispose()
+})
 
 test('synthetic UI fabricates WebcEmojiOpen with a real tab in the ambient stream', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -192,7 +228,8 @@ test('synthetic UI fabricates AttachmentTrayActions (SEND) for an outbound media
     assert.equal(tray?.payload.sendMediaType, 'PHOTO')
     assert.equal(tray?.payload.actionThreadType, 'GROUP_CHAT')
     assert.equal(tray?.payload.isAGroup, true)
-    ui.dispose()})
+    ui.dispose()
+})
 
 test('synthetic UI fabricates no AttachmentTrayActions for a sticker (emoji-panel, not the tray)', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -207,7 +244,8 @@ test('synthetic UI fabricates no AttachmentTrayActions for a sticker (emoji-pane
     })
     mock.timers.tick(13_000)
     assert.equal(h.commits.filter((c) => c.name === 'AttachmentTrayActions').length, 0)
-    ui.dispose()})
+    ui.dispose()
+})
 
 test('synthetic UI samples MemoryStat periodically (main process, uptime, numMessages)', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -225,7 +263,8 @@ test('synthetic UI samples MemoryStat periodically (main process, uptime, numMes
     assert.equal(typeof mem?.payload.workingSetSize, 'number')
     assert.equal(typeof mem?.payload.uptime, 'number')
     assert.ok((mem?.payload.numMessages as number) >= 1)
-    ui.dispose()})
+    ui.dispose()
+})
 
 test('synthetic UI flushes UserActivity with a bitmap matching the active slices', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -243,7 +282,8 @@ test('synthetic UI flushes UserActivity with a bitmap matching the active slices
     assert.equal(ua?.payload.userActivitySessionCum, 1)
     assert.equal(ua?.payload.userActivityBitmapLow, 1)
     assert.equal(ua?.payload.userActivitySessionSeq, 1)
-    ui.dispose()})
+    ui.dispose()
+})
 
 test('synthetic UI keeps emitting UserActivity past the 64-slice cap and rolls the session', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -258,7 +298,8 @@ test('synthetic UI keeps emitting UserActivity past the 64-slice cap and rolls t
     assert.ok(activities.some((c) => c.payload.userActivityBitmapLen === 64))
     assert.equal(activities[activities.length - 1]?.payload.userActivitySessionSeq, 1)
     assert.ok(activities.length > 12)
-    ui.dispose()})
+    ui.dispose()
+})
 
 test('synthetic UI fabricates AboutConsumption for a 1:1 inbound message', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -276,7 +317,8 @@ test('synthetic UI fabricates AboutConsumption for a 1:1 inbound message', () =>
             about?.payload.aboutConsumptionSurface as string
         )
     )
-    ui.dispose()})
+    ui.dispose()
+})
 
 test('synthetic UI fabricates no AboutConsumption for a group message', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -292,7 +334,8 @@ test('synthetic UI fabricates no AboutConsumption for a group message', () => {
     })
     mock.timers.tick(41_000)
     assert.equal(h.commits.filter((c) => c.name === 'AboutConsumption').length, 0)
-    ui.dispose()})
+    ui.dispose()
+})
 
 test('synthetic UI fabricates ContactSearchExperience in the ambient stream', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -326,4 +369,5 @@ test('synthetic UI cancels pending fabrications on dispose', () => {
     h.emit('message', lidMessage())
     ui.dispose()
     mock.timers.tick(120_000)
-    assert.equal(h.commits.length, 0)})
+    assert.equal(h.commits.length, 0)
+})

--- a/packages/wam/src/__tests__/synthetic-ui.test.ts
+++ b/packages/wam/src/__tests__/synthetic-ui.test.ts
@@ -263,6 +263,69 @@ test('synthetic UI flushes UserActivity with a bitmap matching the active slices
     mock.timers.reset()
 })
 
+test('synthetic UI fabricates AboutConsumption for a 1:1 inbound message', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        chatOpenProbability: 0,
+        aboutConsumptionProbability: 1
+    })
+    h.emit('message', lidMessage())
+    mock.timers.tick(41_000)
+    const about = h.commits.find((c) => c.name === 'AboutConsumption')
+    assert.ok(about)
+    assert.ok(
+        ['ONE_ON_ONE_CHAT', 'PROFILE_INFO'].includes(
+            about?.payload.aboutConsumptionSurface as string
+        )
+    )
+    ui.dispose()
+    mock.timers.reset()
+})
+
+test('synthetic UI fabricates no AboutConsumption for a group message', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        chatOpenProbability: 0,
+        infoOpenProbability: 0,
+        aboutConsumptionProbability: 1
+    })
+    h.emit('message', {
+        key: { remoteJid: '1@g.us', isGroup: true, isBroadcast: false, isNewsletter: false },
+        rawNode: { tag: 'message', attrs: {} }
+    })
+    mock.timers.tick(41_000)
+    assert.equal(h.commits.filter((c) => c.name === 'AboutConsumption').length, 0)
+    ui.dispose()
+    mock.timers.reset()
+})
+
+test('synthetic UI fabricates ContactSearchExperience in the ambient stream', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const origRandom = Math.random
+    Math.random = () => 0.15
+    try {
+        const h = makeHarness()
+        const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+            ambientIntervalMinMs: 1,
+            ambientIntervalMaxMs: 2,
+            memoryIntervalMinMs: 10 * 60_000,
+            memoryIntervalMaxMs: 10 * 60_000
+        })
+        mock.timers.tick(5)
+        const search = h.commits.find((c) => c.name === 'ContactSearchExperience')
+        assert.ok(search)
+        assert.equal(search?.payload.contactSearchEntrypoint, 'CHATS_LIST_GLOBAL_SEARCH')
+        assert.equal(search?.payload.isUsernameSearch, false)
+        assert.equal(search?.payload.searchActionName, 'SEARCH_START')
+        ui.dispose()
+    } finally {
+        Math.random = origRandom
+        mock.timers.reset()
+    }
+})
+
 test('synthetic UI cancels pending fabrications on dispose', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
     const h = makeHarness()

--- a/packages/wam/src/__tests__/synthetic-ui.test.ts
+++ b/packages/wam/src/__tests__/synthetic-ui.test.ts
@@ -1,9 +1,13 @@
 import assert from 'node:assert/strict'
-import { mock, test } from 'node:test'
+import { afterEach, mock, test } from 'node:test'
 
 import type { WaWamAutoEmitterContext } from '../WaWamAutoEmitter.js'
 import type { WaWamCoordinator } from '../WaWamCoordinator.js'
 import { WaWamSyntheticUi } from '../WaWamSyntheticUi.js'
+
+afterEach(() => {
+    mock.timers.reset()
+})
 
 interface Commit {
     readonly name: string
@@ -51,9 +55,7 @@ test('synthetic UI fabricates CHAT_OPEN with WA Web fields (preloaded + isLid, n
     assert.ok(webc)
     assert.equal(typeof webc?.payload.webcWindowHeightFloat, 'number')
     assert.equal(typeof webc?.payload.webcUnreadCount, 'number')
-    ui.dispose()
-    mock.timers.reset()
-})
+    ui.dispose()})
 
 test('synthetic UI fabricates IMAGE_OPEN for an image message and only uses web-real types', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -68,9 +70,7 @@ test('synthetic UI fabricates IMAGE_OPEN for an image message and only uses web-
     assert.ok(types.includes('CHAT_OPEN'))
     assert.ok(types.includes('IMAGE_OPEN'))
     assert.ok(types.every((t) => t === 'CHAT_OPEN' || t === 'IMAGE_OPEN'))
-    ui.dispose()
-    mock.timers.reset()
-})
+    ui.dispose()})
 
 test('synthetic UI fabricates GROUP_INFO_OPEN (preloaded + isLid) for a group message', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -88,9 +88,7 @@ test('synthetic UI fabricates GROUP_INFO_OPEN (preloaded + isLid) for a group me
     assert.ok(info)
     assert.equal(info?.payload.uiActionPreloaded, true)
     assert.equal(info?.payload.isLid, false)
-    ui.dispose()
-    mock.timers.reset()
-})
+    ui.dispose()})
 
 test('synthetic UI fabricates CHANNEL_INFO_OPEN without isLid for a newsletter message', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -109,9 +107,7 @@ test('synthetic UI fabricates CHANNEL_INFO_OPEN without isLid for a newsletter m
     assert.equal(info?.payload.uiActionPreloaded, true)
     // WA Web's CHANNEL_INFO_OPEN does not set isLid
     assert.equal(info?.payload.isLid, undefined)
-    ui.dispose()
-    mock.timers.reset()
-})
+    ui.dispose()})
 
 test('synthetic UI fabricates MSG_INFO_OPEN after an outbound message', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -125,9 +121,7 @@ test('synthetic UI fabricates MSG_INFO_OPEN after an outbound message', () => {
     assert.ok(info)
     assert.equal(info?.payload.uiActionPreloaded, true)
     assert.equal(info?.payload.isLid, true)
-    ui.dispose()
-    mock.timers.reset()
-})
+    ui.dispose()})
 
 test('synthetic UI fabricates WebcMediaLoad (SUCCESS) for an inbound audio message', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -142,9 +136,7 @@ test('synthetic UI fabricates WebcMediaLoad (SUCCESS) for an inbound audio messa
     assert.ok(media)
     assert.equal(media?.payload.webcMediaLoadResult, 'SUCCESS')
     assert.equal(typeof media?.payload.webcMediaLoadT, 'number')
-    ui.dispose()
-    mock.timers.reset()
-})
+    ui.dispose()})
 
 test('synthetic UI fabricates nothing outside the configured active hours', () => {
     mock.timers.enable({ apis: ['setTimeout', 'Date'] })
@@ -158,9 +150,7 @@ test('synthetic UI fabricates nothing outside the configured active hours', () =
     h.emit('message', lidMessage())
     mock.timers.tick(61_000)
     assert.equal(h.commits.length, 0)
-    ui.dispose()
-    mock.timers.reset()
-})
+    ui.dispose()})
 
 test('synthetic UI fabricates WebcEmojiOpen with a real tab in the ambient stream', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -202,9 +192,7 @@ test('synthetic UI fabricates AttachmentTrayActions (SEND) for an outbound media
     assert.equal(tray?.payload.sendMediaType, 'PHOTO')
     assert.equal(tray?.payload.actionThreadType, 'GROUP_CHAT')
     assert.equal(tray?.payload.isAGroup, true)
-    ui.dispose()
-    mock.timers.reset()
-})
+    ui.dispose()})
 
 test('synthetic UI fabricates no AttachmentTrayActions for a sticker (emoji-panel, not the tray)', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -219,9 +207,7 @@ test('synthetic UI fabricates no AttachmentTrayActions for a sticker (emoji-pane
     })
     mock.timers.tick(13_000)
     assert.equal(h.commits.filter((c) => c.name === 'AttachmentTrayActions').length, 0)
-    ui.dispose()
-    mock.timers.reset()
-})
+    ui.dispose()})
 
 test('synthetic UI samples MemoryStat periodically (main process, uptime, numMessages)', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -239,9 +225,7 @@ test('synthetic UI samples MemoryStat periodically (main process, uptime, numMes
     assert.equal(typeof mem?.payload.workingSetSize, 'number')
     assert.equal(typeof mem?.payload.uptime, 'number')
     assert.ok((mem?.payload.numMessages as number) >= 1)
-    ui.dispose()
-    mock.timers.reset()
-})
+    ui.dispose()})
 
 test('synthetic UI flushes UserActivity with a bitmap matching the active slices', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -259,9 +243,22 @@ test('synthetic UI flushes UserActivity with a bitmap matching the active slices
     assert.equal(ua?.payload.userActivitySessionCum, 1)
     assert.equal(ua?.payload.userActivityBitmapLow, 1)
     assert.equal(ua?.payload.userActivitySessionSeq, 1)
-    ui.dispose()
-    mock.timers.reset()
-})
+    ui.dispose()})
+
+test('synthetic UI keeps emitting UserActivity past the 64-slice cap and rolls the session', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        chatOpenProbability: 0,
+        memoryIntervalMinMs: 10 * 60_000,
+        memoryIntervalMaxMs: 10 * 60_000
+    })
+    for (let i = 0; i < 69; i += 1) mock.timers.tick(60_000)
+    const activities = h.commits.filter((c) => c.name === 'UserActivity')
+    assert.ok(activities.some((c) => c.payload.userActivityBitmapLen === 64))
+    assert.equal(activities[activities.length - 1]?.payload.userActivitySessionSeq, 1)
+    assert.ok(activities.length > 12)
+    ui.dispose()})
 
 test('synthetic UI fabricates AboutConsumption for a 1:1 inbound message', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -279,9 +276,7 @@ test('synthetic UI fabricates AboutConsumption for a 1:1 inbound message', () =>
             about?.payload.aboutConsumptionSurface as string
         )
     )
-    ui.dispose()
-    mock.timers.reset()
-})
+    ui.dispose()})
 
 test('synthetic UI fabricates no AboutConsumption for a group message', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -297,9 +292,7 @@ test('synthetic UI fabricates no AboutConsumption for a group message', () => {
     })
     mock.timers.tick(41_000)
     assert.equal(h.commits.filter((c) => c.name === 'AboutConsumption').length, 0)
-    ui.dispose()
-    mock.timers.reset()
-})
+    ui.dispose()})
 
 test('synthetic UI fabricates ContactSearchExperience in the ambient stream', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
@@ -333,6 +326,4 @@ test('synthetic UI cancels pending fabrications on dispose', () => {
     h.emit('message', lidMessage())
     ui.dispose()
     mock.timers.tick(120_000)
-    assert.equal(h.commits.length, 0)
-    mock.timers.reset()
-})
+    assert.equal(h.commits.length, 0)})

--- a/packages/wam/src/__tests__/synthetic-ui.test.ts
+++ b/packages/wam/src/__tests__/synthetic-ui.test.ts
@@ -183,6 +183,86 @@ test('synthetic UI fabricates WebcEmojiOpen with a real tab in the ambient strea
     }
 })
 
+test('synthetic UI fabricates AttachmentTrayActions (SEND) for an outbound media message', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, { attachmentTrayProbability: 1 })
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'message',
+            attrs: { to: '1@g.us' },
+            content: [{ tag: 'enc', attrs: { mediatype: 'image' } }]
+        }
+    })
+    mock.timers.tick(13_000)
+    const tray = h.commits.find((c) => c.name === 'AttachmentTrayActions')
+    assert.ok(tray)
+    assert.equal(tray?.payload.attachmentTrayAction, 'SEND')
+    assert.equal(tray?.payload.attachmentTrayActionTarget, 'GALLERY')
+    assert.equal(tray?.payload.sendMediaType, 'PHOTO')
+    assert.equal(tray?.payload.actionThreadType, 'GROUP_CHAT')
+    assert.equal(tray?.payload.isAGroup, true)
+    ui.dispose()
+    mock.timers.reset()
+})
+
+test('synthetic UI fabricates no AttachmentTrayActions for a sticker (emoji-panel, not the tray)', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, { attachmentTrayProbability: 1 })
+    h.emit('debug_transport_node_out', {
+        node: {
+            tag: 'message',
+            attrs: { to: '456@s.whatsapp.net' },
+            content: [{ tag: 'enc', attrs: { mediatype: 'sticker' } }]
+        }
+    })
+    mock.timers.tick(13_000)
+    assert.equal(h.commits.filter((c) => c.name === 'AttachmentTrayActions').length, 0)
+    ui.dispose()
+    mock.timers.reset()
+})
+
+test('synthetic UI samples MemoryStat periodically (main process, uptime, numMessages)', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        chatOpenProbability: 0,
+        memoryIntervalMinMs: 1,
+        memoryIntervalMaxMs: 2
+    })
+    h.emit('message', lidMessage())
+    mock.timers.tick(5)
+    const mem = h.commits.find((c) => c.name === 'MemoryStat')
+    assert.ok(mem)
+    assert.equal(mem?.payload.processType, 'main')
+    assert.equal(typeof mem?.payload.workingSetSize, 'number')
+    assert.equal(typeof mem?.payload.uptime, 'number')
+    assert.ok((mem?.payload.numMessages as number) >= 1)
+    ui.dispose()
+    mock.timers.reset()
+})
+
+test('synthetic UI flushes UserActivity with a bitmap matching the active slices', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        chatOpenProbability: 0,
+        memoryIntervalMinMs: 10 * 60_000,
+        memoryIntervalMaxMs: 10 * 60_000
+    })
+    h.emit('message', lidMessage())
+    for (let i = 0; i < 5; i += 1) mock.timers.tick(60_000)
+    const ua = h.commits.find((c) => c.name === 'UserActivity')
+    assert.ok(ua)
+    assert.equal(ua?.payload.userActivityBitmapLen, 5)
+    assert.equal(ua?.payload.userActivitySessionCum, 1)
+    assert.equal(ua?.payload.userActivityBitmapLow, 1)
+    assert.equal(ua?.payload.userActivitySessionSeq, 1)
+    ui.dispose()
+    mock.timers.reset()
+})
+
 test('synthetic UI cancels pending fabrications on dispose', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
     const h = makeHarness()

--- a/packages/wam/src/__tests__/synthetic-ui.test.ts
+++ b/packages/wam/src/__tests__/synthetic-ui.test.ts
@@ -1,0 +1,195 @@
+import assert from 'node:assert/strict'
+import { mock, test } from 'node:test'
+
+import type { WaWamAutoEmitterContext } from '../WaWamAutoEmitter.js'
+import type { WaWamCoordinator } from '../WaWamCoordinator.js'
+import { WaWamSyntheticUi } from '../WaWamSyntheticUi.js'
+
+interface Commit {
+    readonly name: string
+    readonly payload: Record<string, unknown>
+}
+
+function makeHarness() {
+    const commits: Commit[] = []
+    const handlers = new Map<string, (event: unknown) => void>()
+    const coordinator = {
+        commit: (name: string, payload: Record<string, unknown>) => commits.push({ name, payload })
+    } as unknown as WaWamCoordinator
+    const ctx = {
+        on: (event: string, handler: (event: unknown) => void) => handlers.set(event, handler),
+        off: (event: string, handler: (event: unknown) => void) => {
+            if (handlers.get(event) === handler) handlers.delete(event)
+        }
+    } as unknown as WaWamAutoEmitterContext
+    const emit = (event: string, payload: unknown) => handlers.get(event)?.(payload)
+    return { commits, ctx, coordinator, emit }
+}
+
+const lidMessage = (extra: Record<string, unknown> = {}) => ({
+    key: { remoteJid: '456@lid', isGroup: false, isBroadcast: false, isNewsletter: false },
+    rawNode: { tag: 'message', attrs: {} },
+    ...extra
+})
+
+test('synthetic UI fabricates CHAT_OPEN with WA Web fields (preloaded + isLid, no chatType)', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, { chatOpenProbability: 1 })
+    h.emit('message', lidMessage())
+    mock.timers.tick(61_000)
+    const open = h.commits.find((c) => c.payload.uiActionType === 'CHAT_OPEN')
+    assert.ok(open)
+    assert.equal(open?.name, 'UiAction')
+    assert.equal(open?.payload.uiActionPreloaded, true)
+    assert.equal(open?.payload.isLid, true)
+    assert.equal(typeof open?.payload.uiActionT, 'number')
+    // WA Web's CHAT_OPEN does not set uiActionChatType
+    assert.equal(open?.payload.uiActionChatType, undefined)
+    // WA Web pairs every CHAT_OPEN with a WebcChatOpen event
+    const webc = h.commits.find((c) => c.name === 'WebcChatOpen')
+    assert.ok(webc)
+    assert.equal(typeof webc?.payload.webcWindowHeightFloat, 'number')
+    assert.equal(typeof webc?.payload.webcUnreadCount, 'number')
+    ui.dispose()
+    mock.timers.reset()
+})
+
+test('synthetic UI fabricates IMAGE_OPEN for an image message and only uses web-real types', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        chatOpenProbability: 1,
+        imageOpenProbability: 1
+    })
+    h.emit('message', lidMessage({ message: { imageMessage: {} } }))
+    mock.timers.tick(91_000)
+    const types = h.commits.filter((c) => c.name === 'UiAction').map((c) => c.payload.uiActionType)
+    assert.ok(types.includes('CHAT_OPEN'))
+    assert.ok(types.includes('IMAGE_OPEN'))
+    assert.ok(types.every((t) => t === 'CHAT_OPEN' || t === 'IMAGE_OPEN'))
+    ui.dispose()
+    mock.timers.reset()
+})
+
+test('synthetic UI fabricates GROUP_INFO_OPEN (preloaded + isLid) for a group message', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        chatOpenProbability: 0,
+        infoOpenProbability: 1
+    })
+    h.emit('message', {
+        key: { remoteJid: '1@g.us', isGroup: true, isBroadcast: false, isNewsletter: false },
+        rawNode: { tag: 'message', attrs: {} }
+    })
+    mock.timers.tick(121_000)
+    const info = h.commits.find((c) => c.payload.uiActionType === 'GROUP_INFO_OPEN')
+    assert.ok(info)
+    assert.equal(info?.payload.uiActionPreloaded, true)
+    assert.equal(info?.payload.isLid, false)
+    ui.dispose()
+    mock.timers.reset()
+})
+
+test('synthetic UI fabricates CHANNEL_INFO_OPEN without isLid for a newsletter message', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        chatOpenProbability: 0,
+        infoOpenProbability: 1
+    })
+    h.emit('message', {
+        key: { remoteJid: 'x@newsletter', isGroup: false, isBroadcast: false, isNewsletter: true },
+        rawNode: { tag: 'message', attrs: {} }
+    })
+    mock.timers.tick(121_000)
+    const info = h.commits.find((c) => c.payload.uiActionType === 'CHANNEL_INFO_OPEN')
+    assert.ok(info)
+    assert.equal(info?.payload.uiActionPreloaded, true)
+    // WA Web's CHANNEL_INFO_OPEN does not set isLid
+    assert.equal(info?.payload.isLid, undefined)
+    ui.dispose()
+    mock.timers.reset()
+})
+
+test('synthetic UI fabricates MSG_INFO_OPEN after an outbound message', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, { infoOpenProbability: 1 })
+    h.emit('debug_transport_node_out', {
+        node: { tag: 'message', attrs: { to: '456@lid', id: 'm1', addressing_mode: 'lid' } }
+    })
+    mock.timers.tick(121_000)
+    const info = h.commits.find((c) => c.payload.uiActionType === 'MSG_INFO_OPEN')
+    assert.ok(info)
+    assert.equal(info?.payload.uiActionPreloaded, true)
+    assert.equal(info?.payload.isLid, true)
+    ui.dispose()
+    mock.timers.reset()
+})
+
+test('synthetic UI fabricates WebcMediaLoad (SUCCESS) for an inbound audio message', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        chatOpenProbability: 0,
+        imageOpenProbability: 1
+    })
+    h.emit('message', lidMessage({ message: { audioMessage: {} } }))
+    mock.timers.tick(10_000)
+    const media = h.commits.find((c) => c.name === 'WebcMediaLoad')
+    assert.ok(media)
+    assert.equal(media?.payload.webcMediaLoadResult, 'SUCCESS')
+    assert.equal(typeof media?.payload.webcMediaLoadT, 'number')
+    ui.dispose()
+    mock.timers.reset()
+})
+
+test('synthetic UI fabricates nothing outside the configured active hours', () => {
+    mock.timers.enable({ apis: ['setTimeout', 'Date'] })
+    mock.timers.setTime(new Date(2020, 0, 1, 3, 0, 0).getTime())
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        chatOpenProbability: 1,
+        activeHoursStartHour: 9,
+        activeHoursEndHour: 17
+    })
+    h.emit('message', lidMessage())
+    mock.timers.tick(61_000)
+    assert.equal(h.commits.length, 0)
+    ui.dispose()
+    mock.timers.reset()
+})
+
+test('synthetic UI fabricates WebcEmojiOpen with a real tab in the ambient stream', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const origRandom = Math.random
+    Math.random = () => 0.05
+    try {
+        const h = makeHarness()
+        const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+            ambientIntervalMinMs: 1,
+            ambientIntervalMaxMs: 2
+        })
+        mock.timers.tick(20)
+        const emoji = h.commits.find((c) => c.name === 'WebcEmojiOpen')
+        assert.ok(emoji)
+        assert.ok(['EMOJI', 'GIF', 'STICKER'].includes(emoji?.payload.webcEmojiOpenTab as string))
+        ui.dispose()
+    } finally {
+        Math.random = origRandom
+        mock.timers.reset()
+    }
+})
+
+test('synthetic UI cancels pending fabrications on dispose', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, { chatOpenProbability: 1 })
+    h.emit('message', lidMessage())
+    ui.dispose()
+    mock.timers.tick(120_000)
+    assert.equal(h.commits.length, 0)
+    mock.timers.reset()
+})

--- a/packages/wam/src/globals.ts
+++ b/packages/wam/src/globals.ts
@@ -1,0 +1,79 @@
+import { WA_WAM_GLOBALS, type WaWamChannel, type WaWamGlobalName } from '@vinikjkkj/wa-wam'
+import { WA_VERSION } from 'zapo-js'
+import {
+    getWaBrowserDisplayName,
+    resolveWaDeviceIdentity,
+    type WaDeviceIdentityOptions
+} from 'zapo-js/protocol'
+
+import { resolveWamEnumValue } from './registry.js'
+import type { WamGlobalValue } from './wire/WamBatch.js'
+
+/**
+ * Batch-level global inputs. Resolves platform/browser/OS from the same identity
+ * the client advertises in pairing, so the globals never contradict the
+ * `ClientPayload` (an inconsistent global is a worse fingerprint than none).
+ */
+export interface WamGlobalsInput extends WaDeviceIdentityOptions {
+    /** Per-session stream id, stamped both in the header and as global 3543. */
+    readonly streamId: number
+    /** Overrides the advertised app version (defaults to the bundled WA_VERSION). */
+    readonly appVersion?: string
+    /** `service_improvement_opt_out` consent bit (defaults to `false`). */
+    readonly serviceImprovementOptOut?: boolean
+}
+
+/** Maps an OS display name to the `WEBC_WEB_PLATFORM_TYPE` enum key. */
+function webcWebPlatformKey(osDisplayName: string): string {
+    const os = osDisplayName.toLowerCase()
+    if (os.includes('win')) return 'WIN32'
+    if (os.includes('mac') || os.includes('os x') || os.includes('darwin')) return 'DARWIN'
+    return 'WEB'
+}
+
+/** The globals a headless client can honestly populate (enum globals as their value KEY), omitting what it cannot truthfully know. */
+function buildNamedGlobals(
+    input: WamGlobalsInput
+): Partial<Record<WaWamGlobalName, WamGlobalValue>> {
+    const identity = resolveWaDeviceIdentity(input)
+    return {
+        platform: 'WEBCLIENT',
+        webcWebPlatform: webcWebPlatformKey(identity.osDisplayName),
+        appVersion: input.appVersion ?? WA_VERSION,
+        osVersion: identity.osDisplayName,
+        browser: getWaBrowserDisplayName(identity.browser),
+        deviceName: 'Desktop',
+        streamId: input.streamId,
+        mcc: 0,
+        mnc: 0,
+        serviceImprovementOptOut: input.serviceImprovementOptOut ?? false
+    }
+}
+
+/**
+ * Resolves the named globals into the id-keyed map `WamBatch` consumes for a
+ * given channel: filters to globals valid on that channel and converts enum
+ * globals from their key string to the numeric value.
+ */
+export function resolveWamGlobals(
+    input: WamGlobalsInput,
+    channel: WaWamChannel = 'regular'
+): Map<number, WamGlobalValue> {
+    const named = buildNamedGlobals(input)
+    const byId = new Map<number, WamGlobalValue>()
+    for (const name of Object.keys(named) as WaWamGlobalName[]) {
+        const raw = named[name]
+        if (raw === undefined || raw === null) continue
+        const global = WA_WAM_GLOBALS[name]
+        if (global === undefined) continue
+        if (!(global.channels as readonly WaWamChannel[]).includes(channel)) continue
+        if (global.type === 'enum') {
+            const numeric = resolveWamEnumValue(global.enum, String(raw))
+            if (numeric === null) continue
+            byId.set(global.id, numeric)
+        } else {
+            byId.set(global.id, raw)
+        }
+    }
+    return byId
+}

--- a/packages/wam/src/index.ts
+++ b/packages/wam/src/index.ts
@@ -3,6 +3,7 @@ export type { WamPluginOptions } from './plugin.js'
 
 export { WaWamCoordinator } from './WaWamCoordinator.js'
 export type { WaWamCoordinatorOptions } from './WaWamCoordinator.js'
+export type { WaWamSyntheticUiOptions } from './WaWamSyntheticUi.js'
 
 export type { WamGlobalsInput } from './globals.js'
 export type { WamGlobalValue, WamResolvedField } from './wire/WamBatch.js'

--- a/packages/wam/src/index.ts
+++ b/packages/wam/src/index.ts
@@ -1,0 +1,8 @@
+export { wamPlugin } from './plugin.js'
+export type { WamPluginOptions } from './plugin.js'
+
+export { WaWamCoordinator } from './WaWamCoordinator.js'
+export type { WaWamCoordinatorOptions } from './WaWamCoordinator.js'
+
+export type { WamGlobalsInput } from './globals.js'
+export type { WamGlobalValue, WamResolvedField } from './wire/WamBatch.js'

--- a/packages/wam/src/index.ts
+++ b/packages/wam/src/index.ts
@@ -3,7 +3,7 @@ export type { WamPluginOptions } from './plugin.js'
 
 export { WaWamCoordinator } from './WaWamCoordinator.js'
 export type { WaWamCoordinatorOptions } from './WaWamCoordinator.js'
-export type { WaWamSyntheticUiOptions } from './WaWamSyntheticUi.js'
+export type { WaWamSyntheticUiOptions } from './synthetic/index.js'
 
 export type { WamGlobalsInput } from './globals.js'
 export type { WamGlobalValue, WamResolvedField } from './wire/WamBatch.js'

--- a/packages/wam/src/plugin.ts
+++ b/packages/wam/src/plugin.ts
@@ -1,0 +1,38 @@
+import { defineWaClientPlugin } from 'zapo-js'
+
+import { WaWamCoordinator, type WaWamCoordinatorOptions } from './WaWamCoordinator.js'
+
+export interface WamPluginOptions extends WaWamCoordinatorOptions {}
+
+/**
+ * WaClient plugin that emits WhatsApp Web WAM (`w:stats`) telemetry, exposing
+ * {@link WaWamCoordinator} at `client.wam`. Sending the telemetry a real WA Web
+ * client sends improves parity; batch globals derive from the client's own
+ * device identity so they agree with the pairing `ClientPayload`.
+ *
+ * @example
+ * ```ts
+ * import { WaClient } from 'zapo-js'
+ * import { wamPlugin } from '@zapo-js/wam'
+ *
+ * const client = new WaClient({
+ *   store,
+ *   sessionId: 'main',
+ *   plugins: [wamPlugin()]
+ * })
+ *
+ * client.wam.commit('UiAction', { uiActionType: 'CHAT_OPEN' })
+ * ```
+ */
+export function wamPlugin(options: WamPluginOptions = {}) {
+    return defineWaClientPlugin<'wam', WaWamCoordinator>({
+        id: '@zapo-js/wam',
+        exposeAs: 'wam',
+        setup(ctx) {
+            return new WaWamCoordinator(ctx, options)
+        },
+        async dispose(coordinator) {
+            await coordinator.dispose()
+        }
+    })
+}

--- a/packages/wam/src/registry.ts
+++ b/packages/wam/src/registry.ts
@@ -1,0 +1,67 @@
+import {
+    WA_WAM_ENUMS,
+    WA_WAM_EVENTS,
+    type WaWamEnumName,
+    type WaWamEventName,
+    type WaWamField
+} from '@vinikjkkj/wa-wam'
+
+import type { WamValueKind } from './wire/encoder.js'
+import type { WamResolvedField } from './wire/WamBatch.js'
+
+/** Maps a registry field/global `type` to its wire encoding kind. */
+export function wamValueKind(type: WaWamField['type']): WamValueKind | null {
+    switch (type) {
+        case 'boolean':
+            return 'bool'
+        case 'integer':
+        case 'timer':
+        case 'enum':
+            return 'int'
+        case 'number':
+            return 'float'
+        case 'string':
+            return 'string'
+        default:
+            return null
+    }
+}
+
+/** Resolves an enum value key (e.g. `'CHAT_OPEN'`) to its numeric wire value, or `null` if unknown. */
+export function resolveWamEnumValue(enumName: WaWamEnumName, key: string): number | null {
+    const table = WA_WAM_ENUMS[enumName]
+    if (table === undefined) return null
+    const value = (table.values as Record<string, number>)[key]
+    return typeof value === 'number' ? value : null
+}
+
+/**
+ * Turns a typed event payload into the ordered wire-ready field list, converting
+ * enum keys to numeric ids and dropping absent, untyped, or unresolvable fields.
+ */
+export function resolveWamEventFields(
+    name: WaWamEventName,
+    payload: Readonly<Record<string, unknown>>
+): WamResolvedField[] {
+    const fields = WA_WAM_EVENTS[name].fields as Readonly<Record<string, WaWamField>>
+    const resolved: WamResolvedField[] = []
+    for (const fieldName of Object.keys(fields)) {
+        const raw = payload[fieldName]
+        if (raw === undefined || raw === null) continue
+        const meta = fields[fieldName]
+        const kind = wamValueKind(meta.type)
+        if (kind === null) continue
+        if (meta.type === 'enum') {
+            const numeric = resolveWamEnumValue(meta.enum, String(raw))
+            if (numeric === null) continue
+            resolved[resolved.length] = { id: meta.id, kind, value: numeric }
+        } else if (kind === 'bool') {
+            resolved[resolved.length] = { id: meta.id, kind, value: Boolean(raw) }
+        } else if (kind === 'string') {
+            resolved[resolved.length] = { id: meta.id, kind, value: String(raw) }
+        } else {
+            resolved[resolved.length] = { id: meta.id, kind, value: Number(raw) }
+        }
+    }
+    return resolved
+}

--- a/packages/wam/src/registry.ts
+++ b/packages/wam/src/registry.ts
@@ -5,9 +5,19 @@ import {
     type WaWamEventName,
     type WaWamField
 } from '@vinikjkkj/wa-wam'
+import { toSafeNumber } from 'zapo-js/util'
 
 import type { WamValueKind } from './wire/encoder.js'
 import type { WamResolvedField } from './wire/WamBatch.js'
+
+/** Coerces a payload value to a finite safe integer via {@link toSafeNumber}, or null if it is not one. */
+function toSafeInt(raw: unknown): number | null {
+    try {
+        return toSafeNumber(raw as number, 'wam field')
+    } catch {
+        return null
+    }
+}
 
 /** Maps a registry field/global `type` to its wire encoding kind. */
 export function wamValueKind(type: WaWamField['type']): WamValueKind | null {
@@ -59,8 +69,14 @@ export function resolveWamEventFields(
             resolved[resolved.length] = { id: meta.id, kind, value: Boolean(raw) }
         } else if (kind === 'string') {
             resolved[resolved.length] = { id: meta.id, kind, value: String(raw) }
+        } else if (kind === 'int') {
+            const numeric = toSafeInt(raw)
+            if (numeric === null) continue
+            resolved[resolved.length] = { id: meta.id, kind, value: numeric }
         } else {
-            resolved[resolved.length] = { id: meta.id, kind, value: Number(raw) }
+            const numeric = Number(raw)
+            if (!Number.isFinite(numeric)) continue
+            resolved[resolved.length] = { id: meta.id, kind, value: numeric }
         }
     }
     return resolved

--- a/packages/wam/src/send-parse.ts
+++ b/packages/wam/src/send-parse.ts
@@ -1,5 +1,13 @@
 import type { BinaryNode } from 'zapo-js'
-import { isGroupJid } from 'zapo-js/protocol'
+import {
+    isGroupJid,
+    isNewsletterJid,
+    isStatusBroadcastJid,
+    WA_EDIT_ATTRS,
+    WA_ENC_CIPHERTEXT_TYPES,
+    WA_ENC_MEDIA_TYPES,
+    WA_MESSAGE_TAGS
+} from 'zapo-js/protocol'
 
 export type WamCiphertextTypeKey =
     | 'MESSAGE'
@@ -27,7 +35,7 @@ export function findFirstEncNode(node: BinaryNode): BinaryNode | null {
     const content = node.content
     if (!Array.isArray(content)) return null
     for (const child of content) {
-        if (child.tag === 'enc') return child
+        if (child.tag === WA_MESSAGE_TAGS.ENC) return child
         const nested = findFirstEncNode(child)
         if (nested !== null) return nested
     }
@@ -37,13 +45,13 @@ export function findFirstEncNode(node: BinaryNode): BinaryNode | null {
 /** `<enc type>` attr → E2E_CIPHERTEXT_TYPE enum key. */
 export function ciphertextTypeKey(encType: string | undefined): WamCiphertextTypeKey | null {
     switch (encType) {
-        case 'msg':
+        case WA_ENC_CIPHERTEXT_TYPES.MESSAGE:
             return 'MESSAGE'
-        case 'pkmsg':
+        case WA_ENC_CIPHERTEXT_TYPES.PREKEY:
             return 'PREKEY_MESSAGE'
-        case 'skmsg':
+        case WA_ENC_CIPHERTEXT_TYPES.SENDER_KEY:
             return 'SENDER_KEY_MESSAGE'
-        case 'msmsg':
+        case WA_ENC_CIPHERTEXT_TYPES.MESSAGE_SECRET:
             return 'MESSAGE_SECRET_MESSAGE'
         default:
             return null
@@ -53,21 +61,21 @@ export function ciphertextTypeKey(encType: string | undefined): WamCiphertextTyp
 /** `<message to>` jid → E2E_DESTINATION enum key. */
 export function e2eDestinationKey(to: string): WamE2eDestinationKey {
     if (isGroupJid(to)) return 'GROUP'
-    if (to === 'status@broadcast') return 'STATUS'
-    if (to.endsWith('@newsletter')) return 'CHANNEL'
+    if (isStatusBroadcastJid(to)) return 'STATUS'
+    if (isNewsletterJid(to)) return 'CHANNEL'
     return 'INDIVIDUAL'
 }
 
 const MEDIA_TYPE_BY_ATTR: Readonly<Record<string, WamMediaTypeKey>> = {
-    image: 'PHOTO',
-    video: 'VIDEO',
-    audio: 'AUDIO',
-    ptt: 'PTT',
-    document: 'DOCUMENT',
-    sticker: 'STICKER',
-    gif: 'GIF',
+    [WA_ENC_MEDIA_TYPES.IMAGE]: 'PHOTO',
+    [WA_ENC_MEDIA_TYPES.VIDEO]: 'VIDEO',
+    [WA_ENC_MEDIA_TYPES.AUDIO]: 'AUDIO',
+    [WA_ENC_MEDIA_TYPES.PTT]: 'PTT',
+    [WA_ENC_MEDIA_TYPES.DOCUMENT]: 'DOCUMENT',
+    [WA_ENC_MEDIA_TYPES.STICKER]: 'STICKER',
+    [WA_ENC_MEDIA_TYPES.GIF]: 'GIF',
     contact: 'CONTACT',
-    location: 'LOCATION'
+    [WA_ENC_MEDIA_TYPES.LOCATION]: 'LOCATION'
 }
 
 /** `<enc mediatype>` attr → MEDIA_TYPE enum key (null for text / unknown). */
@@ -79,16 +87,57 @@ export function mediaTypeKey(mediatype: string | undefined): WamMediaTypeKey | n
 /** `<message edit>` attr → EDIT_TYPE enum key (null when the message is not an edit/revoke). */
 export function editTypeKey(edit: string | undefined): WamEditTypeKey | null {
     switch (edit) {
-        case '1':
-        case '3':
+        case WA_EDIT_ATTRS.MESSAGE_EDIT:
+        case WA_EDIT_ATTRS.NEWSLETTER_EDIT:
             return 'EDITED'
-        case '2':
+        case WA_EDIT_ATTRS.PIN_IN_CHAT:
             return 'PIN'
-        case '7':
+        case WA_EDIT_ATTRS.SENDER_REVOKE:
             return 'SENDER_REVOKE'
-        case '8':
+        case WA_EDIT_ATTRS.ADMIN_REVOKE:
             return 'ADMIN_REVOKE'
         default:
             return null
     }
+}
+
+export type WamDocumentTypeKey =
+    | 'OTHER'
+    | 'IMAGE'
+    | 'VIDEO'
+    | 'AUDIO'
+    | 'DOCUMENT'
+    | 'COMPRESSED_FILE'
+    | 'EXECUTABLE'
+    | 'VCARD'
+
+/** Lowercase file extension from a document `fileName`, when present. */
+export function fileExtension(fileName: string | null | undefined): string | undefined {
+    if (!fileName) return undefined
+    const dot = fileName.lastIndexOf('.')
+    if (dot <= 0 || dot === fileName.length - 1) return undefined
+    return fileName.slice(dot + 1).toLowerCase()
+}
+
+/** Document `mimetype` → DOCUMENT_TYPE enum key. */
+export function documentTypeFor(mimetype: string | null | undefined): WamDocumentTypeKey {
+    const mime = (mimetype ?? '').toLowerCase()
+    if (mime.startsWith('image/')) return 'IMAGE'
+    if (mime.startsWith('video/')) return 'VIDEO'
+    if (mime.startsWith('audio/')) return 'AUDIO'
+    if (mime.includes('vcard')) return 'VCARD'
+    if (mime.includes('zip') || mime.includes('rar') || mime.includes('7z') || mime.includes('tar'))
+        return 'COMPRESSED_FILE'
+    if (mime.includes('msdownload') || mime.includes('executable') || mime.includes('x-msdos'))
+        return 'EXECUTABLE'
+    if (
+        mime.includes('pdf') ||
+        mime.includes('word') ||
+        mime.includes('document') ||
+        mime.includes('sheet') ||
+        mime.includes('presentation') ||
+        mime.startsWith('text/')
+    )
+        return 'DOCUMENT'
+    return 'OTHER'
 }

--- a/packages/wam/src/send-parse.ts
+++ b/packages/wam/src/send-parse.ts
@@ -1,4 +1,5 @@
 import type { BinaryNode } from 'zapo-js'
+import { proto } from 'zapo-js/proto'
 import {
     isGroupJid,
     isNewsletterJid,
@@ -29,6 +30,15 @@ export type WamMediaTypeKey =
     | 'GIF'
     | 'CONTACT'
     | 'LOCATION'
+
+export type WamPinInChatTypeKey = 'PIN_FOR_ALL' | 'UNPIN_FOR_ALL'
+
+/** Maps a `pinInChatMessage.type` proto enum to its WAM `PIN_IN_CHAT_TYPE` key. */
+export function pinInChatTypeKey(type: number | null | undefined): WamPinInChatTypeKey | null {
+    if (type === proto.Message.PinInChatMessage.Type.PIN_FOR_ALL) return 'PIN_FOR_ALL'
+    if (type === proto.Message.PinInChatMessage.Type.UNPIN_FOR_ALL) return 'UNPIN_FOR_ALL'
+    return null
+}
 
 /** Depth-first search for the first `<enc>` node (direct, group `skmsg`, or nested under `<participants>`). */
 export function findFirstEncNode(node: BinaryNode): BinaryNode | null {

--- a/packages/wam/src/send-parse.ts
+++ b/packages/wam/src/send-parse.ts
@@ -1,0 +1,75 @@
+import type { BinaryNode } from 'zapo-js'
+import { isGroupJid } from 'zapo-js/protocol'
+
+export type WamCiphertextTypeKey =
+    | 'MESSAGE'
+    | 'PREKEY_MESSAGE'
+    | 'SENDER_KEY_MESSAGE'
+    | 'MESSAGE_SECRET_MESSAGE'
+
+export type WamE2eDestinationKey = 'INDIVIDUAL' | 'GROUP' | 'STATUS' | 'CHANNEL'
+
+export type WamMediaTypeKey =
+    | 'PHOTO'
+    | 'VIDEO'
+    | 'AUDIO'
+    | 'PTT'
+    | 'DOCUMENT'
+    | 'STICKER'
+    | 'GIF'
+    | 'CONTACT'
+    | 'LOCATION'
+
+/** Depth-first search for the first `<enc>` node (direct, group `skmsg`, or nested under `<participants>`). */
+export function findFirstEncNode(node: BinaryNode): BinaryNode | null {
+    const content = node.content
+    if (!Array.isArray(content)) return null
+    for (const child of content) {
+        if (child.tag === 'enc') return child
+        const nested = findFirstEncNode(child)
+        if (nested !== null) return nested
+    }
+    return null
+}
+
+/** `<enc type>` attr → E2E_CIPHERTEXT_TYPE enum key. */
+export function ciphertextTypeKey(encType: string | undefined): WamCiphertextTypeKey | null {
+    switch (encType) {
+        case 'msg':
+            return 'MESSAGE'
+        case 'pkmsg':
+            return 'PREKEY_MESSAGE'
+        case 'skmsg':
+            return 'SENDER_KEY_MESSAGE'
+        case 'msmsg':
+            return 'MESSAGE_SECRET_MESSAGE'
+        default:
+            return null
+    }
+}
+
+/** `<message to>` jid → E2E_DESTINATION enum key. */
+export function e2eDestinationKey(to: string): WamE2eDestinationKey {
+    if (isGroupJid(to)) return 'GROUP'
+    if (to === 'status@broadcast') return 'STATUS'
+    if (to.endsWith('@newsletter')) return 'CHANNEL'
+    return 'INDIVIDUAL'
+}
+
+const MEDIA_TYPE_BY_ATTR: Readonly<Record<string, WamMediaTypeKey>> = {
+    image: 'PHOTO',
+    video: 'VIDEO',
+    audio: 'AUDIO',
+    ptt: 'PTT',
+    document: 'DOCUMENT',
+    sticker: 'STICKER',
+    gif: 'GIF',
+    contact: 'CONTACT',
+    location: 'LOCATION'
+}
+
+/** `<enc mediatype>` attr → MEDIA_TYPE enum key (null for text / unknown). */
+export function mediaTypeKey(mediatype: string | undefined): WamMediaTypeKey | null {
+    if (mediatype === undefined) return null
+    return MEDIA_TYPE_BY_ATTR[mediatype] ?? null
+}

--- a/packages/wam/src/send-parse.ts
+++ b/packages/wam/src/send-parse.ts
@@ -9,6 +9,8 @@ export type WamCiphertextTypeKey =
 
 export type WamE2eDestinationKey = 'INDIVIDUAL' | 'GROUP' | 'STATUS' | 'CHANNEL'
 
+export type WamEditTypeKey = 'EDITED' | 'PIN' | 'SENDER_REVOKE' | 'ADMIN_REVOKE'
+
 export type WamMediaTypeKey =
     | 'PHOTO'
     | 'VIDEO'
@@ -72,4 +74,21 @@ const MEDIA_TYPE_BY_ATTR: Readonly<Record<string, WamMediaTypeKey>> = {
 export function mediaTypeKey(mediatype: string | undefined): WamMediaTypeKey | null {
     if (mediatype === undefined) return null
     return MEDIA_TYPE_BY_ATTR[mediatype] ?? null
+}
+
+/** `<message edit>` attr → EDIT_TYPE enum key (null when the message is not an edit/revoke). */
+export function editTypeKey(edit: string | undefined): WamEditTypeKey | null {
+    switch (edit) {
+        case '1':
+        case '3':
+            return 'EDITED'
+        case '2':
+            return 'PIN'
+        case '7':
+            return 'SENDER_REVOKE'
+        case '8':
+            return 'ADMIN_REVOKE'
+        default:
+            return null
+    }
 }

--- a/packages/wam/src/synthetic/WaWamSyntheticUi.ts
+++ b/packages/wam/src/synthetic/WaWamSyntheticUi.ts
@@ -289,7 +289,7 @@ export class WaWamSyntheticUi {
 
         if (media !== null) {
             const isPhotoVideo = media === 'PHOTO' || media === 'VIDEO'
-            if (Math.random() < 0.35) {
+            if ((isPhotoVideo || media === 'DOCUMENT') && Math.random() < 0.35) {
                 this.schedule(rand(1500, 15_000), () => this.emitMediaPicker(media, to))
             }
             if (isPhotoVideo && Math.random() < 0.3) {
@@ -418,7 +418,7 @@ export class WaWamSyntheticUi {
             bitarrayLow: this.bitmapLow,
             cumulativeBits: this.activeSliceCount,
             sessionSeq: this.activitySeq,
-            relativeTimestampMs: Math.max(0, this.activityStartMs - this.sessionStartMs),
+            relativeTimestampMs: Math.max(0, Date.now() - this.sessionStartMs),
             tsTimestampMs: Date.now(),
             unifiedSessionId: this.unifiedSessionId,
             ...(len > 32 ? { bitarrayHigh: this.bitmapHigh } : {})
@@ -695,7 +695,7 @@ export class WaWamSyntheticUi {
         if (!this.canEmit()) return
         this.coordinator.commit('TsNavigation', {
             tsSessionId: this.tsSessionId,
-            relativeTimestampMs: Math.max(0, this.activityStartMs - this.sessionStartMs),
+            relativeTimestampMs: Math.max(0, Date.now() - this.sessionStartMs),
             navigationSource: 'CHAT_LIST',
             navigationDestination: 'CHAT_THREAD',
             navigationDestinationViewName: '',

--- a/packages/wam/src/synthetic/WaWamSyntheticUi.ts
+++ b/packages/wam/src/synthetic/WaWamSyntheticUi.ts
@@ -2,8 +2,11 @@ import type { WaWamEventArgs } from '@vinikjkkj/wa-wam'
 import type { BinaryNode, WaClientPluginContext, WaIncomingMessageEvent } from 'zapo-js'
 import { isGroupJid, isLidJid, WA_ADDRESSING_MODES, WA_MESSAGE_TAGS } from 'zapo-js/protocol'
 
-import { findFirstEncNode, mediaTypeKey, type WamMediaTypeKey } from './send-parse.js'
-import type { WaWamCoordinator } from './WaWamCoordinator.js'
+import { findFirstEncNode, mediaTypeKey, type WamMediaTypeKey } from '../send-parse.js'
+import type { WaWamCoordinator } from '../WaWamCoordinator.js'
+
+import { AMBIENT_FABS, type FabSession } from './fabrications.js'
+import { rand, randB64, randHex, randInt, randUuid } from './random.js'
 
 type Ctx = Pick<WaClientPluginContext, 'on' | 'off'>
 
@@ -49,12 +52,15 @@ export interface WaWamSyntheticUiOptions {
      */
     readonly activeHoursStartHour?: number
     readonly activeHoursEndHour?: number
+    /**
+     * Capability gates for context-specific ambient events, all default `false`.
+     * Enable only when the session genuinely has that surface — firing a
+     * channel/community/business event on an account that lacks it is a tell.
+     */
+    readonly channels?: boolean
+    readonly communities?: boolean
+    readonly business?: boolean
 }
-
-const rand = (min: number, max: number): number => min + Math.random() * (max - min)
-const randInt = (min: number, max: number): number => Math.floor(rand(min, max))
-const randHex = (len: number): string =>
-    Array.from({ length: len }, () => Math.floor(Math.random() * 16).toString(16)).join('')
 
 const clampProbability = (value: number | undefined, fallback: number): number =>
     typeof value === 'number' && Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : fallback
@@ -105,6 +111,8 @@ export class WaWamSyntheticUi {
     private readonly infoOpenProbability: number
     private readonly attachmentTrayProbability: number
     private readonly aboutConsumptionProbability: number
+    private readonly gates: Record<'channels' | 'communities' | 'business', boolean>
+    private readonly session: FabSession
     private readonly ambientMinMs: number
     private readonly ambientMaxMs: number
     private readonly memoryMinMs: number
@@ -113,7 +121,13 @@ export class WaWamSyntheticUi {
     private readonly activeEndHour: number | undefined
     private readonly windowHeightFloat = randInt(680, 1040)
     private readonly sessionStartMs = Date.now()
+    private readonly unifiedSessionId = randHex(16)
+    private readonly appSessionId = randUuid()
+    private readonly gifProvider: 'TENOR' | 'GIPHY' = Math.random() < 0.75 ? 'TENOR' : 'GIPHY'
+    /** Weighted ambient-fabrication table; one entry is picked per ambient tick. Gated events are only present when their capability flag is on. */
+    private readonly ambientSpecs: Array<{ readonly w: number; readonly emit: () => void }> = []
     private activitySessionId = randHex(8)
+    private tsSessionId = randInt(1, 2_000_000_000)
     private activityStartMs = Date.now()
     private lastOpenMs = 0
     private lastInfoOpenMs = 0
@@ -149,6 +163,17 @@ export class WaWamSyntheticUi {
         this.memoryMaxMs = clampInterval(options.memoryIntervalMaxMs, 5 * 60_000)
         this.activeStartHour = options.activeHoursStartHour
         this.activeEndHour = options.activeHoursEndHour
+        this.gates = {
+            channels: options.channels === true,
+            communities: options.communities === true,
+            business: options.business === true
+        }
+        this.session = {
+            unifiedSessionId: this.unifiedSessionId,
+            appSessionId: this.appSessionId,
+            gifProvider: this.gifProvider
+        }
+        this.registerAmbientSpecs()
         const onMessage = (event: WaIncomingMessageEvent): void => this.onMessage(event)
         const onNodeOut = (event: { readonly node: BinaryNode }): void => this.onNodeOut(event.node)
         ctx.on('message', onMessage)
@@ -210,13 +235,36 @@ export class WaWamSyntheticUi {
             this.lastAboutMs = now
             this.schedule(rand(2000, 40_000), () => this.emitAboutConsumption())
         }
+
+        const msg = event.message
+        if (msg?.videoMessage && Math.random() < 0.3) {
+            this.schedule(rand(1500, 20_000), () => this.emitMediaStreamPlayback())
+        }
+        if (key.isGroup === true && Math.random() < 0.05) {
+            this.schedule(rand(2000, 30_000), () => this.emitGroupCatchUp())
+        }
+        const linkUrl = msg?.extendedTextMessage?.matchedText
+        if (linkUrl && /youtu/i.test(linkUrl) && Math.random() < 0.4) {
+            this.schedule(rand(3000, 60_000), () =>
+                this.emitInlineVideoClosed(key.isGroup === true)
+            )
+        }
+        if (
+            this.gates.business &&
+            (msg?.buttonsMessage ?? msg?.interactiveMessage ?? msg?.templateMessage) &&
+            Math.random() < 0.25
+        ) {
+            this.schedule(rand(2000, 30_000), () => this.emitStructuredMessageBuyerInteraction())
+        }
     }
 
     private emitAboutConsumption(): void {
         if (!this.canEmit()) return
-        this.coordinator.commit('AboutConsumption', {
-            aboutConsumptionSurface: Math.random() < 0.5 ? 'ONE_ON_ONE_CHAT' : 'PROFILE_INFO'
-        })
+        const aboutConsumptionSurface = Math.random() < 0.5 ? 'ONE_ON_ONE_CHAT' : 'PROFILE_INFO'
+        this.coordinator.commit('AboutConsumption', { aboutConsumptionSurface })
+        if (Math.random() < 0.35) {
+            this.coordinator.commit('AboutInteraction', { aboutConsumptionSurface })
+        }
     }
 
     private emitMediaLoad(): void {
@@ -237,6 +285,24 @@ export class WaWamSyntheticUi {
         const media = enc !== null ? mediaTypeKey(enc.attrs.mediatype) : null
         if (media !== null && Math.random() < this.attachmentTrayProbability) {
             this.schedule(rand(1000, 12_000), () => this.emitAttachmentTray(media, to))
+        }
+
+        if (media !== null) {
+            const isPhotoVideo = media === 'PHOTO' || media === 'VIDEO'
+            if (Math.random() < 0.35) {
+                this.schedule(rand(1500, 15_000), () => this.emitMediaPicker(media, to))
+            }
+            if (isPhotoVideo && Math.random() < 0.3) {
+                this.schedule(rand(1000, 12_000), () => this.emitMediaEditorSend())
+            }
+            if (isPhotoVideo && Math.random() < 0.12) {
+                this.schedule(rand(800, 8000), () => this.emitHdMediaAwareness())
+            }
+        } else if (enc !== null && Math.random() < 0.04) {
+            this.schedule(rand(2000, 30_000), () => this.emitTextMessageUserJourney(isGroupJid(to)))
+        }
+        if (isGroupJid(to) && Math.random() < 0.07) {
+            this.schedule(rand(1500, 20_000), () => this.emitMentionPickerAction())
         }
 
         if (this.infoOpenAllowed()) {
@@ -329,6 +395,7 @@ export class WaWamSyntheticUi {
         this.activeSliceCount = 0
         this.activitySeq = 0
         this.activitySessionId = randHex(8)
+        this.tsSessionId = randInt(1, 2_000_000_000)
         this.activityStartMs = Date.now()
     }
 
@@ -345,21 +412,70 @@ export class WaWamSyntheticUi {
             userActivitySessionCum: this.activeSliceCount,
             ...(len > 32 ? { userActivityBitmapHigh: this.bitmapHigh } : {})
         })
+        this.coordinator.commit('TsBitArray', {
+            tsSessionId: this.tsSessionId,
+            bitarrayLength: len,
+            bitarrayLow: this.bitmapLow,
+            cumulativeBits: this.activeSliceCount,
+            sessionSeq: this.activitySeq,
+            relativeTimestampMs: Math.max(0, this.activityStartMs - this.sessionStartMs),
+            tsTimestampMs: Date.now(),
+            unifiedSessionId: this.unifiedSessionId,
+            ...(len > 32 ? { bitarrayHigh: this.bitmapHigh } : {})
+        })
     }
 
     private scheduleAmbient(): void {
         this.schedule(rand(this.ambientMinMs, this.ambientMaxMs), () => {
-            const r = Math.random()
-            if (r < 0.12) {
-                this.emitEmojiOpen()
-            } else if (r < 0.2) {
-                this.emitContactSearch()
-            } else {
-                const isLid = this.recentChatIsLid[randInt(0, this.recentChatIsLid.length)]
-                if (isLid !== undefined) this.emitChatOpen(isLid)
-            }
+            this.pickAmbient()
             this.scheduleAmbient()
         })
+    }
+
+    /** Picks one ambient fabrication from the weighted table and fires it, keeping the aggregate ambient rate constant while adding variety. */
+    private pickAmbient(): void {
+        const specs = this.ambientSpecs
+        if (specs.length === 0) return
+        let total = 0
+        for (const s of specs) total += s.w
+        let r = Math.random() * total
+        for (const s of specs) {
+            r -= s.w
+            if (r < 0) {
+                s.emit()
+                return
+            }
+        }
+    }
+
+    /** Ambient re-open of a recent chat (the high-weight default ambient action). */
+    private emitChatOpenAmbient(): void {
+        const isLid = this.recentChatIsLid[randInt(0, this.recentChatIsLid.length)]
+        if (isLid !== undefined) this.emitChatOpen(isLid)
+    }
+
+    /**
+     * Registers the weighted ambient table: the base UI-open actions plus every
+     * wa-web-grounded synthetic event. Capability-gated events (channel/community/
+     * business) are only added when their flag is on, so they never fire on an
+     * account that lacks the surface. Weights follow cadence (common ≫ occasional ≫ rare).
+     */
+    private registerAmbientSpecs(): void {
+        const add = (w: number, emit: () => void): void => {
+            this.ambientSpecs.push({ w, emit })
+        }
+        add(40, () => this.emitChatOpenAmbient())
+        add(5, () => this.emitEmojiOpen())
+        add(3, () => this.emitStickerPickerOpened())
+        add(4, () => this.emitContactSearch())
+        add(3, () => this.emitTsNavigation())
+        add(1, () => this.emitDisappearingModeSetting())
+        add(3, () => this.emitGifSearchSession())
+        add(8, () => this.emitMessageContextMenu())
+        for (const fab of AMBIENT_FABS) {
+            if (fab.gate !== undefined && !this.gates[fab.gate]) continue
+            add(fab.weight, () => fab.emit(this.coordinator, this.session))
+        }
     }
 
     private emitEmojiOpen(): void {
@@ -367,6 +483,12 @@ export class WaWamSyntheticUi {
         this.coordinator.commit('WebcEmojiOpen', {
             webcEmojiOpenTab: EMOJI_TABS[randInt(0, EMOJI_TABS.length)]
         })
+    }
+
+    /** Sticker-picker open: a fieldless UI-open marker, like the emoji-picker open. */
+    private emitStickerPickerOpened(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('StickerPickerOpened', {})
     }
 
     private emitContactSearch(): void {
@@ -420,6 +542,190 @@ export class WaWamSyntheticUi {
             uiActionPreloaded: true,
             isLid,
             uiActionT: randInt(60, 600)
+        })
+    }
+
+    private emitDisappearingModeSetting(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('DisappearingModeSettingEvents', {
+            disappearingModeSettingEventName: 'DEFAULT_MESSAGE_TIMER_OPEN',
+            disappearingModeEntryPoint: 'ACCOUNT_SETTINGS',
+            isAfterRead: false
+        })
+        this.schedule(rand(2000, 30_000), () => {
+            if (!this.canEmit()) return
+            this.coordinator.commit('DisappearingModeSettingEvents', {
+                disappearingModeSettingEventName: 'DEFAULT_MESSAGE_TIMER_EXIT',
+                disappearingModeEntryPoint: 'ACCOUNT_SETTINGS',
+                isAfterRead: false
+            })
+        })
+    }
+
+    private emitGifSearchSession(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('GifSearchSessionStarted', { gifSearchProvider: this.gifProvider })
+        if (Math.random() < 0.2)
+            this.schedule(rand(1500, 6000), () => this.emitGifSearchNoResults())
+        this.schedule(rand(3000, 20_000), () => this.emitGifSearchCancelled())
+    }
+
+    private emitGifSearchCancelled(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('GifSearchCancelled', { gifSearchProvider: this.gifProvider })
+    }
+
+    private emitGifSearchNoResults(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('GifSearchNoResults', { gifSearchProvider: this.gifProvider })
+    }
+
+    private emitGroupCatchUp(): void {
+        if (!this.canEmit()) return
+        const pct = Math.random() < 0.8 ? 0 : randInt(1, 5) * 10
+        this.coordinator.commit('GroupCatchUp', { mentionsCountPendingPercentage: pct })
+    }
+
+    private emitInlineVideoClosed(isGroup: boolean): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('InlineVideoPlaybackClosed', {
+            inlineVideoType: 'YOUTUBE',
+            inlineVideoPlayed: true,
+            messageType: isGroup ? 'GROUP' : 'INDIVIDUAL',
+            inlineVideoHasRcat: false,
+            inlineVideoPlayStartT: randInt(300, 3000),
+            inlineVideoDurationT: randInt(45, 600)
+        })
+    }
+
+    private emitMediaPicker(media: WamMediaTypeKey, to: string): void {
+        if (!this.canEmit()) return
+        const isDoc = media === 'DOCUMENT'
+        this.coordinator.commit('MediaPicker', {
+            mediaPickerSent: 1,
+            mediaPickerSentUnchanged: 1,
+            mediaPickerT: randInt(1500, 15_000),
+            mediaType: isDoc ? 'DOCUMENT' : media === 'VIDEO' ? 'VIDEO' : 'PHOTO',
+            mediaPickerOrigin: isDoc ? 'DOCUMENT_PICKER' : 'CHAT_PHOTO_LIBRARY',
+            mediaPickerChanged: 0,
+            mediaPickerCroppedRotated: 0,
+            mediaPickerDrawing: 0,
+            mediaPickerStickers: 0,
+            mediaPickerText: 0,
+            mediaPickerLikeDoc: 0,
+            mediaPickerNotLikeDoc: 0,
+            mediaPickerDeleted: 0,
+            chatRecipients: 1,
+            isViewOnce: false
+        })
+    }
+
+    private emitMediaStreamPlayback(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('MediaStreamPlayback', {
+            playbackOrigin: 'CONVERSATION',
+            mediaType: 'VIDEO',
+            didPlay: true,
+            playbackState: Math.random() < 0.5 ? 'READY_PAUSE' : 'ENDED',
+            videoDuration: randInt(5, 180),
+            initialBufferingT: randInt(50, 900)
+        })
+    }
+
+    private emitMentionPickerAction(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('MentionPickerAction', {
+            isAGroup: true,
+            mentionType: 'REGULAR_USER',
+            threadId: randB64(32)
+        })
+    }
+
+    private emitMessageContextMenu(): void {
+        if (!this.canEmit()) return
+        const isAGroup = Math.random() < 0.4
+        const isOriginalSender = Math.random() < 0.35
+        this.coordinator.commit('MessageContextMenuActions', {
+            isAGroup,
+            isMultiAction: false,
+            isOriginalSender,
+            messageContextMenuAction: 'OPEN'
+        })
+        if (Math.random() < 0.5) {
+            const options = ['REACT', 'REPLY', 'COPY', 'FORWARD', 'STAR_OR_UNSTAR'] as const
+            this.schedule(rand(400, 3000), () => {
+                if (!this.canEmit()) return
+                this.coordinator.commit('MessageContextMenuActions', {
+                    isAGroup,
+                    isMultiAction: false,
+                    isOriginalSender,
+                    messageContextMenuAction: 'CLICK',
+                    messageContextMenuOption: options[randInt(0, options.length)]
+                })
+            })
+        }
+    }
+
+    private emitStructuredMessageBuyerInteraction(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('StructuredMessageBuyerInteraction', {
+            bizPlatform: 'SMB',
+            messageClass: 'BUTTON_NFM',
+            messageClassAttributes: '{}',
+            messageInteraction: 'USER_VIEW',
+            messageMediaType: 'NONE'
+        })
+    }
+
+    private emitTextMessageUserJourney(isGroup: boolean): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('TextMessageUserJourney', {
+            appSessionId: this.appSessionId,
+            unifiedSessionId: this.unifiedSessionId,
+            userJourneyFunnelId: randUuid(),
+            uiSurface: isGroup ? 'GROUP_CHAT' : 'CHAT_THREAD',
+            textMessageUserJourneyAction: 'SENT',
+            userJourneyChatType: isGroup ? 'GROUP' : 'INDIVIDUAL',
+            userJourneyEventMs: Date.now(),
+            chatbarInitialState: 'EMPTY'
+        })
+    }
+
+    private emitTsNavigation(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('TsNavigation', {
+            tsSessionId: this.tsSessionId,
+            relativeTimestampMs: Math.max(0, this.activityStartMs - this.sessionStartMs),
+            navigationSource: 'CHAT_LIST',
+            navigationDestination: 'CHAT_THREAD',
+            navigationDestinationViewName: '',
+            isCanonicalEntPresent: true,
+            tsTimestampMs: Date.now(),
+            unifiedSessionId: this.unifiedSessionId
+        })
+    }
+
+    private emitMediaEditorSend(): void {
+        if (!this.canEmit()) return
+        const imageCount = Math.random() < 0.85 ? 1 : 2
+        const editedImageCount = Math.random() < 0.25 ? 1 : 0
+        const textLayerCount = editedImageCount && Math.random() < 0.6 ? 1 : 0
+        const emojiLayerCount = editedImageCount && textLayerCount === 0 ? 1 : 0
+        this.coordinator.commit('WebcMediaEditorSend', {
+            imageCount,
+            editedImageCount,
+            paintedImageCount: 0,
+            blurImageCount: 0,
+            emojiLayerCount,
+            stickerLayerCount: 0,
+            textLayerCount
+        })
+    }
+
+    private emitHdMediaAwareness(): void {
+        if (!this.canEmit()) return
+        this.coordinator.commit('WebHdMediaAwarenessInteraction', {
+            hdMediaSelected: Math.random() < 0.5
         })
     }
 

--- a/packages/wam/src/synthetic/WaWamSyntheticUi.ts
+++ b/packages/wam/src/synthetic/WaWamSyntheticUi.ts
@@ -6,7 +6,7 @@ import { findFirstEncNode, mediaTypeKey, type WamMediaTypeKey } from '../send-pa
 import type { WaWamCoordinator } from '../WaWamCoordinator.js'
 
 import { AMBIENT_FABS, type FabSession } from './fabrications.js'
-import { rand, randB64, randHex, randInt, randUuid } from './random.js'
+import { rand, randB64, randBase36, randInt, randUuid } from './random.js'
 
 type Ctx = Pick<WaClientPluginContext, 'on' | 'off'>
 
@@ -121,12 +121,12 @@ export class WaWamSyntheticUi {
     private readonly activeEndHour: number | undefined
     private readonly windowHeightFloat = randInt(680, 1040)
     private readonly sessionStartMs = Date.now()
-    private readonly unifiedSessionId = randHex(16)
+    private readonly unifiedSessionId = String(randInt(1, 2_000_000_000))
     private readonly appSessionId = randUuid()
     private readonly gifProvider: 'TENOR' | 'GIPHY' = Math.random() < 0.75 ? 'TENOR' : 'GIPHY'
     /** Weighted ambient-fabrication table; one entry is picked per ambient tick. Gated events are only present when their capability flag is on. */
     private readonly ambientSpecs: Array<{ readonly w: number; readonly emit: () => void }> = []
-    private activitySessionId = randHex(8)
+    private activitySessionId = randBase36(6)
     private tsSessionId = randInt(1, 2_000_000_000)
     private activityStartMs = Date.now()
     private lastOpenMs = 0
@@ -394,7 +394,7 @@ export class WaWamSyntheticUi {
         this.activitySlice = 0
         this.activeSliceCount = 0
         this.activitySeq = 0
-        this.activitySessionId = randHex(8)
+        this.activitySessionId = randBase36(6)
         this.tsSessionId = randInt(1, 2_000_000_000)
         this.activityStartMs = Date.now()
     }

--- a/packages/wam/src/synthetic/__tests__/synthetic-ui.test.ts
+++ b/packages/wam/src/synthetic/__tests__/synthetic-ui.test.ts
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict'
 import { afterEach, mock, test } from 'node:test'
 
-import type { WaWamAutoEmitterContext } from '../WaWamAutoEmitter.js'
-import type { WaWamCoordinator } from '../WaWamCoordinator.js'
+import { WA_WAM_EVENTS } from '@vinikjkkj/wa-wam'
+
+import type { WaWamAutoEmitterContext } from '../../WaWamAutoEmitter.js'
+import type { WaWamCoordinator } from '../../WaWamCoordinator.js'
+import { AMBIENT_FABS } from '../fabrications.js'
 import { WaWamSyntheticUi } from '../WaWamSyntheticUi.js'
 
 afterEach(() => {
@@ -188,25 +191,27 @@ test('synthetic UI gates audio WebcMediaLoad on audioLoadProbability, not imageO
     ui.dispose()
 })
 
-test('synthetic UI fabricates WebcEmojiOpen with a real tab in the ambient stream', () => {
+test('ambient stream fabricates the base UI-open events across the weighted table', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
-    const origRandom = Math.random
-    Math.random = () => 0.05
-    try {
-        const h = makeHarness()
-        const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
-            ambientIntervalMinMs: 1,
-            ambientIntervalMaxMs: 2
-        })
-        mock.timers.tick(20)
-        const emoji = h.commits.find((c) => c.name === 'WebcEmojiOpen')
-        assert.ok(emoji)
-        assert.ok(['EMOJI', 'GIF', 'STICKER'].includes(emoji?.payload.webcEmojiOpenTab as string))
-        ui.dispose()
-    } finally {
-        Math.random = origRandom
-        mock.timers.reset()
-    }
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        ambientIntervalMinMs: 1,
+        ambientIntervalMaxMs: 2,
+        memoryIntervalMinMs: 10 * 60_000,
+        memoryIntervalMaxMs: 10 * 60_000
+    })
+    // Step the scheduler many times (mock timers jump, so loop tick() to cascade the
+    // ambient reschedules); the weighted picker should fire each base UI-open (real random).
+    for (let i = 0; i < 2000; i += 1) mock.timers.tick(2)
+    const names = new Set(h.commits.map((c) => c.name))
+    assert.ok(names.has('WebcEmojiOpen'), 'emoji open should fire')
+    assert.ok(names.has('StickerPickerOpened'), 'sticker picker should fire')
+    assert.ok(names.has('ContactSearchExperience'), 'contact search should fire')
+    const emoji = h.commits.find((c) => c.name === 'WebcEmojiOpen')
+    assert.ok(['EMOJI', 'GIF', 'STICKER'].includes(emoji?.payload.webcEmojiOpenTab as string))
+    const search = h.commits.find((c) => c.name === 'ContactSearchExperience')
+    assert.equal(search?.payload.contactSearchEntrypoint, 'CHATS_LIST_GLOBAL_SEARCH')
+    ui.dispose()
 })
 
 test('synthetic UI fabricates AttachmentTrayActions (SEND) for an outbound media message', () => {
@@ -282,6 +287,12 @@ test('synthetic UI flushes UserActivity with a bitmap matching the active slices
     assert.equal(ua?.payload.userActivitySessionCum, 1)
     assert.equal(ua?.payload.userActivityBitmapLow, 1)
     assert.equal(ua?.payload.userActivitySessionSeq, 1)
+    const ts = h.commits.find((c) => c.name === 'TsBitArray')
+    assert.ok(ts)
+    assert.equal(ts?.payload.bitarrayLength, 5)
+    assert.equal(ts?.payload.bitarrayLow, 1)
+    assert.equal(ts?.payload.cumulativeBits, 1)
+    assert.equal(ts?.payload.sessionSeq, 1)
     ui.dispose()
 })
 
@@ -320,6 +331,28 @@ test('synthetic UI fabricates AboutConsumption for a 1:1 inbound message', () =>
     ui.dispose()
 })
 
+test('synthetic UI fabricates AboutInteraction alongside a fraction of About views', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const origRandom = Math.random
+    Math.random = () => 0.1
+    try {
+        const h = makeHarness()
+        const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+            chatOpenProbability: 0,
+            aboutConsumptionProbability: 1
+        })
+        h.emit('message', lidMessage())
+        mock.timers.tick(41_000)
+        assert.ok(h.commits.some((c) => c.name === 'AboutConsumption'))
+        const interaction = h.commits.find((c) => c.name === 'AboutInteraction')
+        assert.ok(interaction)
+        assert.equal(interaction?.payload.aboutConsumptionSurface, 'ONE_ON_ONE_CHAT')
+        ui.dispose()
+    } finally {
+        Math.random = origRandom
+    }
+})
+
 test('synthetic UI fabricates no AboutConsumption for a group message', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
     const h = makeHarness()
@@ -337,31 +370,6 @@ test('synthetic UI fabricates no AboutConsumption for a group message', () => {
     ui.dispose()
 })
 
-test('synthetic UI fabricates ContactSearchExperience in the ambient stream', () => {
-    mock.timers.enable({ apis: ['setTimeout'] })
-    const origRandom = Math.random
-    Math.random = () => 0.15
-    try {
-        const h = makeHarness()
-        const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
-            ambientIntervalMinMs: 1,
-            ambientIntervalMaxMs: 2,
-            memoryIntervalMinMs: 10 * 60_000,
-            memoryIntervalMaxMs: 10 * 60_000
-        })
-        mock.timers.tick(5)
-        const search = h.commits.find((c) => c.name === 'ContactSearchExperience')
-        assert.ok(search)
-        assert.equal(search?.payload.contactSearchEntrypoint, 'CHATS_LIST_GLOBAL_SEARCH')
-        assert.equal(search?.payload.isUsernameSearch, false)
-        assert.equal(search?.payload.searchActionName, 'SEARCH_START')
-        ui.dispose()
-    } finally {
-        Math.random = origRandom
-        mock.timers.reset()
-    }
-})
-
 test('synthetic UI cancels pending fabrications on dispose', () => {
     mock.timers.enable({ apis: ['setTimeout'] })
     const h = makeHarness()
@@ -370,4 +378,113 @@ test('synthetic UI cancels pending fabrications on dispose', () => {
     ui.dispose()
     mock.timers.tick(120_000)
     assert.equal(h.commits.length, 0)
+})
+
+test('every ambient fabrication commits the registry event it declares', () => {
+    for (const fab of AMBIENT_FABS) {
+        const captured: Commit[] = []
+        const coordinator = {
+            commit: (name: string, payload: Record<string, unknown>) =>
+                captured.push({ name, payload })
+        } as unknown as WaWamCoordinator
+        fab.emit(coordinator, { unifiedSessionId: 'u', appSessionId: 'a', gifProvider: 'TENOR' })
+        assert.ok(fab.event in WA_WAM_EVENTS, `${fab.event} is not a registry event`)
+        assert.ok(captured.length >= 1, `${fab.event} committed nothing`)
+        assert.equal(captured[0]?.name, fab.event, `${fab.event} declared event != commit name`)
+        for (const c of captured) {
+            assert.ok(
+                c.payload && typeof c.payload === 'object',
+                `${fab.event} committed bad payload`
+            )
+        }
+    }
+})
+
+test('capability-gated events stay out of the ambient stream by default', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        ambientIntervalMinMs: 1,
+        ambientIntervalMaxMs: 2,
+        memoryIntervalMinMs: 10 * 60_000,
+        memoryIntervalMaxMs: 10 * 60_000
+    })
+    for (let i = 0; i < 2000; i += 1) mock.timers.tick(2)
+    for (const g of [
+        'ChannelOpen',
+        'CommunityCreation',
+        'GroupJourney',
+        'WaShopsManagement',
+        'MdChatAssignmentSecondaryAction'
+    ]) {
+        assert.ok(!h.commits.some((c) => c.name === g), `${g} leaked with gates off`)
+    }
+    ui.dispose()
+})
+
+test('enabling the communities capability adds its events to the ambient stream', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const h = makeHarness()
+    const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {
+        communities: true,
+        ambientIntervalMinMs: 1,
+        ambientIntervalMaxMs: 2,
+        memoryIntervalMinMs: 10 * 60_000,
+        memoryIntervalMaxMs: 10 * 60_000
+    })
+    for (let i = 0; i < 3000; i += 1) mock.timers.tick(2)
+    const community = [
+        'CommunityCreation',
+        'CommunityFeatureUsage',
+        'CommunityHomeAction',
+        'CommunityTabAction',
+        'GroupJourney'
+    ]
+    assert.ok(
+        community.some((n) => h.commits.some((c) => c.name === n)),
+        'no community event fired with communities:true'
+    )
+    ui.dispose()
+})
+
+test('anchored MediaStreamPlayback rides an inbound video message', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const origRandom = Math.random
+    Math.random = () => 0
+    try {
+        const h = makeHarness()
+        const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {})
+        h.emit('message', lidMessage({ message: { videoMessage: {} } }))
+        mock.timers.tick(21_000)
+        const mp = h.commits.find((c) => c.name === 'MediaStreamPlayback')
+        assert.ok(mp)
+        assert.equal(mp?.payload.playbackOrigin, 'CONVERSATION')
+        assert.equal(mp?.payload.mediaType, 'VIDEO')
+        ui.dispose()
+    } finally {
+        Math.random = origRandom
+    }
+})
+
+test('anchored media-composer events ride an outbound photo send', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const origRandom = Math.random
+    Math.random = () => 0
+    try {
+        const h = makeHarness()
+        const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {})
+        h.emit('debug_transport_node_out', {
+            node: {
+                tag: 'message',
+                attrs: { to: '1@s.whatsapp.net' },
+                content: [{ tag: 'enc', attrs: { mediatype: 'image' } }]
+            }
+        })
+        mock.timers.tick(16_000)
+        assert.ok(h.commits.some((c) => c.name === 'MediaPicker'))
+        assert.ok(h.commits.some((c) => c.name === 'WebcMediaEditorSend'))
+        ui.dispose()
+    } finally {
+        Math.random = origRandom
+    }
 })

--- a/packages/wam/src/synthetic/__tests__/synthetic-ui.test.ts
+++ b/packages/wam/src/synthetic/__tests__/synthetic-ui.test.ts
@@ -488,3 +488,28 @@ test('anchored media-composer events ride an outbound photo send', () => {
         Math.random = origRandom
     }
 })
+
+test('anchored MediaPicker is not fabricated for outbound audio (PHOTO/VIDEO/DOCUMENT only)', () => {
+    mock.timers.enable({ apis: ['setTimeout'] })
+    const origRandom = Math.random
+    Math.random = () => 0
+    try {
+        const h = makeHarness()
+        const ui = new WaWamSyntheticUi(h.coordinator, h.ctx, {})
+        h.emit('debug_transport_node_out', {
+            node: {
+                tag: 'message',
+                attrs: { to: '1@s.whatsapp.net' },
+                content: [{ tag: 'enc', attrs: { mediatype: 'audio' } }]
+            }
+        })
+        mock.timers.tick(16_000)
+        assert.equal(
+            h.commits.find((c) => c.name === 'MediaPicker'),
+            undefined
+        )
+        ui.dispose()
+    } finally {
+        Math.random = origRandom
+    }
+})

--- a/packages/wam/src/synthetic/fabrications.ts
+++ b/packages/wam/src/synthetic/fabrications.ts
@@ -1,0 +1,923 @@
+import type { WaWamCoordinator } from '../WaWamCoordinator.js'
+
+import { randB64, randHex, randInt, randUuid } from './random.js'
+
+/** Per-session ids the fabrications reuse so their payloads stay internally consistent. */
+export interface FabSession {
+    readonly unifiedSessionId: string
+    readonly appSessionId: string
+    readonly gifProvider: 'TENOR' | 'GIPHY'
+}
+
+/** One ambient synthetic event: a weighted, optionally capability-gated fabrication grounded in WA Web's real emit. */
+export interface AmbientFab {
+    readonly event: string
+    readonly weight: number
+    readonly gate?: 'channels' | 'communities' | 'business'
+    readonly emit: (c: WaWamCoordinator, s: FabSession) => void
+}
+
+/**
+ * The ambient fabrication table. Each entry replicates the field subset WA Web's
+ * own emit sets (verified against the deobfuscated bundle), with plausible values.
+ * The engine picks one per ambient tick, weighted by cadence; gated entries are
+ * only eligible when their capability flag is enabled.
+ */
+export const AMBIENT_FABS: AmbientFab[] = [
+    {
+        event: 'AboutConsumptionDaily',
+        weight: 1,
+        emit: (c) => {
+            c.commit('AboutConsumptionDaily', {
+                aboutChatConsumptionCount: randInt(0, 4),
+                aboutChatBubbleTapCount: randInt(0, 3),
+                aboutMessageSendCount: randInt(0, 2)
+            })
+        }
+    },
+    {
+        event: 'ChannelOpen',
+        weight: 1,
+        gate: 'channels',
+        emit: (c) => {
+            c.commit('ChannelOpen', {
+                channelSessionId: randInt(0, 1_000_000_000),
+                channelEntryPoint: 'UPDATES_TAB',
+                channelUserType: 'FOLLOWER',
+                cid: `120363${randInt(100_000_000_000, 1_000_000_000_000)}`,
+                unreadMessages: randInt(0, 6),
+                discoverySurface: 'CHANNEL_UPDATES_HOME'
+            })
+        }
+    },
+    {
+        event: 'ChatFilterEvent',
+        weight: 3,
+        emit: (c) => {
+            c.commit('ChatFilterEvent', {
+                actionType: 'OPEN',
+                filterType: 'NONE',
+                sessionId: randInt(1, 2_000_000_000),
+                targetScreen: 'CHAT_LIST'
+            })
+        }
+    },
+    {
+        event: 'ChatFolderOpen',
+        weight: 3,
+        emit: (c) => {
+            const hasUnread = Math.random() < 0.4
+            c.commit('ChatFolderOpen', {
+                folderType: 'Archive',
+                ...(hasUnread ? { activityIndicatorCount: randInt(1, 8) } : {})
+            })
+        }
+    },
+    {
+        event: 'ChatThemeScreen',
+        weight: 1,
+        emit: (c) => {
+            c.commit('ChatThemeScreen', {
+                appearanceType: Math.random() < 0.45 ? 'DARK' : 'LIGHT',
+                chatThemeChangeApplied: false,
+                chatThemeId: '',
+                chatThemeSource: 'APP_WIDE',
+                chatWallpaperType: 'DEFAULT'
+            })
+        }
+    },
+    {
+        event: 'ChatThreadWallpaper',
+        weight: 3,
+        emit: (c) => {
+            const isGroup = Math.random() < 0.25
+            c.commit('ChatThreadWallpaper', {
+                appearanceType: Math.random() < 0.45 ? 'DARK' : 'LIGHT',
+                belongsToCommunity: false,
+                chatThemeId: 'doodle@whatsapp-green#tonal',
+                chatThemeSource: 'APP_WIDE',
+                chatType: isGroup ? 'GROUP' : 'INDIVIDUAL',
+                threadId: randB64(32),
+                wallpaperApplied: false
+            })
+        }
+    },
+    {
+        event: 'ChatWallpaper',
+        weight: 1,
+        emit: (c) => {
+            c.commit('ChatWallpaper', {
+                appearanceType: Math.random() < 0.45 ? 'DARK' : 'LIGHT',
+                chatWallpaperChangeApplied: false,
+                chatWallpaperSource: 'APP_WIDE',
+                chatWallpaperType: 'DEFAULT',
+                chatWallpaperVisit: true
+            })
+        }
+    },
+    {
+        event: 'CommunityCreation',
+        weight: 1,
+        gate: 'communities',
+        emit: (c) => {
+            c.commit('CommunityCreation', {
+                communityCreationSessionId: randUuid(),
+                communityCreationActionTaken: 'ENTER',
+                communityCreationCurrentScreen: 'COMMUNITIES_TAB',
+                communityCreationEntrypoint: 'COMMUNITIES_TAB'
+            })
+        }
+    },
+    {
+        event: 'CommunityFeatureUsage',
+        weight: 1,
+        gate: 'communities',
+        emit: (c) => {
+            c.commit('CommunityFeatureUsage', {
+                communityId: `120363${randInt(100_000_000_000, 1_000_000_000_000)}`,
+                communityUiAction: 'ENTRY',
+                communityUiFeature: 'SUBGROUP_SWITCH'
+            })
+        }
+    },
+    {
+        event: 'CommunityHomeAction',
+        weight: 1,
+        gate: 'communities',
+        emit: (c) => {
+            c.commit('CommunityHomeAction', {
+                communityHomeId: `120363${randInt(100_000_000_000, 1_000_000_000_000)}`,
+                communityHomeViews: randInt(1, 4),
+                communityHomeGroupNavigations: randInt(0, 3),
+                communityHomeGroupDiscoveries: randInt(0, 2),
+                communityHomeGroupJoins: 0
+            })
+        }
+    },
+    {
+        event: 'CommunityTabAction',
+        weight: 1,
+        gate: 'communities',
+        emit: (c) => {
+            c.commit('CommunityTabAction', {
+                communityTabViews: randInt(1, 4),
+                communityTabGroupNavigations: randInt(0, 2),
+                communityTabToHomeViews: randInt(0, 2),
+                communityTabViewsViaContextMenu: 0
+            })
+        }
+    },
+    {
+        event: 'ContactNotificationSettingUserJourney',
+        weight: 1,
+        emit: (c, s) => {
+            c.commit('ContactNotificationSettingUserJourney', {
+                appSessionId: s.appSessionId,
+                contactNotificationSettingActionType:
+                    Math.random() < 0.7 ? 'MUTE_MENTION_EVERYONE_ON' : 'MUTE_MENTION_EVERYONE_OFF',
+                uiSurface: 'CONTACT_NOTIFICATION_SETTING_PAGE',
+                groupSize: randInt(3, 60)
+            })
+        }
+    },
+    {
+        event: 'DialogEvent',
+        weight: 1,
+        emit: (c) => {
+            if (Math.random() < 0.6) {
+                c.commit('DialogEvent', {
+                    dialogEventSource: 'dismiss',
+                    dialogEventType: 'CLICK',
+                    dialogName: 'HARD_REFRESH'
+                })
+            } else {
+                c.commit('DialogEvent', {
+                    dialogEventSource: 'cancel',
+                    dialogEventType: 'CLICK',
+                    dialogName: 'LOGOUT'
+                })
+            }
+        }
+    },
+    {
+        event: 'DisappearingMessageChatPicker',
+        weight: 1,
+        emit: (c) => {
+            c.commit('DisappearingMessageChatPicker', {
+                dmChatPickerEntryPoint: 'DEFAULT_MODE_SETTING',
+                dmChatPickerEventName: 'CHAT_PICKER_TRAY_OPEN',
+                ephemeralityDuration: Math.random() < 0.8 ? 7_776_000 : 604_800
+            })
+        }
+    },
+    {
+        event: 'ForwardActionUserJourney',
+        weight: 1,
+        emit: (c, s) => {
+            const isGroup = Math.random() < 0.35
+            c.commit('ForwardActionUserJourney', {
+                appSessionId: s.appSessionId,
+                unifiedSessionId: s.unifiedSessionId,
+                userJourneyFunnelId: randUuid(),
+                forwardUserJourneyFunnelId: randUuid(),
+                forwardActionUserJourneyAction: 'CONTEXT_MENU_SHOWN_WITHOUT_FORWARD',
+                uiSurface: isGroup ? 'GROUP_CHAT' : 'CHAT_THREAD',
+                userJourneyChatType: isGroup ? 'GROUP' : 'INDIVIDUAL',
+                messageType: isGroup ? 'GROUP' : 'INDIVIDUAL',
+                messageMediaType: 'TEXT',
+                messageIsFromMe: false
+            })
+        }
+    },
+    {
+        event: 'GroupJourney',
+        weight: 1,
+        gate: 'communities',
+        emit: (c, s) => {
+            c.commit('GroupJourney', {
+                actionType: 'GROUP_NAVIGATION',
+                appSessionId: s.appSessionId,
+                surface: 'COMMUNITY_TAB',
+                groupSize: randInt(6, 180),
+                threadType: 'SUB_GROUP',
+                userRole: 'MEMBER'
+            })
+        }
+    },
+    {
+        event: 'GroupMemberUpdates',
+        weight: 3,
+        emit: (c) => {
+            const groupMemberUpdatesSessionId = randUuid()
+            c.commit('GroupMemberUpdates', {
+                groupMemberUpdatesActionName: 'VIEW',
+                groupMemberUpdatesCurrentScreen: 'GROUP_MEMBER_UPDATES_SCREEN',
+                groupMemberUpdatesSessionId
+            })
+            c.commit('GroupMemberUpdates', {
+                groupMemberUpdatesActionName: 'FETCH_MEMBER_UPDATES_SUCCESS',
+                groupMemberUpdatesCurrentScreen: 'GROUP_MEMBER_UPDATES_SCREEN',
+                groupMemberUpdatesSessionId,
+                fetchedMessageCount: randInt(1, 8),
+                fetchedMessageLatency: randInt(40, 400)
+            })
+        }
+    },
+    {
+        event: 'HfmTextSearchComplete',
+        weight: 1,
+        emit: (c) => {
+            c.commit('HfmTextSearchComplete', {})
+        }
+    },
+    {
+        event: 'KeepInChatErrors',
+        weight: 1,
+        emit: (c) => {
+            const isAGroup = Math.random() < 0.35
+            const isAdmin = isAGroup && Math.random() < 0.5
+            c.commit('KeepInChatErrors', {
+                kicAction: 'KEEP_MESSAGE',
+                isAGroup,
+                isAdmin,
+                canEditDmSettings: isAGroup ? isAdmin : true,
+                kicMessageEphemeralityDuration: 604_800,
+                kicErrorCode: 'OFFLINE'
+            })
+        }
+    },
+    {
+        event: 'KeepInChatNux',
+        weight: 1,
+        emit: (c) => {
+            const durations = [86_400, 604_800, 7_776_000]
+            c.commit('KeepInChatNux', {
+                kicNuxActionName: 'KIC_NUX_IMPRESSION',
+                trigger: 'CHAT_ENTRY',
+                chatEphemeralityDuration: durations[randInt(0, durations.length)]
+            })
+        }
+    },
+    {
+        event: 'LimitSharingSettingUpdate',
+        weight: 1,
+        emit: (c) => {
+            c.commit('LimitSharingSettingUpdate', {
+                toggleUpdateAction: Math.random() < 0.7 ? 'TURN_ON' : 'TURN_OFF'
+            })
+        }
+    },
+    {
+        event: 'ListUpdateUserJourney',
+        weight: 3,
+        emit: (c) => {
+            c.commit('ListUpdateUserJourney', {
+                listAction: 'CREATE',
+                listUpdateUserJourneyAction: 'START',
+                updateEntryPoint: 'ADD_LIST_FILTER'
+            })
+        }
+    },
+    {
+        event: 'LockFolderUnlock',
+        weight: 1,
+        emit: (c) => {
+            c.commit('LockFolderUnlock', {
+                landingSurface: 'FOLDER',
+                totalChatCount: randInt(1, 4),
+                unlockEntryPoint: 'CHAT_LIST'
+            })
+        }
+    },
+    {
+        event: 'MdChatAssignmentSecondaryAction',
+        weight: 1,
+        gate: 'business',
+        emit: (c) => {
+            c.commit('MdChatAssignmentSecondaryAction', {
+                mdChatAssignmentSecondaryActionAgentId: '',
+                mdChatAssignmentSecondaryActionBrowserId: randHex(20),
+                mdChatAssignmentSecondaryActionChatType: 'INDIVIDUAL',
+                mdChatAssignmentSecondaryActionMdId: randInt(0, 30),
+                mdChatAssignmentSecondaryActionSource: 'NONE',
+                mdChatAssignmentSecondaryActionType: 'ACTION_TOOLTIP_SHOWN'
+            })
+        }
+    },
+    {
+        event: 'MediaHubUserJourney',
+        weight: 1,
+        emit: (c, s) => {
+            const mediaHubSessionId = randUuid()
+            c.commit('MediaHubUserJourney', {
+                mediaHubEntryPoint: 'MAIN_SCREEN',
+                mediaHubAction: 'OPEN_MEDIA_HUB',
+                unifiedSessionId: s.unifiedSessionId,
+                mediaHubSurface: 'MEDIA',
+                mediaHubSequenceNumber: 1,
+                mediaHubSessionId,
+                customFields: JSON.stringify({ search_results: false })
+            })
+        }
+    },
+    {
+        event: 'MessagingUserJourney',
+        weight: 1,
+        emit: (c, s) => {
+            c.commit('MessagingUserJourney', {
+                appSessionId: s.appSessionId,
+                userJourneyFunnelId: randHex(16),
+                threadType: 'INDIVIDUAL',
+                uiSurface: 'MESSAGE_MENU',
+                messagingActionType: 'CLICK_PIN',
+                mediaType: 'TEXT'
+            })
+        }
+    },
+    {
+        event: 'PinInChatInteraction',
+        weight: 1,
+        emit: (c) => {
+            c.commit('PinInChatInteraction', {
+                pinInChatInteractionType: 'TAP_ON_BANNER',
+                isAGroup: false,
+                mediaType: 'TEXT',
+                pinCount: 1,
+                pinIndex: 0,
+                isSelfPin: Math.random() < 0.5
+            })
+        }
+    },
+    {
+        event: 'PrivacyHighlightDaily',
+        weight: 1,
+        emit: (c) => {
+            c.commit('PrivacyHighlightDaily', {
+                privacyHighlightCategory: 'E2EE',
+                privacyHighlightSurface: 'GOLDEN_BOX_CONTACT',
+                narrativeAppearCount: randInt(1, 8),
+                dialogAppearCount: 0,
+                dialogSelectCount: 0
+            })
+        }
+    },
+    {
+        event: 'PrivacySettingsClick',
+        weight: 1,
+        emit: (c) => {
+            const items = [
+                'LAST_SEEN_AND_ONLINE',
+                'PROFILE_PHOTO',
+                'ABOUT',
+                'GROUPS',
+                'READ_RECEIPT',
+                'BLOCKED'
+            ] as const
+            c.commit('PrivacySettingsClick', {
+                privacyControlEntryPoint: 'PRIVACY_SETTINGS',
+                privacyControlItem: items[randInt(0, items.length)]
+            })
+        }
+    },
+    {
+        event: 'PrivacyTipAction',
+        weight: 1,
+        emit: (c) => {
+            c.commit('PrivacyTipAction', {
+                privacyTipActionType: Math.random() < 0.8 ? 'VIEW' : 'CLICK_OK'
+            })
+        }
+    },
+    {
+        event: 'QuotedMessageUserJourney',
+        weight: 1,
+        emit: (c, s) => {
+            const funnelId = randUuid()
+            c.commit('QuotedMessageUserJourney', {
+                appSessionId: s.appSessionId,
+                unifiedSessionId: s.unifiedSessionId,
+                userJourneyFunnelId: funnelId,
+                uiSurface: 'CHAT_THREAD',
+                userJourneyChatType: 'INDIVIDUAL',
+                quotedMediaType: 'TEXT',
+                quotedMessageTypeEnum: 'INDIVIDUAL',
+                quotedMessageUserJourneyAction: 'QUOTED_MESSAGE_ADDED',
+                quotedMessageUserJourneyEntryPoint: 'CONTEXT_MENU_REPLY_BUTTON'
+            })
+        }
+    },
+    {
+        event: 'ReactionUserJourney',
+        weight: 3,
+        emit: (c, s) => {
+            c.commit('ReactionUserJourney', {
+                appSessionId: s.appSessionId,
+                unifiedSessionId: s.unifiedSessionId,
+                userJourneyFunnelId: randUuid(),
+                userJourneyEventMs: Date.now(),
+                reactionUserJourneyAction: 'TRAY_OPEN',
+                reactionUserJourneyEntryPoint: 'MACOS_MESSAGE_REACTION_BUTTON',
+                uiSurface: 'CHAT_THREAD',
+                userJourneyChatType: 'INDIVIDUAL',
+                messageType: 'INDIVIDUAL',
+                messageMediaType: 'TEXT',
+                messageHasReaction: false,
+                messageHasOwnReaction: false
+            })
+        }
+    },
+    {
+        event: 'ReportToAdminEvents',
+        weight: 1,
+        emit: (c) => {
+            c.commit('ReportToAdminEvents', {
+                reportToAdminInteraction: 'CLICK_SEND_FOR_ADMIN_REVIEW',
+                rtaGroupId: `120363${randInt(100_000_000_000, 999_999_999_999)}@g.us`
+            })
+        }
+    },
+    {
+        event: 'RingtoneScreen',
+        weight: 1,
+        emit: (c) => {
+            c.commit('RingtoneScreen', {
+                ringtoneChangeApplied: false,
+                ringtoneId: '__default__',
+                ringtoneReset: false,
+                ringtoneSelectionCancelled: true,
+                ringtoneSource: 'APP_WIDE',
+                premiumRingtonesDownloadedCount: randInt(0, 5)
+            })
+        }
+    },
+    {
+        event: 'ScreenLockSettingsData',
+        weight: 1,
+        emit: (c) => {
+            c.commit('ScreenLockSettingsData', {})
+        }
+    },
+    {
+        event: 'SearchActionEvent',
+        weight: 3,
+        emit: (c) => {
+            c.commit('SearchActionEvent', {
+                searchAction: 'TYPEAHEAD_SHOW',
+                searchActionEntryPoint: 'CHATS_LIST',
+                searchAiSuggestionCount: randInt(0, 2),
+                searchChatsCount: randInt(1, 6),
+                searchContactsCount: randInt(0, 4),
+                searchGroupsCount: randInt(0, 3),
+                searchMessagesCount: randInt(0, 5)
+            })
+        }
+    },
+    {
+        event: 'SearchTheWebFunnel',
+        weight: 1,
+        emit: (c) => {
+            c.commit('SearchTheWebFunnel', {
+                stwInteraction: 'ENTRY_POINT_SURFACED',
+                stwEntryPoint: 'HIGHLY_FORWARDED_MESSAGE',
+                stwFormat: 'SINGLE_TEXT',
+                messageType: 'GROUP'
+            })
+        }
+    },
+    {
+        event: 'SettingsChange',
+        weight: 1,
+        emit: (c) => {
+            const toggles = [
+                'IS_ENTER_TO_SEND_ENABLED',
+                'IS_SPELL_CHECK_ENABLED',
+                'DISABLE_LINK_PREVIEWS',
+                'REPLACE_TEXT_WITH_EMOJI'
+            ] as const
+            c.commit('SettingsChange', {
+                settingType: toggles[randInt(0, toggles.length)],
+                currentSettingValue: Math.random() < 0.5 ? 'true' : 'false'
+            })
+        }
+    },
+    {
+        event: 'SettingsClick',
+        weight: 3,
+        emit: (c) => {
+            const items = [
+                'CHATS',
+                'NOTIFICATIONS',
+                'PRIVACY',
+                'ACCOUNT',
+                'STARRED_MESSAGES'
+            ] as const
+            c.commit('SettingsClick', {
+                settingsItem: items[randInt(0, items.length)],
+                settingsClickEntryPoint: 'SETTINGS_SCREEN'
+            })
+        }
+    },
+    {
+        event: 'SettingsSearchInitiate',
+        weight: 1,
+        emit: (c) => {
+            c.commit('SettingsSearchInitiate', {
+                settingsPageType: 'SETTINGS'
+            })
+        }
+    },
+    {
+        event: 'SettingsSearchTap',
+        weight: 1,
+        emit: (c) => {
+            c.commit('SettingsSearchTap', {
+                tapItemName: 'chat-wallpaper',
+                topLevelParentSetting: 'CHATS'
+            })
+        }
+    },
+    {
+        event: 'ShareContentUserJourney',
+        weight: 1,
+        emit: (c, s) => {
+            c.commit('ShareContentUserJourney', {
+                appSessionId: s.appSessionId,
+                unifiedSessionId: s.unifiedSessionId,
+                userJourneyFunnelId: randUuid(),
+                userJourneyEventMs: Date.now(),
+                shareContentUserJourneyAction: 'FUNNEL_START',
+                shareContentUserJourneyEntryPoint: 'CONTEXT_MENU',
+                uiSurface: 'CHAT_THREAD',
+                mediaCount: 0,
+                hasFiles: false
+            })
+        }
+    },
+    {
+        event: 'SnackbarDeleteUndo',
+        weight: 1,
+        emit: (c) => {
+            c.commit('SnackbarDeleteUndo', {
+                snackbarActionType: 'SNACKBAR_SHOWN',
+                isAGroup: false,
+                messagesUndeleted: 1,
+                threadId: randB64(32),
+                mediaType: 'TEXT'
+            })
+        }
+    },
+    {
+        event: 'StatusItemView',
+        weight: 3,
+        emit: (c) => {
+            const viewTime = randInt(2500, 8000)
+            c.commit('StatusItemView', {
+                statusItemViewResult: 'OK',
+                statusItemViewTime: viewTime,
+                statusItemLoadTime: randInt(40, 600),
+                statusItem3sViewCount: viewTime >= 3000 ? 1 : 0,
+                statusItemViewCount: 1,
+                statusItemImpressionCount: 1,
+                statusItemReplied: 0,
+                statusCategory: 'REGULAR_STATUS',
+                statusViewerSessionId: randInt(1, 1_000_000_000),
+                statusRowSection: 'RECENT_STORIES',
+                statusRowIndex: randInt(0, 5),
+                mediaType: 'PHOTO',
+                statusItemUnread: true
+            })
+        }
+    },
+    {
+        event: 'StatusPosterActions',
+        weight: 1,
+        emit: (c) => {
+            c.commit('StatusPosterActions', {
+                statusEventType: 'STATUS_ENTRYPOINT_TAP',
+                statusCreationEntryPoint:
+                    Math.random() < 0.5 ? 'STATUS_TAB_CAMERA' : 'STATUS_TAB_PEN',
+                statusPostingSessionId: randInt(1, 2_000_000_000)
+            })
+        }
+    },
+    {
+        event: 'StatusPostImpression',
+        weight: 1,
+        emit: (c, s) => {
+            const viewTime = randInt(2500, 8000)
+            c.commit('StatusPostImpression', {
+                statusId: randHex(20),
+                statusContentType: 'PHOTO',
+                statusMediaType: 'PHOTO',
+                isSelfView: false,
+                isSubImpression: false,
+                statusViewEntrypoint: 'CHAT_LIST',
+                statusViewTime: viewTime,
+                unifiedSessionId: s.unifiedSessionId,
+                updatesTabSessionId: randInt(1, 1_000_000_000),
+                statusViewerSessionId: randInt(1, 1_000_000_000),
+                statusPogIndex: 0,
+                statusPostIndex: 0,
+                isFirstView: true,
+                isCloseSharingPost: false,
+                isPosterBiz: false,
+                isViewedInLandscape: false,
+                psaLinkAvailable: false,
+                statusCategory: 'REGULAR_STATUS',
+                statusPostPlaybackDuration: viewTime,
+                statusContainsMusic: false,
+                musicBlocked: false,
+                statusContainsQuestion: false,
+                isSuccessfulView: true,
+                statusItemViewResult: 'OK',
+                entryMethod: 'DIRECT_POG_TAP',
+                viewSequenceIndex: 0,
+                isResharable: false,
+                isReshare: false
+            })
+        }
+    },
+    {
+        event: 'StatusReportingEvents',
+        weight: 1,
+        emit: (c) => {
+            c.commit('StatusReportingEvents', {
+                statusReportInteraction: 'CLICK_REPORT'
+            })
+        }
+    },
+    {
+        event: 'StatusRowView',
+        weight: 3,
+        emit: (c) => {
+            c.commit('StatusRowView', {
+                statusRowEntryMethod: 'DIRECT_ROW_TAP',
+                statusRowIndex: randInt(0, 5),
+                statusRowSection: 'RECENT_STORIES',
+                statusRowUnreadItemCount: randInt(1, 4),
+                statusRowViewCount: 1,
+                statusSessionId: randInt(1, 1_000_000_000),
+                statusViewerSessionId: randInt(1, 1_000_000_000)
+            })
+        }
+    },
+    {
+        event: 'StatusViewerAction',
+        weight: 1,
+        emit: (c) => {
+            c.commit('StatusViewerAction', {
+                viewerActionType: 'ATTRIBUTION_TAPPED',
+                attributionType: 'MUSIC',
+                statusCategory: 'REGULAR_STATUS'
+            })
+        }
+    },
+    {
+        event: 'StickerAddToFavorite',
+        weight: 1,
+        emit: (c) => {
+            c.commit('StickerAddToFavorite', {
+                stickerIsAnimated: Math.random() < 0.5,
+                stickerIsFirstParty: false,
+                stickerIsFromStickerMaker: false,
+                stickerIsPremium: false
+            })
+        }
+    },
+    {
+        event: 'StickerStoreOpened',
+        weight: 1,
+        emit: (c) => {
+            c.commit('StickerStoreOpened', {})
+        }
+    },
+    {
+        event: 'SystemMessageClick',
+        weight: 1,
+        emit: (c) => {
+            c.commit('SystemMessageClick', {
+                isAGroup: false,
+                isANewThread: true,
+                systemMessageCategory: 'PRIVACY',
+                systemMessageType: 'E2E_ENCRYPTED_MESSAGES'
+            })
+        }
+    },
+    {
+        event: 'UiMessageYourselfAction',
+        weight: 1,
+        emit: (c) => {
+            const useSearch = Math.random() < 0.4
+            const uiMessageYourselfFunnelName = useSearch ? 'CONTACT_AND_GLOBAL_SEARCH' : 'NEW_CHAT'
+            const uiMessageYourselfActionType =
+                Math.random() < 0.5
+                    ? useSearch
+                        ? 'SEARCH_BAR_PRESSED'
+                        : 'NEW_CHAT_PRESSED'
+                    : 'EXISTING_NTS_OPENED'
+            c.commit('UiMessageYourselfAction', {
+                uiMessageYourselfActionSessionId: randHex(16),
+                uiMessageYourselfActionType,
+                uiMessageYourselfFunnelName
+            })
+        }
+    },
+    {
+        event: 'UiRevokeAction',
+        weight: 1,
+        emit: (c) => {
+            const trash = Math.random() < 0.45
+            c.commit('UiRevokeAction', {
+                messageAction: trash ? 'TRASH_CAN_SELECTED' : 'MESSAGE_SELECTED',
+                uiRevokeActionDuration: trash ? randInt(600, 5000) : 0,
+                uiRevokeActionSessionId: randHex(16)
+            })
+        }
+    },
+    {
+        event: 'UpdatesTabSearch',
+        weight: 1,
+        emit: (c) => {
+            c.commit('UpdatesTabSearch', {
+                updateTabSearchEventType: 'SEARCH_TAP',
+                channelsFollowedCount: randInt(0, 5),
+                channelsAdminCount: 0
+            })
+        }
+    },
+    {
+        event: 'UsernameExposed',
+        weight: 1,
+        emit: (c) => {
+            c.commit('UsernameExposed', {
+                usernameExposureContext: 'contact_info_subtitle'
+            })
+        }
+    },
+    {
+        event: 'ViewBusinessProfile',
+        weight: 1,
+        emit: (c) => {
+            const entryPoints = ['CHAT_HEADER', 'CONTACT_CARD', 'CHATS_HOME'] as const
+            c.commit('ViewBusinessProfile', {
+                viewBusinessProfileAction: 'ACTION_IMPRESSION',
+                catalogSessionId: randHex(16),
+                profileEntryPoint: entryPoints[randInt(0, entryPoints.length)],
+                isProfileLinked: false,
+                hasCoverPhoto: Math.random() < 0.5
+            })
+        }
+    },
+    {
+        event: 'ViewOnceScreenshotActions',
+        weight: 1,
+        emit: (c) => {
+            c.commit('ViewOnceScreenshotActions', {
+                voSsAction: 'PLACEHOLDER_MESSAGE_LEARN_MORE_TAP',
+                voMessageType: Math.random() < 0.75 ? 'PHOTO' : 'VIDEO',
+                isAGroup: false,
+                threadId: randB64(32)
+            })
+        }
+    },
+    {
+        event: 'WaShopsManagement',
+        weight: 1,
+        gate: 'business',
+        emit: (c) => {
+            c.commit('WaShopsManagement', {
+                shopsManagementAction: 'ACTION_CLICK_SHOPS_SETTING',
+                isShopsProductPreviewVisible: false
+            })
+        }
+    },
+    {
+        event: 'WebcButterbarEvent',
+        weight: 3,
+        emit: (c) => {
+            const offline = Math.random() < 0.6
+            c.commit('WebcButterbarEvent', {
+                webcButterbarType: offline ? 'OFFLINE' : 'RESUME_CONNECTING',
+                webcButterbarAction: Math.random() < 0.7 ? 'IMPRESSION' : 'AUTO_DISMISS'
+            })
+        }
+    },
+    {
+        event: 'WebcLinkPreviewDisplay',
+        weight: 1,
+        emit: (c) => {
+            c.commit('WebcLinkPreviewDisplay', {
+                webcDisplayStatus: 'SHOWED_PREVIEW_TO_USER',
+                didRequestHq: true,
+                didRespondHqPreview: true,
+                didFallbackNonHq: false
+            })
+        }
+    },
+    {
+        event: 'WebcMenu',
+        weight: 1,
+        emit: (c) => {
+            const labels = ['NEW_GROUP', 'STARRED', 'ARCHIVED', 'NEW_GROUP', 'STARRED'] as const
+            c.commit('WebcMenu', {
+                webcMenuAction: 'THREADS_SCREEN_CLICK',
+                webcMenuItemLabel: labels[randInt(0, labels.length)]
+            })
+        }
+    },
+    {
+        event: 'WebcNativeUpsellCta',
+        weight: 1,
+        emit: (c) => {
+            const sources = ['CHATLIST_DROPDOWN', 'SETTINGS', 'BUTTERBAR'] as const
+            c.commit('WebcNativeUpsellCta', {
+                webcNativeUpsellCtaEventType: 'IMPRESSION',
+                webcNativeUpsellCtaSource: sources[randInt(0, sources.length)],
+                webcNativeUpsellCtaQrScreenExperimentGroup: 'CONTROL',
+                webcNativeUpsellCtaReleaseChannel: 'PRODUCTION',
+                webcNativeUpsellCtaIsBetaUser: false
+            })
+        }
+    },
+    {
+        event: 'WebcNavbar',
+        weight: 3,
+        emit: (c) => {
+            const r = Math.random()
+            const webcNavbarItemLabel =
+                r < 0.7 ? 'CHATS' : r < 0.85 ? 'STATUS' : r < 0.95 ? 'SETTINGS' : 'COMMUNITIES'
+            c.commit('WebcNavbar', { webcNavbarItemLabel })
+        }
+    },
+    {
+        event: 'WebContactListStartNewChat',
+        weight: 3,
+        emit: (c) => {
+            const isGroup = Math.random() < 0.15
+            c.commit('WebContactListStartNewChat', {
+                webContactListStartNewChatType: isGroup ? 'GROUP' : 'CONTACT',
+                webContactListStartNewChatSearch: isGroup ? true : Math.random() < 0.55
+            })
+        }
+    },
+    {
+        event: 'WebcStickerMakerEvents',
+        weight: 1,
+        emit: (c) => {
+            c.commit('WebcStickerMakerEvents', {
+                stickerMakerEventName: 'STICKER_MAKER_BUTTON_TAP'
+            })
+        }
+    },
+    {
+        event: 'WebcWhatsNewImpression',
+        weight: 1,
+        emit: (c) => {
+            c.commit('WebcWhatsNewImpression', {
+                webcWhatsNewSurface: 'BANNER',
+                webcWhatsNewAction: 'IMPRESSION',
+                webcWhatsNewVariant: randInt(1, 6)
+            })
+        }
+    }
+]

--- a/packages/wam/src/synthetic/index.ts
+++ b/packages/wam/src/synthetic/index.ts
@@ -1,0 +1,2 @@
+export { WaWamSyntheticUi } from './WaWamSyntheticUi.js'
+export type { WaWamSyntheticUiOptions } from './WaWamSyntheticUi.js'

--- a/packages/wam/src/synthetic/random.ts
+++ b/packages/wam/src/synthetic/random.ts
@@ -1,0 +1,18 @@
+import { bytesToBase64 } from 'zapo-js/util'
+
+export const rand = (min: number, max: number): number => min + Math.random() * (max - min)
+export const randInt = (min: number, max: number): number => Math.floor(rand(min, max))
+export const randHex = (len: number): string =>
+    Array.from({ length: len }, () => Math.floor(Math.random() * 16).toString(16)).join('')
+
+/** A v4-shaped UUID (crypto.randomUUID format) for the session/funnel ids WA sets as UUIDs. */
+export const randUuid = (): string => {
+    const variant = (8 + Math.floor(Math.random() * 4)).toString(16)
+    return `${randHex(8)}-${randHex(4)}-4${randHex(3)}-${variant}${randHex(3)}-${randHex(12)}`
+}
+
+/** base64 of `nBytes` random bytes with WA's `getChatThreadID` `/`→`-` convention (threadId is base64(HMAC), not hex). */
+export const randB64 = (nBytes: number): string => {
+    const bytes = Uint8Array.from({ length: nBytes }, () => Math.floor(Math.random() * 256))
+    return bytesToBase64(bytes).replace(/\//g, '-')
+}

--- a/packages/wam/src/synthetic/random.ts
+++ b/packages/wam/src/synthetic/random.ts
@@ -5,6 +5,10 @@ export const randInt = (min: number, max: number): number => Math.floor(rand(min
 export const randHex = (len: number): string =>
     Array.from({ length: len }, () => Math.floor(Math.random() * 16).toString(16)).join('')
 
+/** `len` random base36 chars (0-9a-z) — WA's short session ids (e.g. `userActivitySessionId`) are base36, not hex. */
+export const randBase36 = (len: number): string =>
+    Array.from({ length: len }, () => Math.floor(Math.random() * 36).toString(36)).join('')
+
 /** A v4-shaped UUID (crypto.randomUUID format) for the session/funnel ids WA sets as UUIDs. */
 export const randUuid = (): string => {
     const variant = (8 + Math.floor(Math.random() * 4)).toString(16)

--- a/packages/wam/src/wire/WamBatch.ts
+++ b/packages/wam/src/wire/WamBatch.ts
@@ -1,0 +1,88 @@
+import {
+    WA_WAM_CHANNEL_WIRE_CODES,
+    WA_WAM_PROTOCOL_VERSION,
+    type WaWamChannel
+} from '@vinikjkkj/wa-wam'
+
+import { BinaryWriter } from './binary-writer.js'
+import { type WamValueKind, writeEventHeader, writeField, writeGlobalAttribute } from './encoder.js'
+
+/** Global attribute id `WAWebWamLibContext` re-stamps before every event. */
+const COMMIT_TIME_GLOBAL_ID = 47
+
+export type WamGlobalValue = number | string | boolean | null
+
+/** A single event field resolved to its wire id, encoding kind, and value. */
+export interface WamResolvedField {
+    readonly id: number
+    readonly kind: WamValueKind
+    readonly value: number | string | boolean
+}
+
+/**
+ * One WAM batch for a single channel: the header, a running committed-globals
+ * map (unchanged globals are not re-emitted), and the appended events, mirroring
+ * `WAWamBuffer` + `WAWebWamLibContext`.
+ */
+export class WamBatch {
+    private readonly writer = new BinaryWriter(512)
+    private readonly committedGlobals = new Map<number, WamGlobalValue>()
+    private eventsWritten = 0
+
+    constructor(
+        readonly channel: WaWamChannel,
+        readonly streamId: number,
+        readonly sequenceNumber: number,
+        initialGlobals: ReadonlyMap<number, WamGlobalValue>
+    ) {
+        this.writer.writeString('WAM')
+        this.writer.writeUint8(WA_WAM_PROTOCOL_VERSION)
+        this.writer.writeUint8(streamId & 0xff)
+        this.writer.writeUint16(sequenceNumber & 0xffff)
+        this.writer.writeUint8(WA_WAM_CHANNEL_WIRE_CODES[channel])
+        for (const [id, value] of initialGlobals) {
+            writeGlobalAttribute(this.writer, id, value)
+            this.committedGlobals.set(id, value)
+        }
+    }
+
+    /** Delta-writes a global attribute: only emitted when its value changed. */
+    setGlobal(id: number, value: WamGlobalValue): void {
+        if (this.committedGlobals.get(id) === value) return
+        writeGlobalAttribute(this.writer, id, value)
+        this.committedGlobals.set(id, value)
+    }
+
+    /**
+     * Appends one event: re-stamps `commitTime` (id 47, unix seconds), writes
+     * the event header carrying `weight`, then each present field in order (the
+     * last field flagged so the decoder can close the event group).
+     */
+    writeEvent(
+        commitTimeMs: number,
+        eventId: number,
+        weight: number,
+        fields: readonly WamResolvedField[]
+    ): void {
+        writeGlobalAttribute(this.writer, COMMIT_TIME_GLOBAL_ID, Math.floor(commitTimeMs / 1000))
+        const lastIndex = fields.length - 1
+        writeEventHeader(this.writer, eventId, weight, lastIndex >= 0)
+        for (let i = 0; i <= lastIndex; i += 1) {
+            const field = fields[i]
+            writeField(this.writer, field.id, field.kind, field.value, i === lastIndex)
+        }
+        this.eventsWritten += 1
+    }
+
+    size(): number {
+        return this.writer.size()
+    }
+
+    hasEvents(): boolean {
+        return this.eventsWritten > 0
+    }
+
+    toBytes(): Uint8Array {
+        return this.writer.toBytes()
+    }
+}

--- a/packages/wam/src/wire/__tests__/wire.test.ts
+++ b/packages/wam/src/wire/__tests__/wire.test.ts
@@ -47,8 +47,9 @@ test('WamBatch serialises header + commitTime + event + field byte-for-byte', ()
 
 test('WamBatch delta-encodes globals: unchanged values are not re-emitted', () => {
     const batch = new WamBatch('regular', 1, 1, new Map([[3543, 42]]))
+    const baseline = batch.size()
     batch.setGlobal(3543, 42)
-    const before = batch.size()
+    assert.equal(batch.size(), baseline, 'unchanged global must not be re-emitted')
     batch.setGlobal(3543, 99)
-    assert.ok(batch.size() > before)
+    assert.ok(batch.size() > baseline, 'changed global must be re-emitted')
 })

--- a/packages/wam/src/wire/__tests__/wire.test.ts
+++ b/packages/wam/src/wire/__tests__/wire.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { BinaryWriter } from '../binary-writer.js'
+import { writeGlobalAttribute } from '../encoder.js'
+import { WamBatch } from '../WamBatch.js'
+
+const hex = (bytes: Uint8Array): string =>
+    Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+
+function encodeGlobal(id: number, value: number | string | boolean | null): string {
+    const writer = new BinaryWriter()
+    writeGlobalAttribute(writer, id, value)
+    return hex(writer.toBytes())
+}
+
+test('BinaryWriter writes big-endian integers and raw utf-8', () => {
+    const writer = new BinaryWriter(4)
+    writer.writeUint8(0x05)
+    writer.writeUint16(0x0102)
+    writer.writeUint32(0x0a0b0c0d)
+    writer.writeInt8(-1)
+    writer.writeString('hi')
+    assert.equal(hex(writer.toBytes()), '05' + '0102' + '0a0b0c0d' + 'ff' + '6869')
+})
+
+test('global attribute value encodings match the WAM wire classes', () => {
+    assert.equal(encodeGlobal(5, 0), '1005')
+    assert.equal(encodeGlobal(5, 1), '2005')
+    assert.equal(encodeGlobal(5, 100), '3005' + '64')
+    assert.equal(encodeGlobal(5, 300), '4005' + '012c')
+    assert.equal(encodeGlobal(5, 'hi'), '8005' + '02' + '6869')
+    assert.equal(encodeGlobal(5, null), '0005')
+    assert.equal(encodeGlobal(5, true), '2005')
+    assert.equal(encodeGlobal(300, 1), '28' + '012c')
+})
+
+test('WamBatch serialises header + commitTime + event + field byte-for-byte', () => {
+    const batch = new WamBatch('regular', 7, 1, new Map())
+    batch.writeEvent(100_000, 472, 1, [{ id: 1, kind: 'int', value: 3 }])
+    assert.equal(batch.hasEvents(), true)
+    assert.equal(
+        hex(batch.toBytes()),
+        '57414d' + '05' + '07' + '0001' + '00' + '302f64' + '2901d8' + '360103'
+    )
+})
+
+test('WamBatch delta-encodes globals: unchanged values are not re-emitted', () => {
+    const batch = new WamBatch('regular', 1, 1, new Map([[3543, 42]]))
+    batch.setGlobal(3543, 42)
+    const before = batch.size()
+    batch.setGlobal(3543, 99)
+    assert.ok(batch.size() > before)
+})

--- a/packages/wam/src/wire/__tests__/wire.test.ts
+++ b/packages/wam/src/wire/__tests__/wire.test.ts
@@ -24,6 +24,12 @@ test('BinaryWriter writes big-endian integers and raw utf-8', () => {
     assert.equal(hex(writer.toBytes()), '05' + '0102' + '0a0b0c0d' + 'ff' + '6869')
 })
 
+test('BinaryWriter clamps a zero initial capacity so ensure() cannot loop forever', () => {
+    const writer = new BinaryWriter(0)
+    writer.writeUint32(0x0a0b0c0d)
+    assert.equal(hex(writer.toBytes()), '0a0b0c0d')
+})
+
 test('global attribute value encodings match the WAM wire classes', () => {
     assert.equal(encodeGlobal(5, 0), '1005')
     assert.equal(encodeGlobal(5, 1), '2005')

--- a/packages/wam/src/wire/binary-writer.ts
+++ b/packages/wam/src/wire/binary-writer.ts
@@ -15,7 +15,7 @@ export class BinaryWriter {
     private readonly scratch = new DataView(new ArrayBuffer(8))
 
     constructor(initialCapacity = 256) {
-        this.buffer = new Uint8Array(initialCapacity)
+        this.buffer = new Uint8Array(Math.max(1, initialCapacity))
     }
 
     private ensure(extra: number): void {

--- a/packages/wam/src/wire/binary-writer.ts
+++ b/packages/wam/src/wire/binary-writer.ts
@@ -86,7 +86,6 @@ export class BinaryWriter {
         return this.offset
     }
 
-    /** Returns a copy of the written bytes. */
     toBytes(): Uint8Array {
         return this.buffer.slice(0, this.offset)
     }

--- a/packages/wam/src/wire/binary-writer.ts
+++ b/packages/wam/src/wire/binary-writer.ts
@@ -1,0 +1,93 @@
+import { TEXT_ENCODER } from 'zapo-js/util'
+
+/**
+ * Minimal growable big-endian byte writer used by the WAM TLV encoder.
+ *
+ * Mirrors the subset of WA Web's `WABinary.Binary` the WAM buffer relies on
+ * (`writeUint8/16/32`, `writeInt8/16/32/64`, `writeFloat64`, `writeString`).
+ * Integers are written network order (big-endian), strings as raw UTF-8 with
+ * no length prefix (the caller writes the length itself). `Uint8Array`-only so
+ * the plugin never pulls in `Buffer`.
+ */
+export class BinaryWriter {
+    private buffer: Uint8Array
+    private offset = 0
+    private readonly scratch = new DataView(new ArrayBuffer(8))
+
+    constructor(initialCapacity = 256) {
+        this.buffer = new Uint8Array(initialCapacity)
+    }
+
+    private ensure(extra: number): void {
+        const needed = this.offset + extra
+        if (needed <= this.buffer.length) return
+        let next = this.buffer.length * 2
+        while (next < needed) next *= 2
+        const grown = new Uint8Array(next)
+        grown.set(this.buffer.subarray(0, this.offset))
+        this.buffer = grown
+    }
+
+    writeUint8(value: number): void {
+        this.ensure(1)
+        this.buffer[this.offset++] = value & 0xff
+    }
+
+    writeInt8(value: number): void {
+        this.writeUint8(value)
+    }
+
+    writeUint16(value: number): void {
+        this.ensure(2)
+        this.buffer[this.offset++] = (value >>> 8) & 0xff
+        this.buffer[this.offset++] = value & 0xff
+    }
+
+    writeInt16(value: number): void {
+        this.writeUint16(value)
+    }
+
+    writeUint32(value: number): void {
+        this.ensure(4)
+        this.buffer[this.offset++] = (value >>> 24) & 0xff
+        this.buffer[this.offset++] = (value >>> 16) & 0xff
+        this.buffer[this.offset++] = (value >>> 8) & 0xff
+        this.buffer[this.offset++] = value & 0xff
+    }
+
+    writeInt32(value: number): void {
+        this.writeUint32(value >>> 0)
+    }
+
+    writeInt64(value: number): void {
+        this.ensure(8)
+        this.scratch.setBigInt64(0, BigInt(value), false)
+        for (let i = 0; i < 8; i += 1) this.buffer[this.offset++] = this.scratch.getUint8(i)
+    }
+
+    writeFloat64(value: number): void {
+        this.ensure(8)
+        this.scratch.setFloat64(0, value, false)
+        for (let i = 0; i < 8; i += 1) this.buffer[this.offset++] = this.scratch.getUint8(i)
+    }
+
+    writeBytes(bytes: Uint8Array): void {
+        this.ensure(bytes.length)
+        this.buffer.set(bytes, this.offset)
+        this.offset += bytes.length
+    }
+
+    /** Writes `value` as raw UTF-8 bytes (no length prefix). */
+    writeString(value: string): void {
+        this.writeBytes(TEXT_ENCODER.encode(value))
+    }
+
+    size(): number {
+        return this.offset
+    }
+
+    /** Returns a copy of the written bytes. */
+    toBytes(): Uint8Array {
+        return this.buffer.slice(0, this.offset)
+    }
+}

--- a/packages/wam/src/wire/encoder.ts
+++ b/packages/wam/src/wire/encoder.ts
@@ -10,7 +10,8 @@ const MARK = WA_WAM_WIRE_FORMAT.markers
 const ENC = WA_WAM_WIRE_FORMAT.valueEncodingBits
 
 const INT32_MIN = -2_147_483_648
-const INT32_MAX = 2_147_483_648
+/** Exclusive upper bound (2^31), mirroring WA Web's `r < 2147483648` int32 check in WAWamBuffer. */
+const INT32_UPPER_EXCLUSIVE = 2_147_483_648
 
 /** Writes a TLV tag: marker/encoding byte + id (uint8, or extended-flag + uint16 for id >= 256). */
 function writeTag(writer: BinaryWriter, id: number, markerWithEncoding: number): void {
@@ -35,7 +36,7 @@ function writeInt(writer: BinaryWriter, id: number, marker: number, value: numbe
     } else if (value >= -32_768 && value < 32_768) {
         writeTag(writer, id, ENC.int16 | marker)
         writer.writeInt16(value)
-    } else if (value >= INT32_MIN && value < INT32_MAX) {
+    } else if (value >= INT32_MIN && value < INT32_UPPER_EXCLUSIVE) {
         writeTag(writer, id, ENC.int32 | marker)
         writer.writeInt32(value)
     } else {

--- a/packages/wam/src/wire/encoder.ts
+++ b/packages/wam/src/wire/encoder.ts
@@ -1,0 +1,119 @@
+import { WA_WAM_WIRE_FORMAT } from '@vinikjkkj/wa-wam'
+import { TEXT_ENCODER } from 'zapo-js/util'
+
+import type { BinaryWriter } from './binary-writer.js'
+
+/** How a value is encoded on the wire (from the registry field/global `type`). */
+export type WamValueKind = 'int' | 'float' | 'string' | 'bool'
+
+const MARK = WA_WAM_WIRE_FORMAT.markers
+const ENC = WA_WAM_WIRE_FORMAT.valueEncodingBits
+
+const INT32_MIN = -2_147_483_648
+const INT32_MAX = 2_147_483_648
+
+/** Writes a TLV tag: marker/encoding byte + id (uint8, or extended-flag + uint16 for id >= 256). */
+function writeTag(writer: BinaryWriter, id: number, markerWithEncoding: number): void {
+    if (id < 256) {
+        writer.writeUint8(markerWithEncoding)
+        writer.writeUint8(id)
+    } else {
+        writer.writeUint8(markerWithEncoding | MARK.extendedIdFlag)
+        writer.writeUint16(id)
+    }
+}
+
+/** Writes an integer value with the smallest matching width class. */
+function writeInt(writer: BinaryWriter, id: number, marker: number, value: number): void {
+    if (value === 0) {
+        writeTag(writer, id, ENC.intZero | marker)
+    } else if (value === 1) {
+        writeTag(writer, id, ENC.intOne | marker)
+    } else if (value >= -128 && value < 128) {
+        writeTag(writer, id, ENC.int8 | marker)
+        writer.writeInt8(value)
+    } else if (value >= -32_768 && value < 32_768) {
+        writeTag(writer, id, ENC.int16 | marker)
+        writer.writeInt16(value)
+    } else if (value >= INT32_MIN && value < INT32_MAX) {
+        writeTag(writer, id, ENC.int32 | marker)
+        writer.writeInt32(value)
+    } else {
+        writeTag(writer, id, ENC.int64 | marker)
+        writer.writeInt64(value)
+    }
+}
+
+function writeFloat(writer: BinaryWriter, id: number, marker: number, value: number): void {
+    writeTag(writer, id, ENC.float64 | marker)
+    writer.writeFloat64(value)
+}
+
+function writeStringValue(writer: BinaryWriter, id: number, marker: number, value: string): void {
+    const bytes = TEXT_ENCODER.encode(value)
+    const length = bytes.length
+    if (length < 256) {
+        writeTag(writer, id, ENC.stringShort | marker)
+        writer.writeUint8(length)
+    } else if (length < 65_536) {
+        writeTag(writer, id, ENC.stringMedium | marker)
+        writer.writeUint16(length)
+    } else {
+        writeTag(writer, id, ENC.stringLong | marker)
+        writer.writeUint32(length)
+    }
+    writer.writeBytes(bytes)
+}
+
+/** Writes a global-attribute TLV (marker `0`): numbers as int, booleans as int 0/1, `null` as tag-only. */
+export function writeGlobalAttribute(
+    writer: BinaryWriter,
+    id: number,
+    value: number | string | boolean | null
+): void {
+    const marker = MARK.globalAttribute
+    if (value === null) {
+        writeTag(writer, id, ENC.null | marker)
+    } else if (typeof value === 'string') {
+        writeStringValue(writer, id, marker, value)
+    } else if (typeof value === 'boolean') {
+        writeInt(writer, id, marker, value ? 1 : 0)
+    } else {
+        writeInt(writer, id, marker, value)
+    }
+}
+
+/** Writes the event-header TLV (marker `1`), value = sampling weight; sets the last-flag when it has no fields. */
+export function writeEventHeader(
+    writer: BinaryWriter,
+    id: number,
+    weight: number,
+    hasFields: boolean
+): void {
+    const marker = hasFields ? MARK.event : MARK.event | MARK.lastFlag
+    writeInt(writer, id, marker, weight)
+}
+
+/** Writes a field TLV (marker `2`), `kind`-encoded; the last field in a group sets the last-flag. */
+export function writeField(
+    writer: BinaryWriter,
+    id: number,
+    kind: WamValueKind,
+    value: number | string | boolean,
+    isLast: boolean
+): void {
+    const marker = isLast ? MARK.field | MARK.lastFlag : MARK.field
+    switch (kind) {
+        case 'string':
+            writeStringValue(writer, id, marker, value as string)
+            return
+        case 'float':
+            writeFloat(writer, id, marker, value as number)
+            return
+        case 'bool':
+            writeInt(writer, id, marker, value ? 1 : 0)
+            return
+        default:
+            writeInt(writer, id, marker, value as number)
+    }
+}

--- a/packages/wam/tsconfig.build.cjs.json
+++ b/packages/wam/tsconfig.build.cjs.json
@@ -1,0 +1,15 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.build.paths.json"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+        "noEmit": false,
+        "lib": ["ES2020", "DOM"],
+        "types": ["node"],
+        "declaration": true,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/wam/tsconfig.build.esm.json
+++ b/packages/wam/tsconfig.build.esm.json
@@ -1,0 +1,17 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.build.paths.json"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist/esm",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "noEmit": false,
+        "lib": ["ES2020", "DOM"],
+        "types": ["node"],
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src"],
+    "exclude": ["src/**/__tests__/**"]
+}

--- a/packages/wam/tsconfig.json
+++ b/packages/wam/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": ["../../tsconfig.packages.json", "../tsconfig.paths.json"],
+    "compilerOptions": {
+        "types": ["node"],
+        "lib": ["ES2020", "DOM"],
+        "rootDir": "../..",
+        "noEmit": true
+    },
+    "include": ["src"],
+    "exclude": ["dist", "node_modules"]
+}

--- a/src/appstate/types.ts
+++ b/src/appstate/types.ts
@@ -38,7 +38,6 @@ export type WaAppStateMutationInput =
           readonly collection: AppStateCollectionName
           readonly operation: 'remove'
           readonly index: string
-          readonly previousValue: Proto.ISyncActionValue
           readonly version: number
           readonly timestamp: number
       }

--- a/src/appstate/types.ts
+++ b/src/appstate/types.ts
@@ -46,7 +46,7 @@ export type WaAppStateMutationInput =
 export interface WaAppStateMutation {
     readonly collection: AppStateCollectionName
     readonly operation: 'set' | 'remove'
-    readonly source: 'snapshot' | 'patch'
+    readonly source: 'snapshot' | 'patch' | 'local'
     readonly index: string
     readonly value: Proto.ISyncActionValue | null
     readonly version: number

--- a/src/auth/WaAuthClient.ts
+++ b/src/auth/WaAuthClient.ts
@@ -13,7 +13,7 @@ import type {
     WaSuccessPersistAttributes
 } from '@auth/types'
 import type { Logger } from '@infra/log/types'
-import { getWaCompanionPlatformId, WA_DEFAULTS, WA_NOTIFICATION_TYPES } from '@protocol/constants'
+import { resolveWaDeviceIdentity, WA_NOTIFICATION_TYPES } from '@protocol/constants'
 import type { WaAuthStore } from '@store/contracts/auth.store'
 import type { WaPreKeyStore } from '@store/contracts/pre-key.store'
 import type { WaSignalStore } from '@store/contracts/signal.store'
@@ -23,7 +23,6 @@ import type { WaNoiseRootCa } from '@transport/noise/WaNoiseCert'
 import type { BinaryNode, WaCommsConfig } from '@transport/types'
 import { uint8Equal } from '@util/bytes'
 import { toError } from '@util/primitives'
-import { getRuntimeOsDisplayName } from '@util/runtime'
 
 type WaAuthClientDeps = Readonly<{
     readonly logger: Logger
@@ -73,12 +72,7 @@ export class WaAuthClient {
     private versionOverride: string | null = null
 
     public constructor(options: WaAuthClientOptions, deps: WaAuthClientDeps) {
-        const deviceBrowser = options.deviceBrowser ?? WA_DEFAULTS.DEVICE_BROWSER
-        const device = Object.freeze({
-            browser: deviceBrowser,
-            osDisplayName: options.deviceOsDisplayName ?? getRuntimeOsDisplayName(),
-            platform: options.devicePlatform ?? getWaCompanionPlatformId(deviceBrowser)
-        })
+        const device = resolveWaDeviceIdentity(options)
         this.options = Object.freeze({
             ...options,
             deviceBrowser: device.browser,
@@ -131,7 +125,7 @@ export class WaAuthClient {
                       getCredentials: () => this.credentials,
                       updateCredentials: this.updateCredentials.bind(this)
                   },
-                  deviceType: resolveDevicePropsPlatformType(deviceBrowser)
+                  deviceType: resolveDevicePropsPlatformType(device.browser)
               })
             : null
     }

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -897,8 +897,8 @@ export function buildWaClientDependencies(input: {
         isConnected: () => connectionManager?.isConnected() ?? false,
         serverClock,
         emitSnapshotMutations: options.chatEvents?.emitSnapshotMutations === true,
-        emitLocalMutations: options.chatEvents?.emitLocalMutations === true,
         emitMutation: (event) => runtime.emitEvent('mutation', event),
+        emitMutationSend: (event) => runtime.emitEvent('mutation_send', event),
         nctSaltSink: (salt) => trustedContactToken.handleNctSaltSync(salt),
         contactSink: runtime.persistContact,
         pushNameSink: (name) => {

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -744,6 +744,7 @@ export function buildWaClientDependencies(input: {
 
     messageDispatch = new WaMessageDispatchCoordinator({
         logger,
+        emitMessageSend: (event) => runtime.emitEvent('message_send', event),
         messageClient,
         retryTracker,
         sessionResolver,

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -92,7 +92,7 @@ import {
 } from '@message/primitives/peer-data-operation'
 import { WaMessageClient } from '@message/WaMessageClient'
 import {
-    getWaCompanionPlatformId,
+    resolveWaDeviceIdentity,
     WA_DEFAULTS,
     WA_DISCONNECT_REASONS,
     WA_NEWSLETTER_NOTIFICATION_TAGS,
@@ -131,7 +131,6 @@ import { isProxyTransport, toProxyAgent } from '@transport/proxy'
 import type { BinaryNode } from '@transport/types'
 import { createServerClock } from '@util/clock'
 import { toError } from '@util/primitives'
-import { getRuntimeOsDisplayName } from '@util/runtime'
 
 interface WaClientBase {
     readonly options: Readonly<WaClientOptions>
@@ -259,7 +258,7 @@ function validateProxyOptions(options: WaClientOptions): void {
 export function resolveWaClientBase(options: WaClientOptions, logger: Logger): WaClientBase {
     validateProxyOptions(options)
 
-    const deviceBrowser = options.deviceBrowser ?? WA_DEFAULTS.DEVICE_BROWSER
+    const device = resolveWaDeviceIdentity(options)
     const sessionId = options.sessionId.trim()
     if (sessionId.length === 0) {
         throw new Error('sessionId must be a non-empty string')
@@ -269,9 +268,9 @@ export function resolveWaClientBase(options: WaClientOptions, logger: Logger): W
     const normalizedOptions = Object.freeze({
         ...options,
         sessionId,
-        deviceBrowser,
-        deviceOsDisplayName: options.deviceOsDisplayName ?? getRuntimeOsDisplayName(),
-        devicePlatform: options.devicePlatform ?? getWaCompanionPlatformId(deviceBrowser),
+        deviceBrowser: device.browser,
+        deviceOsDisplayName: device.osDisplayName,
+        devicePlatform: device.platform,
         urls: options.urls ?? options.chatSocketUrls ?? WA_DEFAULTS.CHAT_SOCKET_URLS,
         iqTimeoutMs: options.iqTimeoutMs ?? WA_DEFAULTS.IQ_TIMEOUT_MS,
         nodeQueryTimeoutMs: options.nodeQueryTimeoutMs ?? WA_DEFAULTS.NODE_QUERY_TIMEOUT_MS,

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -896,6 +896,7 @@ export function buildWaClientDependencies(input: {
         isConnected: () => connectionManager?.isConnected() ?? false,
         serverClock,
         emitSnapshotMutations: options.chatEvents?.emitSnapshotMutations === true,
+        emitLocalMutations: options.chatEvents?.emitLocalMutations === true,
         emitMutation: (event) => runtime.emitEvent('mutation', event),
         nctSaltSink: (salt) => trustedContactToken.handleNctSaltSync(salt),
         contactSink: runtime.persistContact,

--- a/src/client/coordinators/WaAppStateMutationCoordinator.ts
+++ b/src/client/coordinators/WaAppStateMutationCoordinator.ts
@@ -286,8 +286,8 @@ interface WaAppStateMutationCoordinatorOptions {
     readonly serverClock: ServerClock
     readonly archiveRangeLimit?: number
     readonly emitMutation?: (event: WaAppStateMutationEvent) => void
+    readonly emitMutationSend?: (event: WaAppStateMutationEvent) => void
     readonly emitSnapshotMutations?: boolean
-    readonly emitLocalMutations?: boolean
     readonly nctSaltSink?: (salt: Uint8Array | null) => Promise<void>
     /**
      * Persistence sink for `Contact` collection mutations (the locally-saved
@@ -337,8 +337,8 @@ export class WaAppStateMutationCoordinator {
     private readonly serverClock: ServerClock
     private readonly archiveRangeLimit: number
     private readonly emitMutation?: (event: WaAppStateMutationEvent) => void
+    private readonly emitMutationSend?: (event: WaAppStateMutationEvent) => void
     private readonly emitSnapshotMutations: boolean
-    private readonly emitLocalMutations: boolean
     private readonly nctSaltSink?: (salt: Uint8Array | null) => Promise<void>
     private readonly contactSink?: (record: WaStoredContactRecord) => void
     private readonly pushNameSink?: (name: string) => void
@@ -358,8 +358,8 @@ export class WaAppStateMutationCoordinator {
             'WaAppStateMutationCoordinatorOptions.archiveRangeLimit'
         )
         this.emitMutation = options.emitMutation
+        this.emitMutationSend = options.emitMutationSend
         this.emitSnapshotMutations = options.emitSnapshotMutations === true
-        this.emitLocalMutations = options.emitLocalMutations === true
         this.nctSaltSink = options.nctSaltSink
         this.contactSink = options.contactSink
         this.pushNameSink = options.pushNameSink
@@ -845,12 +845,12 @@ export class WaAppStateMutationCoordinator {
     }
 
     /**
-     * Emits a `source: 'local'` mutation event for an action this client is
-     * sending, so consumers can observe their own change at action time. Gated
-     * by `emitLocalMutations`; parse failures are swallowed (best-effort).
+     * Surfaces an action this client is sending via the outbound `mutation_send`
+     * event, so consumers can observe their own change at action time. Parse
+     * failures are swallowed (best-effort).
      */
     private emitLocalMutation(input: WaAppStateMutationInput): void {
-        if (!this.emitLocalMutations || !this.emitMutation) return
+        if (!this.emitMutationSend) return
         const value = input.operation === 'set' ? input.value : null
         try {
             const event = parseAppStateMutationEvent({
@@ -865,7 +865,7 @@ export class WaAppStateMutationCoordinator {
                 keyId: EMPTY_MUTATION_MAC,
                 timestamp: input.timestamp
             })
-            if (event) this.emitMutation(event)
+            if (event) this.emitMutationSend(event)
         } catch (error) {
             this.logger.debug('failed to emit local app-state mutation event', {
                 collection: input.collection,

--- a/src/client/coordinators/WaAppStateMutationCoordinator.ts
+++ b/src/client/coordinators/WaAppStateMutationCoordinator.ts
@@ -56,7 +56,7 @@ const WA_APP_STATE_MUTATION_FLUSH_SUCCESS_STATES = new Set<string>([
 const WA_APP_STATE_ARCHIVE_RANGE_DEFAULT_LIMIT = 256
 
 /** Placeholder MACs for locally-emitted mutation events (the parser ignores them). */
-const EMPTY_MUTATION_MAC = new Uint8Array(0)
+const WA_EMPTY_MUTATION_MAC = new Uint8Array(0)
 
 type IndexArgsForSchema<S extends WaAppstateSchema> = {
     readonly [Part in S['indexParts'][number] as Part extends { type: 'literal' }
@@ -860,9 +860,9 @@ export class WaAppStateMutationCoordinator {
                 index: input.index,
                 value,
                 version: input.version,
-                indexMac: EMPTY_MUTATION_MAC,
-                valueMac: EMPTY_MUTATION_MAC,
-                keyId: EMPTY_MUTATION_MAC,
+                indexMac: WA_EMPTY_MUTATION_MAC,
+                valueMac: WA_EMPTY_MUTATION_MAC,
+                keyId: WA_EMPTY_MUTATION_MAC,
                 timestamp: input.timestamp
             })
             if (event) this.emitMutationSend(event)

--- a/src/client/coordinators/WaAppStateMutationCoordinator.ts
+++ b/src/client/coordinators/WaAppStateMutationCoordinator.ts
@@ -272,7 +272,6 @@ function buildRemoveMutationFromSchema<S extends WaAppstateSchema>(input: {
         collection: input.schema.collection,
         operation: 'remove',
         index: buildMutationIndexFromSchema(input.schema, input.indexArgs),
-        previousValue: { timestamp: input.timestamp },
         version: input.schema.version,
         timestamp: input.timestamp
     }
@@ -852,7 +851,7 @@ export class WaAppStateMutationCoordinator {
      */
     private emitLocalMutation(input: WaAppStateMutationInput): void {
         if (!this.emitLocalMutations || !this.emitMutation) return
-        const value = input.operation === 'set' ? input.value : input.previousValue
+        const value = input.operation === 'set' ? input.value : null
         try {
             const event = parseAppStateMutationEvent({
                 collection: input.collection,

--- a/src/client/coordinators/WaAppStateMutationCoordinator.ts
+++ b/src/client/coordinators/WaAppStateMutationCoordinator.ts
@@ -55,6 +55,9 @@ const WA_APP_STATE_MUTATION_FLUSH_SUCCESS_STATES = new Set<string>([
 
 const WA_APP_STATE_ARCHIVE_RANGE_DEFAULT_LIMIT = 256
 
+/** Placeholder MACs for locally-emitted mutation events (the parser ignores them). */
+const EMPTY_MUTATION_MAC = new Uint8Array(0)
+
 type IndexArgsForSchema<S extends WaAppstateSchema> = {
     readonly [Part in S['indexParts'][number] as Part extends { type: 'literal' }
         ? never
@@ -285,6 +288,7 @@ interface WaAppStateMutationCoordinatorOptions {
     readonly archiveRangeLimit?: number
     readonly emitMutation?: (event: WaAppStateMutationEvent) => void
     readonly emitSnapshotMutations?: boolean
+    readonly emitLocalMutations?: boolean
     readonly nctSaltSink?: (salt: Uint8Array | null) => Promise<void>
     /**
      * Persistence sink for `Contact` collection mutations (the locally-saved
@@ -335,6 +339,7 @@ export class WaAppStateMutationCoordinator {
     private readonly archiveRangeLimit: number
     private readonly emitMutation?: (event: WaAppStateMutationEvent) => void
     private readonly emitSnapshotMutations: boolean
+    private readonly emitLocalMutations: boolean
     private readonly nctSaltSink?: (salt: Uint8Array | null) => Promise<void>
     private readonly contactSink?: (record: WaStoredContactRecord) => void
     private readonly pushNameSink?: (name: string) => void
@@ -355,6 +360,7 @@ export class WaAppStateMutationCoordinator {
         )
         this.emitMutation = options.emitMutation
         this.emitSnapshotMutations = options.emitSnapshotMutations === true
+        this.emitLocalMutations = options.emitLocalMutations === true
         this.nctSaltSink = options.nctSaltSink
         this.contactSink = options.contactSink
         this.pushNameSink = options.pushNameSink
@@ -834,8 +840,40 @@ export class WaAppStateMutationCoordinator {
     private async enqueueAndFlush(mutations: readonly WaAppStateMutationInput[]): Promise<void> {
         for (const mutation of mutations) {
             this.enqueueMutation(mutation)
+            this.emitLocalMutation(mutation)
         }
         await this.flushMutations()
+    }
+
+    /**
+     * Emits a `source: 'local'` mutation event for an action this client is
+     * sending, so consumers can observe their own change at action time. Gated
+     * by `emitLocalMutations`; parse failures are swallowed (best-effort).
+     */
+    private emitLocalMutation(input: WaAppStateMutationInput): void {
+        if (!this.emitLocalMutations || !this.emitMutation) return
+        const value = input.operation === 'set' ? input.value : input.previousValue
+        try {
+            const event = parseAppStateMutationEvent({
+                collection: input.collection,
+                operation: input.operation,
+                source: 'local',
+                index: input.index,
+                value,
+                version: input.version,
+                indexMac: EMPTY_MUTATION_MAC,
+                valueMac: EMPTY_MUTATION_MAC,
+                keyId: EMPTY_MUTATION_MAC,
+                timestamp: input.timestamp
+            })
+            if (event) this.emitMutation(event)
+        } catch (error) {
+            this.logger.debug('failed to emit local app-state mutation event', {
+                collection: input.collection,
+                index: input.index,
+                message: toError(error).message
+            })
+        }
     }
 
     private enqueueMutation(mutation: WaAppStateMutationInput): void {

--- a/src/client/coordinators/WaGroupCoordinator.ts
+++ b/src/client/coordinators/WaGroupCoordinator.ts
@@ -3,6 +3,7 @@ import type { WaMexOperationResponses } from '@mex'
 import { WA_DEFAULTS } from '@protocol/defaults'
 import { WA_GROUP_PARTICIPANT_TYPES, type WaGroupSetting } from '@protocol/group'
 import { parseJidFull } from '@protocol/jid'
+import { WA_ADDRESSING_MODES } from '@protocol/message'
 import { WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/nodes'
 import { WA_GROUP_NOTIFICATION_TAGS } from '@protocol/notification'
 import { buildListParticipatingGroupsIq } from '@transport/node/builders/account-sync'
@@ -554,7 +555,11 @@ function parseGroupCommons(target: BinaryNode): GroupCommons {
 
     const addressingModeRaw = attrs.addressing_mode
     const addressingMode: 'lid' | 'pn' | undefined =
-        addressingModeRaw === 'lid' ? 'lid' : addressingModeRaw === 'pn' ? 'pn' : undefined
+        addressingModeRaw === WA_ADDRESSING_MODES.LID
+            ? WA_ADDRESSING_MODES.LID
+            : addressingModeRaw === WA_ADDRESSING_MODES.PN
+              ? WA_ADDRESSING_MODES.PN
+              : undefined
 
     const rawJid = attrs.id ?? attrs.jid ?? ''
     const jid = rawJid && !rawJid.includes('@') ? `${rawJid}@${WA_DEFAULTS.GROUP_SERVER}` : rawJid

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -3,7 +3,12 @@ import type { WaAuthCredentials } from '@auth/types'
 import type { DeviceFanoutResolver } from '@client/messaging/fanout'
 import type { GroupMetadataCache } from '@client/messaging/group-metadata'
 import type { AppStateSyncKeyProtocol } from '@client/messaging/key-protocol'
-import type { WaGroupEvent, WaSendMessageOptions, WaSignalMessagePublishInput } from '@client/types'
+import type {
+    WaGroupEvent,
+    WaOutgoingMessageEvent,
+    WaSendMessageOptions,
+    WaSignalMessagePublishInput
+} from '@client/types'
 import { randomBytesAsync, sha256 } from '@crypto'
 import { md5Bytes } from '@crypto/core/primitives'
 import type { Logger } from '@infra/log/types'
@@ -46,7 +51,12 @@ import type {
 } from '@message/types'
 import type { WaMessageClient } from '@message/WaMessageClient'
 import { proto, type Proto } from '@proto'
-import { WA_DEFAULTS, WA_NACK_REASONS, type WaStatusDistributionSetting } from '@protocol/constants'
+import {
+    WA_ADDRESSING_MODES,
+    WA_DEFAULTS,
+    WA_NACK_REASONS,
+    type WaStatusDistributionSetting
+} from '@protocol/constants'
 import {
     canonicalizeOwnAccountJid,
     isBotJid,
@@ -88,6 +98,8 @@ import { toError } from '@util/primitives'
 
 interface WaMessageDispatchCoordinatorOptions {
     readonly logger: Logger
+    /** Emits the outbound decrypted message (`message_send` event); best-effort. */
+    readonly emitMessageSend?: (event: WaOutgoingMessageEvent) => void
     readonly messageClient: WaMessageClient
     readonly retryTracker: OutboundRetryTracker
     readonly sessionResolver: SignalSessionResolver
@@ -387,6 +399,15 @@ export class WaMessageDispatchCoordinator {
               }
             : withViewOnce
         const upload = built.upload
+        if (this.deps.emitMessageSend) {
+            try {
+                this.deps.emitMessageSend({ to: recipientJid, id: sendOptions.id, message })
+            } catch (error) {
+                this.deps.logger.debug('message_send emit failed', {
+                    message: toError(error).message
+                })
+            }
+        }
         const messageWithOverride = options.messageSecret
             ? {
                   ...message,
@@ -1240,7 +1261,7 @@ export class WaMessageDispatchCoordinator {
     ): GroupAddressingMode {
         for (let index = 0; index < participantUserJids.length; index += 1) {
             if (isLidJid(participantUserJids[index])) {
-                return 'lid'
+                return WA_ADDRESSING_MODES.LID
             }
         }
 
@@ -1248,14 +1269,14 @@ export class WaMessageDispatchCoordinator {
             groupJid,
             participants: participantUserJids.length
         })
-        return 'pn'
+        return WA_ADDRESSING_MODES.PN
     }
 
     private resolveSenderForAddressingMode(
         addressingMode: GroupAddressingMode,
         meJid: string
     ): string {
-        if (addressingMode === 'lid') {
+        if (addressingMode === WA_ADDRESSING_MODES.LID) {
             const meLid = this.deps.getCurrentCredentials()?.meLid
             if (meLid && meLid.includes('@')) {
                 try {

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -942,15 +942,16 @@ test('app-state mutation coordinator emits pin + archive mutations when pinning 
     assert.equal(typeof syncCalls[0][1].value.timestamp, 'number')
 })
 
-test('app-state mutation coordinator emits a local mutation event when emitLocalMutations is set', async () => {
+test('app-state mutation coordinator emits mutation_send for a local action, not the inbound mutation event', async () => {
     const messageStore = new WaMessageMemoryStore()
-    const events: WaAppStateMutationEvent[] = []
+    const sent: WaAppStateMutationEvent[] = []
+    const inbound: WaAppStateMutationEvent[] = []
     const coordinator = new WaAppStateMutationCoordinator({
         serverClock: { nowMs: () => 1_000_000, nowSeconds: () => 1_000 },
         logger: createNoopLogger(),
         messageStore,
-        emitLocalMutations: true,
-        emitMutation: (event) => events.push(event),
+        emitMutation: (event) => inbound.push(event),
+        emitMutationSend: (event) => sent.push(event),
         ...fakeSyncImpl(async (options = {}) =>
             buildAppStateSyncResult(
                 options.pendingMutations ?? [],
@@ -961,33 +962,15 @@ test('app-state mutation coordinator emits a local mutation event when emitLocal
 
     await coordinator.setChatMute('551100000000@s.whatsapp.net', true, 2_000_000)
 
-    const local = events.find((e) => e.schema === 'Mute')
-    assert.ok(local)
-    assert.equal(local?.source, 'local')
-    if (local?.schema === 'Mute' && local.operation === 'set') {
-        assert.equal(local.chatJid, '551100000000@s.whatsapp.net')
-        assert.equal(local.muted, true)
+    const send = sent.find((e) => e.schema === 'Mute')
+    assert.ok(send)
+    assert.equal(send?.source, 'local')
+    if (send?.schema === 'Mute' && send.operation === 'set') {
+        assert.equal(send.chatJid, '551100000000@s.whatsapp.net')
+        assert.equal(send.muted, true)
     }
-})
-
-test('app-state mutation coordinator emits no local mutation event by default', async () => {
-    const messageStore = new WaMessageMemoryStore()
-    const events: WaAppStateMutationEvent[] = []
-    const coordinator = new WaAppStateMutationCoordinator({
-        serverClock: { nowMs: () => 1_000_000, nowSeconds: () => 1_000 },
-        logger: createNoopLogger(),
-        messageStore,
-        emitMutation: (event) => events.push(event),
-        ...fakeSyncImpl(async (options = {}) =>
-            buildAppStateSyncResult(
-                options.pendingMutations ?? [],
-                WA_APP_STATE_COLLECTION_STATES.SUCCESS
-            )
-        )
-    })
-
-    await coordinator.setChatPin('551100000000@s.whatsapp.net', false)
-    assert.equal(events.length, 0)
+    // Local actions surface only on `mutation_send`, never on the inbound `mutation` stream.
+    assert.equal(inbound.length, 0)
 })
 
 test('app-state mutation coordinator flushes only targeted collections for queued mutation batch', async () => {

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -13,7 +13,7 @@ import { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDisp
 import { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTasksCoordinator'
 import { createStreamControlHandler } from '@client/coordinators/WaStreamControlCoordinator'
 import { createGroupMetadataCache } from '@client/messaging/group-metadata'
-import type { WaGroupEvent, WaGroupEventAction } from '@client/types'
+import type { WaAppStateMutationEvent, WaGroupEvent, WaGroupEventAction } from '@client/types'
 import { createNoopLogger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import {
@@ -917,6 +917,54 @@ test('app-state mutation coordinator emits pin + archive mutations when pinning 
     }
     assert.equal(typeof syncCalls[0][0].value.timestamp, 'number')
     assert.equal(typeof syncCalls[0][1].value.timestamp, 'number')
+})
+
+test('app-state mutation coordinator emits a local mutation event when emitLocalMutations is set', async () => {
+    const messageStore = new WaMessageMemoryStore()
+    const events: WaAppStateMutationEvent[] = []
+    const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => 1_000_000, nowSeconds: () => 1_000 },
+        logger: createNoopLogger(),
+        messageStore,
+        emitLocalMutations: true,
+        emitMutation: (event) => events.push(event),
+        ...fakeSyncImpl(async (options = {}) =>
+            buildAppStateSyncResult(
+                options.pendingMutations ?? [],
+                WA_APP_STATE_COLLECTION_STATES.SUCCESS
+            )
+        )
+    })
+
+    await coordinator.setChatMute('551100000000@s.whatsapp.net', true, 2_000_000)
+
+    const local = events.find((e) => e.schema === 'Mute')
+    assert.ok(local)
+    assert.equal(local?.source, 'local')
+    if (local?.schema === 'Mute' && local.operation === 'set') {
+        assert.equal(local.chatJid, '551100000000@s.whatsapp.net')
+        assert.equal(local.muted, true)
+    }
+})
+
+test('app-state mutation coordinator emits no local mutation event by default', async () => {
+    const messageStore = new WaMessageMemoryStore()
+    const events: WaAppStateMutationEvent[] = []
+    const coordinator = new WaAppStateMutationCoordinator({
+        serverClock: { nowMs: () => 1_000_000, nowSeconds: () => 1_000 },
+        logger: createNoopLogger(),
+        messageStore,
+        emitMutation: (event) => events.push(event),
+        ...fakeSyncImpl(async (options = {}) =>
+            buildAppStateSyncResult(
+                options.pendingMutations ?? [],
+                WA_APP_STATE_COLLECTION_STATES.SUCCESS
+            )
+        )
+    })
+
+    await coordinator.setChatPin('551100000000@s.whatsapp.net', false)
+    assert.equal(events.length, 0)
 })
 
 test('app-state mutation coordinator flushes only targeted collections for queued mutation batch', async () => {

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -13,7 +13,12 @@ import { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDisp
 import { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTasksCoordinator'
 import { createStreamControlHandler } from '@client/coordinators/WaStreamControlCoordinator'
 import { createGroupMetadataCache } from '@client/messaging/group-metadata'
-import type { WaAppStateMutationEvent, WaGroupEvent, WaGroupEventAction } from '@client/types'
+import type {
+    WaAppStateMutationEvent,
+    WaGroupEvent,
+    WaGroupEventAction,
+    WaOutgoingMessageEvent
+} from '@client/types'
 import { createNoopLogger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import {
@@ -116,6 +121,7 @@ function createMessageDispatchCoordinator(
         readonly deviceListStore?: {
             readonly findByAnyUserJid: (jid: string) => Promise<unknown>
         }
+        readonly emitMessageSend?: (event: WaOutgoingMessageEvent) => void
     }
 ): WaMessageDispatchCoordinator {
     const groupMetadataCache = createGroupMetadataCache({
@@ -126,6 +132,7 @@ function createMessageDispatchCoordinator(
 
     return new WaMessageDispatchCoordinator({
         logger: createNoopLogger(),
+        emitMessageSend: overrides?.emitMessageSend,
         messageClient: {} as never,
         retryTracker: {} as never,
         sessionResolver: {} as never,
@@ -179,6 +186,22 @@ function callResolvePeerRecipientPn(
         }
     ).resolvePeerRecipientPn(recipientUserJid, directRecipientJid)
 }
+
+test('message dispatch emits message_send with the outbound proto and destination', async () => {
+    const events: WaOutgoingMessageEvent[] = []
+    const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore(), {
+        meJid: '5511000000000@s.whatsapp.net',
+        emitMessageSend: (event) => events.push(event)
+    })
+    // The mocked signal/crypto deps throw after the proto is built; the event
+    // fires before encryption, so it lands even though the send itself rejects.
+    await coordinator
+        .sendMessage('5511999999999@s.whatsapp.net', { text: 'oi' } as never, {})
+        .catch(() => undefined)
+    assert.equal(events.length, 1)
+    assert.equal(events[0]?.to, '5511999999999@s.whatsapp.net')
+    assert.ok(events[0]?.message)
+})
 
 test('resolvePeerRecipientPn: a PN-addressed caller on a LID envelope stamps that PN', async () => {
     const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore())

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -165,9 +165,14 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
      * Chat-event emission tuning. `emitSnapshotMutations: true` re-emits
      * `app_state_mutation` events for every mutation seen during a snapshot
      * sync (off by default – those mutations represent historical state).
+     * `emitLocalMutations: true` also emits a `mutation` event (with
+     * `source: 'local'`) for every app-state action this client sends
+     * (mute/pin/archive/…), so consumers can observe their own changes at
+     * action time (off by default).
      */
     readonly chatEvents?: {
         readonly emitSnapshotMutations?: boolean
+        readonly emitLocalMutations?: boolean
     }
     /**
      * Privacy-token (trusted-contact-token) cache tuning. Controls how often
@@ -1225,7 +1230,7 @@ export interface WaHistorySyncChunkEvent {
     readonly progress?: number
 }
 
-export type WaAppStateMutationSource = 'snapshot' | 'patch'
+export type WaAppStateMutationSource = 'snapshot' | 'patch' | 'local'
 
 type MutationEventBase = {
     readonly source: WaAppStateMutationSource

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -165,14 +165,10 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
      * Chat-event emission tuning. `emitSnapshotMutations: true` re-emits
      * `app_state_mutation` events for every mutation seen during a snapshot
      * sync (off by default – those mutations represent historical state).
-     * `emitLocalMutations: true` also emits a `mutation` event (with
-     * `source: 'local'`) for every app-state action this client sends
-     * (mute/pin/archive/…), so consumers can observe their own changes at
-     * action time (off by default).
+     * This client's own outbound app-state actions surface on `mutation_send`.
      */
     readonly chatEvents?: {
         readonly emitSnapshotMutations?: boolean
-        readonly emitLocalMutations?: boolean
     }
     /**
      * Privacy-token (trusted-contact-token) cache tuning. Controls how often
@@ -1270,6 +1266,13 @@ export type WaAppStateMutationEvent = {
               WaAppstateIndexArgs<K>)
 }[WaAppstateActionKey]
 
+/**
+ * Listener shared by the inbound `mutation` and outbound `mutation_send`
+ * events. A single named alias so the (large) `WaAppStateMutationEvent` union
+ * is referenced once by the event map rather than expanded per event.
+ */
+type WaAppStateMutationListener = (event: WaAppStateMutationEvent) => void
+
 export type WaConnectionEvent =
     | {
           readonly status: 'open'
@@ -1409,11 +1412,20 @@ export interface WaClientEventMap {
     /** Profile/group/community picture change notification – the new picture must still be fetched explicitly. */
     readonly picture: (event: WaPictureEvent) => void
     /**
-     * A parsed app-state mutation crossed the sync boundary – chat mute/star/
-     * read/pin/archive/contact/label/etc. Use the discriminator
-     * (`event.action`) to branch on the mutation kind.
+     * A parsed app-state mutation arriving from a sync – chat mute/star/read/
+     * pin/archive/contact/label/etc. changed on another device. Inbound only;
+     * this client's own outbound actions surface on `mutation_send`. Use the
+     * discriminator (`event.schema`) to branch on the mutation kind.
      */
-    readonly mutation: (event: WaAppStateMutationEvent) => void
+    readonly mutation: WaAppStateMutationListener
+    /**
+     * An app-state action this client is sending (mute/star/read/pin/archive/
+     * clear/delete/…) surfaced at action time – the outbound counterpart to
+     * `mutation`, symmetric to how `message_send` pairs with `message`.
+     * `event.source` is always `'local'`. Optimistic: emitted as the mutation
+     * is enqueued, before the server flush confirms it.
+     */
+    readonly mutation_send: WaAppStateMutationListener
     /**
      * One chunk of history-sync data, fired both during the initial
      * bootstrap that the primary device pushes after pairing and for any

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -598,6 +598,23 @@ export interface WaIncomingMessageEvent extends Omit<WaIncomingBaseEvent, 'chatJ
     readonly message?: Proto.IMessage
 }
 
+/**
+ * An outbound message this client sent, surfaced with its decrypted
+ * {@link Proto.IMessage} – the symmetric counterpart to
+ * {@link WaIncomingMessageEvent}. Fires from {@link WaMessageCoordinator.send}
+ * as the stanza is built, so plugins/loggers can observe outgoing content
+ * (forwards, reactions, polls, media) that the encrypted `<message>` on the
+ * wire does not reveal.
+ */
+export interface WaOutgoingMessageEvent {
+    /** Destination jid (chat / group / status). */
+    readonly to: string
+    /** Outgoing stanza id, when assigned. */
+    readonly id?: string
+    /** The decrypted message proto being sent. */
+    readonly message: Proto.IMessage
+}
+
 export interface WaIncomingProtocolMessageEvent extends WaIncomingMessageEvent {
     readonly protocolMessage: Proto.Message.IProtocolMessage
 }
@@ -1326,6 +1343,13 @@ export interface WaClientEventMap {
      * `options.quote` for threads).
      */
     readonly message: (event: WaIncomingMessageEvent) => void
+    /**
+     * An outbound message this client is sending, with its decrypted
+     * {@link Proto.IMessage} – the symmetric counterpart to `message`. Lets
+     * plugins/loggers observe outgoing content (forwards, reactions, polls,
+     * media) the encrypted wire stanza hides.
+     */
+    readonly message_send: (event: WaOutgoingMessageEvent) => void
     /**
      * A decrypted addon (poll vote, reaction, edit, comment, ...) attached to
      * a previous message. Fires unless `addons.autoDecrypt` is explicitly

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ export type {
     WaMexUsernameSetEvent,
     WaMexUsernameUpdateHintEvent,
     WaOfflineResumeEvent,
+    WaOutgoingMessageEvent,
     WaPictureEvent,
     WaPictureEventAction,
     WaPrivacyTokenUpdateEvent,
@@ -226,7 +227,13 @@ export type {
     WaSendStickerPackTrayIcon,
     WaSendTextMessage
 } from '@message/types'
-export { getContentType, resolveMessageTarget } from '@message/encode/content'
+export {
+    getContentType,
+    resolveEncMediaType,
+    resolveMessageTarget,
+    unwrapMessage
+} from '@message/encode/content'
+export { getContextInfo } from '@message/context-info'
 export { resolveMediaPayload } from '@message/encode/media-payload'
 export { unpadPkcs7, writeRandomPadMax16 } from '@message/encode/padding'
 export type { WaResolvedMediaPayload } from '@message/encode/media-payload'

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,6 +255,7 @@ export { PinoLogger, createPinoLogger } from '@infra/log/PinoLogger'
 export type { PinoLoggerOptions } from '@infra/log/PinoLogger'
 export { createNoopLogger } from '@infra/log/types'
 export type { Logger, LogLevel } from '@infra/log/types'
+export { WA_VERSION } from '@version-spec'
 export { createStore, WaAuthMemoryStore } from '@store'
 export type {
     WaAppStateCollectionStoreState,

--- a/src/message/WaMessageClient.ts
+++ b/src/message/WaMessageClient.ts
@@ -12,7 +12,13 @@ import type {
     WaMessagePublishResult,
     WaSendReceiptInput
 } from '@message/types'
-import { WA_DEFAULTS, WA_MESSAGE_TAGS, WA_MESSAGE_TYPES, WA_NODE_TAGS } from '@protocol/constants'
+import {
+    WA_ADDRESSING_MODES,
+    WA_DEFAULTS,
+    WA_MESSAGE_TAGS,
+    WA_MESSAGE_TYPES,
+    WA_NODE_TAGS
+} from '@protocol/constants'
 import { buildReceiptNode } from '@transport/node/builders/global'
 import type { BinaryNode } from '@transport/types'
 import { delay } from '@util/async'
@@ -282,7 +288,8 @@ export class WaMessageClient {
     private extractAckMetadata(ackNode: BinaryNode): WaMessageAckMetadata {
         const addressingModeRaw = ackNode.attrs.addressing_mode
         const addressingMode =
-            addressingModeRaw === 'pn' || addressingModeRaw === 'lid'
+            addressingModeRaw === WA_ADDRESSING_MODES.PN ||
+            addressingModeRaw === WA_ADDRESSING_MODES.LID
                 ? addressingModeRaw
                 : undefined
         return {

--- a/src/message/context-info.ts
+++ b/src/message/context-info.ts
@@ -129,6 +129,11 @@ function pickContextInfoTarget(message: Proto.IMessage): ContextInfoCarrier | nu
     return null
 }
 
+/** Reads the `contextInfo` off a message's first content submessage (null when absent). */
+export function getContextInfo(message: Proto.IMessage): Proto.IContextInfo | null {
+    return pickContextInfoTarget(message)?.contextInfo ?? null
+}
+
 /**
  * Anything that identifies a quoted message. Accepts a {@link WaQuoteRef}, a
  * {@link WaMessageKey} (bare proto key), or a full incoming message event (its

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -32,7 +32,9 @@ export {
 } from '@protocol/call'
 export type { WaCallPayloadTag } from '@protocol/call'
 export {
+    WA_ADDRESSING_MODES,
     WA_EDIT_ATTRS,
+    WA_ENC_CIPHERTEXT_TYPES,
     WA_ENC_MEDIA_TYPES,
     WA_EVENT_META_TYPES,
     WA_MESSAGE_TAGS,
@@ -42,7 +44,7 @@ export {
     WA_RETRYABLE_ACK_CODES,
     WA_STANZA_MSG_TYPES
 } from '@protocol/message'
-export type { WaOutboundReceiptType } from '@protocol/message'
+export type { WaAddressingMode, WaEncCiphertextType, WaOutboundReceiptType } from '@protocol/message'
 export {
     WA_APP_STATE_COLLECTIONS,
     WA_APP_STATE_COLLECTION_STATES,
@@ -118,7 +120,11 @@ export {
     WA_ABPROPS_REFRESH_BOUNDS
 } from '@protocol/abprops'
 export type { AbPropConfigEntry, AbPropName, AbPropType, AbPropValue } from '@protocol/abprops'
-export { WA_GROUP_PARTICIPANT_TYPES, type WaGroupSetting } from '@protocol/group'
+export {
+    WA_GROUP_MEMBERSHIP_ACTION_TAGS,
+    WA_GROUP_PARTICIPANT_TYPES,
+    type WaGroupSetting
+} from '@protocol/group'
 export { WA_USYNC_CONTEXTS, WA_USYNC_DEFAULTS, WA_USYNC_MODES } from '@protocol/usync'
 export {
     WA_NEWSLETTER_FETCH_KEY_TYPES,

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -44,7 +44,11 @@ export {
     WA_RETRYABLE_ACK_CODES,
     WA_STANZA_MSG_TYPES
 } from '@protocol/message'
-export type { WaAddressingMode, WaEncCiphertextType, WaOutboundReceiptType } from '@protocol/message'
+export type {
+    WaAddressingMode,
+    WaEncCiphertextType,
+    WaOutboundReceiptType
+} from '@protocol/message'
 export {
     WA_APP_STATE_COLLECTIONS,
     WA_APP_STATE_COLLECTION_STATES,

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -1,4 +1,11 @@
-export { getWaCompanionPlatformId, WA_BROWSERS, WA_COMPANION_PLATFORM_IDS } from '@protocol/browser'
+export {
+    getWaBrowserDisplayName,
+    getWaCompanionPlatformId,
+    WA_BROWSERS,
+    WA_COMPANION_PLATFORM_IDS
+} from '@protocol/browser'
+export { resolveWaDeviceIdentity } from '@protocol/device-identity'
+export type { WaDeviceIdentity, WaDeviceIdentityOptions } from '@protocol/device-identity'
 export { WA_SIGNALING, WA_PAIRING_KDF_INFO } from '@protocol/auth'
 export {
     WA_CONNECTION_REASONS,

--- a/src/protocol/device-identity.ts
+++ b/src/protocol/device-identity.ts
@@ -1,0 +1,38 @@
+import { getWaCompanionPlatformId } from '@protocol/browser'
+import { WA_DEFAULTS } from '@protocol/defaults'
+import { getRuntimeOsDisplayName } from '@util/runtime'
+
+/**
+ * Raw device-identity inputs a caller may set. Any field left unset is filled
+ * with the same default the client uses, so callers that resolve identity
+ * independently (e.g. the WAM analytics plugin) stay consistent with the
+ * pairing `ClientPayload`.
+ */
+export interface WaDeviceIdentityOptions {
+    readonly deviceBrowser?: string
+    readonly deviceOsDisplayName?: string
+    readonly devicePlatform?: string
+}
+
+/** Fully-resolved device identity advertised to WhatsApp. */
+export interface WaDeviceIdentity {
+    readonly browser: string
+    readonly osDisplayName: string
+    readonly platform: string
+}
+
+/**
+ * Resolves the device identity from raw options, applying the shared defaults:
+ * browser falls back to {@link WA_DEFAULTS}.DEVICE_BROWSER, OS name to the
+ * detected runtime OS, and platform id is inferred from the browser. This is
+ * the single source of truth used by both the client factory and the auth
+ * client so the pairing payload and any analytics/telemetry agree.
+ */
+export function resolveWaDeviceIdentity(options: WaDeviceIdentityOptions): WaDeviceIdentity {
+    const browser = options.deviceBrowser ?? WA_DEFAULTS.DEVICE_BROWSER
+    return Object.freeze({
+        browser,
+        osDisplayName: options.deviceOsDisplayName ?? getRuntimeOsDisplayName(),
+        platform: options.devicePlatform ?? getWaCompanionPlatformId(browser)
+    })
+}

--- a/src/protocol/group.ts
+++ b/src/protocol/group.ts
@@ -4,6 +4,13 @@ export const WA_GROUP_PARTICIPANT_TYPES = Object.freeze({
     REGULAR: 'participant'
 } as const)
 
+/** `<membership_requests_action>` child tags for approving/rejecting group join requests. */
+export const WA_GROUP_MEMBERSHIP_ACTION_TAGS = Object.freeze({
+    REQUESTS_ACTION: 'membership_requests_action',
+    APPROVE: 'approve',
+    REJECT: 'reject'
+} as const)
+
 export type WaGroupSetting =
     | 'announcement'
     | 'restrict'

--- a/src/protocol/message.ts
+++ b/src/protocol/message.ts
@@ -6,6 +6,25 @@ export const WA_MESSAGE_TAGS = Object.freeze({
     ERROR: 'error'
 } as const)
 
+/** `<enc type>` ciphertext kinds (Signal `msg`/`pkmsg`, group `skmsg`, message-secret `msmsg`). */
+export const WA_ENC_CIPHERTEXT_TYPES = Object.freeze({
+    MESSAGE: 'msg',
+    PREKEY: 'pkmsg',
+    SENDER_KEY: 'skmsg',
+    MESSAGE_SECRET: 'msmsg'
+} as const)
+
+export type WaEncCiphertextType =
+    (typeof WA_ENC_CIPHERTEXT_TYPES)[keyof typeof WA_ENC_CIPHERTEXT_TYPES]
+
+/** `addressing_mode` stanza attr: phone-number vs LID addressing. */
+export const WA_ADDRESSING_MODES = Object.freeze({
+    PN: 'pn',
+    LID: 'lid'
+} as const)
+
+export type WaAddressingMode = (typeof WA_ADDRESSING_MODES)[keyof typeof WA_ADDRESSING_MODES]
+
 export const WA_MESSAGE_TYPES = Object.freeze({
     ENC_VERSION: '2',
     MEDIA_NOTIFY: 'medianotify',

--- a/src/protocol/nodes.ts
+++ b/src/protocol/nodes.ts
@@ -10,6 +10,7 @@ export const WA_NODE_TAGS = Object.freeze({
     NOTIFICATION: 'notification',
     SUCCESS: 'success',
     INFO_BULLETIN: 'ib',
+    OFFLINE: 'offline',
     DIRTY: 'dirty',
     EDGE_ROUTING: 'edge_routing',
     ROUTING_INFO: 'routing_info',

--- a/src/retry/replay.ts
+++ b/src/retry/replay.ts
@@ -5,7 +5,7 @@ import { wrapDeviceSentMessage } from '@message/encode/device-sent'
 import { unpadPkcs7, writeRandomPadMax16 } from '@message/encode/padding'
 import type { WaMessageClient } from '@message/WaMessageClient'
 import { proto, type Proto } from '@proto'
-import { WA_DEFAULTS, WA_NODE_TAGS } from '@protocol/constants'
+import { WA_ADDRESSING_MODES, WA_DEFAULTS, WA_NODE_TAGS } from '@protocol/constants'
 import {
     isGroupOrBroadcastJid,
     isHostedDeviceJid,
@@ -301,8 +301,8 @@ export class WaRetryReplayService {
             addressingMode: isStatus
                 ? undefined
                 : requesterAddress.server === WA_DEFAULTS.LID_SERVER
-                  ? 'lid'
-                  : 'pn',
+                  ? WA_ADDRESSING_MODES.LID
+                  : WA_ADDRESSING_MODES.PN,
             encType: encrypted.type,
             ciphertext: encrypted.ciphertext,
             retryCount,

--- a/src/transport/node/builders/group.ts
+++ b/src/transport/node/builders/group.ts
@@ -1,4 +1,5 @@
 import { WA_DEFAULTS } from '@protocol/defaults'
+import { WA_GROUP_MEMBERSHIP_ACTION_TAGS } from '@protocol/group'
 import { WA_IQ_TYPES, WA_XMLNS } from '@protocol/nodes'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
@@ -112,20 +113,20 @@ export function buildMembershipRequestsActionIq(input: {
     const children: BinaryNode[] = []
     if (approve.length > 0) {
         children.push({
-            tag: 'approve',
+            tag: WA_GROUP_MEMBERSHIP_ACTION_TAGS.APPROVE,
             attrs: {},
             content: approve.map((jid) => ({ tag: 'participant', attrs: { jid } }))
         })
     }
     if (reject.length > 0) {
         children.push({
-            tag: 'reject',
+            tag: WA_GROUP_MEMBERSHIP_ACTION_TAGS.REJECT,
             attrs: {},
             content: reject.map((jid) => ({ tag: 'participant', attrs: { jid } }))
         })
     }
     return buildIqNode(WA_IQ_TYPES.SET, input.groupJid, WA_XMLNS.GROUPS, [
-        { tag: 'membership_requests_action', attrs: {}, content: children }
+        { tag: WA_GROUP_MEMBERSHIP_ACTION_TAGS.REQUESTS_ACTION, attrs: {}, content: children }
     ])
 }
 

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,3 +1,4 @@
+export { delay } from '@util/async'
 export {
     base64ToBytes,
     bytesToBase64,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the `@zapo-js/wam` telemetry plugin with buffered `w:stats` uploads and optional synthetic UI emissions.
  * Added `client.wam` telemetry coordinator plus new `wamPlugin()` configuration and `WaWam*` APIs.
  * Added outbound `message_send` and optimistic local `mutation_send` event emission support.
  * Exposed additional public helpers/constants (including `WA_VERSION`, context info, unwrap/media-type utilities).
* **Bug Fixes**
  * Improved device-identity resolution and standardized addressing-mode handling across dispatch/retry flows.
* **Tests / CI**
  * Expanded WAM unit test coverage (auto-emitter, synthetic UI, wire, globals/registry/send parsing, coordinator).
  * Added a dedicated CI job for WAM tests and updated linting project scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->