### PR TITLE
fix: send ephemeralSettingTimestamp on outgoing ephemeral messages (1:1 + group)

### DIFF
--- a/packages/store-mongo/src/thread.store.ts
+++ b/packages/store-mongo/src/thread.store.ts
@@ -15,6 +15,7 @@ interface ThreadDoc {
     mute_end_ms: number | null
     marked_as_unread: boolean | null
     ephemeral_expiration: number | null
+    ephemeral_setting_timestamp: number | null
 }
 
 function docToRecord(doc: ThreadDoc): WaStoredThreadRecord {
@@ -26,7 +27,8 @@ function docToRecord(doc: ThreadDoc): WaStoredThreadRecord {
         pinned: doc.pinned ?? undefined,
         muteEndMs: doc.mute_end_ms ?? undefined,
         markedAsUnread: doc.marked_as_unread ?? undefined,
-        ephemeralExpiration: doc.ephemeral_expiration ?? undefined
+        ephemeralExpiration: doc.ephemeral_expiration ?? undefined,
+        ephemeralSettingTimestamp: doc.ephemeral_setting_timestamp ?? undefined
     }
 }
 
@@ -40,6 +42,8 @@ function buildCoalesceSet(record: WaStoredThreadRecord): Partial<ThreadDoc> {
     if (record.markedAsUnread !== undefined) set.marked_as_unread = record.markedAsUnread
     if (record.ephemeralExpiration !== undefined)
         set.ephemeral_expiration = record.ephemeralExpiration
+    if (record.ephemeralSettingTimestamp !== undefined)
+        set.ephemeral_setting_timestamp = record.ephemeralSettingTimestamp
     return set
 }
 

--- a/packages/store-mysql/src/connection.ts
+++ b/packages/store-mysql/src/connection.ts
@@ -362,6 +362,14 @@ const MIGRATIONS: readonly Migration[] = [
             ALTER TABLE \`__PREFIX__retry_inbound_counters\`
                 DROP COLUMN updated_at_ms
         `
+    },
+    {
+        name: '0018_mailbox_threads_ephemeral_setting_timestamp',
+        domain: 'mailbox',
+        sql: `
+            ALTER TABLE \`__PREFIX__mailbox_threads\`
+                ADD COLUMN ephemeral_setting_timestamp BIGINT
+        `
     }
 ]
 

--- a/packages/store-mysql/src/thread.store.ts
+++ b/packages/store-mysql/src/thread.store.ts
@@ -15,8 +15,8 @@ export class WaThreadMysqlStore extends BaseMysqlStore implements WaThreadStore 
         await this.pool.execute(
             `INSERT INTO ${this.t('mailbox_threads')} (
                 session_id, jid, name, unread_count, archived, pinned,
-                mute_end_ms, marked_as_unread, ephemeral_expiration
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                mute_end_ms, marked_as_unread, ephemeral_expiration, ephemeral_setting_timestamp
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON DUPLICATE KEY UPDATE
                 name = COALESCE(VALUES(name), name),
                 unread_count = COALESCE(VALUES(unread_count), unread_count),
@@ -24,7 +24,8 @@ export class WaThreadMysqlStore extends BaseMysqlStore implements WaThreadStore 
                 pinned = COALESCE(VALUES(pinned), pinned),
                 mute_end_ms = COALESCE(VALUES(mute_end_ms), mute_end_ms),
                 marked_as_unread = COALESCE(VALUES(marked_as_unread), marked_as_unread),
-                ephemeral_expiration = COALESCE(VALUES(ephemeral_expiration), ephemeral_expiration)`,
+                ephemeral_expiration = COALESCE(VALUES(ephemeral_expiration), ephemeral_expiration),
+                ephemeral_setting_timestamp = COALESCE(VALUES(ephemeral_setting_timestamp), ephemeral_setting_timestamp)`,
             [
                 this.sessionId,
                 record.jid,
@@ -34,7 +35,8 @@ export class WaThreadMysqlStore extends BaseMysqlStore implements WaThreadStore 
                 record.pinned ?? null,
                 record.muteEndMs ?? null,
                 record.markedAsUnread === undefined ? null : record.markedAsUnread ? 1 : 0,
-                record.ephemeralExpiration ?? null
+                record.ephemeralExpiration ?? null,
+                record.ephemeralSettingTimestamp ?? null
             ]
         )
     }
@@ -45,7 +47,7 @@ export class WaThreadMysqlStore extends BaseMysqlStore implements WaThreadStore 
             executor: { execute: PoolConnection['execute'] },
             chunk: readonly WaStoredThreadRecord[]
         ): Promise<void> => {
-            const placeholders = chunk.map(() => '(?, ?, ?, ?, ?, ?, ?, ?, ?)').join(', ')
+            const placeholders = chunk.map(() => '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)').join(', ')
             const params: MysqlParam[] = []
             for (const record of chunk) {
                 params.push(
@@ -57,13 +59,14 @@ export class WaThreadMysqlStore extends BaseMysqlStore implements WaThreadStore 
                     record.pinned ?? null,
                     record.muteEndMs ?? null,
                     record.markedAsUnread === undefined ? null : record.markedAsUnread ? 1 : 0,
-                    record.ephemeralExpiration ?? null
+                    record.ephemeralExpiration ?? null,
+                    record.ephemeralSettingTimestamp ?? null
                 )
             }
             await executor.execute(
                 `INSERT INTO ${this.t('mailbox_threads')} (
                     session_id, jid, name, unread_count, archived, pinned,
-                    mute_end_ms, marked_as_unread, ephemeral_expiration
+                    mute_end_ms, marked_as_unread, ephemeral_expiration, ephemeral_setting_timestamp
                 ) VALUES ${placeholders}
                 ON DUPLICATE KEY UPDATE
                     name = COALESCE(VALUES(name), name),
@@ -72,7 +75,8 @@ export class WaThreadMysqlStore extends BaseMysqlStore implements WaThreadStore 
                     pinned = COALESCE(VALUES(pinned), pinned),
                     mute_end_ms = COALESCE(VALUES(mute_end_ms), mute_end_ms),
                     marked_as_unread = COALESCE(VALUES(marked_as_unread), marked_as_unread),
-                    ephemeral_expiration = COALESCE(VALUES(ephemeral_expiration), ephemeral_expiration)`,
+                    ephemeral_expiration = COALESCE(VALUES(ephemeral_expiration), ephemeral_expiration),
+                    ephemeral_setting_timestamp = COALESCE(VALUES(ephemeral_setting_timestamp), ephemeral_setting_timestamp)`,
                 params
             )
         }
@@ -96,7 +100,7 @@ export class WaThreadMysqlStore extends BaseMysqlStore implements WaThreadStore 
         const row = queryFirst(
             await this.pool.execute(
                 `SELECT jid, name, unread_count, archived, pinned,
-                    mute_end_ms, marked_as_unread, ephemeral_expiration
+                    mute_end_ms, marked_as_unread, ephemeral_expiration, ephemeral_setting_timestamp
              FROM ${this.t('mailbox_threads')}
              WHERE session_id = ? AND jid = ?`,
                 [this.sessionId, jid]
@@ -112,7 +116,7 @@ export class WaThreadMysqlStore extends BaseMysqlStore implements WaThreadStore 
         return queryRows(
             await this.pool.execute(
                 `SELECT jid, name, unread_count, archived, pinned,
-                    mute_end_ms, marked_as_unread, ephemeral_expiration
+                    mute_end_ms, marked_as_unread, ephemeral_expiration, ephemeral_setting_timestamp
              FROM ${this.t('mailbox_threads')}
              WHERE session_id = ?
              LIMIT ${resolved}`,
@@ -151,6 +155,10 @@ function rowToRecord(row: MysqlRow): WaStoredThreadRecord {
         markedAsUnread:
             row.marked_as_unread === null ? undefined : Number(row.marked_as_unread) === 1,
         ephemeralExpiration:
-            row.ephemeral_expiration !== null ? Number(row.ephemeral_expiration) : undefined
+            row.ephemeral_expiration !== null ? Number(row.ephemeral_expiration) : undefined,
+        ephemeralSettingTimestamp:
+            row.ephemeral_setting_timestamp !== null
+                ? Number(row.ephemeral_setting_timestamp)
+                : undefined
     }
 }

--- a/packages/store-postgres/src/connection.ts
+++ b/packages/store-postgres/src/connection.ts
@@ -369,6 +369,13 @@ const MIGRATIONS: readonly Migration[] = [
             ALTER TABLE "__PREFIX__retry_outbound_messages" DROP COLUMN IF EXISTS created_at_ms;
             ALTER TABLE "__PREFIX__retry_inbound_counters" DROP COLUMN IF EXISTS updated_at_ms
         `
+    },
+    {
+        name: '0018_mailbox_threads_ephemeral_setting_timestamp',
+        domain: 'mailbox',
+        sql: `
+            ALTER TABLE "__PREFIX__mailbox_threads" ADD COLUMN IF NOT EXISTS ephemeral_setting_timestamp BIGINT
+        `
     }
 ]
 

--- a/packages/store-postgres/src/thread.store.ts
+++ b/packages/store-postgres/src/thread.store.ts
@@ -15,7 +15,11 @@ function rowToRecord(row: PgRow): WaStoredThreadRecord {
         muteEndMs: row.mute_end_ms !== null ? Number(row.mute_end_ms) : undefined,
         markedAsUnread: row.marked_as_unread === null ? undefined : Boolean(row.marked_as_unread),
         ephemeralExpiration:
-            row.ephemeral_expiration !== null ? Number(row.ephemeral_expiration) : undefined
+            row.ephemeral_expiration !== null ? Number(row.ephemeral_expiration) : undefined,
+        ephemeralSettingTimestamp:
+            row.ephemeral_setting_timestamp !== null
+                ? Number(row.ephemeral_setting_timestamp)
+                : undefined
     }
 }
 
@@ -27,7 +31,7 @@ export class WaThreadPgStore extends BasePgStore implements WaThreadStore {
     private upsertQuery(values: unknown[]) {
         return {
             name: this.stmtName('thread_upsert'),
-            text: `INSERT INTO ${this.t('mailbox_threads')} (session_id, jid, name, unread_count, archived, pinned, mute_end_ms, marked_as_unread, ephemeral_expiration) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT (session_id, jid) DO UPDATE SET name = COALESCE(EXCLUDED.name, ${this.t('mailbox_threads')}.name), unread_count = COALESCE(EXCLUDED.unread_count, ${this.t('mailbox_threads')}.unread_count), archived = COALESCE(EXCLUDED.archived, ${this.t('mailbox_threads')}.archived), pinned = COALESCE(EXCLUDED.pinned, ${this.t('mailbox_threads')}.pinned), mute_end_ms = COALESCE(EXCLUDED.mute_end_ms, ${this.t('mailbox_threads')}.mute_end_ms), marked_as_unread = COALESCE(EXCLUDED.marked_as_unread, ${this.t('mailbox_threads')}.marked_as_unread), ephemeral_expiration = COALESCE(EXCLUDED.ephemeral_expiration, ${this.t('mailbox_threads')}.ephemeral_expiration)`,
+            text: `INSERT INTO ${this.t('mailbox_threads')} (session_id, jid, name, unread_count, archived, pinned, mute_end_ms, marked_as_unread, ephemeral_expiration, ephemeral_setting_timestamp) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) ON CONFLICT (session_id, jid) DO UPDATE SET name = COALESCE(EXCLUDED.name, ${this.t('mailbox_threads')}.name), unread_count = COALESCE(EXCLUDED.unread_count, ${this.t('mailbox_threads')}.unread_count), archived = COALESCE(EXCLUDED.archived, ${this.t('mailbox_threads')}.archived), pinned = COALESCE(EXCLUDED.pinned, ${this.t('mailbox_threads')}.pinned), mute_end_ms = COALESCE(EXCLUDED.mute_end_ms, ${this.t('mailbox_threads')}.mute_end_ms), marked_as_unread = COALESCE(EXCLUDED.marked_as_unread, ${this.t('mailbox_threads')}.marked_as_unread), ephemeral_expiration = COALESCE(EXCLUDED.ephemeral_expiration, ${this.t('mailbox_threads')}.ephemeral_expiration), ephemeral_setting_timestamp = COALESCE(EXCLUDED.ephemeral_setting_timestamp, ${this.t('mailbox_threads')}.ephemeral_setting_timestamp)`,
             values
         }
     }
@@ -44,7 +48,8 @@ export class WaThreadPgStore extends BasePgStore implements WaThreadStore {
                 record.pinned ?? null,
                 record.muteEndMs ?? null,
                 record.markedAsUnread ?? null,
-                record.ephemeralExpiration ?? null
+                record.ephemeralExpiration ?? null,
+                record.ephemeralSettingTimestamp ?? null
             ])
         )
     }
@@ -59,8 +64,8 @@ export class WaThreadPgStore extends BasePgStore implements WaThreadStore {
             let paramIdx = 1
             const placeholders = chunk
                 .map(() => {
-                    const p = `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}, $${paramIdx + 5}, $${paramIdx + 6}, $${paramIdx + 7}, $${paramIdx + 8})`
-                    paramIdx += 9
+                    const p = `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}, $${paramIdx + 5}, $${paramIdx + 6}, $${paramIdx + 7}, $${paramIdx + 8}, $${paramIdx + 9})`
+                    paramIdx += 10
                     return p
                 })
                 .join(', ')
@@ -75,14 +80,15 @@ export class WaThreadPgStore extends BasePgStore implements WaThreadStore {
                     record.pinned ?? null,
                     record.muteEndMs ?? null,
                     record.markedAsUnread ?? null,
-                    record.ephemeralExpiration ?? null
+                    record.ephemeralExpiration ?? null,
+                    record.ephemeralSettingTimestamp ?? null
                 )
             }
             await executor.query({
                 name: this.stmtName(`thread_upsert_batch_${chunk.length}`),
                 text: `INSERT INTO ${table} (
                     session_id, jid, name, unread_count, archived, pinned,
-                    mute_end_ms, marked_as_unread, ephemeral_expiration
+                    mute_end_ms, marked_as_unread, ephemeral_expiration, ephemeral_setting_timestamp
                 ) VALUES ${placeholders}
                 ON CONFLICT (session_id, jid) DO UPDATE SET
                     name = COALESCE(EXCLUDED.name, ${table}.name),
