### PR TITLE
fix(wam): gate telemetry uploads on account registration

### DIFF
--- a/packages/wam/CHANGELOG.md
+++ b/packages/wam/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @zapo-js/wam
+
+## 0.1.1
+
+### Patch Changes
+
+- Gate WAM telemetry uploads on account registration: batches are dropped until the client has registered credentials (`meJid`), so no analytics is uploaded before login even when the socket is already connected.

--- a/packages/wam/package.json
+++ b/packages/wam/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zapo-js/wam",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "WhatsApp Web WAM (analytics/telemetry) plugin for zapo-js — emits the client-side metrics batches WA Web sends, for wire parity and anti-fingerprinting",
     "license": "MIT",
     "author": "vinikjkkj <contact@vinicius.email> (https://github.com/vinikjkkj)",

--- a/packages/wam/src/WaWamCoordinator.ts
+++ b/packages/wam/src/WaWamCoordinator.ts
@@ -64,6 +64,7 @@ export class WaWamCoordinator {
     private flushTimer: ReturnType<typeof setTimeout> | null = null
     private disposed = false
     private readonly isConnected: () => boolean
+    private readonly isRegistered: () => boolean
 
     constructor(ctx: WaClientPluginContext, options: WaWamCoordinatorOptions = {}) {
         this.logger = ctx.logger.child({ scope: '@zapo-js/wam' }, { level: options.logLevel })
@@ -94,6 +95,10 @@ export class WaWamCoordinator {
                           : {}
                   )
         this.isConnected = (): boolean => ctx.deps.connectionManager.isConnected()
+        this.isRegistered = (): boolean => {
+            const meJid = ctx.deps.authClient.getCurrentCredentials()?.meJid
+            return meJid !== null && meJid !== undefined
+        }
     }
 
     /**
@@ -150,8 +155,8 @@ export class WaWamCoordinator {
         if (batch === undefined) return
         this.openBatches.delete(channel)
         if (!batch.hasEvents()) return
-        if (!this.isConnected()) {
-            this.logger.trace('wam batch dropped: not connected', {
+        if (!this.isConnected() || !this.isRegistered()) {
+            this.logger.trace('wam batch dropped: not connected or unregistered', {
                 channel,
                 size: batch.size()
             })

--- a/packages/wam/src/__tests__/coordinator.test.ts
+++ b/packages/wam/src/__tests__/coordinator.test.ts
@@ -16,20 +16,31 @@ const noopLogger = {
     }
 }
 
-function makeCoordinator(connectedInitially: boolean) {
+function makeCoordinator(connectedInitially: boolean, registeredInitially = true) {
     const uploads: BinaryNode[] = []
     let connected = connectedInitially
+    let registered = registeredInitially
     const ctx = {
         logger: noopLogger,
         queryWithContext: async (_context: string, node: BinaryNode) => {
             uploads.push(node)
             return { tag: 'iq', attrs: { type: 'result' }, content: [] } as BinaryNode
         },
-        deps: { connectionManager: { isConnected: () => connected } },
+        deps: {
+            connectionManager: { isConnected: () => connected },
+            authClient: {
+                getCurrentCredentials: () => (registered ? { meJid: 'me@s.whatsapp.net' } : null)
+            }
+        },
         options: { deviceBrowser: 'Chrome', deviceOsDisplayName: 'Windows' }
     } as unknown as WaClientPluginContext
     const coordinator = new WaWamCoordinator(ctx, { autoEmit: false, syntheticUi: false })
-    return { coordinator, uploads, setConnected: (value: boolean) => (connected = value) }
+    return {
+        coordinator,
+        uploads,
+        setConnected: (value: boolean) => (connected = value),
+        setRegistered: (value: boolean) => (registered = value)
+    }
 }
 
 test('WaWamCoordinator drops the batch while disconnected instead of buffering or uploading', async () => {
@@ -38,6 +49,17 @@ test('WaWamCoordinator drops the batch while disconnected instead of buffering o
     await coordinator.flush()
     assert.equal(uploads.length, 0)
     setConnected(true)
+    await coordinator.flush()
+    assert.equal(uploads.length, 0)
+    await coordinator.dispose()
+})
+
+test('WaWamCoordinator drops the batch while unregistered even when connected (no WAM before login)', async () => {
+    const { coordinator, uploads, setRegistered } = makeCoordinator(true, false)
+    coordinator.commit('UiAction', { uiActionType: 'CHAT_OPEN' })
+    await coordinator.flush()
+    assert.equal(uploads.length, 0)
+    setRegistered(true)
     await coordinator.flush()
     assert.equal(uploads.length, 0)
     await coordinator.dispose()


### PR DESCRIPTION
Drop WAM batches until the client has registered credentials (meJid), so nothing is uploaded before login even when the socket is connected. Mirrors the existing not-connected drop path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented message batches from being uploaded before the client is authenticated, even when a connection is active.
  * Ensured pending batches are safely discarded while the client remains unregistered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->