### PR TITLE
fix(plugins): reinstall client plugins after a disconnect/reconnect cycle

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -20,7 +20,7 @@ import { createIgnoreKeyFilter, validateIgnoreKey } from '@client/messaging/igno
 import { runHistorySyncNotification } from '@client/persistence/history-sync'
 import { persistIncomingMailboxEntities } from '@client/persistence/mailbox'
 import { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
-import { installWaClientPlugins } from '@client/plugins/install'
+import { installWaClientPlugins, type WaClientPluginInstallInput } from '@client/plugins/install'
 import type {
     WaClientExposedFromPlugins,
     WaClientPluginDefinition,
@@ -74,6 +74,7 @@ class WaClientImpl extends EventEmitter {
     private activeIncomingHandlers = 0
     private readonly incomingHandlersDrainedWaiters: Array<() => void> = []
     private disposePlugins: (() => Promise<void>) | null = null
+    private pluginInstallInput!: WaClientPluginInstallInput
 
     /**
      * @param options Client configuration (store, transport, addons, history...).
@@ -127,17 +128,14 @@ class WaClientImpl extends EventEmitter {
         this.appStateSync = dependencies.appStateSync
         this.mediaTransfer = dependencies.mediaTransfer
 
-        this.disposePlugins = installWaClientPlugins(
-            this,
-            {
-                options: this.options,
-                logger: this.logger,
-                stores: this.stores,
-                deps: this.deps,
-                queryWithContext: this.queryWithContext.bind(this)
-            },
-            this.options.plugins ?? []
-        )
+        this.pluginInstallInput = {
+            options: this.options,
+            logger: this.logger,
+            stores: this.stores,
+            deps: this.deps,
+            queryWithContext: this.queryWithContext.bind(this)
+        }
+        this.installPlugins()
 
         this.bindNodeTransportEvents()
         this.on('connection', (event) => {
@@ -159,6 +157,14 @@ class WaClientImpl extends EventEmitter {
                 })
             })
         })
+    }
+
+    private installPlugins(): void {
+        this.disposePlugins = installWaClientPlugins(
+            this,
+            this.pluginInstallInput,
+            this.options.plugins ?? []
+        )
     }
 
     private async runClientTooOldRecover(): Promise<void> {
@@ -444,6 +450,10 @@ class WaClientImpl extends EventEmitter {
             return this.connectPromise
         }
 
+        if (!this.disposePlugins) {
+            this.installPlugins()
+        }
+
         this.writeBehind.restart()
 
         this.acceptingIncomingEvents = true
@@ -469,11 +479,12 @@ class WaClientImpl extends EventEmitter {
 
     /**
      * Closes the transport gracefully: pauses incoming events, flushes the
-     * write-behind persistence queue, and emits a `connection` close event
-     * with reason `client_disconnected`. Does not clear stored credentials -
-     * call {@link connect} again to resume the same session. There is no
-     * built-in auto-reconnect; subscribe to `connection: { status: 'close' }`
-     * and decide your own backoff.
+     * write-behind persistence queue, disposes installed plugins, and emits a
+     * `connection` close event with reason `client_disconnected`. Does not
+     * clear stored credentials - call {@link connect} again to resume the same
+     * session, which reinstalls the plugins. There is no built-in
+     * auto-reconnect; subscribe to `connection: { status: 'close' }` and decide
+     * your own backoff.
      */
     public async disconnect(): Promise<void> {
         await this.pauseIncomingEventsAndWaitDrain()

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -74,7 +74,7 @@ class WaClientImpl extends EventEmitter {
     private activeIncomingHandlers = 0
     private readonly incomingHandlersDrainedWaiters: Array<() => void> = []
     private disposePlugins: (() => Promise<void>) | null = null
-    private pluginInstallInput!: WaClientPluginInstallInput
+    private readonly pluginInstallInput!: WaClientPluginInstallInput
 
     /**
      * @param options Client configuration (store, transport, addons, history...).

--- a/src/client/plugins/__tests__/plugins.test.ts
+++ b/src/client/plugins/__tests__/plugins.test.ts
@@ -117,6 +117,46 @@ test('expose plugin defines enumerable getter on client', () => {
     assert.equal(Object.prototype.propertyIsEnumerable.call(client, 'api'), true)
 })
 
+test('expose plugin survives a dispose and reinstall cycle', async () => {
+    let created = 0
+    const plugin = defineWaClientPlugin({
+        id: 'api',
+        exposeAs: 'api',
+        setup: () => ({ n: (created += 1) })
+    })
+    const client = {
+        emit: () => true,
+        on: () => ({}),
+        off: () => ({}),
+        once: () => ({})
+    } as never
+    const input = {
+        options: { store: {} as never, sessionId: 'x' },
+        logger: createNoopLogger(),
+        stores: {} as never,
+        deps: {
+            lowLevelCoordinator: {
+                registerIncomingHandler: () => () => undefined,
+                registerIncomingStanzaFilter: () => () => undefined
+            }
+        } as never,
+        queryWithContext: async () => ({ tag: 'iq', attrs: {} })
+    }
+    const readApi = (): { n: number } | undefined =>
+        (client as unknown as { api?: { n: number } }).api
+
+    const dispose1 = installWaClientPlugins(client, input, [plugin])
+    assert.equal(readApi()?.n, 1)
+
+    await dispose1()
+    assert.equal(readApi(), undefined)
+
+    const dispose2 = installWaClientPlugins(client, input, [plugin])
+    assert.equal(readApi()?.n, 2)
+
+    await dispose2()
+})
+
 test('install rejects duplicate plugin id', () => {
     const plugin = defineWaClientPlugin({
         id: 'dup',

--- a/src/client/plugins/__tests__/plugins.test.ts
+++ b/src/client/plugins/__tests__/plugins.test.ts
@@ -157,6 +157,45 @@ test('expose plugin survives a dispose and reinstall cycle', async () => {
     await dispose2()
 })
 
+test('expose plugin can still read its client getter during dispose', async () => {
+    let seenDuringDispose: unknown = 'unset'
+    const api = { value: 7 }
+    const plugin = defineWaClientPlugin({
+        id: 'api',
+        exposeAs: 'api',
+        setup: () => api,
+        dispose: (_instance: typeof api, ctx: WaClientPluginContext) => {
+            seenDuringDispose = (ctx.client as unknown as { api?: unknown }).api
+        }
+    })
+    const client = {
+        emit: () => true,
+        on: () => ({}),
+        off: () => ({}),
+        once: () => ({})
+    } as never
+    const dispose = installWaClientPlugins(
+        client,
+        {
+            options: { store: {} as never, sessionId: 'x' },
+            logger: createNoopLogger(),
+            stores: {} as never,
+            deps: {
+                lowLevelCoordinator: {
+                    registerIncomingHandler: () => () => undefined,
+                    registerIncomingStanzaFilter: () => () => undefined
+                }
+            } as never,
+            queryWithContext: async () => ({ tag: 'iq', attrs: {} })
+        },
+        [plugin]
+    )
+
+    await dispose()
+    assert.equal(seenDuringDispose, api)
+    assert.equal((client as unknown as { api?: unknown }).api, undefined)
+})
+
 test('install rejects duplicate plugin id', () => {
     const plugin = defineWaClientPlugin({
         id: 'dup',

--- a/src/client/plugins/install.ts
+++ b/src/client/plugins/install.ts
@@ -120,13 +120,13 @@ export function installWaClientPlugins(
 
             const instance = plugin.setup(pluginCtx)
             registry.instances.set(exposeAs, instance)
+            registerDispose(() => {
+                registry.instances.delete(exposeAs)
+            })
             if (plugin.dispose) {
                 const dispose = plugin.dispose
                 registerDispose(() => dispose(instance, pluginCtx))
             }
-            registerDispose(() => {
-                registry.instances.delete(exposeAs)
-            })
             pluginCtx.logger.debug('wa client plugin installed', { exposeAs })
         } else {
             plugin.setup(pluginCtx)

--- a/src/client/plugins/install.ts
+++ b/src/client/plugins/install.ts
@@ -18,15 +18,47 @@ export interface WaClientPluginInstallInput {
     readonly queryWithContext: WaClientPluginContext['queryWithContext']
 }
 
+interface PluginRegistry {
+    readonly instances: Map<string, unknown>
+    readonly exposedDefined: Set<string>
+}
+
+const PLUGIN_REGISTRY = Symbol('waClientPluginRegistry')
+
+/**
+ * Per-client store for exposed-plugin state that must survive a
+ * disconnect/connect cycle. Each `exposeAs` property is defined on the client
+ * exactly once (a non-configurable getter reading `instances`); reinstalls
+ * only repopulate the slot, so plugins can be torn down on disconnect and
+ * rebuilt on the next connect without redefining reserved members.
+ */
+function getPluginRegistry(client: WaClient): PluginRegistry {
+    const holder = client as unknown as { [PLUGIN_REGISTRY]?: PluginRegistry }
+    const existing = holder[PLUGIN_REGISTRY]
+    if (existing) {
+        return existing
+    }
+    const registry: PluginRegistry = { instances: new Map(), exposedDefined: new Set() }
+    Object.defineProperty(client, PLUGIN_REGISTRY, {
+        value: registry,
+        enumerable: false,
+        configurable: false,
+        writable: false
+    })
+    return registry
+}
+
 /**
  * Installs {@link WaClientOptions.plugins} on `client`. Returns a dispose
- * function invoked by {@link WaClient.disconnect}.
+ * function invoked by {@link WaClient.disconnect}. Safe to call again after a
+ * dispose to reinstall the same plugins on reconnect.
  */
 export function installWaClientPlugins(
     client: WaClient,
     input: WaClientPluginInstallInput,
     plugins: readonly WaClientPluginDefinition[]
 ): () => Promise<void> {
+    const registry = getPluginRegistry(client)
     const seenIds = new Set<string>()
     const seenExposeAs = new Set<string>()
     const disposeCallbacks: Array<() => void | Promise<void>> = []
@@ -66,28 +98,36 @@ export function installWaClientPlugins(
         }
 
         if (isWaClientExposePluginDefinition(plugin)) {
-            if (seenExposeAs.has(plugin.exposeAs)) {
-                throw new Error(`duplicate wa client plugin exposeAs: ${plugin.exposeAs}`)
+            const exposeAs = plugin.exposeAs
+            if (seenExposeAs.has(exposeAs)) {
+                throw new Error(`duplicate wa client plugin exposeAs: ${exposeAs}`)
             }
-            seenExposeAs.add(plugin.exposeAs)
+            seenExposeAs.add(exposeAs)
 
-            if (plugin.exposeAs in client) {
-                throw new Error(
-                    `wa client plugin exposeAs "${plugin.exposeAs}" collides with a reserved client member`
-                )
+            if (!registry.exposedDefined.has(exposeAs)) {
+                if (exposeAs in client) {
+                    throw new Error(
+                        `wa client plugin exposeAs "${exposeAs}" collides with a reserved client member`
+                    )
+                }
+                registry.exposedDefined.add(exposeAs)
+                Object.defineProperty(client, exposeAs, {
+                    get: () => registry.instances.get(exposeAs),
+                    enumerable: true,
+                    configurable: false
+                })
             }
 
             const instance = plugin.setup(pluginCtx)
-            Object.defineProperty(client, plugin.exposeAs, {
-                get: () => instance,
-                enumerable: true,
-                configurable: false
-            })
+            registry.instances.set(exposeAs, instance)
             if (plugin.dispose) {
                 const dispose = plugin.dispose
                 registerDispose(() => dispose(instance, pluginCtx))
             }
-            pluginCtx.logger.debug('wa client plugin installed', { exposeAs: plugin.exposeAs })
+            registerDispose(() => {
+                registry.instances.delete(exposeAs)
+            })
+            pluginCtx.logger.debug('wa client plugin installed', { exposeAs })
         } else {
             plugin.setup(pluginCtx)
             if (plugin.dispose) {


### PR DESCRIPTION
disconnect() disposed the plugins and connect() never reinstalled them, so a reconnected session silently lost every plugin (and each `client.<exposeAs>` getter went stale) despite the documented "call connect() again to resume".

Each exposeAs property is now defined once as a non-configurable getter that reads a mutable slot in an internal per-client registry (keyed by a private Symbol). dispose() clears the slot and runs the dispose callbacks; connect() reinstalls the plugins when they are absent, repopulating the slot with fresh instances without redefining the property or colliding with reserved members.

No public API change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugins now reliably reinstall after disconnecting and reconnecting.
  * Exposed plugin APIs are restored correctly after a reinstall.
  * Plugin cleanup no longer prevents future plugin installations.
  * Duplicate exposed plugin names are detected during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->