@@ -91,7 +97,8 @@ export class WaThreadPgStore extends BasePgStore implements WaThreadStore {
                     pinned = COALESCE(EXCLUDED.pinned, ${table}.pinned),
                     mute_end_ms = COALESCE(EXCLUDED.mute_end_ms, ${table}.mute_end_ms),
                     marked_as_unread = COALESCE(EXCLUDED.marked_as_unread, ${table}.marked_as_unread),
-                    ephemeral_expiration = COALESCE(EXCLUDED.ephemeral_expiration, ${table}.ephemeral_expiration)`,
+                    ephemeral_expiration = COALESCE(EXCLUDED.ephemeral_expiration, ${table}.ephemeral_expiration),
+                    ephemeral_setting_timestamp = COALESCE(EXCLUDED.ephemeral_setting_timestamp, ${table}.ephemeral_setting_timestamp)`,
                 values: params
             })
         }
@@ -116,7 +123,7 @@ export class WaThreadPgStore extends BasePgStore implements WaThreadStore {
             await this.pool.query({
                 name: this.stmtName('thread_get_by_jid'),
                 text: `SELECT jid, name, unread_count, archived, pinned,
-                    mute_end_ms, marked_as_unread, ephemeral_expiration
+                    mute_end_ms, marked_as_unread, ephemeral_expiration, ephemeral_setting_timestamp
              FROM ${this.t('mailbox_threads')}
              WHERE session_id = $1 AND jid = $2`,
                 values: [this.sessionId, jid]
@@ -133,7 +140,7 @@ export class WaThreadPgStore extends BasePgStore implements WaThreadStore {
             await this.pool.query({
                 name: this.stmtName('thread_list'),
                 text: `SELECT jid, name, unread_count, archived, pinned,
-                    mute_end_ms, marked_as_unread, ephemeral_expiration
+                    mute_end_ms, marked_as_unread, ephemeral_expiration, ephemeral_setting_timestamp
              FROM ${this.t('mailbox_threads')}
              WHERE session_id = $1
              LIMIT $2`,

--- a/packages/store-redis/src/thread.store.ts
+++ b/packages/store-redis/src/thread.store.ts
@@ -76,22 +76,11 @@ export class WaThreadRedisStore extends BaseRedisStore implements WaThreadStore 
         const newFields = recordToHash(record)
 
         if (existing && Object.keys(existing).length > 0) {
+            // Partial upserts (archive, pin, mark-read) omit ephemeral fields.
+            // Retain previously persisted values, matching SQL COALESCE behavior.
             const merged: Record<string, string> = { ...existing }
             for (const [field, value] of Object.entries(newFields)) {
                 merged[field] = value
-            }
-            // When a field is absent from the incoming record, the merge retains
-            // the previously-persisted value. Explicitly delete the ephemeral keys
-            // so a chat that just disabled disappearing mode does not keep a stale
-            // timestamp (causing the peer to warn "message will not disappear").
-            if (
-                record.ephemeralSettingTimestamp === undefined &&
-                'ephemeral_setting_timestamp' in merged
-            ) {
-                delete merged.ephemeral_setting_timestamp
-            }
-            if (record.ephemeralExpiration === undefined && 'ephemeral_expiration' in merged) {
-                delete merged.ephemeral_expiration
             }
             await this.redis.hset(key, merged)
         } else {

--- a/packages/store-redis/src/thread.store.ts
+++ b/packages/store-redis/src/thread.store.ts
@@ -20,6 +20,10 @@ function hashToRecord(data: Record<string, string>): WaStoredThreadRecord {
         ephemeralExpiration:
             toStringOrNull(data.ephemeral_expiration) !== null
                 ? Number(data.ephemeral_expiration)
+                : undefined,
+        ephemeralSettingTimestamp:
+            toStringOrNull(data.ephemeral_setting_timestamp) !== null
+                ? Number(data.ephemeral_setting_timestamp)
                 : undefined
     }
 }
@@ -50,6 +54,9 @@ function recordToHash(record: WaStoredThreadRecord): Record<string, string> {
     if (record.ephemeralExpiration !== undefined) {
         fields.ephemeral_expiration = String(record.ephemeralExpiration)
     }
+    if (record.ephemeralSettingTimestamp !== undefined) {
+        fields.ephemeral_setting_timestamp = String(record.ephemeralSettingTimestamp)
+    }
 
     return fields
 }
@@ -72,6 +79,19 @@ export class WaThreadRedisStore extends BaseRedisStore implements WaThreadStore 
             const merged: Record<string, string> = { ...existing }
             for (const [field, value] of Object.entries(newFields)) {
                 merged[field] = value
+            }
+            // When a field is absent from the incoming record, the merge retains
+            // the previously-persisted value. Explicitly delete the ephemeral keys
+            // so a chat that just disabled disappearing mode does not keep a stale
+            // timestamp (causing the peer to warn "message will not disappear").
+            if (
+                record.ephemeralSettingTimestamp === undefined &&
+                'ephemeral_setting_timestamp' in merged
+            ) {
+                delete merged.ephemeral_setting_timestamp
+            }
+            if (record.ephemeralExpiration === undefined && 'ephemeral_expiration' in merged) {
+                delete merged.ephemeral_expiration
             }
             await this.redis.hset(key, merged)
         } else {

--- a/packages/store-redis/src/thread.store.ts
+++ b/packages/store-redis/src/thread.store.ts
@@ -76,8 +76,6 @@ export class WaThreadRedisStore extends BaseRedisStore implements WaThreadStore 
         const newFields = recordToHash(record)
 
         if (existing && Object.keys(existing).length > 0) {
-            // Partial upserts (archive, pin, mark-read) omit ephemeral fields.
-            // Retain previously persisted values, matching SQL COALESCE behavior.
             const merged: Record<string, string> = { ...existing }
             for (const [field, value] of Object.entries(newFields)) {
                 merged[field] = value

--- a/packages/store-sqlite/src/migrations.ts
+++ b/packages/store-sqlite/src/migrations.ts
@@ -424,6 +424,19 @@ const SQLITE_MIGRATIONS: readonly WaSqliteMigration[] = [
                 ALTER TABLE retry_inbound_counters DROP COLUMN updated_at_ms;
             `)
         }
+    },
+    {
+        id: '0017_mailbox_threads_ephemeral_setting_timestamp',
+        domain: 'mailbox',
+        up: (db) => {
+            // Ephemeral disappear timestamps come from the app-state Conversation
+            // record and must be persisted so outgoing ephemeral messages carry
+            // contextInfo.ephemeralSettingTimestamp (otherwise the peer shows a
+            // "message will not disappear" warning).
+            db.exec(`
+                ALTER TABLE mailbox_threads ADD COLUMN ephemeral_setting_timestamp INTEGER;
+            `)
+        }
     }
 ]
 

--- a/packages/store-sqlite/src/migrations.ts
+++ b/packages/store-sqlite/src/migrations.ts
@@ -429,10 +429,6 @@ const SQLITE_MIGRATIONS: readonly WaSqliteMigration[] = [
         id: '0017_mailbox_threads_ephemeral_setting_timestamp',
         domain: 'mailbox',
         up: (db) => {
-            // Ephemeral disappear timestamps come from the app-state Conversation
-            // record and must be persisted so outgoing ephemeral messages carry
-            // contextInfo.ephemeralSettingTimestamp (otherwise the peer shows a
-            // "message will not disappear" warning).
             db.exec(`
                 ALTER TABLE mailbox_threads ADD COLUMN ephemeral_setting_timestamp INTEGER;
             `)

--- a/packages/store-sqlite/src/thread.store.ts
+++ b/packages/store-sqlite/src/thread.store.ts
@@ -12,7 +12,7 @@ import type { WaSqliteConnection } from './connection'
 import type { WaSqliteStorageOptions } from './types'
 
 const THREAD_COLUMNS =
-    'jid, name, unread_count, archived, pinned, mute_end_ms, marked_as_unread, ephemeral_expiration'
+    'jid, name, unread_count, archived, pinned, mute_end_ms, marked_as_unread, ephemeral_expiration, ephemeral_setting_timestamp'
 
 interface ThreadRow extends Record<string, unknown> {
     readonly jid: unknown
@@ -23,6 +23,7 @@ interface ThreadRow extends Record<string, unknown> {
     readonly mute_end_ms: unknown
     readonly marked_as_unread: unknown
     readonly ephemeral_expiration: unknown
+    readonly ephemeral_setting_timestamp: unknown
 }
 
 function decodeThreadRow(row: ThreadRow): WaStoredThreadRecord {
@@ -37,6 +38,10 @@ function decodeThreadRow(row: ThreadRow): WaStoredThreadRecord {
         ephemeralExpiration: asOptionalNumber(
             row.ephemeral_expiration,
             'mailbox_threads.ephemeral_expiration'
+        ),
+        ephemeralSettingTimestamp: asOptionalNumber(
+            row.ephemeral_setting_timestamp,
+            'mailbox_threads.ephemeral_setting_timestamp'
         )
     }
 }
@@ -109,8 +114,8 @@ export class WaThreadSqliteStore extends BaseSqliteStore implements Contract {
         db.run(
             `INSERT INTO mailbox_threads (
                 session_id, jid, name, unread_count, archived, pinned,
-                mute_end_ms, marked_as_unread, ephemeral_expiration
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                mute_end_ms, marked_as_unread, ephemeral_expiration, ephemeral_setting_timestamp
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(session_id, jid) DO UPDATE SET
                 name=COALESCE(excluded.name, mailbox_threads.name),
                 unread_count=COALESCE(excluded.unread_count, mailbox_threads.unread_count),
@@ -118,7 +123,8 @@ export class WaThreadSqliteStore extends BaseSqliteStore implements Contract {
                 pinned=COALESCE(excluded.pinned, mailbox_threads.pinned),
                 mute_end_ms=COALESCE(excluded.mute_end_ms, mailbox_threads.mute_end_ms),
                 marked_as_unread=COALESCE(excluded.marked_as_unread, mailbox_threads.marked_as_unread),
-                ephemeral_expiration=COALESCE(excluded.ephemeral_expiration, mailbox_threads.ephemeral_expiration)`,
+                ephemeral_expiration=COALESCE(excluded.ephemeral_expiration, mailbox_threads.ephemeral_expiration),
+                ephemeral_setting_timestamp=COALESCE(excluded.ephemeral_setting_timestamp, mailbox_threads.ephemeral_setting_timestamp)`,
             [
                 this.options.sessionId,
                 record.jid,
@@ -128,7 +134,8 @@ export class WaThreadSqliteStore extends BaseSqliteStore implements Contract {
                 record.pinned ?? null,
                 record.muteEndMs ?? null,
                 record.markedAsUnread === undefined ? null : record.markedAsUnread ? 1 : 0,
-                record.ephemeralExpiration ?? null
+                record.ephemeralExpiration ?? null,
+                record.ephemeralSettingTimestamp ?? null
             ]
         )
     }

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -17,6 +17,7 @@ import type { WaPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordin
 import type { WaProfileCoordinator } from '@client/coordinators/WaProfileCoordinator'
 import type { WaStatusCoordinator } from '@client/coordinators/WaStatusCoordinator'
 import { createIgnoreKeyFilter, validateIgnoreKey } from '@client/messaging/ignore-key'
+import { persistIncomingEphemeralSetting } from '@client/persistence/ephemeral-setting'
 import { runGroupHistoryBundle } from '@client/persistence/group-history'
 import { runHistorySyncNotification } from '@client/persistence/history-sync'
 import { persistIncomingMailboxEntities } from '@client/persistence/mailbox'
@@ -375,6 +376,16 @@ class WaClientImpl extends EventEmitter {
                 } else if (sendHistSyncReceipt) {
                     await sendHistSyncReceipt()
                 }
+                return
+            }
+
+            if (protocolType === proto.Message.ProtocolMessage.Type.EPHEMERAL_SETTING) {
+                persistIncomingEphemeralSetting({
+                    logger: this.logger,
+                    writeBehind: this.writeBehind,
+                    event,
+                    protocolMessage
+                })
                 return
             }
 

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -769,6 +769,7 @@ export function buildWaClientDependencies(input: {
         sessionStore: sessionStore.session,
         identityStore: sessionStore.identity,
         deviceListStore: sessionStore.deviceList,
+        threadStore: sessionStore.threads,
         signalDeviceSync,
         messageSecretStore: sessionStore.messageSecret,
         persistAllMessageSecrets: options.addons?.persistAllSecrets === true,

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -53,6 +53,7 @@ import type {
 import type { WaMessageClient } from '@message/WaMessageClient'
 import { proto, type Proto } from '@proto'
 import {
+    normalizeEphemeralSettingSeconds,
     WA_ADDRESSING_MODES,
     WA_DEFAULTS,
     WA_NACK_REASONS,
@@ -240,13 +241,6 @@ interface WaOutboundEnvelope {
     readonly sendOptions: WaSendMessageOptions
 }
 
-/** Values above ~year 2286 in seconds are treated as legacy millisecond rows. */
-const EPHEMERAL_SETTING_MS_THRESHOLD = 10_000_000_000
-
-function normalizeEphemeralSettingUnixSeconds(value: number): number {
-    return value > EPHEMERAL_SETTING_MS_THRESHOLD ? Math.floor(value / 1000) : value
-}
-
 export class WaMessageDispatchCoordinator {
     private readonly deps: WaMessageDispatchCoordinatorOptions
     private readonly mobileMessageIdFormat: () => boolean
@@ -262,30 +256,17 @@ export class WaMessageDispatchCoordinator {
     }
 
     /**
-     * Resolves disappearing-message fields for an outgoing send into a chat with
-     * disappearing-mode on.
-     *
-     * - Groups: `expiration` only, from the group metadata cache. Groups do not
-     *   carry `ephemeralSettingTimestamp` on the wire (a disappearing group
-     *   reports `0`), so the thread store is not consulted.
-     * - 1:1: `expiration` + `ephemeralSettingTimestamp` from the thread store
-     *   (app-state `Conversation` record, stored as Unix seconds).
-     *
-     * Returns an empty object when nothing resolvable is found.
+     * Disappearing-message fields for a send into a chat with the mode on, or
+     * `{}` when nothing resolves. Groups get `expiration` only – their trigger
+     * lives in the group metadata, which the cached snapshot does not carry.
      */
-    private async resolveChatEphemeral(
-        recipientJid: string,
-        base: WaSendContextInfo | undefined
-    ): Promise<Partial<WaSendContextInfo>> {
+    private async resolveChatEphemeral(recipientJid: string): Promise<Partial<WaSendContextInfo>> {
         if (isGroupJid(recipientJid)) {
             const cached = await this.deps.groupMetadataCache.resolveEphemeral(recipientJid)
             if (!cached || cached <= 0) {
                 return {}
             }
-            return {
-                expirationSeconds: cached,
-                disappearingModeTrigger: 1
-            }
+            return { expirationSeconds: cached }
         }
 
         const thread = await this.deps.threadStore.getByJid(recipientJid)
@@ -293,19 +274,15 @@ export class WaMessageDispatchCoordinator {
         if (expiration === undefined || expiration <= 0) {
             return {}
         }
-        const rawTimestamp = base?.ephemeralSettingTimestamp ?? thread?.ephemeralSettingTimestamp
-        // Only set when defined: an explicit content/options-level
-        // ephemeralSettingTimestamp must not be clobbered by `undefined`.
-        // Guard against legacy rows still stored in milliseconds (Conversation wire).
-        const resolvedTimestamp =
-            rawTimestamp !== undefined
-                ? normalizeEphemeralSettingUnixSeconds(rawTimestamp)
-                : undefined
+        const stored = thread?.ephemeralSettingTimestamp
+        const settingTimestamp =
+            stored !== undefined ? normalizeEphemeralSettingSeconds(stored) : undefined
         return {
             expirationSeconds: expiration,
-            disappearingModeTrigger: 1,
-            ...(resolvedTimestamp !== undefined
-                ? { ephemeralSettingTimestamp: resolvedTimestamp }
+            disappearingModeInitiator: proto.DisappearingMode.Initiator.CHANGED_IN_CHAT,
+            disappearingModeTrigger: proto.DisappearingMode.Trigger.CHAT_SETTING,
+            ...(settingTimestamp !== undefined
+                ? { ephemeralSettingTimestamp: settingTimestamp }
                 : {})
         }
     }
@@ -483,13 +460,19 @@ export class WaMessageDispatchCoordinator {
                 ephemeralSettingTimestamp: options.ephemeralSettingTimestamp
             }
         }
+        if (options.disappearingModeTrigger !== undefined) {
+            optionsCtx = {
+                ...optionsCtx,
+                disappearingModeTrigger: options.disappearingModeTrigger
+            }
+        }
         if (
             optionsCtx?.expirationSeconds === undefined &&
             !options.disableGroupEphemeralAutoInject
         ) {
             optionsCtx = {
-                ...optionsCtx,
-                ...(await this.resolveChatEphemeral(recipientJid, optionsCtx))
+                ...(await this.resolveChatEphemeral(recipientJid)),
+                ...optionsCtx
             }
         }
         const ctx = resolveSendContextInfo({

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -450,6 +450,9 @@ export class WaMessageDispatchCoordinator {
                 this.withResolvedMessageId(options)
             ])
         }
+        const directRecipientJid = isGroupJid(recipientJid)
+            ? recipientJid
+            : await this.resolveDirectRecipientLid(toUserJid(recipientJid))
         let optionsCtx = options.contextInfo
         if (options.expirationSeconds !== undefined) {
             optionsCtx = { ...optionsCtx, expirationSeconds: options.expirationSeconds }
@@ -471,7 +474,7 @@ export class WaMessageDispatchCoordinator {
             !options.disableGroupEphemeralAutoInject
         ) {
             optionsCtx = {
-                ...(await this.resolveChatEphemeral(recipientJid)),
+                ...(await this.resolveChatEphemeral(directRecipientJid)),
                 ...optionsCtx
             }
         }
@@ -610,9 +613,6 @@ export class WaMessageDispatchCoordinator {
             sendOptions
         }
 
-        const directRecipientJid = isGroup
-            ? recipientJid
-            : await this.resolveDirectRecipientLid(toUserJid(recipientJid))
         const peerRecipientPn = isGroup
             ? undefined
             : await this.resolvePeerRecipientPn(toUserJid(recipientJid), directRecipientJid)

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -282,7 +282,10 @@ export class WaMessageDispatchCoordinator {
             if (!cached || cached <= 0) {
                 return {}
             }
-            return { expirationSeconds: cached }
+            return {
+                expirationSeconds: cached,
+                disappearingModeTrigger: 1
+            }
         }
 
         const thread = await this.deps.threadStore.getByJid(recipientJid)
@@ -300,6 +303,7 @@ export class WaMessageDispatchCoordinator {
                 : undefined
         return {
             expirationSeconds: expiration,
+            disappearingModeTrigger: 1,
             ...(resolvedTimestamp !== undefined
                 ? { ephemeralSettingTimestamp: resolvedTimestamp }
                 : {})

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -85,6 +85,7 @@ import type { WaIdentityStore } from '@store/contracts/identity.store'
 import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
 import type { WaSessionStore } from '@store/contracts/session.store'
 import type { WaSignalStore } from '@store/contracts/signal.store'
+import type { WaThreadStore } from '@store/contracts/thread.store'
 import { encodeBinaryNode } from '@transport/binary'
 import {
     buildButtonAddonNode,
@@ -121,6 +122,7 @@ interface WaMessageDispatchCoordinatorOptions {
     readonly sessionStore: WaSessionStore
     readonly identityStore: WaIdentityStore
     readonly deviceListStore: WaDeviceListStore
+    readonly threadStore: WaThreadStore
     readonly signalDeviceSync: SignalDeviceSyncApi
     readonly messageSecretStore: WaMessageSecretStore
     /**
@@ -250,6 +252,42 @@ export class WaMessageDispatchCoordinator {
         this.deps = options
         this.mobileMessageIdFormat = options.mobileMessageIdFormat ?? (() => false)
         this.serverClock = options.serverClock
+    }
+
+    /**
+     * Resolves the disappearing-message (`expiration` + `ephemeralSettingTimestamp`)
+     * pair for an outgoing message to a chat with disappearing-mode on. Covers both
+     * 1:1 and group chats: for groups the TTL comes from the group metadata cache,
+     * for 1:1 it comes from the thread store, and the setting timestamp always comes
+     * from the thread store (the app-state `Conversation` record). Returns an empty
+     * object when nothing resolvable is found or the values are absent.
+     */
+    private async resolveChatEphemeral(
+        recipientJid: string,
+        base: WaSendContextInfo | undefined
+    ): Promise<Partial<WaSendContextInfo>> {
+        let expiration: number | null = null
+        if (isGroupJid(recipientJid)) {
+            const cached = await this.deps.groupMetadataCache.resolveEphemeral(recipientJid)
+            expiration = cached && cached > 0 ? cached : null
+        }
+        const thread = await this.deps.threadStore.getByJid(recipientJid)
+        if (expiration === null && !isGroupJid(recipientJid) && thread?.ephemeralExpiration) {
+            expiration = thread.ephemeralExpiration
+        }
+        if (expiration === null || expiration <= 0) {
+            return {}
+        }
+        const resolvedTimestamp =
+            base?.ephemeralSettingTimestamp ?? thread?.ephemeralSettingTimestamp
+        return {
+            expirationSeconds: expiration,
+            // Only set when defined: an explicit content/options-level
+            // ephemeralSettingTimestamp must not be clobbered by `undefined`.
+            ...(resolvedTimestamp !== undefined
+                ? { ephemeralSettingTimestamp: resolvedTimestamp }
+                : {})
+        }
     }
 
     public async publishMessageNode(
@@ -419,15 +457,19 @@ export class WaMessageDispatchCoordinator {
         if (options.expirationSeconds !== undefined) {
             optionsCtx = { ...optionsCtx, expirationSeconds: options.expirationSeconds }
         }
+        if (options.ephemeralSettingTimestamp !== undefined) {
+            optionsCtx = {
+                ...optionsCtx,
+                ephemeralSettingTimestamp: options.ephemeralSettingTimestamp
+            }
+        }
         if (
-            isGroupJid(recipientJid) &&
             optionsCtx?.expirationSeconds === undefined &&
             !options.disableGroupEphemeralAutoInject
         ) {
-            const cachedEphemeral =
-                await this.deps.groupMetadataCache.resolveEphemeral(recipientJid)
-            if (cachedEphemeral !== null && cachedEphemeral > 0) {
-                optionsCtx = { ...optionsCtx, expirationSeconds: cachedEphemeral }
+            optionsCtx = {
+                ...optionsCtx,
+                ...(await this.resolveChatEphemeral(recipientJid, optionsCtx))
             }
         }
         const ctx = resolveSendContextInfo({

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -240,6 +240,13 @@ interface WaOutboundEnvelope {
     readonly sendOptions: WaSendMessageOptions
 }
 
+/** Values above ~year 2286 in seconds are treated as legacy millisecond rows. */
+const EPHEMERAL_SETTING_MS_THRESHOLD = 10_000_000_000
+
+function normalizeEphemeralSettingUnixSeconds(value: number): number {
+    return value > EPHEMERAL_SETTING_MS_THRESHOLD ? Math.floor(value / 1000) : value
+}
+
 export class WaMessageDispatchCoordinator {
     private readonly deps: WaMessageDispatchCoordinatorOptions
     private readonly mobileMessageIdFormat: () => boolean
@@ -255,35 +262,45 @@ export class WaMessageDispatchCoordinator {
     }
 
     /**
-     * Resolves the disappearing-message (`expiration` + `ephemeralSettingTimestamp`)
-     * pair for an outgoing message to a chat with disappearing-mode on. Covers both
-     * 1:1 and group chats: for groups the TTL comes from the group metadata cache,
-     * for 1:1 it comes from the thread store, and the setting timestamp always comes
-     * from the thread store (the app-state `Conversation` record). Returns an empty
-     * object when nothing resolvable is found or the values are absent.
+     * Resolves disappearing-message fields for an outgoing send into a chat with
+     * disappearing-mode on.
+     *
+     * - Groups: `expiration` only, from the group metadata cache. Groups do not
+     *   carry `ephemeralSettingTimestamp` on the wire (a disappearing group
+     *   reports `0`), so the thread store is not consulted.
+     * - 1:1: `expiration` + `ephemeralSettingTimestamp` from the thread store
+     *   (app-state `Conversation` record, stored as Unix seconds).
+     *
+     * Returns an empty object when nothing resolvable is found.
      */
     private async resolveChatEphemeral(
         recipientJid: string,
         base: WaSendContextInfo | undefined
     ): Promise<Partial<WaSendContextInfo>> {
-        let expiration: number | null = null
         if (isGroupJid(recipientJid)) {
             const cached = await this.deps.groupMetadataCache.resolveEphemeral(recipientJid)
-            expiration = cached && cached > 0 ? cached : null
+            if (!cached || cached <= 0) {
+                return {}
+            }
+            return { expirationSeconds: cached }
         }
+
         const thread = await this.deps.threadStore.getByJid(recipientJid)
-        if (expiration === null && !isGroupJid(recipientJid) && thread?.ephemeralExpiration) {
-            expiration = thread.ephemeralExpiration
-        }
-        if (expiration === null || expiration <= 0) {
+        const expiration = thread?.ephemeralExpiration
+        if (expiration === undefined || expiration <= 0) {
             return {}
         }
-        const resolvedTimestamp =
+        const rawTimestamp =
             base?.ephemeralSettingTimestamp ?? thread?.ephemeralSettingTimestamp
+        // Only set when defined: an explicit content/options-level
+        // ephemeralSettingTimestamp must not be clobbered by `undefined`.
+        // Guard against legacy rows still stored in milliseconds (Conversation wire).
+        const resolvedTimestamp =
+            rawTimestamp !== undefined
+                ? normalizeEphemeralSettingUnixSeconds(rawTimestamp)
+                : undefined
         return {
             expirationSeconds: expiration,
-            // Only set when defined: an explicit content/options-level
-            // ephemeralSettingTimestamp must not be clobbered by `undefined`.
             ...(resolvedTimestamp !== undefined
                 ? { ephemeralSettingTimestamp: resolvedTimestamp }
                 : {})

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -290,8 +290,7 @@ export class WaMessageDispatchCoordinator {
         if (expiration === undefined || expiration <= 0) {
             return {}
         }
-        const rawTimestamp =
-            base?.ephemeralSettingTimestamp ?? thread?.ephemeralSettingTimestamp
+        const rawTimestamp = base?.ephemeralSettingTimestamp ?? thread?.ephemeralSettingTimestamp
         // Only set when defined: an explicit content/options-level
         // ephemeralSettingTimestamp must not be clobbered by `undefined`.
         // Guard against legacy rows still stored in milliseconds (Conversation wire).

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -21,16 +21,31 @@ import type {
 } from '@client/types'
 import { createNoopLogger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
+import { getContextInfo } from '@message/context-info'
 import {
     WA_APP_STATE_COLLECTION_STATES,
     WA_CONNECTION_REASONS,
     WA_DISCONNECT_REASONS,
     WA_STREAM_SIGNALING
 } from '@protocol/constants'
+import type { WaStoredThreadRecord, WaThreadStore } from '@store/contracts/thread.store'
 import { WaGroupMetadataMemoryStore } from '@store/memory/group-metadata.store'
 import { WaMessageMemoryStore } from '@store/memory/message.store'
 import type { BinaryNode } from '@transport/types'
 import type { ServerClock } from '@util/clock'
+
+function createStubThreadStore(
+    records: ReadonlyMap<string, WaStoredThreadRecord> = new Map()
+): WaThreadStore {
+    return {
+        upsert: async () => undefined,
+        upsertBatch: async () => undefined,
+        getByJid: async (jid: string) => records.get(jid) ?? null,
+        list: async () => [...records.values()],
+        deleteByJid: async () => 0,
+        clear: async () => undefined
+    }
+}
 
 function fakeSyncImpl(impl: (options?: WaAppStateSyncOptions) => Promise<WaAppStateSyncResult>) {
     return {
@@ -124,6 +139,7 @@ function createMessageDispatchCoordinator(
             ) => Promise<{ readonly lidJid: string | null; readonly pnJid: string | null }>
         }
         readonly emitMessageSend?: (event: WaOutgoingMessageEvent) => void
+        readonly threadStore?: WaThreadStore
     }
 ): WaMessageDispatchCoordinator {
     const groupMetadataCache = createGroupMetadataCache({
@@ -148,6 +164,7 @@ function createMessageDispatchCoordinator(
         sessionStore: {} as never,
         identityStore: {} as never,
         deviceListStore: {} as never,
+        threadStore: overrides?.threadStore ?? createStubThreadStore(),
         signalDeviceSync: (overrides?.signalDeviceSync ?? {}) as never,
         messageSecretStore: {
             set: async (_id: string, _entry: { secret: Uint8Array; senderJid: string }) => {}
@@ -1589,6 +1606,119 @@ test('passive tasks coordinator requeues remaining receipts on transient error',
     assert.ok(requeuedIds.includes('r1'), 'transient-failed receipt should be requeued')
     assert.ok(requeuedIds.includes('r4'), 'unsent receipts from next batch should be requeued')
     assert.ok(requeuedIds.includes('r5'), 'unsent receipts from next batch should be requeued')
+})
+
+test('message dispatch injects ephemeral expiration + timestamp for 1:1 chats', async () => {
+    const events: WaOutgoingMessageEvent[] = []
+    const threadStore = createStubThreadStore(
+        new Map<string, WaStoredThreadRecord>([
+            [
+                '5511999999999@s.whatsapp.net',
+                {
+                    jid: '5511999999999@s.whatsapp.net',
+                    ephemeralExpiration: 86_400,
+                    ephemeralSettingTimestamp: 1_751_808_692
+                }
+            ]
+        ])
+    )
+    const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore(), {
+        meJid: '5511000000000@s.whatsapp.net',
+        emitMessageSend: (event) => events.push(event),
+        threadStore
+    })
+    await coordinator
+        .sendMessage('5511999999999@s.whatsapp.net', { text: 'oi' } as never, {})
+        .catch(() => undefined)
+    assert.equal(events.length, 1)
+    const ctx = getContextInfo(events[0].message)
+    assert.ok(ctx)
+    assert.equal(ctx.expiration, 86_400)
+    assert.equal(ctx.ephemeralSettingTimestamp, 1_751_808_692)
+})
+
+test('message dispatch injects ephemeral expiration + timestamp for group chats', async () => {
+    const events: WaOutgoingMessageEvent[] = []
+    const groupMetadataStore = new WaGroupMetadataMemoryStore(60_000)
+    // Group TTL flows from the group metadata cache; the setting timestamp
+    // always comes from the thread store (app-state Conversation record).
+    const threadStore = createStubThreadStore(
+        new Map<string, WaStoredThreadRecord>([
+            [
+                '120@g.us',
+                {
+                    jid: '120@g.us',
+                    ephemeralSettingTimestamp: 1_751_808_692
+                }
+            ]
+        ])
+    )
+    const coordinator = createMessageDispatchCoordinator(groupMetadataStore, {
+        meJid: '5511000000000@s.whatsapp.net',
+        emitMessageSend: (event) => events.push(event),
+        threadStore
+    })
+    await groupMetadataStore.upsertGroupMetadata({
+        groupJid: '120@g.us',
+        participants: [],
+        updatedAtMs: Date.now(),
+        ephemeral: 60_480
+    })
+    await coordinator.sendMessage('120@g.us', { text: 'oi' } as never, {}).catch(() => undefined)
+    assert.equal(events.length, 1)
+    const ctx = getContextInfo(events[0].message)
+    assert.ok(ctx)
+    assert.equal(ctx.expiration, 60_480)
+    assert.equal(ctx.ephemeralSettingTimestamp, 1_751_808_692)
+    await groupMetadataStore.destroy()
+})
+
+test('message dispatch honors explicit options.ephemeralSettingTimestamp override', async () => {
+    const events: WaOutgoingMessageEvent[] = []
+    const threadStore = createStubThreadStore(
+        new Map<string, WaStoredThreadRecord>([
+            [
+                '5511999999999@s.whatsapp.net',
+                {
+                    jid: '5511999999999@s.whatsapp.net',
+                    ephemeralExpiration: 86_400,
+                    ephemeralSettingTimestamp: 1_751_808_692
+                }
+            ]
+        ])
+    )
+    const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore(), {
+        meJid: '5511000000000@s.whatsapp.net',
+        emitMessageSend: (event) => events.push(event),
+        threadStore
+    })
+    await coordinator
+        .sendMessage('5511999999999@s.whatsapp.net', { text: 'oi' } as never, {
+            expirationSeconds: 604_800,
+            ephemeralSettingTimestamp: 1_700_000_000
+        })
+        .catch(() => undefined)
+    assert.equal(events.length, 1)
+    const ctx = getContextInfo(events[0].message)
+    assert.ok(ctx)
+    assert.equal(ctx.expiration, 604_800)
+    assert.equal(ctx.ephemeralSettingTimestamp, 1_700_000_000)
+})
+
+test('message dispatch skips ephemeral fields when chat has no disappearing mode', async () => {
+    const events: WaOutgoingMessageEvent[] = []
+    const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore(), {
+        meJid: '5511000000000@s.whatsapp.net',
+        emitMessageSend: (event) => events.push(event),
+        threadStore: createStubThreadStore()
+    })
+    await coordinator
+        .sendMessage('5511999999999@s.whatsapp.net', { text: 'oi' } as never, {})
+        .catch(() => undefined)
+    assert.equal(events.length, 1)
+    const ctx = getContextInfo(events[0].message)
+    assert.equal(ctx?.expiration, undefined)
+    assert.equal(ctx?.ephemeralSettingTimestamp, undefined)
 })
 
 test('passive tasks coordinator drops non-retryable receipt errors without stopping', async () => {

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -7,20 +7,23 @@ import type {
     WaAppStateSyncOptions,
     WaAppStateSyncResult
 } from '@appstate/types'
-import { WaAppStateMutationCoordinator } from '@client/coordinators/WaAppStateMutationCoordinator'
-import { WaIncomingNodeCoordinator } from '@client/coordinators/WaIncomingNodeCoordinator'
-import { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
-import { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTasksCoordinator'
-import { createStreamControlHandler } from '@client/coordinators/WaStreamControlCoordinator'
-import { createGroupMetadataCache } from '@client/messaging/group-metadata'
 import type {
     WaAppStateMutationEvent,
     WaGroupEvent,
     WaGroupEventAction,
     WaOutgoingMessageEvent
 } from '@client/types'
-import { createNoopLogger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
+import type { WaStoredThreadRecord, WaThreadStore } from '@store/contracts/thread.store'
+import type { BinaryNode } from '@transport/types'
+import type { ServerClock } from '@util/clock'
+import { WaAppStateMutationCoordinator } from '@client/coordinators/WaAppStateMutationCoordinator'
+import { WaIncomingNodeCoordinator } from '@client/coordinators/WaIncomingNodeCoordinator'
+import { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
+import { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTasksCoordinator'
+import { createStreamControlHandler } from '@client/coordinators/WaStreamControlCoordinator'
+import { createGroupMetadataCache } from '@client/messaging/group-metadata'
+import { createNoopLogger } from '@infra/log/types'
 import { getContextInfo } from '@message/context-info'
 import {
     WA_APP_STATE_COLLECTION_STATES,
@@ -28,11 +31,8 @@ import {
     WA_DISCONNECT_REASONS,
     WA_STREAM_SIGNALING
 } from '@protocol/constants'
-import type { WaStoredThreadRecord, WaThreadStore } from '@store/contracts/thread.store'
 import { WaGroupMetadataMemoryStore } from '@store/memory/group-metadata.store'
 import { WaMessageMemoryStore } from '@store/memory/message.store'
-import type { BinaryNode } from '@transport/types'
-import type { ServerClock } from '@util/clock'
 
 function createStubThreadStore(
     records: ReadonlyMap<string, WaStoredThreadRecord> = new Map()
@@ -1637,26 +1637,25 @@ test('message dispatch injects ephemeral expiration + timestamp for 1:1 chats', 
     assert.equal(ctx.ephemeralSettingTimestamp, 1_751_808_692)
 })
 
-test('message dispatch injects ephemeral expiration + timestamp for group chats', async () => {
+test('message dispatch injects ephemeral expiration only for group chats', async () => {
     const events: WaOutgoingMessageEvent[] = []
     const groupMetadataStore = new WaGroupMetadataMemoryStore(60_000)
-    // Group TTL flows from the group metadata cache; the setting timestamp
-    // always comes from the thread store (app-state Conversation record).
-    const threadStore = createStubThreadStore(
-        new Map<string, WaStoredThreadRecord>([
-            [
-                '120@g.us',
-                {
-                    jid: '120@g.us',
-                    ephemeralSettingTimestamp: 1_751_808_692
-                }
-            ]
-        ])
-    )
+    // Groups send expiration from the metadata cache and never carry
+    // ephemeralSettingTimestamp, so the thread store is not consulted.
     const coordinator = createMessageDispatchCoordinator(groupMetadataStore, {
         meJid: '5511000000000@s.whatsapp.net',
         emitMessageSend: (event) => events.push(event),
-        threadStore
+        threadStore: createStubThreadStore(
+            new Map<string, WaStoredThreadRecord>([
+                [
+                    '120@g.us',
+                    {
+                        jid: '120@g.us',
+                        ephemeralSettingTimestamp: 1_751_808_692
+                    }
+                ]
+            ])
+        )
     })
     await groupMetadataStore.upsertGroupMetadata({
         groupJid: '120@g.us',
@@ -1669,8 +1668,38 @@ test('message dispatch injects ephemeral expiration + timestamp for group chats'
     const ctx = getContextInfo(events[0].message)
     assert.ok(ctx)
     assert.equal(ctx.expiration, 60_480)
-    assert.equal(ctx.ephemeralSettingTimestamp, 1_751_808_692)
+    assert.equal(ctx.ephemeralSettingTimestamp, undefined)
     await groupMetadataStore.destroy()
+})
+
+test('message dispatch normalizes legacy millisecond ephemeralSettingTimestamp on 1:1 send', async () => {
+    const events: WaOutgoingMessageEvent[] = []
+    const threadStore = createStubThreadStore(
+        new Map<string, WaStoredThreadRecord>([
+            [
+                '5511999999999@s.whatsapp.net',
+                {
+                    jid: '5511999999999@s.whatsapp.net',
+                    ephemeralExpiration: 86_400,
+                    // Legacy row still stored as Conversation milliseconds.
+                    ephemeralSettingTimestamp: 1_751_808_692_000
+                }
+            ]
+        ])
+    )
+    const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore(), {
+        meJid: '5511000000000@s.whatsapp.net',
+        emitMessageSend: (event) => events.push(event),
+        threadStore
+    })
+    await coordinator
+        .sendMessage('5511999999999@s.whatsapp.net', { text: 'oi' } as never, {})
+        .catch(() => undefined)
+    assert.equal(events.length, 1)
+    const ctx = getContextInfo(events[0].message)
+    assert.ok(ctx)
+    assert.equal(ctx.expiration, 86_400)
+    assert.equal(ctx.ephemeralSettingTimestamp, 1_751_808_692)
 })
 
 test('message dispatch honors explicit options.ephemeralSettingTimestamp override', async () => {

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -7,23 +7,20 @@ import type {
     WaAppStateSyncOptions,
     WaAppStateSyncResult
 } from '@appstate/types'
-import type {
-    WaAppStateMutationEvent,
-    WaGroupEvent,
-    WaGroupEventAction,
-    WaOutgoingMessageEvent
-} from '@client/types'
-import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
-import type { WaStoredThreadRecord, WaThreadStore } from '@store/contracts/thread.store'
-import type { BinaryNode } from '@transport/types'
-import type { ServerClock } from '@util/clock'
 import { WaAppStateMutationCoordinator } from '@client/coordinators/WaAppStateMutationCoordinator'
 import { WaIncomingNodeCoordinator } from '@client/coordinators/WaIncomingNodeCoordinator'
 import { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
 import { WaPassiveTasksCoordinator } from '@client/coordinators/WaPassiveTasksCoordinator'
 import { createStreamControlHandler } from '@client/coordinators/WaStreamControlCoordinator'
 import { createGroupMetadataCache } from '@client/messaging/group-metadata'
+import type {
+    WaAppStateMutationEvent,
+    WaGroupEvent,
+    WaGroupEventAction,
+    WaOutgoingMessageEvent
+} from '@client/types'
 import { createNoopLogger } from '@infra/log/types'
+import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import { getContextInfo } from '@message/context-info'
 import {
     WA_APP_STATE_COLLECTION_STATES,
@@ -31,8 +28,11 @@ import {
     WA_DISCONNECT_REASONS,
     WA_STREAM_SIGNALING
 } from '@protocol/constants'
+import type { WaStoredThreadRecord, WaThreadStore } from '@store/contracts/thread.store'
 import { WaGroupMetadataMemoryStore } from '@store/memory/group-metadata.store'
 import { WaMessageMemoryStore } from '@store/memory/message.store'
+import type { BinaryNode } from '@transport/types'
+import type { ServerClock } from '@util/clock'
 
 function createStubThreadStore(
     records: ReadonlyMap<string, WaStoredThreadRecord> = new Map()

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -1635,14 +1635,12 @@ test('message dispatch injects ephemeral expiration + timestamp for 1:1 chats', 
     assert.ok(ctx)
     assert.equal(ctx.expiration, 86_400)
     assert.equal(ctx.ephemeralSettingTimestamp, 1_751_808_692)
-    assert.deepEqual(ctx.disappearingMode, { trigger: 1 })
+    assert.deepEqual(ctx.disappearingMode, { initiator: 0, trigger: 1 })
 })
 
 test('message dispatch injects ephemeral expiration only for group chats', async () => {
     const events: WaOutgoingMessageEvent[] = []
     const groupMetadataStore = new WaGroupMetadataMemoryStore(60_000)
-    // Groups send expiration from the metadata cache and never carry
-    // ephemeralSettingTimestamp, so the thread store is not consulted.
     const coordinator = createMessageDispatchCoordinator(groupMetadataStore, {
         meJid: '5511000000000@s.whatsapp.net',
         emitMessageSend: (event) => events.push(event),
@@ -1670,11 +1668,11 @@ test('message dispatch injects ephemeral expiration only for group chats', async
     assert.ok(ctx)
     assert.equal(ctx.expiration, 60_480)
     assert.equal(ctx.ephemeralSettingTimestamp, undefined)
-    assert.deepEqual(ctx.disappearingMode, { trigger: 1 })
+    assert.equal(ctx.disappearingMode, undefined)
     await groupMetadataStore.destroy()
 })
 
-test('message dispatch normalizes legacy millisecond ephemeralSettingTimestamp on 1:1 send', async () => {
+test('message dispatch honors explicit options.disappearingModeTrigger override', async () => {
     const events: WaOutgoingMessageEvent[] = []
     const threadStore = createStubThreadStore(
         new Map<string, WaStoredThreadRecord>([
@@ -1683,8 +1681,7 @@ test('message dispatch normalizes legacy millisecond ephemeralSettingTimestamp o
                 {
                     jid: '5511999999999@s.whatsapp.net',
                     ephemeralExpiration: 86_400,
-                    // Legacy row still stored as Conversation milliseconds.
-                    ephemeralSettingTimestamp: 1_751_808_692_000
+                    ephemeralSettingTimestamp: 1_751_808_692
                 }
             ]
         ])
@@ -1695,13 +1692,14 @@ test('message dispatch normalizes legacy millisecond ephemeralSettingTimestamp o
         threadStore
     })
     await coordinator
-        .sendMessage('5511999999999@s.whatsapp.net', { text: 'oi' } as never, {})
+        .sendMessage('5511999999999@s.whatsapp.net', { text: 'oi' } as never, {
+            disappearingModeTrigger: 2
+        })
         .catch(() => undefined)
     assert.equal(events.length, 1)
     const ctx = getContextInfo(events[0].message)
     assert.ok(ctx)
-    assert.equal(ctx.expiration, 86_400)
-    assert.equal(ctx.ephemeralSettingTimestamp, 1_751_808_692)
+    assert.deepEqual(ctx.disappearingMode, { initiator: 0, trigger: 2 })
 })
 
 test('message dispatch honors explicit options.ephemeralSettingTimestamp override', async () => {

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -165,7 +165,9 @@ function createMessageDispatchCoordinator(
         identityStore: {} as never,
         deviceListStore: {} as never,
         threadStore: overrides?.threadStore ?? createStubThreadStore(),
-        signalDeviceSync: (overrides?.signalDeviceSync ?? {}) as never,
+        signalDeviceSync: (overrides?.signalDeviceSync ?? {
+            resolveUserJidPair: async (userJid: string) => ({ lidJid: null, pnJid: userJid })
+        }) as never,
         messageSecretStore: {
             set: async (_id: string, _entry: { secret: Uint8Array; senderJid: string }) => {}
         } as never,
@@ -1636,6 +1638,74 @@ test('message dispatch injects ephemeral expiration + timestamp for 1:1 chats', 
     assert.equal(ctx.expiration, 86_400)
     assert.equal(ctx.ephemeralSettingTimestamp, 1_751_808_692)
     assert.deepEqual(ctx.disappearingMode, { initiator: 0, trigger: 1 })
+})
+
+test('message dispatch resolves a PN recipient to its LID thread row', async () => {
+    const events: WaOutgoingMessageEvent[] = []
+    const threadStore = createStubThreadStore(
+        new Map<string, WaStoredThreadRecord>([
+            [
+                '88880000@lid',
+                {
+                    jid: '88880000@lid',
+                    ephemeralExpiration: 86_400,
+                    ephemeralSettingTimestamp: 1_751_808_692
+                }
+            ]
+        ])
+    )
+    const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore(), {
+        meJid: '5511000000000@s.whatsapp.net',
+        emitMessageSend: (event) => events.push(event),
+        threadStore,
+        signalDeviceSync: {
+            resolveUserJidPair: async () => ({
+                lidJid: '88880000@lid',
+                pnJid: '5511999999999@s.whatsapp.net'
+            })
+        }
+    })
+    await coordinator
+        .sendMessage('5511999999999@s.whatsapp.net', { text: 'oi' } as never, {})
+        .catch(() => undefined)
+    assert.equal(events.length, 1)
+    const ctx = getContextInfo(events[0].message)
+    assert.ok(ctx, 'a PN recipient must reach the LID-keyed thread row')
+    assert.equal(ctx.expiration, 86_400)
+    assert.equal(ctx.ephemeralSettingTimestamp, 1_751_808_692)
+    assert.deepEqual(ctx.disappearingMode, { initiator: 0, trigger: 1 })
+})
+
+test('message dispatch leaves a PN recipient alone when no LID is known', async () => {
+    const events: WaOutgoingMessageEvent[] = []
+    const threadStore = createStubThreadStore(
+        new Map<string, WaStoredThreadRecord>([
+            [
+                '5511999999999@s.whatsapp.net',
+                {
+                    jid: '5511999999999@s.whatsapp.net',
+                    ephemeralExpiration: 86_400,
+                    ephemeralSettingTimestamp: 1_751_808_692
+                }
+            ]
+        ])
+    )
+    const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore(), {
+        meJid: '5511000000000@s.whatsapp.net',
+        emitMessageSend: (event) => events.push(event),
+        threadStore,
+        signalDeviceSync: {
+            resolveUserJidPair: async (userJid: string) => ({ lidJid: null, pnJid: userJid })
+        }
+    })
+    await coordinator
+        .sendMessage('5511999999999@s.whatsapp.net', { text: 'oi' } as never, {})
+        .catch(() => undefined)
+    assert.equal(events.length, 1)
+    const ctx = getContextInfo(events[0].message)
+    assert.ok(ctx, 'an unresolvable PN must fall back to the PN-keyed row')
+    assert.equal(ctx.expiration, 86_400)
+    assert.equal(ctx.ephemeralSettingTimestamp, 1_751_808_692)
 })
 
 test('message dispatch injects ephemeral expiration only for group chats', async () => {

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -1635,6 +1635,7 @@ test('message dispatch injects ephemeral expiration + timestamp for 1:1 chats', 
     assert.ok(ctx)
     assert.equal(ctx.expiration, 86_400)
     assert.equal(ctx.ephemeralSettingTimestamp, 1_751_808_692)
+    assert.deepEqual(ctx.disappearingMode, { trigger: 1 })
 })
 
 test('message dispatch injects ephemeral expiration only for group chats', async () => {
@@ -1669,6 +1670,7 @@ test('message dispatch injects ephemeral expiration only for group chats', async
     assert.ok(ctx)
     assert.equal(ctx.expiration, 60_480)
     assert.equal(ctx.ephemeralSettingTimestamp, undefined)
+    assert.deepEqual(ctx.disappearingMode, { trigger: 1 })
     await groupMetadataStore.destroy()
 })
 

--- a/src/client/persistence/WriteBehindPersistence.ts
+++ b/src/client/persistence/WriteBehindPersistence.ts
@@ -32,7 +32,9 @@ function mergeThread(
         pinned: incoming.pinned ?? previous.pinned,
         muteEndMs: incoming.muteEndMs ?? previous.muteEndMs,
         markedAsUnread: incoming.markedAsUnread ?? previous.markedAsUnread,
-        ephemeralExpiration: incoming.ephemeralExpiration ?? previous.ephemeralExpiration
+        ephemeralExpiration: incoming.ephemeralExpiration ?? previous.ephemeralExpiration,
+        ephemeralSettingTimestamp:
+            incoming.ephemeralSettingTimestamp ?? previous.ephemeralSettingTimestamp
     }
 }
 

--- a/src/client/persistence/__tests__/WriteBehindPersistence.test.ts
+++ b/src/client/persistence/__tests__/WriteBehindPersistence.test.ts
@@ -120,6 +120,60 @@ test('write-behind merges partial thread upserts for the same jid', async () => 
     assert.equal(targetWrites[0].archived, true)
 })
 
+test('write-behind merges partial thread ephemeral fields across upserts', async () => {
+    let releaseBlock: () => void = () => undefined
+    const blocked = new Promise<void>((resolve) => {
+        releaseBlock = resolve
+    })
+    const threadWrites: WaStoredThreadRecord[] = []
+
+    const threadUpsert = async (record: WaStoredThreadRecord): Promise<void> => {
+        if (record.jid === 'block-thread@s.whatsapp.net') {
+            await blocked
+        }
+        threadWrites.push(record)
+    }
+    const writeBehind = new WriteBehindPersistence(
+        {
+            messageStore: {
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
+            } as never,
+            threadStore: {
+                upsert: threadUpsert,
+                upsertBatch: async (records: readonly WaStoredThreadRecord[]) => {
+                    for (const record of records) await threadUpsert(record)
+                }
+            } as never,
+            contactStore: {
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
+            } as never
+        },
+        createNoopLogger()
+    )
+
+    writeBehind.persistThread({
+        jid: 'block-thread@s.whatsapp.net'
+    })
+    writeBehind.persistThread({
+        jid: 'thread@s.whatsapp.net',
+        ephemeralExpiration: 86_400
+    })
+    writeBehind.persistThread({
+        jid: 'thread@s.whatsapp.net',
+        ephemeralSettingTimestamp: 1_751_808_692
+    })
+
+    releaseBlock()
+    await writeBehind.flush(2_000)
+
+    const targetWrites = threadWrites.filter((record) => record.jid === 'thread@s.whatsapp.net')
+    assert.equal(targetWrites.length, 1)
+    assert.equal(targetWrites[0].ephemeralExpiration, 86_400)
+    assert.equal(targetWrites[0].ephemeralSettingTimestamp, 1_751_808_692)
+})
+
 test('write-behind flush and destroy expose remaining pending entries', async () => {
     let releaseBlock: () => void = () => undefined
     const blocked = new Promise<void>((resolve) => {

--- a/src/client/persistence/__tests__/ephemeral-setting.test.ts
+++ b/src/client/persistence/__tests__/ephemeral-setting.test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { persistIncomingEphemeralSetting } from '@client/persistence/ephemeral-setting'
+import type { WaIncomingMessageEvent } from '@client/types'
+import { createNoopLogger } from '@infra/log/types'
+import { proto } from '@proto'
+import type { WaStoredThreadRecord } from '@store/contracts/thread.store'
+
+function baseEvent(
+    overrides: Partial<WaIncomingMessageEvent> & {
+        readonly keyOverrides?: Partial<WaIncomingMessageEvent['key']>
+    } = {}
+): WaIncomingMessageEvent {
+    const { keyOverrides, ...rest } = overrides
+    return {
+        key: {
+            remoteJid: '5511999999999@s.whatsapp.net',
+            id: 'msg-1',
+            fromMe: false,
+            isGroup: false,
+            isBroadcast: false,
+            isNewsletter: false,
+            senderDevice: 0,
+            ...keyOverrides
+        },
+        rawNode: {
+            tag: 'message',
+            attrs: {}
+        },
+        timestampSeconds: 1_784_900_697,
+        ...rest
+    }
+}
+
+test('ephemeral setting persist enables 1:1 thread with protocol expiration + message timestamp', () => {
+    const threads: WaStoredThreadRecord[] = []
+    const writeBehind = {
+        persistThread: (record: WaStoredThreadRecord) => {
+            threads.push(record)
+        }
+    }
+
+    persistIncomingEphemeralSetting({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        event: baseEvent(),
+        protocolMessage: {
+            type: proto.Message.ProtocolMessage.Type.EPHEMERAL_SETTING,
+            ephemeralExpiration: 86_400
+        }
+    })
+
+    assert.equal(threads.length, 1)
+    assert.equal(threads[0].jid, '5511999999999@s.whatsapp.net')
+    assert.equal(threads[0].ephemeralExpiration, 86_400)
+    assert.equal(threads[0].ephemeralSettingTimestamp, 1_784_900_697)
+})
+
+test('ephemeral setting persist prefers protocol ephemeralSettingTimestamp over message timestamp', () => {
+    const threads: WaStoredThreadRecord[] = []
+    const writeBehind = {
+        persistThread: (record: WaStoredThreadRecord) => {
+            threads.push(record)
+        }
+    }
+
+    persistIncomingEphemeralSetting({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        event: baseEvent({ timestampSeconds: 1_700_000_000 }),
+        protocolMessage: {
+            type: proto.Message.ProtocolMessage.Type.EPHEMERAL_SETTING,
+            ephemeralExpiration: 604_800,
+            ephemeralSettingTimestamp: 1_751_808_692
+        }
+    })
+
+    assert.equal(threads[0].ephemeralExpiration, 604_800)
+    assert.equal(threads[0].ephemeralSettingTimestamp, 1_751_808_692)
+})
+
+test('ephemeral setting persist disables 1:1 thread with expiration 0', () => {
+    const threads: WaStoredThreadRecord[] = []
+    const writeBehind = {
+        persistThread: (record: WaStoredThreadRecord) => {
+            threads.push(record)
+        }
+    }
+
+    persistIncomingEphemeralSetting({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        event: baseEvent({ timestampSeconds: 1_784_900_714 }),
+        protocolMessage: {
+            type: proto.Message.ProtocolMessage.Type.EPHEMERAL_SETTING,
+            ephemeralExpiration: 0
+        }
+    })
+
+    assert.equal(threads[0].ephemeralExpiration, 0)
+    assert.equal(threads[0].ephemeralSettingTimestamp, 1_784_900_714)
+})
+
+test('ephemeral setting persist normalizes legacy millisecond timestamps', () => {
+    const threads: WaStoredThreadRecord[] = []
+    const writeBehind = {
+        persistThread: (record: WaStoredThreadRecord) => {
+            threads.push(record)
+        }
+    }
+
+    persistIncomingEphemeralSetting({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        event: baseEvent(),
+        protocolMessage: {
+            type: proto.Message.ProtocolMessage.Type.EPHEMERAL_SETTING,
+            ephemeralExpiration: 86_400,
+            ephemeralSettingTimestamp: 1_751_808_692_000
+        }
+    })
+
+    assert.equal(threads[0].ephemeralSettingTimestamp, 1_751_808_692)
+})
+
+test('ephemeral setting persist skips group chats', () => {
+    const threads: WaStoredThreadRecord[] = []
+    const writeBehind = {
+        persistThread: (record: WaStoredThreadRecord) => {
+            threads.push(record)
+        }
+    }
+
+    persistIncomingEphemeralSetting({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        event: baseEvent({
+            keyOverrides: {
+                remoteJid: '120363000000000000@g.us',
+                isGroup: true
+            }
+        }),
+        protocolMessage: {
+            type: proto.Message.ProtocolMessage.Type.EPHEMERAL_SETTING,
+            ephemeralExpiration: 86_400
+        }
+    })
+
+    assert.equal(threads.length, 0)
+})

--- a/src/client/persistence/__tests__/ephemeral-setting.test.ts
+++ b/src/client/persistence/__tests__/ephemeral-setting.test.ts
@@ -102,7 +102,7 @@ test('ephemeral setting persist disables 1:1 thread with expiration 0', () => {
     assert.equal(threads[0].ephemeralSettingTimestamp, 1_784_900_714)
 })
 
-test('ephemeral setting persist normalizes legacy millisecond timestamps', () => {
+test('ephemeral setting persist normalizes a millisecond protocol timestamp', () => {
     const threads: WaStoredThreadRecord[] = []
     const writeBehind = {
         persistThread: (record: WaStoredThreadRecord) => {

--- a/src/client/persistence/__tests__/history-sync.test.ts
+++ b/src/client/persistence/__tests__/history-sync.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { promisify } from 'node:util'
+import { gzip } from 'node:zlib'
+
+import { processHistorySyncNotification } from '@client/persistence/history-sync'
+import { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
+import { createNoopLogger } from '@infra/log/types'
+import { proto } from '@proto'
+import type { WaStoredThreadRecord } from '@store/contracts/thread.store'
+import { toBytesView } from '@util/bytes'
+
+const gzipAsync = promisify(gzip)
+
+function createThreadCapture(): {
+    readonly writes: WaStoredThreadRecord[]
+    readonly writeBehind: WriteBehindPersistence
+} {
+    const writes: WaStoredThreadRecord[] = []
+    const writeBehind = new WriteBehindPersistence(
+        {
+            messageStore: {
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
+            } as never,
+            threadStore: {
+                upsert: async (record: WaStoredThreadRecord) => {
+                    writes.push(record)
+                },
+                upsertBatch: async (records: readonly WaStoredThreadRecord[]) => {
+                    writes.push(...records)
+                }
+            } as never,
+            contactStore: {
+                upsert: async () => undefined,
+                upsertBatch: async () => undefined
+            } as never
+        },
+        createNoopLogger()
+    )
+    return { writes, writeBehind }
+}
+
+async function buildInlineNotification(
+    conversation: proto.IConversation
+): Promise<proto.Message.IHistorySyncNotification> {
+    const payload = proto.HistorySync.encode({
+        syncType: proto.HistorySync.HistorySyncType.RECENT,
+        conversations: [conversation]
+    }).finish()
+    return {
+        syncType: proto.Message.HistorySyncType.RECENT,
+        initialHistBootstrapInlinePayload: toBytesView(await gzipAsync(payload))
+    }
+}
+
+test('history sync converts Conversation.ephemeralSettingTimestamp from ms to seconds', async () => {
+    const { writes, writeBehind } = createThreadCapture()
+    const notification = await buildInlineNotification({
+        id: '5511999999999@s.whatsapp.net',
+        ephemeralExpiration: 86_400,
+        ephemeralSettingTimestamp: 1_751_808_692_000
+    })
+
+    await processHistorySyncNotification(
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: {} as never,
+            writeBehind,
+            emitEvent: () => undefined
+        } as never,
+        notification
+    )
+    await writeBehind.flush()
+
+    const thread = writes.find((record) => record.jid === '5511999999999@s.whatsapp.net')
+    assert.ok(thread, 'conversation should be persisted as a thread row')
+    assert.equal(thread.ephemeralExpiration, 86_400)
+    assert.equal(thread.ephemeralSettingTimestamp, 1_751_808_692)
+})
+
+test('history sync keeps an already-seconds Conversation timestamp untouched', async () => {
+    const { writes, writeBehind } = createThreadCapture()
+    const notification = await buildInlineNotification({
+        id: '5511777777777@s.whatsapp.net',
+        ephemeralExpiration: 86_400,
+        ephemeralSettingTimestamp: 1_751_808_692
+    })
+
+    await processHistorySyncNotification(
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: {} as never,
+            writeBehind,
+            emitEvent: () => undefined
+        } as never,
+        notification
+    )
+    await writeBehind.flush()
+
+    const thread = writes.find((record) => record.jid === '5511777777777@s.whatsapp.net')
+    assert.ok(thread)
+    assert.equal(thread.ephemeralSettingTimestamp, 1_751_808_692)
+})
+
+test('history sync leaves ephemeralSettingTimestamp absent for a non-ephemeral chat', async () => {
+    const { writes, writeBehind } = createThreadCapture()
+    const notification = await buildInlineNotification({
+        id: '5511888888888@s.whatsapp.net'
+    })
+
+    await processHistorySyncNotification(
+        {
+            logger: createNoopLogger(),
+            mediaTransfer: {} as never,
+            writeBehind,
+            emitEvent: () => undefined
+        } as never,
+        notification
+    )
+    await writeBehind.flush()
+
+    const thread = writes.find((record) => record.jid === '5511888888888@s.whatsapp.net')
+    assert.ok(thread)
+    assert.equal(thread.ephemeralSettingTimestamp, undefined)
+})

--- a/src/client/persistence/ephemeral-setting.ts
+++ b/src/client/persistence/ephemeral-setting.ts
@@ -1,0 +1,63 @@
+import type { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
+import type { WaIncomingMessageEvent } from '@client/types'
+import type { Logger } from '@infra/log/types'
+import type { Proto } from '@proto'
+import { isGroupJid } from '@protocol/jid'
+import { longToNumber, toError } from '@util/primitives'
+
+/** Values above ~year 2286 in seconds are treated as legacy millisecond rows. */
+const EPHEMERAL_SETTING_MS_THRESHOLD = 10_000_000_000
+
+function normalizeEphemeralSettingUnixSeconds(value: number): number {
+    return value > EPHEMERAL_SETTING_MS_THRESHOLD ? Math.floor(value / 1000) : value
+}
+
+export interface WaPersistIncomingEphemeralSettingOptions {
+    readonly logger: Logger
+    readonly writeBehind: WriteBehindPersistence
+    readonly event: WaIncomingMessageEvent
+    readonly protocolMessage: Proto.Message.IProtocolMessage
+}
+
+/**
+ * Persists a 1:1 {@link proto.Message.ProtocolMessage.Type.EPHEMERAL_SETTING}
+ * into the thread store so outgoing sends pick up the peer's disappearing-mode
+ * change without waiting for history sync.
+ *
+ * Groups are skipped – their timer is driven by group notifications and the
+ * in-memory group metadata cache, not protocol messages.
+ */
+export function persistIncomingEphemeralSetting(
+    options: WaPersistIncomingEphemeralSettingOptions
+): void {
+    const { logger, writeBehind, event, protocolMessage } = options
+    const chatJid = event.key.remoteJid
+    if (!chatJid || event.key.isGroup || isGroupJid(chatJid)) {
+        return
+    }
+
+    const expiration = protocolMessage.ephemeralExpiration ?? 0
+    const rawTimestamp =
+        protocolMessage.ephemeralSettingTimestamp !== undefined &&
+        protocolMessage.ephemeralSettingTimestamp !== null
+            ? longToNumber(protocolMessage.ephemeralSettingTimestamp)
+            : event.timestampSeconds
+
+    try {
+        writeBehind.persistThread({
+            jid: chatJid,
+            ephemeralExpiration: expiration,
+            ...(rawTimestamp !== undefined
+                ? {
+                      ephemeralSettingTimestamp: normalizeEphemeralSettingUnixSeconds(rawTimestamp)
+                  }
+                : {})
+        })
+    } catch (error) {
+        logger.warn('failed to persist incoming ephemeral setting', {
+            jid: chatJid,
+            expiration,
+            message: toError(error).message
+        })
+    }
+}

--- a/src/client/persistence/ephemeral-setting.ts
+++ b/src/client/persistence/ephemeral-setting.ts
@@ -3,14 +3,8 @@ import type { WaIncomingMessageEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import type { Proto } from '@proto'
 import { isGroupJid } from '@protocol/jid'
+import { normalizeEphemeralSettingSeconds } from '@protocol/message'
 import { longToNumber, toError } from '@util/primitives'
-
-/** Values above ~year 2286 in seconds are treated as legacy millisecond rows. */
-const EPHEMERAL_SETTING_MS_THRESHOLD = 10_000_000_000
-
-function normalizeEphemeralSettingUnixSeconds(value: number): number {
-    return value > EPHEMERAL_SETTING_MS_THRESHOLD ? Math.floor(value / 1000) : value
-}
 
 export interface WaPersistIncomingEphemeralSettingOptions {
     readonly logger: Logger
@@ -20,12 +14,9 @@ export interface WaPersistIncomingEphemeralSettingOptions {
 }
 
 /**
- * Persists a 1:1 {@link proto.Message.ProtocolMessage.Type.EPHEMERAL_SETTING}
- * into the thread store so outgoing sends pick up the peer's disappearing-mode
- * change without waiting for history sync.
- *
- * Groups are skipped – their timer is driven by group notifications and the
- * in-memory group metadata cache, not protocol messages.
+ * Persists a 1:1 `EPHEMERAL_SETTING` protocol message so outgoing sends pick up
+ * the peer's change without waiting for history sync. Groups are skipped –
+ * their timer comes from group notifications, not protocol messages.
  */
 export function persistIncomingEphemeralSetting(
     options: WaPersistIncomingEphemeralSettingOptions
@@ -42,15 +33,15 @@ export function persistIncomingEphemeralSetting(
         protocolMessage.ephemeralSettingTimestamp !== null
             ? longToNumber(protocolMessage.ephemeralSettingTimestamp)
             : event.timestampSeconds
+    const settingTimestamp =
+        rawTimestamp !== undefined ? normalizeEphemeralSettingSeconds(rawTimestamp) : undefined
 
     try {
         writeBehind.persistThread({
             jid: chatJid,
             ephemeralExpiration: expiration,
-            ...(rawTimestamp !== undefined
-                ? {
-                      ephemeralSettingTimestamp: normalizeEphemeralSettingUnixSeconds(rawTimestamp)
-                  }
+            ...(settingTimestamp !== undefined
+                ? { ephemeralSettingTimestamp: settingTimestamp }
                 : {})
         })
     } catch (error) {

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -184,8 +184,10 @@ export async function processHistorySyncNotification(
             muteEndMs: longToNumber(conversation.muteEndTime) || undefined,
             markedAsUnread: conversation.markedAsUnread ?? undefined,
             ephemeralExpiration: conversation.ephemeralExpiration ?? undefined,
-            ephemeralSettingTimestamp:
-                longToNumber(conversation.ephemeralSettingTimestamp) || undefined
+            // Conversation carries milliseconds; ContextInfo / thread store use Unix seconds.
+            ephemeralSettingTimestamp: ephemeralSettingTimestampMsToUnixSeconds(
+                longToNumber(conversation.ephemeralSettingTimestamp)
+            )
         })
         if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
             await flushPendingWrites(pendingWrites)
@@ -292,6 +294,11 @@ export async function processHistorySyncNotification(
     if (deps.onProcessed) {
         await deps.onProcessed(syncType)
     }
+}
+
+/** History-sync `Conversation.ephemeralSettingTimestamp` is milliseconds; store Unix seconds. */
+function ephemeralSettingTimestampMsToUnixSeconds(ms: number): number | undefined {
+    return ms > 0 ? Math.floor(ms / 1000) : undefined
 }
 
 async function downloadHistorySyncBlob(

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -183,7 +183,9 @@ export async function processHistorySyncNotification(
             pinned: conversation.pinned ?? undefined,
             muteEndMs: longToNumber(conversation.muteEndTime) || undefined,
             markedAsUnread: conversation.markedAsUnread ?? undefined,
-            ephemeralExpiration: conversation.ephemeralExpiration ?? undefined
+            ephemeralExpiration: conversation.ephemeralExpiration ?? undefined,
+            ephemeralSettingTimestamp:
+                longToNumber(conversation.ephemeralSettingTimestamp) || undefined
         })
         if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
             await flushPendingWrites(pendingWrites)

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -8,6 +8,7 @@ import type { Logger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import { proto, type Proto } from '@proto'
 import { isUserJid } from '@protocol/jid'
+import { normalizeEphemeralSettingSeconds } from '@protocol/message'
 import { decodeProtoBytes, toBytesView } from '@util/bytes'
 import { longToNumber, toError } from '@util/primitives'
 
@@ -184,10 +185,10 @@ export async function processHistorySyncNotification(
             muteEndMs: longToNumber(conversation.muteEndTime) || undefined,
             markedAsUnread: conversation.markedAsUnread ?? undefined,
             ephemeralExpiration: conversation.ephemeralExpiration ?? undefined,
-            // Conversation carries milliseconds; ContextInfo / thread store use Unix seconds.
-            ephemeralSettingTimestamp: ephemeralSettingTimestampMsToUnixSeconds(
-                longToNumber(conversation.ephemeralSettingTimestamp)
-            )
+            ephemeralSettingTimestamp:
+                normalizeEphemeralSettingSeconds(
+                    longToNumber(conversation.ephemeralSettingTimestamp)
+                ) || undefined
         })
         if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
             await flushPendingWrites(pendingWrites)
@@ -294,11 +295,6 @@ export async function processHistorySyncNotification(
     if (deps.onProcessed) {
         await deps.onProcessed(syncType)
     }
-}
-
-/** History-sync `Conversation.ephemeralSettingTimestamp` is milliseconds; store Unix seconds. */
-function ephemeralSettingTimestampMsToUnixSeconds(ms: number): number | undefined {
-    return ms > 0 ? Math.floor(ms / 1000) : undefined
 }
 
 async function downloadHistorySyncBlob(

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -407,34 +407,22 @@ export interface WaSendMessageOptions extends WaMessagePublishOptions {
      */
     readonly expirationSeconds?: number
     /**
-     * Unix seconds when disappearing-mode was enabled for this chat, mirrored into
-     * `contextInfo.ephemeralSettingTimestamp`. Applies to **1:1 chats only** – groups
-     * never send this field on the wire. When set it overrides the value resolved
-     * automatically from the thread store (which is already applied for you via the
-     * disappearing-mode auto-inject). Omit to let the runtime resolve it from the
-     * cached `Conversation` record. Leaving it absent while `expirationSeconds` is
-     * set on a 1:1 chat causes the peer to warn that the message will not
-     * disappear, so prefer the auto-resolved value whenever possible.
+     * Unix seconds when disappearing-mode was enabled, sent as
+     * `contextInfo.ephemeralSettingTimestamp`. 1:1 only – groups never carry it.
+     * Overrides the value the auto-inject resolves from the thread store; omit
+     * it unless you have a reason, since a missing timestamp makes the peer warn
+     * that the message will not disappear.
      */
     readonly ephemeralSettingTimestamp?: number
     /**
-     * Forces the `contextInfo.disappearingMode.trigger` value on outgoing
-     * ephemeral messages. The auto-inject sets this to `1` (`CHAT_SETTING`)
-     * automatically when it resolves an ephemeral send, so you only need to set
-     * this when you want a non-default trigger. Leave it undefined to use the
-     * runtime default.
+     * Overrides `contextInfo.disappearingMode.trigger`. The 1:1 auto-inject
+     * already sets `CHAT_SETTING`.
      */
-    readonly disappearingModeTrigger?: 1 | 2 | 3 | 4 | 5
+    readonly disappearingModeTrigger?: Proto.DisappearingMode.Trigger
     /**
-     * Skip the automatic disappearing-message injection applied to messages sent
-     * into chats with disappearing-mode on.
-     *
-     * - Groups: only `contextInfo.expiration` is auto-injected (from the group
-     *   metadata cache). Groups do not carry `ephemeralSettingTimestamp`.
-     * - 1:1: both `expiration` and `ephemeralSettingTimestamp` are auto-injected
-     *   from the thread store (app-state `Conversation` record).
-     *
-     * Off by default.
+     * Skip the automatic disappearing-message injection. Despite the name it
+     * covers 1:1 too: groups get `expiration` only, 1:1 also gets
+     * `ephemeralSettingTimestamp` and `disappearingMode`. Off by default.
      *
      * Relationship with {@link expirationSeconds}: a non-undefined
      * `expirationSeconds` already short-circuits the auto-inject, so this flag is

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -407,9 +407,22 @@ export interface WaSendMessageOptions extends WaMessagePublishOptions {
      */
     readonly expirationSeconds?: number
     /**
-     * Skip the automatic `ephemeralSettingTimestamp`/`expiration` injection
-     * applied to messages sent into groups with disappearing-mode on (the cached
-     * group ephemeral is otherwise fetched and applied for you). Off by default.
+     * Unix seconds when disappearing-mode was enabled for this chat, mirrored into
+     * `contextInfo.ephemeralSettingTimestamp`. When set it overrides the value
+     * resolved automatically from the thread store (which is already applied for
+     * you via the disappearing-mode auto-inject). Omit to let the runtime resolve
+     * it from the cached `Conversation` record. Leaving it absent while
+     * `expirationSeconds` is set causes the peer to warn that the message will not
+     * disappear, so prefer the auto-resolved value whenever possible.
+     */
+    readonly ephemeralSettingTimestamp?: number
+    /**
+     * Skip the automatic disappearing-message (`expiration` + `ephemeralSettingTimestamp`)
+     * injection applied to messages sent into chats with disappearing-mode on.
+     * This covers both 1:1 and group chats: the ephemeral TTL is fetched from
+     * the group metadata cache (groups) or the thread store (1:1), and the
+     * setting timestamp always comes from the thread store (app-state
+     * Conversation record). Off by default.
      *
      * Relationship with {@link expirationSeconds}: a non-undefined
      * `expirationSeconds` already short-circuits the auto-inject, so this flag is

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -418,6 +418,14 @@ export interface WaSendMessageOptions extends WaMessagePublishOptions {
      */
     readonly ephemeralSettingTimestamp?: number
     /**
+     * Forces the `contextInfo.disappearingMode.trigger` value on outgoing
+     * ephemeral messages. The auto-inject sets this to `1` (`CHAT_SETTING`)
+     * automatically when it resolves an ephemeral send, so you only need to set
+     * this when you want a non-default trigger. Leave it undefined to use the
+     * runtime default.
+     */
+    readonly disappearingModeTrigger?: 1 | 2 | 3 | 4 | 5
+    /**
      * Skip the automatic disappearing-message injection applied to messages sent
      * into chats with disappearing-mode on.
      *

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -408,21 +408,25 @@ export interface WaSendMessageOptions extends WaMessagePublishOptions {
     readonly expirationSeconds?: number
     /**
      * Unix seconds when disappearing-mode was enabled for this chat, mirrored into
-     * `contextInfo.ephemeralSettingTimestamp`. When set it overrides the value
-     * resolved automatically from the thread store (which is already applied for
-     * you via the disappearing-mode auto-inject). Omit to let the runtime resolve
-     * it from the cached `Conversation` record. Leaving it absent while
-     * `expirationSeconds` is set causes the peer to warn that the message will not
+     * `contextInfo.ephemeralSettingTimestamp`. Applies to **1:1 chats only** – groups
+     * never send this field on the wire. When set it overrides the value resolved
+     * automatically from the thread store (which is already applied for you via the
+     * disappearing-mode auto-inject). Omit to let the runtime resolve it from the
+     * cached `Conversation` record. Leaving it absent while `expirationSeconds` is
+     * set on a 1:1 chat causes the peer to warn that the message will not
      * disappear, so prefer the auto-resolved value whenever possible.
      */
     readonly ephemeralSettingTimestamp?: number
     /**
-     * Skip the automatic disappearing-message (`expiration` + `ephemeralSettingTimestamp`)
-     * injection applied to messages sent into chats with disappearing-mode on.
-     * This covers both 1:1 and group chats: the ephemeral TTL is fetched from
-     * the group metadata cache (groups) or the thread store (1:1), and the
-     * setting timestamp always comes from the thread store (app-state
-     * Conversation record). Off by default.
+     * Skip the automatic disappearing-message injection applied to messages sent
+     * into chats with disappearing-mode on.
+     *
+     * - Groups: only `contextInfo.expiration` is auto-injected (from the group
+     *   metadata cache). Groups do not carry `ephemeralSettingTimestamp`.
+     * - 1:1: both `expiration` and `ephemeralSettingTimestamp` are auto-injected
+     *   from the thread store (app-state `Conversation` record).
+     *
+     * Off by default.
      *
      * Relationship with {@link expirationSeconds}: a non-undefined
      * `expirationSeconds` already short-circuits the auto-inject, so this flag is

--- a/src/message/__tests__/context-info.test.ts
+++ b/src/message/__tests__/context-info.test.ts
@@ -235,6 +235,21 @@ test('resolveSendContextInfo populates mentions', () => {
     assert.deepEqual(result?.mentionedJids, ['a@s.whatsapp.net'])
 })
 
+test('buildContextInfoProto maps ephemeralSettingTimestamp to proto field 26', () => {
+    const proto = buildContextInfoProto({
+        expirationSeconds: 86_400,
+        ephemeralSettingTimestamp: 1_751_808_692
+    })
+    assert.equal(proto.expiration, 86_400)
+    assert.equal(proto.ephemeralSettingTimestamp, 1_751_808_692)
+})
+
+test('buildContextInfoProto omits ephemeralSettingTimestamp when absent', () => {
+    const proto = buildContextInfoProto({ expirationSeconds: 86_400 })
+    assert.equal(proto.expiration, 86_400)
+    assert.equal(proto.ephemeralSettingTimestamp, undefined)
+})
+
 test('resolveSendContextInfo merges content-level + options-level + quote + forward + mentions', () => {
     const result = resolveSendContextInfo({
         contentLevel: { isSpoiler: true },

--- a/src/message/__tests__/context-info.test.ts
+++ b/src/message/__tests__/context-info.test.ts
@@ -250,6 +250,20 @@ test('buildContextInfoProto omits ephemeralSettingTimestamp when absent', () => 
     assert.equal(proto.ephemeralSettingTimestamp, undefined)
 })
 
+test('buildContextInfoProto maps disappearingModeTrigger to proto field 32', () => {
+    const proto = buildContextInfoProto({
+        expirationSeconds: 86_400,
+        ephemeralSettingTimestamp: 1_751_808_692,
+        disappearingModeTrigger: 1
+    })
+    assert.deepEqual(proto.disappearingMode, { trigger: 1 })
+})
+
+test('buildContextInfoProto omits disappearingMode when trigger absent', () => {
+    const proto = buildContextInfoProto({ expirationSeconds: 86_400 })
+    assert.equal(proto.disappearingMode, undefined)
+})
+
 test('resolveSendContextInfo merges content-level + options-level + quote + forward + mentions', () => {
     const result = resolveSendContextInfo({
         contentLevel: { isSpoiler: true },

--- a/src/message/context-info.ts
+++ b/src/message/context-info.ts
@@ -14,6 +14,7 @@ export interface WaSendContextInfo {
 
     readonly isSpoiler?: boolean
     readonly expirationSeconds?: number
+    readonly ephemeralSettingTimestamp?: number
 
     readonly groupSubject?: string
     readonly parentGroupJid?: string
@@ -45,6 +46,9 @@ export function buildContextInfoProto(input: WaSendContextInfo): Proto.IContextI
 
     if (input.isSpoiler !== undefined) ctx.isSpoiler = input.isSpoiler
     if (input.expirationSeconds !== undefined) ctx.expiration = input.expirationSeconds
+    if (input.ephemeralSettingTimestamp !== undefined) {
+        ctx.ephemeralSettingTimestamp = input.ephemeralSettingTimestamp
+    }
 
     if (input.groupSubject !== undefined) ctx.groupSubject = input.groupSubject
     if (input.parentGroupJid !== undefined) ctx.parentGroupJid = input.parentGroupJid

--- a/src/message/context-info.ts
+++ b/src/message/context-info.ts
@@ -15,6 +15,7 @@ export interface WaSendContextInfo {
     readonly isSpoiler?: boolean
     readonly expirationSeconds?: number
     readonly ephemeralSettingTimestamp?: number
+    readonly disappearingModeTrigger?: 1 | 2 | 3 | 4 | 5
 
     readonly groupSubject?: string
     readonly parentGroupJid?: string
@@ -48,6 +49,11 @@ export function buildContextInfoProto(input: WaSendContextInfo): Proto.IContextI
     if (input.expirationSeconds !== undefined) ctx.expiration = input.expirationSeconds
     if (input.ephemeralSettingTimestamp !== undefined) {
         ctx.ephemeralSettingTimestamp = input.ephemeralSettingTimestamp
+    }
+    if (input.disappearingModeTrigger !== undefined) {
+        ctx.disappearingMode = {
+            trigger: input.disappearingModeTrigger
+        }
     }
 
     if (input.groupSubject !== undefined) ctx.groupSubject = input.groupSubject

--- a/src/message/context-info.ts
+++ b/src/message/context-info.ts
@@ -15,7 +15,8 @@ export interface WaSendContextInfo {
     readonly isSpoiler?: boolean
     readonly expirationSeconds?: number
     readonly ephemeralSettingTimestamp?: number
-    readonly disappearingModeTrigger?: 1 | 2 | 3 | 4 | 5
+    readonly disappearingModeInitiator?: Proto.DisappearingMode.Initiator
+    readonly disappearingModeTrigger?: Proto.DisappearingMode.Trigger
 
     readonly groupSubject?: string
     readonly parentGroupJid?: string
@@ -50,9 +51,17 @@ export function buildContextInfoProto(input: WaSendContextInfo): Proto.IContextI
     if (input.ephemeralSettingTimestamp !== undefined) {
         ctx.ephemeralSettingTimestamp = input.ephemeralSettingTimestamp
     }
-    if (input.disappearingModeTrigger !== undefined) {
+    if (
+        input.disappearingModeInitiator !== undefined ||
+        input.disappearingModeTrigger !== undefined
+    ) {
         ctx.disappearingMode = {
-            trigger: input.disappearingModeTrigger
+            ...(input.disappearingModeInitiator !== undefined
+                ? { initiator: input.disappearingModeInitiator }
+                : {}),
+            ...(input.disappearingModeTrigger !== undefined
+                ? { trigger: input.disappearingModeTrigger }
+                : {})
         }
     }
 

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -32,6 +32,7 @@ export {
 } from '@protocol/call'
 export type { WaCallPayloadTag } from '@protocol/call'
 export {
+    normalizeEphemeralSettingSeconds,
     WA_ADDRESSING_MODES,
     WA_EDIT_ATTRS,
     WA_ENC_CIPHERTEXT_TYPES,

--- a/src/protocol/message.ts
+++ b/src/protocol/message.ts
@@ -135,3 +135,12 @@ export const WA_ENC_MEDIA_TYPES = Object.freeze({
     NATIVE_FLOW_RESPONSE: 'native_flow_response',
     GROUP_HISTORY: 'group_history'
 } as const)
+
+/**
+ * `ephemeralSettingTimestamp` to Unix seconds. `ContextInfo` uses seconds, the
+ * history-sync `Conversation` record milliseconds, and both feed one stored
+ * field. Anything past ~year 2286 in seconds can only be a millisecond stamp.
+ */
+export function normalizeEphemeralSettingSeconds(value: number): number {
+    return value > 10_000_000_000 ? Math.floor(value / 1000) : value
+}

--- a/src/store/contracts/thread.store.ts
+++ b/src/store/contracts/thread.store.ts
@@ -7,6 +7,11 @@ export interface WaStoredThreadRecord {
     readonly muteEndMs?: number
     readonly markedAsUnread?: boolean
     readonly ephemeralExpiration?: number
+    /**
+     * Unix seconds when disappearing mode was enabled for this chat, from the
+     * app-state `Conversation` record. Present only while the chat is ephemeral.
+     */
+    readonly ephemeralSettingTimestamp?: number
 }
 
 export interface WaThreadStore {

--- a/src/store/contracts/thread.store.ts
+++ b/src/store/contracts/thread.store.ts
@@ -8,8 +8,10 @@ export interface WaStoredThreadRecord {
     readonly markedAsUnread?: boolean
     readonly ephemeralExpiration?: number
     /**
-     * Unix seconds when disappearing mode was enabled for this chat, from the
-     * app-state `Conversation` record. Present only while the chat is ephemeral.
+     * Unix seconds when disappearing mode was enabled for this chat.
+     * History-sync `Conversation` delivers milliseconds; ingest converts to
+     * seconds before persistence. Present only while the chat is ephemeral
+     * (1:1). Groups do not use this field on outgoing messages.
      */
     readonly ephemeralSettingTimestamp?: number
 }

--- a/src/store/contracts/thread.store.ts
+++ b/src/store/contracts/thread.store.ts
@@ -8,10 +8,9 @@ export interface WaStoredThreadRecord {
     readonly markedAsUnread?: boolean
     readonly ephemeralExpiration?: number
     /**
-     * Unix seconds when disappearing mode was enabled for this chat.
-     * History-sync `Conversation` delivers milliseconds; ingest converts to
-     * seconds before persistence. Present only while the chat is ephemeral
-     * (1:1). Groups do not use this field on outgoing messages.
+     * Unix seconds when disappearing mode was enabled, normalized on ingest to
+     * the unit `ContextInfo` uses on the wire. Set only for ephemeral 1:1 chats;
+     * groups do not carry it on outgoing messages.
      */
     readonly ephemeralSettingTimestamp?: number
 }


### PR DESCRIPTION
## Summary

zapo-js was sending `contextInfo.expiration` but never `contextInfo.ephemeralSettingTimestamp`
(proto field 26) on messages in disappearing chats. Without the timestamp, recipients saw the
warning _"This message will not disappear. The person may be using an older version of WhatsApp."_

This fixes the gap for **both 1:1 and group chats**:

- Group TTL is resolved from the group metadata cache; 1:1 TTL from the thread store ephemeral expiration.
- The setting timestamp is always read from the thread store (app-state `Conversation` record, fields 9–10).
- Both fields are injected automatically whenever the chat is in disappearing mode.
- Optional overrides are honored: `sendMessage({ expirationSeconds, ephemeralSettingTimestamp })` and `disableGroupEphemeralAutoInject`.

## Changes

- `src/client/coordinators/WaMessageDispatchCoordinator.ts`: replaced the group-only block with
  `resolveChatEphemeral()` covering 1:1 and group; wired `threadStore` dependency.
- `src/message/context-info.ts`: `WaSendContextInfo.ephemeralSettingTimestamp` → `buildContextInfoProto` (field 26).
- `src/client/types.ts`: `WaSendMessageOptions.ephemeralSettingTimestamp` documented.
- `src/store/contracts/thread.store.ts`: `WaStoredThreadRecord.ephemeralSettingTimestamp`.
- `src/client/persistence/history-sync.ts` + `WriteBehindPersistence.ts`: persist/merge the timestamp.
- Store providers (sqlite + migration 0017, mysql, postgres, redis, mongo): carry the new column.
- `src/client/WaClientFactory.ts`: wire `threadStore` into the dispatch coordinator.
- Tests: context-info, WriteBehindPersistence merge, and coordinator dispatch (1:1 + group + override + absent).

## Verification

`npm run typecheck`, `npm run typecheck:packages` (10/10), `npm run lint`, `npm run format:check`,
`npm run test` (909 pass), and `npm run test:structure` all pass. No `ephemeralSettingTimestamp` is
logged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced disappearing-message support for one-to-one chats by persisting and propagating the “enablement” (ephemeral setting) timestamp.
  * Outgoing one-to-one messages now automatically include both expiration and the enablement timestamp when available.
  * Added support for explicitly providing the enablement timestamp when sending.
  * History sync and write-behind persistence now retain enablement timestamps consistently.
* **Bug Fixes**
  * Improved compatibility with legacy millisecond timestamp formats.
  * Prevented enablement timestamp metadata from affecting group messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->