### PR TITLE
fix(transport): keepalive dead-socket detection starved by pending queries

### DIFF
--- a/src/transport/WaComms.ts
+++ b/src/transport/WaComms.ts
@@ -633,6 +633,7 @@ export class WaComms {
             this.resumeHandshakeFailures = 0
         }
         this.noiseSession = null
+        this.lastInboundAtMs = 0
         this.clearPendingFrames()
         this.pendingFramesOverflowClosing = false
         if (options.clearHandlers) {

--- a/src/transport/WaComms.ts
+++ b/src/transport/WaComms.ts
@@ -55,6 +55,7 @@ export class WaComms {
     private usedResumeHandshake: boolean
     private noiseSession: WaNoiseSession | null
     private lastServerStaticKey: Uint8Array | null
+    private lastInboundAtMs: number
     private frameProcessingQueue: Promise<void>
     private readonly frameHandlerQueue: BoundedTaskQueue
 
@@ -123,6 +124,7 @@ export class WaComms {
         this.usedResumeHandshake = false
         this.noiseSession = null
         this.lastServerStaticKey = null
+        this.lastInboundAtMs = 0
         this.frameProcessingQueue = Promise.resolve()
         this.frameHandlerQueue = new BoundedTaskQueue(
             WA_FRAME_HANDLER_QUEUE_MAX_SIZE,
@@ -266,6 +268,11 @@ export class WaComms {
         await this.socket.send(wire)
     }
 
+    /** Timestamp (`Date.now()` ms) of the last raw payload received from the socket; `0` before any inbound. */
+    public getLastInboundAtMs(): number {
+        return this.lastInboundAtMs
+    }
+
     public getCommsState(): Readonly<WaCommsState> {
         return {
             started: this.started,
@@ -354,6 +361,7 @@ export class WaComms {
     }
 
     private onSocketMessage(payload: Uint8Array): void {
+        this.lastInboundAtMs = Date.now()
         this.frameProcessingQueue = this.frameProcessingQueue.then(
             () => this.processSocketPayload(payload),
             () => this.processSocketPayload(payload)

--- a/src/transport/keepalive/WaKeepAlive.ts
+++ b/src/transport/keepalive/WaKeepAlive.ts
@@ -12,6 +12,7 @@ interface WaKeepAliveOptions {
     readonly logger: Logger
     readonly nodeOrchestrator: {
         hasPending(): boolean
+        clearPending(reason: Error): void
         query(node: BinaryNode, timeoutMs?: number): Promise<BinaryNode>
     }
     readonly getComms: () => WaComms | null
@@ -26,8 +27,13 @@ interface WaKeepAliveOptions {
 
 /**
  * Periodically pings the server with a ping IQ to detect dead sockets and
- * measure clock skew. Skips when the orchestrator has other traffic in
- * flight; recovers a queued/dropped ping via the configured `getComms()`.
+ * measure clock skew. A ping is skipped while another ping is in flight, or
+ * while other queries are pending and the socket shows recent inbound
+ * activity. A socket silent past the dead-socket timeout is pinged even with
+ * queries pending: pending queries on a silent socket are evidence of a dead
+ * connection, so steady outbound traffic must not starve detection. On ping
+ * failure it rejects pending queries and resumes the socket via the
+ * configured `getComms()`.
  */
 export class WaKeepAlive {
     private readonly logger: Logger
@@ -112,13 +118,25 @@ export class WaKeepAlive {
             return
         }
 
-        if (this.inFlight || this.nodeOrchestrator.hasPending()) {
-            this.logger.trace('keepalive skipped: in-flight or pending queries', {
-                inFlight: this.inFlight,
-                pendingQueries: this.nodeOrchestrator.hasPending()
-            })
+        if (this.inFlight) {
+            this.logger.trace('keepalive skipped: ping already in flight')
             this.schedule(generation)
             return
+        }
+
+        if (this.nodeOrchestrator.hasPending()) {
+            const inboundIdleMs = Date.now() - comms.getLastInboundAtMs()
+            if (inboundIdleMs < this.timeoutMs) {
+                this.logger.trace('keepalive skipped: pending queries with recent inbound', {
+                    inboundIdleMs
+                })
+                this.schedule(generation)
+                return
+            }
+            this.logger.debug('keepalive pinging despite pending queries: inbound is silent', {
+                inboundIdleMs,
+                timeoutMs: this.timeoutMs
+            })
         }
 
         this.inFlight = true
@@ -152,6 +170,9 @@ export class WaKeepAlive {
             this.logger.warn('keepalive ping failed, reconnecting socket', {
                 message: toError(error).message
             })
+            this.nodeOrchestrator.clearPending(
+                new Error('socket resume requested by keepalive ping failure')
+            )
             try {
                 await comms.closeSocketAndResume()
             } catch (resumeError) {

--- a/src/transport/keepalive/__tests__/keepalive.test.ts
+++ b/src/transport/keepalive/__tests__/keepalive.test.ts
@@ -12,6 +12,7 @@ test('keepalive issues ping queries when connected and idle', async (t) => {
         logger: createNoopLogger(),
         nodeOrchestrator: {
             hasPending: () => false,
+            clearPending: () => undefined,
             query: async () => {
                 queryCount += 1
                 return { tag: 'iq', attrs: { type: 'result' } }
@@ -44,6 +45,7 @@ test('keepalive asks comms to resume when ping fails', async (t) => {
         logger: createNoopLogger(),
         nodeOrchestrator: {
             hasPending: () => false,
+            clearPending: () => undefined,
             query: async () => {
                 throw new Error('timeout')
             }
@@ -88,6 +90,7 @@ test('keepalive reports clock skew from ping response with half-RTT compensation
         logger: createNoopLogger(),
         nodeOrchestrator: {
             hasPending: () => false,
+            clearPending: () => undefined,
             query: async () => {
                 nowMs += latencyMs
                 return {
@@ -128,6 +131,7 @@ test('keepalive skips clock skew update when ping response has no t', async (t) 
         logger: createNoopLogger(),
         nodeOrchestrator: {
             hasPending: () => false,
+            clearPending: () => undefined,
             query: async () => ({ tag: 'iq', attrs: { type: 'result' } })
         },
         getComms: () =>
@@ -158,6 +162,7 @@ test('keepalive ignores invalid t attribute', async (t) => {
         logger: createNoopLogger(),
         nodeOrchestrator: {
             hasPending: () => false,
+            clearPending: () => undefined,
             query: async () => ({
                 tag: 'iq',
                 attrs: { type: 'result', t: 'not-a-number' }
@@ -192,6 +197,7 @@ test('keepalive does not resume when stopped while a ping is in flight', async (
         logger: createNoopLogger(),
         nodeOrchestrator: {
             hasPending: () => false,
+            clearPending: () => undefined,
             query: () =>
                 new Promise<never>((_resolve, reject) => {
                     rejectPing = reject
@@ -221,4 +227,112 @@ test('keepalive does not resume when stopped while a ping is in flight', async (
     await Promise.resolve()
 
     assert.equal(resumed, 0)
+})
+
+test('keepalive pings despite pending queries when inbound is silent', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    let queryCount = 0
+    const keepAlive = new WaKeepAlive({
+        logger: createNoopLogger(),
+        nodeOrchestrator: {
+            hasPending: () => true,
+            clearPending: () => undefined,
+            query: async () => {
+                queryCount += 1
+                return { tag: 'iq', attrs: { type: 'result' } }
+            }
+        },
+        getComms: () =>
+            ({
+                getCommsState: () => ({ connected: true }),
+                getLastInboundAtMs: () => 0
+            }) as never,
+        intervalMs: 5,
+        timeoutMs: 5,
+        jitterRatio: 0,
+        minJitterMs: 0
+    })
+
+    keepAlive.start()
+    t.mock.timers.tick(5)
+    await Promise.resolve()
+    await Promise.resolve()
+    keepAlive.stop()
+
+    assert.ok(queryCount >= 1)
+})
+
+test('keepalive skips ping while pending queries have recent inbound', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    let queryCount = 0
+    const keepAlive = new WaKeepAlive({
+        logger: createNoopLogger(),
+        nodeOrchestrator: {
+            hasPending: () => true,
+            clearPending: () => undefined,
+            query: async () => {
+                queryCount += 1
+                return { tag: 'iq', attrs: { type: 'result' } }
+            }
+        },
+        getComms: () =>
+            ({
+                getCommsState: () => ({ connected: true }),
+                getLastInboundAtMs: () => Date.now()
+            }) as never,
+        intervalMs: 5,
+        timeoutMs: 5,
+        jitterRatio: 0,
+        minJitterMs: 0
+    })
+
+    keepAlive.start()
+    t.mock.timers.tick(5)
+    await Promise.resolve()
+    await Promise.resolve()
+    keepAlive.stop()
+
+    assert.equal(queryCount, 0)
+})
+
+test('keepalive rejects pending queries when ping fails', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] })
+
+    let resumed = 0
+    const clearReasons: string[] = []
+    const keepAlive = new WaKeepAlive({
+        logger: createNoopLogger(),
+        nodeOrchestrator: {
+            hasPending: () => false,
+            clearPending: (reason) => {
+                clearReasons.push(reason.message)
+            },
+            query: async () => {
+                throw new Error('timeout')
+            }
+        },
+        getComms: () =>
+            ({
+                getCommsState: () => ({ connected: true }),
+                closeSocketAndResume: async () => {
+                    resumed += 1
+                }
+            }) as never,
+        intervalMs: 5,
+        timeoutMs: 5,
+        jitterRatio: 0,
+        minJitterMs: 0
+    })
+
+    keepAlive.start()
+    t.mock.timers.tick(5)
+    await Promise.resolve()
+    await Promise.resolve()
+    keepAlive.stop()
+
+    assert.equal(clearReasons.length, 1)
+    assert.equal(clearReasons[0], 'socket resume requested by keepalive ping failure')
+    assert.equal(resumed, 1)
 })


### PR DESCRIPTION
The keepalive skipped its ping whenever the orchestrator had pending queries, treating them as proof of live traffic. On a zombie socket the opposite is true: writes succeed, responses never arrive, so a busy session always has pending queries and the dead-socket detector never runs - the connection stays stuck timing out every query until the server happens to push a stream:error.

Track the last raw inbound payload timestamp on WaComms and only skip the ping while pending queries are backed by recent inbound activity. A socket silent past deadSocketTimeoutMs is pinged even with queries pending. On ping failure, reject pending queries before resuming the socket (parity with the stream:error resume path) so callers fail fast instead of waiting out their own timers.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection keepalive behavior by skipping unnecessary pings when recent inbound activity is detected, even when queries are pending.
  * On keepalive ping failure, pending queries are now cleared with an error reason before the socket is resumed.
* **Reliability**
  * Added tracking for the timestamp of the most recent inbound socket message to enable more accurate connection health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->