### PR TITLE
feat(media): expose client.message.upload() and WaMediaCrypto

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -543,7 +543,7 @@ class WaClientImpl extends EventEmitter {
     public get auth(): WaAuthClient {
         return this.deps.authClient
     }
-    /** Message coordinator: send/receive, receipts, addons, media download. */
+    /** Message coordinator: send/receive, receipts, addons, media upload/download. */
     public get message(): WaMessageCoordinator {
         return this.deps.messageCoordinator
     }

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -803,6 +803,7 @@ export function buildWaClientDependencies(input: {
     const messageCoordinator = new WaMessageCoordinator({
         messageDispatch,
         mediaTransfer,
+        mediaUploadOptions: mediaMessageBuildOptions,
         logger,
         messageStore: sessionStore.messages,
         messageSecretStore: sessionStore.messageSecret,

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -11,7 +11,11 @@ import {
     isReadableStream,
     type WaUploadMediaSource
 } from '@client/media'
-import { uploadMedia, type WaMediaMessageOptions } from '@client/messaging/messages'
+import {
+    uploadMedia,
+    type UploadResult,
+    type WaMediaMessageOptions
+} from '@client/messaging/messages'
 import type {
     WaDownloadMediaOptions,
     WaIncomingAddonEvent,
@@ -21,6 +25,7 @@ import type {
 import type { Logger } from '@infra/log/types'
 import { MEDIA_UPLOAD_PATHS } from '@media/constants'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
+import type { MediaKind } from '@media/types'
 import {
     buildAddonAdditionalData,
     decodeAddonPlaintext,
@@ -135,15 +140,7 @@ function parseMessageCappingMexResponse(
  * Media kinds accepted by {@link WaMessageCoordinator.upload}. `gif` is a
  * GIF-playback video, `ptt` a voice note, `ptv` a round video note.
  */
-export type WaUploadMediaType =
-    | 'image'
-    | 'video'
-    | 'audio'
-    | 'document'
-    | 'sticker'
-    | 'ptv'
-    | 'gif'
-    | 'ptt'
+export type WaUploadMediaType = MediaKind | 'gif' | 'ptt'
 
 /** Options for {@link WaMessageCoordinator.upload}. */
 export interface WaUploadMediaOptions {
@@ -163,32 +160,15 @@ export interface WaUploadMediaOptions {
     readonly signal?: AbortSignal
 }
 
-/** Reusable descriptor returned by {@link WaMessageCoordinator.upload}. */
-export interface WaMediaUploadResult {
-    /** Absolute CDN URL of the uploaded ciphertext. */
-    readonly url: string
-    /** Host-relative path; pairs with a media host or feeds `downloadMediaMessage`. */
-    readonly directPath: string
-    /** 32-byte media key used to encrypt (and later decrypt) the payload. */
-    readonly mediaKey: Uint8Array
-    /** SHA-256 of the plaintext. */
-    readonly fileSha256: Uint8Array
-    /** SHA-256 of the encrypted `ciphertext||mac`. */
-    readonly fileEncSha256: Uint8Array
-    /** Plaintext byte length. */
-    readonly fileLength: number
+/**
+ * Reusable descriptor returned by {@link WaMessageCoordinator.upload}: the
+ * {@link UploadResult} fields plus the media-key timestamp and echoed mimetype.
+ */
+export interface WaMediaUploadResult extends UploadResult {
     /** Unix seconds the media key was minted; belongs on the message proto. */
     readonly mediaKeyTimestamp: number
     /** Echo of the `mimetype` option when provided. */
     readonly mimetype?: string
-    /** Server metadata URL, when the CDN returns one (video). */
-    readonly metadataUrl?: string
-    /** Streaming sidecar for seekable playback, when computed. */
-    readonly streamingSidecar?: Uint8Array
-    /** First-frame sidecar for animated stickers, when computed. */
-    readonly firstFrameSidecar?: Uint8Array
-    /** First-frame length echoed back for animated stickers. */
-    readonly firstFrameLength?: number
 }
 
 const SIDECAR_UPLOAD_TYPES: ReadonlySet<WaUploadMediaType> = new Set([
@@ -512,18 +492,9 @@ export class WaMessageCoordinator {
             logLabel: 'user media upload'
         })
         return {
-            url: result.url,
-            directPath: result.directPath,
-            mediaKey: result.mediaKey,
-            fileSha256: result.fileSha256,
-            fileEncSha256: result.fileEncSha256,
-            fileLength: result.fileLength,
+            ...result,
             mediaKeyTimestamp: this.mediaUploadOptions.serverClock.nowSeconds(),
-            mimetype: options.mimetype,
-            metadataUrl: result.metadataUrl,
-            streamingSidecar: result.streamingSidecar,
-            firstFrameSidecar: result.firstFrameSidecar,
-            firstFrameLength: result.firstFrameLength
+            mimetype: options.mimetype
         }
     }
 

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -495,10 +495,14 @@ export class WaMessageCoordinator {
         source: WaUploadMediaSource,
         options: WaUploadMediaOptions
     ): Promise<WaMediaUploadResult> {
+        const uploadPath = MEDIA_UPLOAD_PATHS[options.type as keyof typeof MEDIA_UPLOAD_PATHS]
+        if (!uploadPath) {
+            throw new Error(`unknown media upload type: ${String(options.type)}`)
+        }
         const result = await uploadMedia(this.mediaUploadOptions, {
             source: await normalizeUploadSource(source),
             cryptoType: options.type,
-            uploadPath: MEDIA_UPLOAD_PATHS[options.type],
+            uploadPath,
             contentType: options.mimetype,
             mediaKey: options.mediaKey,
             sidecar: options.sidecar ?? SIDECAR_UPLOAD_TYPES.has(options.type),

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -1,11 +1,17 @@
-import { createWriteStream } from 'node:fs'
+import { createReadStream, createWriteStream } from 'node:fs'
 import type { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 
 import type { WaMessageDispatchCoordinator } from '@client/coordinators/WaMessageDispatchCoordinator'
 import type { WaTrustedContactTokenCoordinator } from '@client/coordinators/WaTrustedContactTokenCoordinator'
 import { aggregateReceiptTargets } from '@client/events/receipt'
-import { downloadMediaMessage } from '@client/media'
+import {
+    assertReadableFile,
+    downloadMediaMessage,
+    isReadableStream,
+    type WaUploadMediaSource
+} from '@client/media'
+import { uploadMedia, type WaMediaMessageOptions } from '@client/messaging/messages'
 import type {
     WaDownloadMediaOptions,
     WaIncomingAddonEvent,
@@ -13,6 +19,7 @@ import type {
     WaSendMessageOptions
 } from '@client/types'
 import type { Logger } from '@infra/log/types'
+import { MEDIA_UPLOAD_PATHS } from '@media/constants'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import {
     buildAddonAdditionalData,
@@ -45,6 +52,8 @@ import { toError } from '@util/primitives'
 export interface WaMessageCoordinatorDeps {
     readonly messageDispatch: WaMessageDispatchCoordinator
     readonly mediaTransfer: WaMediaTransferClient
+    /** Media upload wiring shared with the send path; backs {@link WaMessageCoordinator.upload}. */
+    readonly mediaUploadOptions: WaMediaMessageOptions
     readonly logger: Logger
     readonly messageStore: WaMessageStore
     readonly messageSecretStore: WaMessageSecretStore
@@ -123,13 +132,96 @@ function parseMessageCappingMexResponse(
 }
 
 /**
+ * Media kinds accepted by {@link WaMessageCoordinator.upload}. `gif` is a
+ * GIF-playback video, `ptt` a voice note, `ptv` a round video note.
+ */
+export type WaUploadMediaType =
+    | 'image'
+    | 'video'
+    | 'audio'
+    | 'document'
+    | 'sticker'
+    | 'ptv'
+    | 'gif'
+    | 'ptt'
+
+/** Options for {@link WaMessageCoordinator.upload}. */
+export interface WaUploadMediaOptions {
+    /** Media type: sets the encryption context and CDN upload path. */
+    readonly type: WaUploadMediaType
+    /** `Content-Type` for the upload and the mimetype for the message proto. */
+    readonly mimetype?: string
+    /** Reuse a 32-byte media key instead of generating one. */
+    readonly mediaKey?: Uint8Array
+    /** Override the streaming sidecar (default on for video/ptv/audio/gif/ptt). */
+    readonly sidecar?: boolean
+    /** Animated-sticker first-frame length for the first-frame sidecar. */
+    readonly firstFrameLength?: number
+    /** Per-upload transfer timeout override (ms). */
+    readonly timeoutMs?: number
+    /** Cancellation signal forwarded to the CDN request. */
+    readonly signal?: AbortSignal
+}
+
+/** Reusable descriptor returned by {@link WaMessageCoordinator.upload}. */
+export interface WaMediaUploadResult {
+    /** Absolute CDN URL of the uploaded ciphertext. */
+    readonly url: string
+    /** Host-relative path; pairs with a media host or feeds `downloadMediaMessage`. */
+    readonly directPath: string
+    /** 32-byte media key used to encrypt (and later decrypt) the payload. */
+    readonly mediaKey: Uint8Array
+    /** SHA-256 of the plaintext. */
+    readonly fileSha256: Uint8Array
+    /** SHA-256 of the encrypted `ciphertext||mac`. */
+    readonly fileEncSha256: Uint8Array
+    /** Plaintext byte length. */
+    readonly fileLength: number
+    /** Unix seconds the media key was minted; belongs on the message proto. */
+    readonly mediaKeyTimestamp: number
+    /** Echo of the `mimetype` option when provided. */
+    readonly mimetype?: string
+    /** Server metadata URL, when the CDN returns one (video). */
+    readonly metadataUrl?: string
+    /** Streaming sidecar for seekable playback, when computed. */
+    readonly streamingSidecar?: Uint8Array
+    /** First-frame sidecar for animated stickers, when computed. */
+    readonly firstFrameSidecar?: Uint8Array
+    /** First-frame length echoed back for animated stickers. */
+    readonly firstFrameLength?: number
+}
+
+const SIDECAR_UPLOAD_TYPES: ReadonlySet<WaUploadMediaType> = new Set([
+    'video',
+    'ptv',
+    'audio',
+    'gif',
+    'ptt'
+])
+
+async function normalizeUploadSource(source: WaUploadMediaSource): Promise<Uint8Array | Readable> {
+    if (source instanceof Uint8Array) {
+        return source
+    }
+    if (typeof source === 'string') {
+        await assertReadableFile(source)
+        return createReadStream(source)
+    }
+    if (isReadableStream(source)) {
+        return source
+    }
+    throw new Error('media upload received unsupported source type')
+}
+
+/**
  * Coordinates outbound message sending, receipts, addon decryption, media
- * download, and the related MEX account queries. Accessed via
+ * upload/download, and the related MEX account queries. Accessed via
  * {@link WaClient.message}.
  */
 export class WaMessageCoordinator {
     private readonly messageDispatch: WaMessageDispatchCoordinator
     private readonly mediaTransfer: WaMediaTransferClient
+    private readonly mediaUploadOptions: WaMediaMessageOptions
     private readonly logger: Logger
     private readonly messageStore: WaMessageStore
     private readonly messageSecretStore: WaMessageSecretStore
@@ -141,6 +233,7 @@ export class WaMessageCoordinator {
     public constructor(deps: WaMessageCoordinatorDeps) {
         this.messageDispatch = deps.messageDispatch
         this.mediaTransfer = deps.mediaTransfer
+        this.mediaUploadOptions = deps.mediaUploadOptions
         this.logger = deps.logger
         this.messageStore = deps.messageStore
         this.messageSecretStore = deps.messageSecretStore
@@ -366,6 +459,67 @@ export class WaMessageCoordinator {
                 ...options,
                 participant: group.participant
             })
+        }
+    }
+
+    /**
+     * Encrypts and uploads standalone media to the WhatsApp CDN and returns the
+     * reusable descriptor, without sending a message - pre-upload once and
+     * reference it across sends, or build custom protos. Needs a connected
+     * session (the host token comes from a `media_conn` IQ). `source` is bytes,
+     * a file path, or a `Readable`. To send the result, spread its fields onto
+     * the matching proto message and pass that to {@link send}.
+     *
+     * @throws when `source` is unsupported, the file is unreadable, or the upload fails.
+     * @example
+     * ```ts
+     * const media = await client.message.upload(await readFile('photo.jpg'), {
+     *     type: 'image',
+     *     mimetype: 'image/jpeg'
+     * })
+     * await client.message.send(jid, {
+     *     imageMessage: {
+     *         url: media.url,
+     *         directPath: media.directPath,
+     *         mediaKey: media.mediaKey,
+     *         fileSha256: media.fileSha256,
+     *         fileEncSha256: media.fileEncSha256,
+     *         fileLength: media.fileLength,
+     *         mediaKeyTimestamp: media.mediaKeyTimestamp,
+     *         mimetype: media.mimetype
+     *     }
+     * })
+     * ```
+     */
+    public async upload(
+        source: WaUploadMediaSource,
+        options: WaUploadMediaOptions
+    ): Promise<WaMediaUploadResult> {
+        const result = await uploadMedia(this.mediaUploadOptions, {
+            source: await normalizeUploadSource(source),
+            cryptoType: options.type,
+            uploadPath: MEDIA_UPLOAD_PATHS[options.type],
+            contentType: options.mimetype,
+            mediaKey: options.mediaKey,
+            sidecar: options.sidecar ?? SIDECAR_UPLOAD_TYPES.has(options.type),
+            firstFrameLength: options.firstFrameLength,
+            timeoutMs: options.timeoutMs,
+            signal: options.signal,
+            logLabel: 'user media upload'
+        })
+        return {
+            url: result.url,
+            directPath: result.directPath,
+            mediaKey: result.mediaKey,
+            fileSha256: result.fileSha256,
+            fileEncSha256: result.fileEncSha256,
+            fileLength: result.fileLength,
+            mediaKeyTimestamp: this.mediaUploadOptions.serverClock.nowSeconds(),
+            mimetype: options.mimetype,
+            metadataUrl: result.metadataUrl,
+            streamingSidecar: result.streamingSidecar,
+            firstFrameSidecar: result.firstFrameSidecar,
+            firstFrameLength: result.firstFrameLength
         }
     }
 

--- a/src/client/coordinators/__tests__/message-coordinator-upload.test.ts
+++ b/src/client/coordinators/__tests__/message-coordinator-upload.test.ts
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict'
+import { Readable } from 'node:stream'
+import test from 'node:test'
+
+import { WaMessageCoordinator } from '@client/coordinators/WaMessageCoordinator'
+import type { WaMediaMessageOptions } from '@client/messaging/messages'
+import { sha256 } from '@crypto'
+import { createNoopLogger } from '@infra/log/types'
+import { WaMediaCrypto } from '@media/crypto/WaMediaCrypto'
+import { readAllBytes, TEXT_ENCODER } from '@util/bytes'
+
+interface CapturedUpload {
+    url?: string
+    method?: string
+    contentType?: string
+    contentLength?: number
+    body?: Uint8Array
+    timeoutMs?: number
+}
+
+const SERVER_NOW_SECONDS = 4242
+
+function fakeMediaUploadOptions(
+    captured: CapturedUpload,
+    response: unknown = { url: 'https://cdn/enc', direct_path: '/v/enc' }
+): { readonly options: WaMediaMessageOptions; readonly queryCalls: () => number } {
+    let queryCalls = 0
+    const mediaTransfer = {
+        uploadStream: async (req: {
+            readonly url: string
+            readonly method?: string
+            readonly body: Uint8Array | Readable
+            readonly contentLength?: number
+            readonly contentType?: string
+            readonly timeoutMs?: number
+        }) => {
+            captured.url = req.url
+            captured.method = req.method
+            captured.contentType = req.contentType
+            captured.contentLength = req.contentLength
+            captured.timeoutMs = req.timeoutMs
+            captured.body = req.body instanceof Uint8Array ? req.body : await readAllBytes(req.body)
+            return { url: req.url, status: 200, ok: true, headers: {}, body: null }
+        },
+        readResponseBytes: async () => TEXT_ENCODER.encode(JSON.stringify(response))
+    }
+    const options = {
+        logger: createNoopLogger(),
+        mediaTransfer,
+        getMediaConnCache: () => ({
+            auth: 'AUTH-TOKEN',
+            expiresAtMs: Date.now() + 3_600_000,
+            hosts: [
+                { hostname: 'mmg-fallback.whatsapp.net', isFallback: true },
+                { hostname: 'mmg.whatsapp.net', isFallback: false }
+            ]
+        }),
+        setMediaConnCache: () => undefined,
+        queryWithContext: async () => {
+            queryCalls += 1
+            throw new Error('media_conn should not be queried when the cache is fresh')
+        },
+        serverClock: {
+            nowSeconds: () => SERVER_NOW_SECONDS,
+            nowMs: () => SERVER_NOW_SECONDS * 1000
+        }
+    } as unknown as WaMediaMessageOptions
+    return { options, queryCalls: () => queryCalls }
+}
+
+function createUploadCoordinator(mediaUploadOptions: WaMediaMessageOptions): WaMessageCoordinator {
+    return new WaMessageCoordinator({
+        messageDispatch: {} as never,
+        mediaTransfer: {} as never,
+        mediaUploadOptions,
+        logger: createNoopLogger(),
+        messageStore: {} as never,
+        messageSecretStore: {} as never,
+        trustedContactToken: {} as never,
+        emitAddon: () => undefined,
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
+        peerDataOperation: {} as never
+    })
+}
+
+test('upload encrypts image bytes, targets the non-fallback host + type path, echoes descriptor', async () => {
+    const captured: CapturedUpload = {}
+    const { options } = fakeMediaUploadOptions(captured)
+    const coordinator = createUploadCoordinator(options)
+    const plaintext = TEXT_ENCODER.encode('hello media payload')
+
+    const result = await coordinator.upload(plaintext, { type: 'image', mimetype: 'image/jpeg' })
+
+    assert.match(captured.url ?? '', /^https:\/\/mmg\.whatsapp\.net\/mms\/image\//)
+    assert.match(captured.url ?? '', /auth=AUTH-TOKEN/)
+    assert.equal(captured.method, 'POST')
+    assert.equal(captured.contentType, 'image/jpeg')
+
+    assert.equal(result.url, 'https://cdn/enc')
+    assert.equal(result.directPath, '/v/enc')
+    assert.equal(result.mimetype, 'image/jpeg')
+    assert.equal(result.mediaKeyTimestamp, SERVER_NOW_SECONDS)
+    assert.equal(result.mediaKey.byteLength, 32)
+    assert.equal(result.fileLength, plaintext.byteLength)
+    assert.deepEqual(result.fileSha256, sha256(plaintext))
+    assert.equal(result.streamingSidecar, undefined)
+
+    const roundTrip = await WaMediaCrypto.decryptBytes(
+        'image',
+        result.mediaKey,
+        captured.body!,
+        result.fileSha256,
+        result.fileEncSha256
+    )
+    assert.deepEqual(roundTrip.plaintext, plaintext)
+})
+
+test('upload defaults the streaming sidecar on for video and forwards timeout', async () => {
+    const captured: CapturedUpload = {}
+    const { options } = fakeMediaUploadOptions(captured)
+    const coordinator = createUploadCoordinator(options)
+
+    const result = await coordinator.upload(TEXT_ENCODER.encode('a video body'), {
+        type: 'video',
+        mimetype: 'video/mp4',
+        timeoutMs: 9_999
+    })
+
+    assert.match(captured.url ?? '', /\/mms\/video\//)
+    assert.equal(captured.timeoutMs, 9_999)
+    assert.ok(result.streamingSidecar && result.streamingSidecar.byteLength > 0)
+})
+
+test('upload accepts a readable stream source and reports the plaintext length', async () => {
+    const captured: CapturedUpload = {}
+    const { options } = fakeMediaUploadOptions(captured)
+    const coordinator = createUploadCoordinator(options)
+    const payload = TEXT_ENCODER.encode('streamed document bytes')
+
+    const result = await coordinator.upload(Readable.from([payload]), {
+        type: 'document',
+        mimetype: 'application/pdf'
+    })
+
+    assert.match(captured.url ?? '', /\/mms\/document\//)
+    assert.equal(result.fileLength, payload.byteLength)
+    const roundTrip = await WaMediaCrypto.decryptBytes(
+        'document',
+        result.mediaKey,
+        captured.body!,
+        result.fileSha256,
+        result.fileEncSha256
+    )
+    assert.deepEqual(roundTrip.plaintext, payload)
+})
+
+test('upload reuses a caller-supplied media key', async () => {
+    const captured: CapturedUpload = {}
+    const { options } = fakeMediaUploadOptions(captured)
+    const coordinator = createUploadCoordinator(options)
+    const mediaKey = await WaMediaCrypto.generateMediaKey()
+
+    const result = await coordinator.upload(TEXT_ENCODER.encode('x'), {
+        type: 'image',
+        mimetype: 'image/png',
+        mediaKey
+    })
+
+    assert.deepEqual(result.mediaKey, mediaKey)
+})
+
+test('upload rejects an unsupported source type', async () => {
+    const captured: CapturedUpload = {}
+    const { options } = fakeMediaUploadOptions(captured)
+    const coordinator = createUploadCoordinator(options)
+
+    await assert.rejects(
+        () => coordinator.upload({ not: 'a source' } as never, { type: 'image' }),
+        /unsupported source type/
+    )
+})

--- a/src/client/coordinators/__tests__/message-coordinator-upload.test.ts
+++ b/src/client/coordinators/__tests__/message-coordinator-upload.test.ts
@@ -179,3 +179,15 @@ test('upload rejects an unsupported source type', async () => {
         /unsupported source type/
     )
 })
+
+test('upload rejects an unknown media type before reaching the CDN', async () => {
+    const captured: CapturedUpload = {}
+    const { options } = fakeMediaUploadOptions(captured)
+    const coordinator = createUploadCoordinator(options)
+
+    await assert.rejects(
+        () => coordinator.upload(TEXT_ENCODER.encode('x'), { type: 'bogus' as never }),
+        /unknown media upload type: bogus/
+    )
+    assert.equal(captured.url, undefined)
+})

--- a/src/client/coordinators/__tests__/message-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/message-coordinator.test.ts
@@ -35,6 +35,7 @@ function createCoordinator(peerDataOperation: PeerDataOperationRequester): WaMes
     return new WaMessageCoordinator({
         messageDispatch: {} as never,
         mediaTransfer: {} as never,
+        mediaUploadOptions: {} as never,
         logger: createNoopLogger(),
         messageStore: {} as never,
         messageSecretStore: {} as never,

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -323,7 +323,7 @@ export interface ResolvedMediaInputs {
     readonly tempFilePath?: string
 }
 
-async function assertReadableFile(filePath: string): Promise<void> {
+export async function assertReadableFile(filePath: string): Promise<void> {
     try {
         const stats = await stat(filePath)
         if (!stats.isFile()) {

--- a/src/client/messaging/messages.ts
+++ b/src/client/messaging/messages.ts
@@ -536,9 +536,15 @@ async function buildMediaMessage(
                 ? (content.firstFrameLength ?? detectedFirstFrameLength)
                 : undefined
 
-        const uploadPromise = isReadableStream(resolved.uploadMedia)
-            ? uploadMediaStream(options, content, resolved.uploadMedia, firstFrameLength, mimetype)
-            : uploadMediaBytes(options, content, resolved.uploadMedia, firstFrameLength, mimetype)
+        const uploadType = resolveUploadType(content)
+        const uploadPromise = uploadMedia(options, {
+            source: resolved.uploadMedia,
+            cryptoType: uploadType,
+            uploadPath: resolveUploadPath(uploadType),
+            contentType: mimetype,
+            sidecar: needsSidecar(content),
+            firstFrameLength
+        })
         const processPromise = runMediaProcessor(
             options.media,
             resolved.processorInput,
@@ -736,41 +742,71 @@ function parseUploadResponse(
     }
 }
 
+/** Fully-resolved input for {@link uploadMedia} (crypto type, path, sidecar already decided). */
+export interface WaMediaUploadInput {
+    readonly source: Uint8Array | Readable
+    readonly cryptoType: MediaCryptoType
+    readonly uploadPath: string
+    readonly contentType?: string
+    readonly mediaKey?: Uint8Array
+    readonly sidecar: boolean
+    readonly firstFrameLength?: number
+    readonly logLabel?: string
+    readonly timeoutMs?: number
+    readonly signal?: AbortSignal
+}
+
+/**
+ * Shared media upload primitive: derives (or reuses) a media key, encrypts,
+ * fetches a media connection, and POSTs the ciphertext. Bytes take a
+ * zero-temp-file fast path; streams stage to a temp file first. Backs both the
+ * send path and `WaMessageCoordinator.upload`.
+ */
+export async function uploadMedia(
+    options: WaMediaMessageOptions,
+    input: WaMediaUploadInput
+): Promise<UploadResult> {
+    const mediaKey = input.mediaKey ?? (await WaMediaCrypto.generateMediaKey())
+    if (input.source instanceof Uint8Array) {
+        return uploadMediaBytes(options, input, mediaKey, input.source)
+    }
+    return uploadMediaStream(options, input, mediaKey, input.source)
+}
+
 async function uploadMediaBytes(
     options: WaMediaMessageOptions,
-    content: Exclude<WaSendMediaMessage, WaSendStickerPackMessage>,
-    mediaBytes: Uint8Array,
-    firstFrameLength: number | undefined,
-    mimetype: string
+    input: WaMediaUploadInput,
+    mediaKey: Uint8Array,
+    mediaBytes: Uint8Array
 ): Promise<UploadResult> {
-    const uploadType = resolveUploadType(content)
-    const mediaKey = await WaMediaCrypto.generateMediaKey()
     const [encrypted, mediaConn] = await Promise.all([
-        WaMediaCrypto.encryptBytes(uploadType, mediaKey, mediaBytes, {
-            sidecar: needsSidecar(content),
-            firstFrameLength
+        WaMediaCrypto.encryptBytes(input.cryptoType, mediaKey, mediaBytes, {
+            sidecar: input.sidecar,
+            firstFrameLength: input.firstFrameLength
         }),
         getMediaConn(options)
     ])
     const selectedHost = selectMediaUploadHost(mediaConn)
     const uploadUrl = buildMediaUploadUrl(
         selectedHost,
-        resolveUploadPath(uploadType),
+        input.uploadPath,
         mediaConn.auth,
         encrypted.fileEncSha256
     )
 
-    options.logger.debug('sending media upload request', {
-        mediaType: content.type,
-        uploadType,
-        host: selectedHost
+    options.logger.debug(input.logLabel ?? 'sending media upload request', {
+        cryptoType: input.cryptoType,
+        host: selectedHost,
+        size: mediaBytes.byteLength
     })
     const uploadResponse = await options.mediaTransfer.uploadStream({
         url: uploadUrl,
         method: 'POST',
         body: encrypted.ciphertextHmac,
         contentLength: encrypted.ciphertextHmac.byteLength,
-        contentType: mimetype
+        contentType: input.contentType,
+        timeoutMs: input.timeoutMs,
+        signal: input.signal
     })
     const responseBody = await options.mediaTransfer.readResponseBytes(uploadResponse)
     const parsed = parseUploadResponse(responseBody, uploadResponse.status)
@@ -782,31 +818,20 @@ async function uploadMediaBytes(
         fileLength: mediaBytes.byteLength,
         streamingSidecar: encrypted.streamingSidecar,
         firstFrameSidecar: encrypted.firstFrameSidecar,
-        firstFrameLength
+        firstFrameLength: input.firstFrameLength
     }
 }
 
-interface EncryptedStreamUploadInput {
-    readonly plaintext: Readable
-    readonly mediaKey: Uint8Array
-    readonly cryptoType: MediaCryptoType
-    readonly uploadPath: string
-    readonly contentType: string
-    readonly logLabel: string
-    readonly sidecar: boolean
-    readonly firstFrameLength?: number
-}
-
-async function uploadEncryptedStream(
+async function uploadMediaStream(
     options: WaMediaMessageOptions,
-    input: EncryptedStreamUploadInput
+    input: WaMediaUploadInput,
+    mediaKey: Uint8Array,
+    plaintext: Readable
 ): Promise<UploadResult> {
-    const encResult = await WaMediaCrypto.encryptToFile(
-        input.cryptoType,
-        input.mediaKey,
-        input.plaintext,
-        { sidecar: input.sidecar, firstFrameLength: input.firstFrameLength }
-    )
+    const encResult = await WaMediaCrypto.encryptToFile(input.cryptoType, mediaKey, plaintext, {
+        sidecar: input.sidecar,
+        firstFrameLength: input.firstFrameLength
+    })
     let readStream: ReturnType<typeof createReadStream> | undefined
     try {
         const mediaConn = await getMediaConn(options)
@@ -818,9 +843,9 @@ async function uploadEncryptedStream(
             encResult.fileEncSha256
         )
 
-        options.logger.debug(input.logLabel, {
+        options.logger.debug(input.logLabel ?? 'sending media stream upload request', {
+            cryptoType: input.cryptoType,
             host: selectedHost,
-            uploadPath: input.uploadPath,
             plaintextLength: encResult.plaintextLength,
             encryptedSize: encResult.fileSize
         })
@@ -830,13 +855,15 @@ async function uploadEncryptedStream(
             method: 'POST',
             body: readStream,
             contentLength: encResult.fileSize,
-            contentType: input.contentType
+            contentType: input.contentType,
+            timeoutMs: input.timeoutMs,
+            signal: input.signal
         })
         const responseBody = await options.mediaTransfer.readResponseBytes(uploadResponse)
         const parsed = parseUploadResponse(responseBody, uploadResponse.status)
         return {
             ...parsed,
-            mediaKey: input.mediaKey,
+            mediaKey,
             fileSha256: encResult.fileSha256,
             fileEncSha256: encResult.fileEncSha256,
             fileLength: encResult.plaintextLength,
@@ -855,26 +882,6 @@ async function uploadEncryptedStream(
     }
 }
 
-async function uploadMediaStream(
-    options: WaMediaMessageOptions,
-    content: Exclude<WaSendMediaMessage, WaSendStickerPackMessage>,
-    stream: Readable,
-    firstFrameLength: number | undefined,
-    mimetype: string
-): Promise<UploadResult> {
-    const cryptoType = resolveUploadType(content)
-    return uploadEncryptedStream(options, {
-        plaintext: stream,
-        mediaKey: await WaMediaCrypto.generateMediaKey(),
-        cryptoType,
-        uploadPath: resolveUploadPath(cryptoType),
-        contentType: mimetype,
-        logLabel: 'sending media stream upload request',
-        sidecar: needsSidecar(content),
-        firstFrameLength
-    })
-}
-
 function openStickerPackInputStream(media: Uint8Array | string): Readable {
     return typeof media === 'string' ? createReadStream(media) : Readable.from([media])
 }
@@ -891,23 +898,23 @@ async function buildStickerPackMediaMessage(
 
     const mediaKey = await WaMediaCrypto.generateMediaKey()
     const [bundle, cover] = await Promise.all([
-        uploadEncryptedStream(options, {
-            plaintext: createStickerPackZipStream(toStickerPackZipEntries(content)),
-            mediaKey,
+        uploadMedia(options, {
+            source: createStickerPackZipStream(toStickerPackZipEntries(content)),
             cryptoType: 'sticker-pack',
             uploadPath: MEDIA_UPLOAD_PATHS['sticker-pack'],
             contentType: 'application/zip',
-            logLabel: 'sending sticker pack bundle upload',
-            sidecar: false
-        }),
-        uploadEncryptedStream(options, {
-            plaintext: openStickerPackInputStream(coverThumbnail),
             mediaKey,
+            sidecar: false,
+            logLabel: 'sending sticker pack bundle upload'
+        }),
+        uploadMedia(options, {
+            source: openStickerPackInputStream(coverThumbnail),
             cryptoType: 'thumbnail-sticker-pack',
             uploadPath: MEDIA_UPLOAD_PATHS['thumbnail-sticker-pack'],
             contentType: 'image/jpeg',
-            logLabel: 'sending sticker pack thumbnail upload',
-            sidecar: false
+            mediaKey,
+            sidecar: false,
+            logLabel: 'sending sticker pack thumbnail upload'
         })
     ])
     if (cover.fileLength === 0) {

--- a/src/client/messaging/messages.ts
+++ b/src/client/messaging/messages.ts
@@ -697,16 +697,27 @@ async function buildMediaMessage(
     }
 }
 
-interface UploadResult {
+/** Descriptor produced by {@link uploadMedia}: CDN location, media key, hashes, and optional sidecars. */
+export interface UploadResult {
+    /** Absolute CDN URL of the uploaded ciphertext. */
     readonly url: string
+    /** Host-relative path; pairs with a media host or feeds `downloadMediaMessage`. */
     readonly directPath: string
+    /** 32-byte media key used to encrypt (and later decrypt) the payload. */
     readonly mediaKey: Uint8Array
+    /** SHA-256 of the plaintext. */
     readonly fileSha256: Uint8Array
+    /** SHA-256 of the encrypted `ciphertext||mac`. */
     readonly fileEncSha256: Uint8Array
+    /** Plaintext byte length. */
     readonly fileLength: number
+    /** Server metadata URL, when the CDN returns one (video). */
     readonly metadataUrl?: string
+    /** Streaming sidecar for seekable playback, when computed. */
     readonly streamingSidecar?: Uint8Array
+    /** First-frame sidecar for animated stickers, when computed. */
     readonly firstFrameSidecar?: Uint8Array
+    /** First-frame length echoed back for animated stickers. */
     readonly firstFrameLength?: number
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,12 @@ export type {
     WaWriteBehindOptions
 } from '@client/types'
 export type { WaClientPluginContext, WaClientPluginDefinition } from '@client/plugins'
-export type { WaMessageCoordinator } from '@client/coordinators/WaMessageCoordinator'
+export type {
+    WaMediaUploadResult,
+    WaMessageCoordinator,
+    WaUploadMediaOptions,
+    WaUploadMediaType
+} from '@client/coordinators/WaMessageCoordinator'
 export type {
     WaAccountTakeoverNoticeEvent,
     WaAppStateMutationEvent,
@@ -105,6 +110,21 @@ export type {
 } from '@client/coordinators/WaBusinessCoordinator'
 export { downloadMediaMessage } from '@client/media'
 export type { WaDownloadMediaMessageOptions, WaUploadMediaSource } from '@client/media'
+export { WaMediaCrypto } from '@media/crypto/WaMediaCrypto'
+export { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
+export type {
+    MediaCryptoType,
+    MediaKind,
+    WaMediaConn,
+    WaMediaDecryptReadableOptions,
+    WaMediaDecryptionResult,
+    WaMediaDerivedKeys,
+    WaMediaEncryptionResult,
+    WaMediaFileEncryptionResult,
+    WaMediaReadableDecryptionResult,
+    WaMediaReadableEncryptionResult,
+    WaMediaTransferClientOptions
+} from '@media/types'
 export type { WaEditBusinessProfileInput } from '@transport/node/builders/business'
 export type {
     WaEmailCoordinator,


### PR DESCRIPTION
Add a session-bound client.message.upload(source, options) that encrypts and uploads standalone media to the WhatsApp CDN, returning the reusable descriptor (url, directPath, mediaKey, file hashes, sidecars, mediaKeyTimestamp) without sending a message. Extract a shared uploadMedia() primitive so the media send path, sticker-pack upload, and the new method share one encrypt/conn/upload/parse flow instead of duplicating it. Bytes take a zero-temp-file fast path; streams stage to a temp file.

Re-export WaMediaCrypto and WaMediaTransferClient (plus their result and option types) from the package root, making media encryption/decryption usable standalone and fixing WaDownloadMediaMessageOptions.transfer referencing a type that was not exported.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled standalone media pre-upload to the CDN with reusable encrypted-media details for later message creation.
  * Media uploads now support byte arrays, file paths, and readable streams, with configurable options such as sidecars, timeouts, content types, and media-key reuse.
  * Updated sticker-pack ZIP and thumbnail uploads to use the unified upload flow.
  * Expanded public exports for media crypto/transfer and media-upload/coordinator types.
* **Tests**
  * Added end-to-end coverage for media upload behavior and input validation.
* **Documentation**
  * Updated media coordinator documentation to reflect both upload and download capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->