### PR TITLE
fix(signal): correlate lid-sync response by contact echo

### DIFF
--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -528,7 +528,7 @@ export class WaMessageDispatchCoordinator {
         }
         try {
             const results = await this.deps.signalDeviceSync.queryLidsByPhoneJids([pnUserJid])
-            const match = results.find((entry) => entry.phoneJid === pnUserJid)
+            const match = results.find((entry) => entry.queriedJid === pnUserJid)
             if (match?.lidJid) return match.lidJid
         } catch (error) {
             this.deps.logger.debug('lid resolution failed for direct recipient', {

--- a/src/client/coordinators/__tests__/profile-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/profile-coordinator.test.ts
@@ -1213,9 +1213,11 @@ test('profile coordinator resolves lids by phone numbers', async () => {
             portCalls.push(phoneJids)
             return [
                 {
+                    queriedJid: '5511999999999@s.whatsapp.net',
                     phoneJid: '5511999999999@s.whatsapp.net',
                     lidJid: '1234@lid',
-                    exists: true
+                    exists: true,
+                    invalid: false
                 }
             ]
         }
@@ -1225,9 +1227,11 @@ test('profile coordinator resolves lids by phone numbers', async () => {
 
     assert.deepEqual(result, [
         {
+            queriedJid: '5511999999999@s.whatsapp.net',
             phoneJid: '5511999999999@s.whatsapp.net',
             lidJid: '1234@lid',
-            exists: true
+            exists: true,
+            invalid: false
         }
     ])
     assert.equal(portCalls.length, 1)

--- a/src/signal/api/SignalDeviceSyncApi.ts
+++ b/src/signal/api/SignalDeviceSyncApi.ts
@@ -1,14 +1,14 @@
 import type { Logger } from '@infra/log/types'
 import { PromiseDedup } from '@infra/perf/PromiseDedup'
 import { WA_DEFAULTS, WA_NODE_TAGS, WA_USYNC_CONTEXTS } from '@protocol/constants'
-import { buildDeviceJid, isHostedDeviceId, splitJid, toUserJid } from '@protocol/jid'
+import { buildDeviceJid, isHostedDeviceId, parsePhoneJid, splitJid, toUserJid } from '@protocol/jid'
 import type { WaDeviceListStore } from '@store/contracts/device-list.store'
 import {
     buildUsyncIq,
     iterateUsyncUsers,
     parseUsyncResultEnvelope
 } from '@transport/node/builders/usync'
-import { findNodeChild, getNodeChildrenByTag } from '@transport/node/helpers'
+import { findNodeChild, getNodeChildrenByTag, getNodeTextContent } from '@transport/node/helpers'
 import { assertIqResult } from '@transport/node/query'
 import {
     createUsyncSidGenerator,
@@ -27,9 +27,23 @@ interface SignalDeviceSyncApiOptions {
 }
 
 export interface SignalLidSyncResult {
+    /**
+     * The phone jid the caller queried (normalized), so results can be correlated
+     * back to the input by value rather than by array position. Equals `phoneJid`
+     * unless the server corrected the number.
+     */
+    readonly queriedJid: string
+    /** The server's canonical/corrected phone jid (e.g. BR 9th digit added). */
     readonly phoneJid: string
     readonly lidJid: string | null
     readonly exists: boolean
+    /**
+     * `true` when the server rejected the number as malformed (`<user
+     * jid='undefined'>` with `<contact type='invalid'>`) - distinct from a
+     * well-formed number that simply has no WhatsApp account (`exists: false`,
+     * `invalid: false`).
+     */
+    readonly invalid: boolean
 }
 
 /**
@@ -175,25 +189,24 @@ export class SignalDeviceSyncApi {
         })
         const response = await this.query(request, timeoutMs)
         const parsed = this.parseLidSyncResponse(response, normalizedPhoneJids)
-        const parsedByPhoneJid = new Map<string, SignalLidSyncResult>()
+        const parsedByPhoneJid = new Map<string, Omit<SignalLidSyncResult, 'queriedJid'>>()
         for (let index = 0; index < parsed.length; index += 1) {
             const entry = parsed[index]
-            const phoneJid = entry.phoneJid ?? entry.jid
-            parsedByPhoneJid.set(phoneJid, {
-                phoneJid,
+            parsedByPhoneJid.set(entry.jid, {
+                phoneJid: entry.phoneJid ?? entry.jid,
                 lidJid: entry.lidJid,
-                exists: entry.exists
+                exists: entry.exists,
+                invalid: entry.invalid
             })
         }
         const result = new Array<SignalLidSyncResult>(normalizedPhoneJids.length)
         let found = 0
         for (let index = 0; index < normalizedPhoneJids.length; index += 1) {
-            const phoneJid = normalizedPhoneJids[index]
-            const resolved = parsedByPhoneJid.get(phoneJid) ?? {
-                phoneJid,
-                lidJid: null,
-                exists: false
-            }
+            const queriedJid = normalizedPhoneJids[index]
+            const hit = parsedByPhoneJid.get(queriedJid)
+            const resolved: SignalLidSyncResult = hit
+                ? { queriedJid, ...hit }
+                : { queriedJid, phoneJid: queriedJid, lidJid: null, exists: false, invalid: false }
             if (resolved.exists) {
                 found += 1
             }
@@ -362,7 +375,13 @@ export class SignalDeviceSyncApi {
             if (!userJid) {
                 continue
             }
-            const normalizedUserJid = this.normalizeUserJid(userJid)
+            const normalizedUserJid = this.tryNormalizeUserJid(userJid)
+            if (normalizedUserJid === null) {
+                this.logger.debug('signal device sync skipping user node with invalid jid', {
+                    jid: userJid
+                })
+                continue
+            }
             if (!requestedSet.has(normalizedUserJid)) {
                 continue
             }
@@ -384,6 +403,7 @@ export class SignalDeviceSyncApi {
         readonly lidJid: string | null
         readonly phoneJid: string | null
         readonly exists: boolean
+        readonly invalid: boolean
     }[] {
         assertIqResult(node, 'signal lid sync')
         logUsyncProtocolErrors(parseUsyncResultEnvelope(node), this.logger, 'signal.lidSync')
@@ -393,88 +413,109 @@ export class SignalDeviceSyncApi {
         }
 
         const requestedSet = new Set(requestedUsers)
-        const parsed = new Array<{
+        const parsed: {
             readonly jid: string
             readonly lidJid: string | null
             readonly phoneJid: string | null
             readonly exists: boolean
-        }>(userNodes.length)
-        let parsedCount = 0
+            readonly invalid: boolean
+        }[] = []
         for (let index = 0; index < userNodes.length; index += 1) {
             const userNode = userNodes[index]
-            const userJid = userNode.attrs.jid
-            if (!userJid) {
+            const rawUserJid = userNode.attrs.jid
+            if (!rawUserJid) {
                 continue
             }
-
-            const normalizedUserJid = this.normalizeUserJid(userJid)
-            const normalizedPhoneJid = userNode.attrs.pn_jid
-                ? this.normalizeUserJid(userNode.attrs.pn_jid)
+            const resolvedJid = this.tryNormalizeUserJid(rawUserJid)
+            const pnJid = userNode.attrs.pn_jid
+                ? this.tryNormalizeUserJid(userNode.attrs.pn_jid)
                 : null
-            const wasRequested =
-                requestedSet.has(normalizedUserJid) ||
-                (normalizedPhoneJid !== null && requestedSet.has(normalizedPhoneJid))
-            if (!wasRequested) {
-                continue
-            }
+            const phoneJid = pnJid ?? resolvedJid
 
             const lidNode = findNodeChild(userNode, WA_NODE_TAGS.LID)
-            const contactNode = findNodeChild(userNode, WA_NODE_TAGS.CONTACT)
-            if (!lidNode) {
-                parsed[parsedCount] = this.buildLidSyncResult(
-                    normalizedUserJid,
-                    normalizedPhoneJid,
-                    contactNode,
-                    null
-                )
-                parsedCount += 1
-                continue
-            }
-            const errorNode = findNodeChild(lidNode, WA_NODE_TAGS.ERROR)
-            if (errorNode) {
+            const lidErrorNode = lidNode ? findNodeChild(lidNode, WA_NODE_TAGS.ERROR) : null
+            if (lidErrorNode) {
                 this.logger.warn('signal lid sync user error', {
-                    jid: normalizedUserJid,
-                    code: errorNode.attrs.code,
-                    text: errorNode.attrs.text
+                    jid: resolvedJid ?? rawUserJid,
+                    code: lidErrorNode.attrs.code,
+                    text: lidErrorNode.attrs.text
                 })
-                parsed[parsedCount] = this.buildLidSyncResult(
-                    normalizedUserJid,
-                    normalizedPhoneJid,
-                    contactNode,
-                    null
-                )
-                parsedCount += 1
+            }
+            const lidJid =
+                !lidErrorNode && lidNode?.attrs.val
+                    ? this.tryNormalizeUserJid(lidNode.attrs.val)
+                    : null
+
+            const contactNodes = getNodeChildrenByTag(userNode, WA_NODE_TAGS.CONTACT)
+            let matched = false
+            for (let c = 0; c < contactNodes.length; c += 1) {
+                const contactNode = contactNodes[c]
+                const inputJid = this.recoverContactJid(contactNode)
+                if (inputJid === null || !requestedSet.has(inputJid)) {
+                    continue
+                }
+                matched = true
+                const invalid = resolvedJid === null || contactNode.attrs.type === 'invalid'
+                parsed.push({
+                    jid: inputJid,
+                    phoneJid: phoneJid ?? inputJid,
+                    lidJid,
+                    exists:
+                        !invalid &&
+                        this.parseLidSyncContactExists(contactNode, inputJid, lidJid !== null),
+                    invalid
+                })
+            }
+            if (matched) {
                 continue
             }
-            const lidJid = lidNode.attrs.val ? this.normalizeUserJid(lidNode.attrs.val) : null
-            parsed[parsedCount] = this.buildLidSyncResult(
-                normalizedUserJid,
-                normalizedPhoneJid,
-                contactNode,
-                lidJid
-            )
-            parsedCount += 1
+
+            if (resolvedJid === null) {
+                this.logger.debug('signal lid sync skipping user node with invalid jid', {
+                    jid: rawUserJid
+                })
+                continue
+            }
+            const requestedKey = requestedSet.has(resolvedJid)
+                ? resolvedJid
+                : pnJid !== null && requestedSet.has(pnJid)
+                  ? pnJid
+                  : null
+            if (requestedKey === null) {
+                this.logger.debug('signal lid sync unmatched user (no contact echo)', {
+                    jid: resolvedJid,
+                    pnJid
+                })
+                continue
+            }
+            const contactNode = findNodeChild(userNode, WA_NODE_TAGS.CONTACT)
+            parsed.push({
+                jid: requestedKey,
+                phoneJid: phoneJid ?? requestedKey,
+                lidJid,
+                exists: this.parseLidSyncContactExists(contactNode, requestedKey, lidJid !== null),
+                invalid: false
+            })
         }
-        parsed.length = parsedCount
         return parsed
     }
 
-    private buildLidSyncResult(
-        jid: string,
-        phoneJid: string | null,
-        contactNode: BinaryNode | undefined,
-        lidJid: string | null
-    ): {
-        readonly jid: string
-        readonly lidJid: string | null
-        readonly phoneJid: string | null
-        readonly exists: boolean
-    } {
-        return {
-            jid,
-            lidJid,
-            phoneJid,
-            exists: this.parseLidSyncContactExists(contactNode, jid, lidJid !== null)
+    /**
+     * Recovers the queried phone JID from a `<contact>` echo. Each `<contact>` in a
+     * usync response echoes the `+<number>` we sent (base64 text content), so it maps
+     * a response node back to the exact input - even when the server corrected the
+     * `<user jid>` or rejected it as `jid='undefined'`. Returns `null` when there is
+     * no decodable phone echo.
+     */
+    private recoverContactJid(contactNode: BinaryNode): string | null {
+        const echoed = getNodeTextContent(contactNode)
+        if (!echoed) {
+            return null
+        }
+        try {
+            return parsePhoneJid(echoed)
+        } catch {
+            return null
         }
     }
 
@@ -553,7 +594,10 @@ export class SignalDeviceSyncApi {
         let normalizedCount = 0
         const dedup = new Set<string>()
         for (let index = 0; index < userJids.length; index += 1) {
-            const normalizedJid = this.normalizeUserJid(userJids[index])
+            const normalizedJid = toUserJid(userJids[index], {
+                canonicalizeSignalServer: true,
+                hostDomain: this.hostDomain
+            })
             if (dedup.has(normalizedJid)) {
                 continue
             }
@@ -565,10 +609,20 @@ export class SignalDeviceSyncApi {
         return normalized
     }
 
-    private normalizeUserJid(jid: string): string {
-        return toUserJid(jid, {
-            canonicalizeSignalServer: true,
-            hostDomain: this.hostDomain
-        })
+    /**
+     * Canonicalizes a user jid, returning `null` instead of throwing when the input
+     * is not a valid jid (for example the literal `'undefined'` the server returns
+     * for an invalid contact). Lets a single malformed response node be skipped
+     * without discarding the rest of the batch.
+     */
+    private tryNormalizeUserJid(jid: string): string | null {
+        try {
+            return toUserJid(jid, {
+                canonicalizeSignalServer: true,
+                hostDomain: this.hostDomain
+            })
+        } catch {
+            return null
+        }
     }
 }

--- a/src/signal/api/SignalDeviceSyncApi.ts
+++ b/src/signal/api/SignalDeviceSyncApi.ts
@@ -230,27 +230,26 @@ export class SignalDeviceSyncApi {
     private async propagateAltUserJids(results: readonly SignalLidSyncResult[]): Promise<void> {
         if (!this.deviceListStore || results.length === 0) return
         const nowMs = Date.now()
-        const lidByPhoneJid = new Map<string, string>()
-        const phoneJids: string[] = []
+        const lidByQueriedJid = new Map<string, string>()
+        const queriedJids: string[] = []
         for (const entry of results) {
-            if (entry.lidJid && entry.phoneJid) {
-                lidByPhoneJid.set(entry.phoneJid, entry.lidJid)
-                phoneJids.push(entry.phoneJid)
+            if (entry.lidJid) {
+                lidByQueriedJid.set(entry.queriedJid, entry.lidJid)
+                queriedJids.push(entry.queriedJid)
             }
         }
-        if (phoneJids.length === 0) return
-        const existing = await this.deviceListStore.getUserDevicesBatch(phoneJids, nowMs)
+        if (queriedJids.length === 0) return
+        const existing = await this.deviceListStore.getUserDevicesBatch(queriedJids, nowMs)
         const updates: {
             readonly userJid: string
             readonly altUserJid: string
             readonly deviceJids: readonly string[]
             readonly updatedAtMs: number
         }[] = []
-        for (let index = 0; index < phoneJids.length; index += 1) {
+        for (let index = 0; index < queriedJids.length; index += 1) {
             const snapshot = existing[index]
             if (!snapshot) continue
-            const phoneJid = phoneJids[index]
-            const lidJid = lidByPhoneJid.get(phoneJid)
+            const lidJid = lidByQueriedJid.get(queriedJids[index])
             if (!lidJid || snapshot.altUserJid === lidJid) continue
             updates.push({
                 userJid: snapshot.userJid,
@@ -420,6 +419,11 @@ export class SignalDeviceSyncApi {
             readonly exists: boolean
             readonly invalid: boolean
         }[] = []
+        const lidUserErrors: {
+            readonly jid: string
+            readonly code: string | undefined
+            readonly text: string | undefined
+        }[] = []
         for (let index = 0; index < userNodes.length; index += 1) {
             const userNode = userNodes[index]
             const rawUserJid = userNode.attrs.jid
@@ -435,7 +439,7 @@ export class SignalDeviceSyncApi {
             const lidNode = findNodeChild(userNode, WA_NODE_TAGS.LID)
             const lidErrorNode = lidNode ? findNodeChild(lidNode, WA_NODE_TAGS.ERROR) : null
             if (lidErrorNode) {
-                this.logger.warn('signal lid sync user error', {
+                lidUserErrors.push({
                     jid: resolvedJid ?? rawUserJid,
                     code: lidErrorNode.attrs.code,
                     text: lidErrorNode.attrs.text
@@ -495,6 +499,13 @@ export class SignalDeviceSyncApi {
                 lidJid,
                 exists: this.parseLidSyncContactExists(contactNode, requestedKey, lidJid !== null),
                 invalid: false
+            })
+        }
+        if (lidUserErrors.length > 0) {
+            this.logger.warn('signal lid sync user errors', {
+                droppedCount: lidUserErrors.length,
+                totalExpected: requestedUsers.length,
+                sample: lidUserErrors.slice(0, 3)
             })
         }
         return parsed

--- a/src/signal/api/__tests__/api.test.ts
+++ b/src/signal/api/__tests__/api.test.ts
@@ -846,7 +846,8 @@ test('signal device sync api handles lid node user error and preserves contact e
         }
     ])
     assert.equal(warnings.length, 1)
-    assert.equal(warnings[0].message, 'signal lid sync user error')
+    assert.equal(warnings[0].message, 'signal lid sync user errors')
+    assert.equal(warnings[0].context.droppedCount, 1)
 })
 
 test('signal device sync api forces exists=false when contact node has error', async () => {

--- a/src/signal/api/__tests__/api.test.ts
+++ b/src/signal/api/__tests__/api.test.ts
@@ -49,6 +49,185 @@ function iqResult(content: BinaryNode['content']): BinaryNode {
     }
 }
 
+test('signal lid sync skips a malformed user node instead of failing the batch', async () => {
+    // the server answers an invalid contact with `<user jid='undefined'>` +
+    // `<contact type='invalid'>`; the good users in the same batch must survive
+    const debugs: string[] = []
+    const api = new SignalDeviceSyncApi({
+        logger: {
+            ...createNoopLogger(),
+            debug: (message) => {
+                debugs.push(message)
+            }
+        },
+        query: async () =>
+            iqResult([
+                {
+                    tag: WA_NODE_TAGS.USYNC,
+                    attrs: {},
+                    content: [
+                        {
+                            tag: WA_NODE_TAGS.LIST,
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: WA_NODE_TAGS.USER,
+                                    attrs: { jid: 'undefined' },
+                                    content: [
+                                        { tag: WA_NODE_TAGS.CONTACT, attrs: { type: 'invalid' } }
+                                    ]
+                                },
+                                {
+                                    tag: WA_NODE_TAGS.USER,
+                                    attrs: { jid: '5511999999999@s.whatsapp.net' },
+                                    content: [
+                                        { tag: WA_NODE_TAGS.CONTACT, attrs: { type: 'in' } },
+                                        { tag: WA_NODE_TAGS.LID, attrs: { val: '123456789@lid' } }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+    })
+
+    const result = await api.queryLidsByPhoneJids([
+        '000000000000000@s.whatsapp.net',
+        '5511999999999@s.whatsapp.net'
+    ])
+
+    // the good user resolves; the invalid input falls back to exists=false
+    assert.deepEqual(result, [
+        {
+            queriedJid: '000000000000000@s.whatsapp.net',
+            phoneJid: '000000000000000@s.whatsapp.net',
+            lidJid: null,
+            exists: false,
+            invalid: false
+        },
+        {
+            queriedJid: '5511999999999@s.whatsapp.net',
+            phoneJid: '5511999999999@s.whatsapp.net',
+            lidJid: '123456789@lid',
+            exists: true,
+            invalid: false
+        }
+    ])
+    assert.ok(debugs.includes('signal lid sync skipping user node with invalid jid'))
+})
+
+test('signal lid sync flags a server-rejected number as invalid, recovered from the contact echo', async () => {
+    const api = new SignalDeviceSyncApi({
+        logger: createNoopLogger(),
+        query: async () =>
+            iqResult([
+                {
+                    tag: WA_NODE_TAGS.USYNC,
+                    attrs: {},
+                    content: [
+                        {
+                            tag: WA_NODE_TAGS.LIST,
+                            attrs: {},
+                            content: [
+                                {
+                                    // server marks a malformed number: jid='undefined' plus a
+                                    // <contact type='invalid'> echoing the '+<number>' we sent
+                                    tag: WA_NODE_TAGS.USER,
+                                    attrs: { jid: 'undefined' },
+                                    content: [
+                                        {
+                                            tag: WA_NODE_TAGS.CONTACT,
+                                            attrs: { type: 'invalid' },
+                                            content: '+173010275315715'
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+    })
+
+    const result = await api.queryLidsByPhoneJids(['173010275315715@s.whatsapp.net'])
+    assert.deepEqual(result, [
+        {
+            queriedJid: '173010275315715@s.whatsapp.net',
+            phoneJid: '173010275315715@s.whatsapp.net',
+            lidJid: null,
+            exists: false,
+            invalid: true
+        }
+    ])
+})
+
+test('signal lid sync exposes the server-corrected number (BR 9th digit) via the contact echo', async () => {
+    // real captured response: the server collapses the two queried forms into one
+    // <user> with the canonical jid (with the 9) and echoes both queried numbers as
+    // <contact type='in'>. Both inputs must resolve, and phoneJid is the corrected form.
+    const api = new SignalDeviceSyncApi({
+        logger: createNoopLogger(),
+        query: async () =>
+            iqResult([
+                {
+                    tag: WA_NODE_TAGS.USYNC,
+                    attrs: {},
+                    content: [
+                        {
+                            tag: WA_NODE_TAGS.LIST,
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: WA_NODE_TAGS.USER,
+                                    attrs: { jid: '5511982905991@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: WA_NODE_TAGS.LID,
+                                            attrs: { country_code: 'BR', val: '53979165777985@lid' }
+                                        },
+                                        {
+                                            tag: WA_NODE_TAGS.CONTACT,
+                                            attrs: { type: 'in' },
+                                            content: '+5511982905991'
+                                        },
+                                        {
+                                            tag: WA_NODE_TAGS.CONTACT,
+                                            attrs: { type: 'in' },
+                                            content: '+551182905991'
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+    })
+
+    const result = await api.queryLidsByPhoneJids([
+        '551182905991@s.whatsapp.net',
+        '5511982905991@s.whatsapp.net'
+    ])
+    assert.deepEqual(result, [
+        {
+            // queried without the 9 -> corrected to the registered form
+            queriedJid: '551182905991@s.whatsapp.net',
+            phoneJid: '5511982905991@s.whatsapp.net',
+            lidJid: '53979165777985@lid',
+            exists: true,
+            invalid: false
+        },
+        {
+            queriedJid: '5511982905991@s.whatsapp.net',
+            phoneJid: '5511982905991@s.whatsapp.net',
+            lidJid: '53979165777985@lid',
+            exists: true,
+            invalid: false
+        }
+    ])
+})
+
 test('signal api codec decodes exact lengths and unsigned integers', () => {
     const bytes = decodeExactLength(new Uint8Array([0x01, 0x02, 0x03]), 'field', 3)
     assert.deepEqual(bytes, new Uint8Array([0x01, 0x02, 0x03]))
@@ -512,14 +691,18 @@ test('signal device sync api resolves lids by phone jids via usync and returns e
     ])
     assert.deepEqual(result, [
         {
+            queriedJid: '5511999999999@s.whatsapp.net',
             phoneJid: '5511999999999@s.whatsapp.net',
             lidJid: '123456789@lid',
-            exists: true
+            exists: true,
+            invalid: false
         },
         {
+            queriedJid: '5511888888888@s.whatsapp.net',
             phoneJid: '5511888888888@s.whatsapp.net',
             lidJid: null,
-            exists: false
+            exists: false,
+            invalid: false
         }
     ])
 
@@ -592,9 +775,11 @@ test('signal device sync api marks exists=false when contact type is out', async
     const result = await api.queryLidsByPhoneJids(['5511888888888@s.whatsapp.net'])
     assert.deepEqual(result, [
         {
+            queriedJid: '5511888888888@s.whatsapp.net',
             phoneJid: '5511888888888@s.whatsapp.net',
             lidJid: null,
-            exists: false
+            exists: false,
+            invalid: false
         }
     ])
 })
@@ -653,9 +838,11 @@ test('signal device sync api handles lid node user error and preserves contact e
     const result = await api.queryLidsByPhoneJids(['5511999999999@s.whatsapp.net'])
     assert.deepEqual(result, [
         {
+            queriedJid: '5511999999999@s.whatsapp.net',
             phoneJid: '5511999999999@s.whatsapp.net',
             lidJid: null,
-            exists: true
+            exists: true,
+            invalid: false
         }
     ])
     assert.equal(warnings.length, 1)
@@ -716,9 +903,11 @@ test('signal device sync api forces exists=false when contact node has error', a
     const result = await api.queryLidsByPhoneJids(['5511999999999@s.whatsapp.net'])
     assert.deepEqual(result, [
         {
+            queriedJid: '5511999999999@s.whatsapp.net',
             phoneJid: '5511999999999@s.whatsapp.net',
             lidJid: '123456789@lid',
-            exists: false
+            exists: false,
+            invalid: false
         }
     ])
     assert.equal(warnings.length, 1)
@@ -769,9 +958,11 @@ test('signal device sync api maps user response by pn_jid when jid differs', asy
     const result = await api.queryLidsByPhoneJids(['5511999999999@s.whatsapp.net'])
     assert.deepEqual(result, [
         {
+            queriedJid: '5511999999999@s.whatsapp.net',
             phoneJid: '5511999999999@s.whatsapp.net',
             lidJid: '123456789@lid',
-            exists: true
+            exists: true,
+            invalid: false
         }
     ])
 })


### PR DESCRIPTION
The lid usync response is matched back to the queried numbers by the `<contact>` echo each `<user>` node carries, instead of string-matching the `<user jid>`. This fixes two cases the old jid-match dropped:

- number correction (e.g. BR 9th digit): the server collapses the queried forms into one `<user>` with the canonical jid and echoes each queried number; the corrected form is now returned as `phoneJid` and the number resolves as exists instead of falling through to false.
- rejected numbers (`<user jid='undefined'>` + `<contact type='invalid'>`) are recovered from the echo and flagged, instead of one bad node throwing away the whole batch.

SignalLidSyncResult gains `queriedJid` (the queried input, so callers correlate by value not array position) and `invalid` (malformed-number flag, distinct from a valid number with no account). `normalizeUserJid` is folded into `tryNormalizeUserJid`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - LID lookup results now include the original queried number and clearly distinguish invalid numbers from numbers without accounts.
  - Server-corrected phone numbers are surfaced consistently in lookup results.

- **Bug Fixes**
  - Invalid device-sync entries no longer interrupt an entire batch.
  - Improved handling of malformed, rejected, and normalized phone identifiers.

- **Tests**
  - Added coverage for malformed entries, rejected numbers, corrected phone numbers, and expanded result fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->