### PR TITLE
fix(privacy): address blocklist block/unblock by lid

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -654,7 +654,10 @@ export function buildWaClientDependencies(input: {
     })
 
     const privacyCoordinator = createPrivacyCoordinator({
-        queryWithContext: runtime.queryWithContext
+        queryWithContext: runtime.queryWithContext,
+        deviceListStore: sessionStore.deviceList,
+        queryLidsByPhoneJids: (phoneJids) => signalDeviceSync.queryLidsByPhoneJids(phoneJids),
+        logger
     })
 
     const businessCoordinator = createBusinessCoordinator({

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -655,9 +655,7 @@ export function buildWaClientDependencies(input: {
 
     const privacyCoordinator = createPrivacyCoordinator({
         queryWithContext: runtime.queryWithContext,
-        deviceListStore: sessionStore.deviceList,
-        queryLidsByPhoneJids: (phoneJids) => signalDeviceSync.queryLidsByPhoneJids(phoneJids),
-        logger
+        resolveUserJidPair: (userJid) => signalDeviceSync.resolveUserJidPair(userJid)
     })
 
     const businessCoordinator = createBusinessCoordinator({

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -513,30 +513,16 @@ export class WaMessageDispatchCoordinator {
 
     /**
      * For a 1:1 recipient passed in PN form, returns the LID-addressed user JID
-     * (cache-first; falls back to a one-shot `queryLidsByPhoneJids`). Switching
-     * to LID before fanout ensures the envelope, eligible-requester list, and
+     * (via {@link SignalDeviceSyncApi.resolveUserJidPair}). Switching to LID
+     * before fanout ensures the envelope, eligible-requester list, and
      * retry-receipt addressing all agree, which keeps the retry tracker from
      * rejecting receipts that arrive in LID form. Returns the original PN if
      * no LID is known/resolvable. Inputs already in LID form pass through.
      */
     private async resolveDirectRecipientLid(pnUserJid: string): Promise<string> {
         if (isLidJid(pnUserJid)) return pnUserJid
-        const cached = await this.deps.deviceListStore.findByAnyUserJid(pnUserJid)
-        if (cached) {
-            if (isLidJid(cached.userJid)) return cached.userJid
-            if (cached.altUserJid && isLidJid(cached.altUserJid)) return cached.altUserJid
-        }
-        try {
-            const results = await this.deps.signalDeviceSync.queryLidsByPhoneJids([pnUserJid])
-            const match = results.find((entry) => entry.queriedJid === pnUserJid)
-            if (match?.lidJid) return match.lidJid
-        } catch (error) {
-            this.deps.logger.debug('lid resolution failed for direct recipient', {
-                pnUserJid,
-                message: toError(error).message
-            })
-        }
-        return pnUserJid
+        const pair = await this.deps.signalDeviceSync.resolveUserJidPair(pnUserJid)
+        return pair.lidJid ?? pnUserJid
     }
 
     /**
@@ -554,17 +540,8 @@ export class WaMessageDispatchCoordinator {
     ): Promise<string | undefined> {
         if (!isLidJid(directRecipientJid)) return undefined
         if (isUserJid(recipientUserJid)) return recipientUserJid
-        try {
-            const snapshot = await this.deps.deviceListStore.findByAnyUserJid(directRecipientJid)
-            if (snapshot?.userJid && isUserJid(snapshot.userJid)) return snapshot.userJid
-            if (snapshot?.altUserJid && isUserJid(snapshot.altUserJid)) return snapshot.altUserJid
-        } catch (error) {
-            this.deps.logger.trace('peer_recipient_pn store lookup failed', {
-                lid: directRecipientJid,
-                message: toError(error).message
-            })
-        }
-        return undefined
+        const pair = await this.deps.signalDeviceSync.resolveUserJidPair(directRecipientJid)
+        return pair.pnJid ?? undefined
     }
 
     public async syncSignalSession(jid: string, reasonIdentity = false): Promise<void> {

--- a/src/client/coordinators/WaPrivacyCoordinator.ts
+++ b/src/client/coordinators/WaPrivacyCoordinator.ts
@@ -73,7 +73,8 @@ export interface WaPrivacyCoordinator {
     readonly getBlocklist: () => Promise<WaBlocklistResult>
     /**
      * Blocks a user (account-wide blocklist). Accepts a phone-number jid, a
-     * LID jid, or a bare phone number. After this, the peer can no longer
+     * LID jid, or a bare phone number (digits only). After this, the peer can
+     * no longer
      * message/call you and cannot see your last seen/online/photo/status. The
      * block is symmetric only from the peer's read perspective - they don't
      * get an explicit "you were blocked" notification.
@@ -259,12 +260,14 @@ async function resolveBlocklistTarget(
             message: toError(error).message
         })
     }
+    let pnJid = normalized
     if (!lidJid) {
         try {
             const results = await options.queryLidsByPhoneJids([normalized])
             const match = results.find((entry) => entry.queriedJid === normalized)
             if (match?.lidJid) {
                 lidJid = match.lidJid
+                pnJid = match.phoneJid
             }
         } catch (error) {
             options.logger.debug('lid resolution failed for blocklist target', {
@@ -273,7 +276,7 @@ async function resolveBlocklistTarget(
             })
         }
     }
-    return lidJid !== null ? { lidJid, pnJid: normalized } : { lidJid: null, pnJid: normalized }
+    return lidJid !== null ? { lidJid, pnJid } : { lidJid: null, pnJid }
 }
 
 /** Builds a {@link WaPrivacyCoordinator} backed by the given IQ query function. */

--- a/src/client/coordinators/WaPrivacyCoordinator.ts
+++ b/src/client/coordinators/WaPrivacyCoordinator.ts
@@ -1,3 +1,5 @@
+import type { Logger } from '@infra/log/types'
+import { isLidJid, isUserJid, normalizeRecipientJid } from '@protocol/jid'
 import { WA_NODE_TAGS } from '@protocol/nodes'
 import {
     WA_PRIVACY_CATEGORY_TO_SETTING,
@@ -10,16 +12,21 @@ import {
     type WaPrivacySettingValueMap,
     type WaPrivacyValue
 } from '@protocol/privacy'
+import type { SignalLidSyncResult } from '@signal/api/SignalDeviceSyncApi'
+import type { WaDeviceListStore } from '@store/contracts/device-list.store'
 import {
-    buildBlocklistChangeIq,
+    buildBlocklistBlockIq,
+    buildBlocklistUnblockIq,
     buildGetBlocklistIq,
     buildGetPrivacyDisallowedListIq,
     buildGetPrivacySettingsIq,
-    buildSetPrivacyCategoryIq
+    buildSetPrivacyCategoryIq,
+    type WaBlocklistTarget
 } from '@transport/node/builders/privacy'
 import { findNodeChild, getNodeChildren, getNodeChildrenByTag } from '@transport/node/helpers'
 import { assertIqResult } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
+import { toError } from '@util/primitives'
 
 export type WaPrivacySettings = {
     readonly [K in WaPrivacySettingName]?: WaPrivacySettingValueMap[K]
@@ -65,13 +72,23 @@ export interface WaPrivacyCoordinator {
     /** Returns the current account-wide blocklist. */
     readonly getBlocklist: () => Promise<WaBlocklistResult>
     /**
-     * Blocks `jid` (account-wide blocklist). After this, the peer can no
-     * longer message/call you and cannot see your last seen/online/photo/
-     * status. The block is symmetric only from the peer's read perspective -
-     * they don't get an explicit "you were blocked" notification.
+     * Blocks a user (account-wide blocklist). Accepts a phone-number jid, a
+     * LID jid, or a bare phone number. After this, the peer can no longer
+     * message/call you and cannot see your last seen/online/photo/status. The
+     * block is symmetric only from the peer's read perspective - they don't
+     * get an explicit "you were blocked" notification.
+     *
+     * The server keys blocklist entries by LID for migrated accounts, so a
+     * phone-number input is resolved to its LID first (device-list cache,
+     * then a usync query). Non-migrated accounts fall back to the plain
+     * phone-jid form.
      */
     readonly blockUser: (jid: string) => Promise<void>
-    /** Removes `jid` from the blocklist. */
+    /**
+     * Removes a user from the blocklist. Accepts the same inputs as
+     * {@link blockUser} and performs the same LID resolution - unblocking a
+     * migrated entry by phone jid is rejected by the server.
+     */
     readonly unblockUser: (jid: string) => Promise<void>
 }
 
@@ -82,6 +99,11 @@ interface WaPrivacyCoordinatorOptions {
         timeoutMs?: number,
         contextData?: Readonly<Record<string, unknown>>
     ) => Promise<BinaryNode>
+    readonly deviceListStore: Pick<WaDeviceListStore, 'findByAnyUserJid'>
+    readonly queryLidsByPhoneJids: (
+        phoneJids: readonly string[]
+    ) => Promise<readonly SignalLidSyncResult[]>
+    readonly logger: Logger
 }
 
 const IGNORED_SERVER_CATEGORIES = new Set([
@@ -186,6 +208,74 @@ function parseBlocklist(result: BinaryNode): WaBlocklistResult {
     return { jids, dhash }
 }
 
+/**
+ * Resolves a blocklist input into both addressing forms. Phone-jid inputs get
+ * their LID resolved cache-first (device-list store) with a one-shot usync
+ * fallback; LID inputs get their phone jid from the cache when known.
+ * Resolution failures degrade to the single known form instead of throwing -
+ * the server then decides whether that form is acceptable.
+ */
+async function resolveBlocklistTarget(
+    options: WaPrivacyCoordinatorOptions,
+    jid: string
+): Promise<WaBlocklistTarget> {
+    const normalized = normalizeRecipientJid(jid)
+
+    if (isLidJid(normalized)) {
+        let pnJid: string | null = null
+        try {
+            const snapshot = await options.deviceListStore.findByAnyUserJid(normalized)
+            if (snapshot?.userJid && isUserJid(snapshot.userJid)) {
+                pnJid = snapshot.userJid
+            } else if (snapshot?.altUserJid && isUserJid(snapshot.altUserJid)) {
+                pnJid = snapshot.altUserJid
+            }
+        } catch (error) {
+            options.logger.debug('pn lookup failed for blocklist target', {
+                lidJid: normalized,
+                message: toError(error).message
+            })
+        }
+        return { lidJid: normalized, pnJid }
+    }
+
+    if (!isUserJid(normalized)) {
+        throw new Error(`blocklist target must be a user jid: ${jid}`)
+    }
+
+    let lidJid: string | null = null
+    try {
+        const snapshot = await options.deviceListStore.findByAnyUserJid(normalized)
+        if (snapshot) {
+            if (isLidJid(snapshot.userJid)) {
+                lidJid = snapshot.userJid
+            } else if (snapshot.altUserJid && isLidJid(snapshot.altUserJid)) {
+                lidJid = snapshot.altUserJid
+            }
+        }
+    } catch (error) {
+        options.logger.debug('lid cache lookup failed for blocklist target', {
+            pnJid: normalized,
+            message: toError(error).message
+        })
+    }
+    if (!lidJid) {
+        try {
+            const results = await options.queryLidsByPhoneJids([normalized])
+            const match = results.find((entry) => entry.queriedJid === normalized)
+            if (match?.lidJid) {
+                lidJid = match.lidJid
+            }
+        } catch (error) {
+            options.logger.debug('lid resolution failed for blocklist target', {
+                pnJid: normalized,
+                message: toError(error).message
+            })
+        }
+    }
+    return lidJid !== null ? { lidJid, pnJid: normalized } : { lidJid: null, pnJid: normalized }
+}
+
 /** Builds a {@link WaPrivacyCoordinator} backed by the given IQ query function. */
 export function createPrivacyCoordinator(
     options: WaPrivacyCoordinatorOptions
@@ -228,14 +318,21 @@ export function createPrivacyCoordinator(
         },
 
         blockUser: async (jid) => {
-            const node = buildBlocklistChangeIq(jid, 'block')
-            const result = await queryWithContext('privacy.blockUser', node, undefined, { jid })
+            const target = await resolveBlocklistTarget(options, jid)
+            const node = buildBlocklistBlockIq(target)
+            const result = await queryWithContext('privacy.blockUser', node, undefined, {
+                jid: target.lidJid ?? target.pnJid
+            })
             assertIqResult(result, 'privacy.blockUser')
         },
 
         unblockUser: async (jid) => {
-            const node = buildBlocklistChangeIq(jid, 'unblock')
-            const result = await queryWithContext('privacy.unblockUser', node, undefined, { jid })
+            const target = await resolveBlocklistTarget(options, jid)
+            const unblockJid = target.lidJid ?? target.pnJid
+            const node = buildBlocklistUnblockIq(unblockJid)
+            const result = await queryWithContext('privacy.unblockUser', node, undefined, {
+                jid: unblockJid
+            })
             assertIqResult(result, 'privacy.unblockUser')
         }
     }

--- a/src/client/coordinators/WaPrivacyCoordinator.ts
+++ b/src/client/coordinators/WaPrivacyCoordinator.ts
@@ -1,4 +1,3 @@
-import type { Logger } from '@infra/log/types'
 import { isLidJid, isUserJid, normalizeRecipientJid } from '@protocol/jid'
 import { WA_NODE_TAGS } from '@protocol/nodes'
 import {
@@ -12,8 +11,7 @@ import {
     type WaPrivacySettingValueMap,
     type WaPrivacyValue
 } from '@protocol/privacy'
-import type { SignalLidSyncResult } from '@signal/api/SignalDeviceSyncApi'
-import type { WaDeviceListStore } from '@store/contracts/device-list.store'
+import type { SignalUserJidPair } from '@signal/api/SignalDeviceSyncApi'
 import {
     buildBlocklistBlockIq,
     buildBlocklistUnblockIq,
@@ -26,7 +24,6 @@ import {
 import { findNodeChild, getNodeChildren, getNodeChildrenByTag } from '@transport/node/helpers'
 import { assertIqResult } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
-import { toError } from '@util/primitives'
 
 export type WaPrivacySettings = {
     readonly [K in WaPrivacySettingName]?: WaPrivacySettingValueMap[K]
@@ -100,11 +97,7 @@ interface WaPrivacyCoordinatorOptions {
         timeoutMs?: number,
         contextData?: Readonly<Record<string, unknown>>
     ) => Promise<BinaryNode>
-    readonly deviceListStore: Pick<WaDeviceListStore, 'findByAnyUserJid'>
-    readonly queryLidsByPhoneJids: (
-        phoneJids: readonly string[]
-    ) => Promise<readonly SignalLidSyncResult[]>
-    readonly logger: Logger
+    readonly resolveUserJidPair: (userJid: string) => Promise<SignalUserJidPair>
 }
 
 const IGNORED_SERVER_CATEGORIES = new Set([
@@ -210,73 +203,24 @@ function parseBlocklist(result: BinaryNode): WaBlocklistResult {
 }
 
 /**
- * Resolves a blocklist input into both addressing forms. Phone-jid inputs get
- * their LID resolved cache-first (device-list store) with a one-shot usync
- * fallback; LID inputs get their phone jid from the cache when known.
- * Resolution failures degrade to the single known form instead of throwing -
- * the server then decides whether that form is acceptable.
+ * Resolves a blocklist input into both addressing forms via
+ * `resolveUserJidPair` (device-list cache first, usync fallback for phone
+ * jids). Resolution failures degrade to the single known form instead of
+ * throwing - the server then decides whether that form is acceptable.
  */
 async function resolveBlocklistTarget(
     options: WaPrivacyCoordinatorOptions,
     jid: string
 ): Promise<WaBlocklistTarget> {
     const normalized = normalizeRecipientJid(jid)
-
-    if (isLidJid(normalized)) {
-        let pnJid: string | null = null
-        try {
-            const snapshot = await options.deviceListStore.findByAnyUserJid(normalized)
-            if (snapshot?.userJid && isUserJid(snapshot.userJid)) {
-                pnJid = snapshot.userJid
-            } else if (snapshot?.altUserJid && isUserJid(snapshot.altUserJid)) {
-                pnJid = snapshot.altUserJid
-            }
-        } catch (error) {
-            options.logger.debug('pn lookup failed for blocklist target', {
-                lidJid: normalized,
-                message: toError(error).message
-            })
-        }
-        return { lidJid: normalized, pnJid }
-    }
-
-    if (!isUserJid(normalized)) {
+    if (!isLidJid(normalized) && !isUserJid(normalized)) {
         throw new Error(`blocklist target must be a user jid: ${jid}`)
     }
-
-    let lidJid: string | null = null
-    try {
-        const snapshot = await options.deviceListStore.findByAnyUserJid(normalized)
-        if (snapshot) {
-            if (isLidJid(snapshot.userJid)) {
-                lidJid = snapshot.userJid
-            } else if (snapshot.altUserJid && isLidJid(snapshot.altUserJid)) {
-                lidJid = snapshot.altUserJid
-            }
-        }
-    } catch (error) {
-        options.logger.debug('lid cache lookup failed for blocklist target', {
-            pnJid: normalized,
-            message: toError(error).message
-        })
+    const pair = await options.resolveUserJidPair(normalized)
+    if (pair.lidJid !== null) {
+        return { lidJid: pair.lidJid, pnJid: pair.pnJid }
     }
-    let pnJid = normalized
-    if (!lidJid) {
-        try {
-            const results = await options.queryLidsByPhoneJids([normalized])
-            const match = results.find((entry) => entry.queriedJid === normalized)
-            if (match?.lidJid) {
-                lidJid = match.lidJid
-                pnJid = match.phoneJid
-            }
-        } catch (error) {
-            options.logger.debug('lid resolution failed for blocklist target', {
-                pnJid: normalized,
-                message: toError(error).message
-            })
-        }
-    }
-    return lidJid !== null ? { lidJid, pnJid } : { lidJid: null, pnJid }
+    return { lidJid: null, pnJid: pair.pnJid ?? normalized }
 }
 
 /** Builds a {@link WaPrivacyCoordinator} backed by the given IQ query function. */

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -118,8 +118,10 @@ function createMessageDispatchCoordinator(
         readonly meJid?: string
         readonly mobileMessageIdFormat?: () => boolean
         readonly serverClock?: ServerClock
-        readonly deviceListStore?: {
-            readonly findByAnyUserJid: (jid: string) => Promise<unknown>
+        readonly signalDeviceSync?: {
+            readonly resolveUserJidPair: (
+                userJid: string
+            ) => Promise<{ readonly lidJid: string | null; readonly pnJid: string | null }>
         }
         readonly emitMessageSend?: (event: WaOutgoingMessageEvent) => void
     }
@@ -145,8 +147,8 @@ function createMessageDispatchCoordinator(
         signalStore: {} as never,
         sessionStore: {} as never,
         identityStore: {} as never,
-        deviceListStore: (overrides?.deviceListStore ?? {}) as never,
-        signalDeviceSync: {} as never,
+        deviceListStore: {} as never,
+        signalDeviceSync: (overrides?.signalDeviceSync ?? {}) as never,
         messageSecretStore: {
             set: async (_id: string, _entry: { secret: Uint8Array; senderJid: string }) => {}
         } as never,
@@ -213,14 +215,12 @@ test('resolvePeerRecipientPn: a PN-addressed caller on a LID envelope stamps tha
     assert.equal(pn, '5511999999999@s.whatsapp.net')
 })
 
-test('resolvePeerRecipientPn: a LID-addressed caller resolves the PN from the device-list store', async () => {
+test('resolvePeerRecipientPn: a LID-addressed caller resolves the PN from the jid pair', async () => {
     const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore(), {
-        deviceListStore: {
-            findByAnyUserJid: async () => ({
-                userJid: '5511999999999@s.whatsapp.net',
-                altUserJid: '88880000@lid',
-                deviceJids: [],
-                updatedAtMs: 0
+        signalDeviceSync: {
+            resolveUserJidPair: async () => ({
+                lidJid: '88880000@lid',
+                pnJid: '5511999999999@s.whatsapp.net'
             })
         }
     })
@@ -228,9 +228,11 @@ test('resolvePeerRecipientPn: a LID-addressed caller resolves the PN from the de
     assert.equal(pn, '5511999999999@s.whatsapp.net')
 })
 
-test('resolvePeerRecipientPn: a LID-addressed caller with a device-list miss drops the attribute', async () => {
+test('resolvePeerRecipientPn: a LID-addressed caller with an unresolved PN drops the attribute', async () => {
     const coordinator = createMessageDispatchCoordinator(new WaGroupMetadataMemoryStore(), {
-        deviceListStore: { findByAnyUserJid: async () => null }
+        signalDeviceSync: {
+            resolveUserJidPair: async () => ({ lidJid: '88880000@lid', pnJid: null })
+        }
     })
     const pn = await callResolvePeerRecipientPn(coordinator, '88880000@lid', '88880000@lid')
     assert.equal(pn, undefined)

--- a/src/client/coordinators/__tests__/privacy-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/privacy-coordinator.test.ts
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import { createPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordinator'
+import { createNoopLogger } from '@infra/log/types'
 import { WA_PRIVACY_CATEGORIES, WA_PRIVACY_TAGS } from '@protocol/constants'
+import type { SignalLidSyncResult } from '@signal/api/SignalDeviceSyncApi'
+import type { WaDeviceListSnapshot } from '@store/contracts/device-list.store'
 import type { BinaryNode } from '@transport/types'
 
 function createIqResult(content?: readonly BinaryNode[]): BinaryNode {
@@ -10,6 +13,19 @@ function createIqResult(content?: readonly BinaryNode[]): BinaryNode {
         tag: 'iq',
         attrs: { type: 'result' },
         content
+    }
+}
+
+function createBlocklistDeps(overrides?: {
+    readonly findByAnyUserJid?: (jid: string) => Promise<WaDeviceListSnapshot | null>
+    readonly queryLidsByPhoneJids?: (
+        phoneJids: readonly string[]
+    ) => Promise<readonly SignalLidSyncResult[]>
+}) {
+    return {
+        deviceListStore: { findByAnyUserJid: overrides?.findByAnyUserJid ?? (async () => null) },
+        queryLidsByPhoneJids: overrides?.queryLidsByPhoneJids ?? (async () => []),
+        logger: createNoopLogger()
     }
 }
 
@@ -21,6 +37,7 @@ test('privacy coordinator parses settings and ignores error/ignored categories',
     }> = []
 
     const coordinator = createPrivacyCoordinator({
+        ...createBlocklistDeps(),
         queryWithContext: async (context, node, _timeoutMs, contextData) => {
             calls.push({ context, node, contextData })
             return createIqResult([
@@ -83,6 +100,7 @@ test('privacy coordinator maps setting/category for set and disallowed list quer
     }> = []
 
     const coordinator = createPrivacyCoordinator({
+        ...createBlocklistDeps(),
         queryWithContext: async (context, node, _timeoutMs, contextData) => {
             calls.push({ context, node, contextData })
             if (context === 'privacy.getDisallowedList') {
@@ -167,6 +185,7 @@ test('privacy coordinator parses blocklist and sends block/unblock actions', asy
     }> = []
 
     const coordinator = createPrivacyCoordinator({
+        ...createBlocklistDeps(),
         queryWithContext: async (context, node, _timeoutMs, contextData) => {
             calls.push({ context, node, contextData })
             if (context === 'privacy.getBlocklist') {
@@ -202,11 +221,106 @@ test('privacy coordinator parses blocklist and sends block/unblock actions', asy
     if (!Array.isArray(calls[1].node.content)) {
         throw new Error('expected blocklist change content array')
     }
-    assert.equal(calls[1].node.content[0].attrs.action, 'block')
+    assert.deepEqual(calls[1].node.content[0].attrs, {
+        action: 'block',
+        jid: '123@s.whatsapp.net'
+    })
     assert.equal(calls[2].context, 'privacy.unblockUser')
     assert.ok(Array.isArray(calls[2].node.content))
     if (!Array.isArray(calls[2].node.content)) {
         throw new Error('expected unblock content array')
     }
-    assert.equal(calls[2].node.content[0].attrs.action, 'unblock')
+    assert.deepEqual(calls[2].node.content[0].attrs, {
+        jid: '123@s.whatsapp.net',
+        action: 'unblock'
+    })
+})
+
+test('privacy coordinator resolves lid addressing for block/unblock', async () => {
+    const calls: Array<{ readonly context: string; readonly node: BinaryNode }> = []
+    const queryWithContext = async (context: string, node: BinaryNode) => {
+        calls.push({ context, node })
+        return createIqResult()
+    }
+    const itemAttrs = (index: number) => {
+        const content = calls[index].node.content
+        if (!Array.isArray(content)) {
+            throw new Error('expected blocklist change content array')
+        }
+        return content[0].attrs
+    }
+
+    const viaUsync = createPrivacyCoordinator({
+        ...createBlocklistDeps({
+            queryLidsByPhoneJids: async (phoneJids) => [
+                {
+                    queriedJid: phoneJids[0],
+                    phoneJid: phoneJids[0],
+                    lidJid: '999@lid',
+                    exists: true,
+                    invalid: false
+                }
+            ]
+        }),
+        queryWithContext
+    })
+    await viaUsync.blockUser('123@s.whatsapp.net')
+    await viaUsync.unblockUser('123')
+    assert.deepEqual(itemAttrs(0), {
+        action: 'block',
+        jid: '999@lid',
+        pn_jid: '123@s.whatsapp.net'
+    })
+    assert.deepEqual(itemAttrs(1), { jid: '999@lid', action: 'unblock' })
+
+    const viaCache = createPrivacyCoordinator({
+        ...createBlocklistDeps({
+            findByAnyUserJid: async () => ({
+                userJid: '123@s.whatsapp.net',
+                altUserJid: '999@lid',
+                deviceJids: [],
+                updatedAtMs: 0
+            })
+        }),
+        queryWithContext
+    })
+    await viaCache.blockUser('123@s.whatsapp.net')
+    assert.deepEqual(itemAttrs(2), {
+        action: 'block',
+        jid: '999@lid',
+        pn_jid: '123@s.whatsapp.net'
+    })
+
+    const lidInputWithCachedPn = createPrivacyCoordinator({
+        ...createBlocklistDeps({
+            findByAnyUserJid: async () => ({
+                userJid: '999@lid',
+                altUserJid: '123@s.whatsapp.net',
+                deviceJids: [],
+                updatedAtMs: 0
+            })
+        }),
+        queryWithContext
+    })
+    await lidInputWithCachedPn.blockUser('999@lid')
+    assert.deepEqual(itemAttrs(3), {
+        action: 'block',
+        jid: '999@lid',
+        pn_jid: '123@s.whatsapp.net'
+    })
+
+    const lidInputUnknownPn = createPrivacyCoordinator({
+        ...createBlocklistDeps(),
+        queryWithContext
+    })
+    await lidInputUnknownPn.blockUser('999@lid')
+    assert.deepEqual(itemAttrs(4), {
+        action: 'block',
+        jid: '999@lid',
+        unknown_identifier: 'true'
+    })
+
+    await assert.rejects(() => lidInputUnknownPn.blockUser('123-456@g.us'), {
+        message: /blocklist target must be a user jid/
+    })
 })

--- a/src/client/coordinators/__tests__/privacy-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/privacy-coordinator.test.ts
@@ -2,10 +2,8 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import { createPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordinator'
-import { createNoopLogger } from '@infra/log/types'
 import { WA_PRIVACY_CATEGORIES, WA_PRIVACY_TAGS } from '@protocol/constants'
-import type { SignalLidSyncResult } from '@signal/api/SignalDeviceSyncApi'
-import type { WaDeviceListSnapshot } from '@store/contracts/device-list.store'
+import type { SignalUserJidPair } from '@signal/api/SignalDeviceSyncApi'
 import type { BinaryNode } from '@transport/types'
 
 function createIqResult(content?: readonly BinaryNode[]): BinaryNode {
@@ -16,16 +14,14 @@ function createIqResult(content?: readonly BinaryNode[]): BinaryNode {
     }
 }
 
-function createBlocklistDeps(overrides?: {
-    readonly findByAnyUserJid?: (jid: string) => Promise<WaDeviceListSnapshot | null>
-    readonly queryLidsByPhoneJids?: (
-        phoneJids: readonly string[]
-    ) => Promise<readonly SignalLidSyncResult[]>
-}) {
+function createBlocklistDeps(resolveUserJidPair?: (userJid: string) => Promise<SignalUserJidPair>) {
     return {
-        deviceListStore: { findByAnyUserJid: overrides?.findByAnyUserJid ?? (async () => null) },
-        queryLidsByPhoneJids: overrides?.queryLidsByPhoneJids ?? (async () => []),
-        logger: createNoopLogger()
+        resolveUserJidPair:
+            resolveUserJidPair ??
+            (async (userJid: string): Promise<SignalUserJidPair> =>
+                userJid.endsWith('@lid')
+                    ? { lidJid: userJid, pnJid: null }
+                    : { lidJid: null, pnJid: userJid })
     }
 }
 
@@ -250,22 +246,15 @@ test('privacy coordinator resolves lid addressing for block/unblock', async () =
         return content[0].attrs
     }
 
-    const viaUsync = createPrivacyCoordinator({
-        ...createBlocklistDeps({
-            queryLidsByPhoneJids: async (phoneJids) => [
-                {
-                    queriedJid: phoneJids[0],
-                    phoneJid: phoneJids[0],
-                    lidJid: '999@lid',
-                    exists: true,
-                    invalid: false
-                }
-            ]
-        }),
+    const migrated = createPrivacyCoordinator({
+        ...createBlocklistDeps(async () => ({
+            lidJid: '999@lid',
+            pnJid: '123@s.whatsapp.net'
+        })),
         queryWithContext
     })
-    await viaUsync.blockUser('123@s.whatsapp.net')
-    await viaUsync.unblockUser('123')
+    await migrated.blockUser('123@s.whatsapp.net')
+    await migrated.unblockUser('123')
     assert.deepEqual(itemAttrs(0), {
         action: 'block',
         jid: '999@lid',
@@ -273,75 +262,38 @@ test('privacy coordinator resolves lid addressing for block/unblock', async () =
     })
     assert.deepEqual(itemAttrs(1), { jid: '999@lid', action: 'unblock' })
 
-    const viaCache = createPrivacyCoordinator({
-        ...createBlocklistDeps({
-            findByAnyUserJid: async () => ({
-                userJid: '123@s.whatsapp.net',
-                altUserJid: '999@lid',
-                deviceJids: [],
-                updatedAtMs: 0
-            })
-        }),
-        queryWithContext
-    })
-    await viaCache.blockUser('123@s.whatsapp.net')
-    assert.deepEqual(itemAttrs(2), {
-        action: 'block',
-        jid: '999@lid',
-        pn_jid: '123@s.whatsapp.net'
-    })
-
-    const lidInputWithCachedPn = createPrivacyCoordinator({
-        ...createBlocklistDeps({
-            findByAnyUserJid: async () => ({
-                userJid: '999@lid',
-                altUserJid: '123@s.whatsapp.net',
-                deviceJids: [],
-                updatedAtMs: 0
-            })
-        }),
-        queryWithContext
-    })
-    await lidInputWithCachedPn.blockUser('999@lid')
-    assert.deepEqual(itemAttrs(3), {
-        action: 'block',
-        jid: '999@lid',
-        pn_jid: '123@s.whatsapp.net'
-    })
-
     const lidInputUnknownPn = createPrivacyCoordinator({
         ...createBlocklistDeps(),
         queryWithContext
     })
     await lidInputUnknownPn.blockUser('999@lid')
-    assert.deepEqual(itemAttrs(4), {
+    assert.deepEqual(itemAttrs(2), {
         action: 'block',
         jid: '999@lid',
         unknown_identifier: 'true'
     })
 
-    const viaCorrectedUsync = createPrivacyCoordinator({
-        ...createBlocklistDeps({
-            queryLidsByPhoneJids: async (phoneJids) => [
-                {
-                    queriedJid: phoneJids[0],
-                    phoneJid: '5511987654321@s.whatsapp.net',
-                    lidJid: '888@lid',
-                    exists: true,
-                    invalid: false
-                }
-            ]
-        }),
+    const correctedPn = createPrivacyCoordinator({
+        ...createBlocklistDeps(async () => ({
+            lidJid: '888@lid',
+            pnJid: '5511987654321@s.whatsapp.net'
+        })),
         queryWithContext
     })
-    await viaCorrectedUsync.blockUser('551187654321')
-    assert.deepEqual(itemAttrs(5), {
+    await correctedPn.blockUser('551187654321')
+    assert.deepEqual(itemAttrs(3), {
         action: 'block',
         jid: '888@lid',
         pn_jid: '5511987654321@s.whatsapp.net'
     })
 
-    await assert.rejects(() => lidInputUnknownPn.blockUser('123-456@g.us'), {
+    const rejecting = createPrivacyCoordinator({
+        ...createBlocklistDeps(async () => {
+            throw new Error('resolver must not run for non-user jids')
+        }),
+        queryWithContext
+    })
+    await assert.rejects(() => rejecting.blockUser('123-456@g.us'), {
         message: /blocklist target must be a user jid/
     })
 })

--- a/src/client/coordinators/__tests__/privacy-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/privacy-coordinator.test.ts
@@ -320,6 +320,27 @@ test('privacy coordinator resolves lid addressing for block/unblock', async () =
         unknown_identifier: 'true'
     })
 
+    const viaCorrectedUsync = createPrivacyCoordinator({
+        ...createBlocklistDeps({
+            queryLidsByPhoneJids: async (phoneJids) => [
+                {
+                    queriedJid: phoneJids[0],
+                    phoneJid: '5511987654321@s.whatsapp.net',
+                    lidJid: '888@lid',
+                    exists: true,
+                    invalid: false
+                }
+            ]
+        }),
+        queryWithContext
+    })
+    await viaCorrectedUsync.blockUser('551187654321')
+    assert.deepEqual(itemAttrs(5), {
+        action: 'block',
+        jid: '888@lid',
+        pn_jid: '5511987654321@s.whatsapp.net'
+    })
+
     await assert.rejects(() => lidInputUnknownPn.blockUser('123-456@g.us'), {
         message: /blocklist target must be a user jid/
     })

--- a/src/signal/api/SignalDeviceSyncApi.ts
+++ b/src/signal/api/SignalDeviceSyncApi.ts
@@ -1,7 +1,15 @@
 import type { Logger } from '@infra/log/types'
 import { PromiseDedup } from '@infra/perf/PromiseDedup'
 import { WA_DEFAULTS, WA_NODE_TAGS, WA_USYNC_CONTEXTS } from '@protocol/constants'
-import { buildDeviceJid, isHostedDeviceId, parsePhoneJid, splitJid, toUserJid } from '@protocol/jid'
+import {
+    buildDeviceJid,
+    isHostedDeviceId,
+    isLidJid,
+    isUserJid,
+    parsePhoneJid,
+    splitJid,
+    toUserJid
+} from '@protocol/jid'
 import type { WaDeviceListStore } from '@store/contracts/device-list.store'
 import {
     buildUsyncIq,
@@ -16,6 +24,7 @@ import {
     type WaUsyncSidGenerator
 } from '@transport/node/usync'
 import type { BinaryNode } from '@transport/types'
+import { toError } from '@util/primitives'
 
 interface SignalDeviceSyncApiOptions {
     readonly logger: Logger
@@ -44,6 +53,18 @@ export interface SignalLidSyncResult {
      * `invalid: false`).
      */
     readonly invalid: boolean
+}
+
+/** Both addressing forms of a 1:1 user, as far as they could be resolved. */
+export interface SignalUserJidPair {
+    /** LID user jid, or `null` when no LID mapping is known. */
+    readonly lidJid: string | null
+    /**
+     * Phone-number user jid, or `null` when unknown. When resolved through
+     * the usync fallback this is the server-canonical form, which may differ
+     * from the queried number (e.g. BR 9th digit added).
+     */
+    readonly pnJid: string | null
 }
 
 /**
@@ -218,6 +239,69 @@ export class SignalDeviceSyncApi {
         })
         await this.propagateAltUserJids(result)
         return result
+    }
+
+    /**
+     * Resolves both addressing forms for a 1:1 user jid (PN or LID input),
+     * cache-first via the device-list store (`userJid`/`altUserJid`) with a
+     * one-shot {@link queryLidsByPhoneJids} fallback for PN inputs. LID
+     * inputs have no reverse lookup - their PN side stays `null` on a cache
+     * miss. Store/usync failures are logged at debug and degrade to the
+     * forms already known. Inputs that are neither PN nor LID user jids
+     * resolve to `{ lidJid: null, pnJid: null }`.
+     */
+    public async resolveUserJidPair(
+        userJid: string,
+        timeoutMs = this.defaultTimeoutMs
+    ): Promise<SignalUserJidPair> {
+        if (isLidJid(userJid)) {
+            return { lidJid: userJid, pnJid: await this.findCachedAltForm(userJid, isUserJid) }
+        }
+        if (!isUserJid(userJid)) {
+            return { lidJid: null, pnJid: null }
+        }
+        const cachedLid = await this.findCachedAltForm(userJid, isLidJid)
+        if (cachedLid) {
+            return { lidJid: cachedLid, pnJid: userJid }
+        }
+        try {
+            const results = await this.queryLidsByPhoneJids([userJid], timeoutMs)
+            const match = results.find((entry) => entry.queriedJid === userJid)
+            if (match?.lidJid) {
+                return { lidJid: match.lidJid, pnJid: match.phoneJid }
+            }
+        } catch (error) {
+            this.logger.debug('lid usync resolution failed for jid pair', {
+                jid: userJid,
+                message: toError(error).message
+            })
+        }
+        return { lidJid: null, pnJid: userJid }
+    }
+
+    /**
+     * Returns the device-list snapshot form of `userJid` that satisfies
+     * `matches` (checked against `userJid` then `altUserJid`), or `null` when
+     * the store is absent, misses, or fails.
+     */
+    private async findCachedAltForm(
+        userJid: string,
+        matches: (jid: string) => boolean
+    ): Promise<string | null> {
+        if (!this.deviceListStore) return null
+        try {
+            const snapshot = await this.deviceListStore.findByAnyUserJid(userJid)
+            if (snapshot) {
+                if (matches(snapshot.userJid)) return snapshot.userJid
+                if (snapshot.altUserJid && matches(snapshot.altUserJid)) return snapshot.altUserJid
+            }
+        } catch (error) {
+            this.logger.debug('device-list lookup failed for jid pair', {
+                jid: userJid,
+                message: toError(error).message
+            })
+        }
+        return null
     }
 
     /**

--- a/src/signal/api/__tests__/api.test.ts
+++ b/src/signal/api/__tests__/api.test.ts
@@ -162,6 +162,105 @@ test('signal lid sync flags a server-rejected number as invalid, recovered from 
     ])
 })
 
+test('resolveUserJidPair resolves both forms from the device-list cache without usync', async () => {
+    const deviceListStore = new WaDeviceListMemoryStore(60_000)
+    try {
+        await deviceListStore.upsertUserDevicesBatch([
+            {
+                userJid: '5511999999999@s.whatsapp.net',
+                altUserJid: '123456789@lid',
+                deviceJids: [],
+                updatedAtMs: Date.now()
+            }
+        ])
+        const api = new SignalDeviceSyncApi({
+            logger: createNoopLogger(),
+            query: async () => {
+                throw new Error('usync must not run on a cache hit')
+            },
+            deviceListStore
+        })
+
+        assert.deepEqual(await api.resolveUserJidPair('5511999999999@s.whatsapp.net'), {
+            lidJid: '123456789@lid',
+            pnJid: '5511999999999@s.whatsapp.net'
+        })
+        assert.deepEqual(await api.resolveUserJidPair('123456789@lid'), {
+            lidJid: '123456789@lid',
+            pnJid: '5511999999999@s.whatsapp.net'
+        })
+    } finally {
+        await deviceListStore.destroy()
+    }
+})
+
+test('resolveUserJidPair falls back to usync on a PN cache miss and keeps the canonical pn', async () => {
+    const api = new SignalDeviceSyncApi({
+        logger: createNoopLogger(),
+        query: async () =>
+            iqResult([
+                {
+                    tag: WA_NODE_TAGS.USYNC,
+                    attrs: {},
+                    content: [
+                        {
+                            tag: WA_NODE_TAGS.LIST,
+                            attrs: {},
+                            content: [
+                                {
+                                    tag: WA_NODE_TAGS.USER,
+                                    attrs: { jid: '5511982905991@s.whatsapp.net' },
+                                    content: [
+                                        {
+                                            tag: WA_NODE_TAGS.LID,
+                                            attrs: { val: '53979165777985@lid' }
+                                        },
+                                        {
+                                            tag: WA_NODE_TAGS.CONTACT,
+                                            attrs: { type: 'in' },
+                                            content: '+551182905991'
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+    })
+
+    // queried without the BR 9th digit -> lid resolves and pn comes back corrected
+    assert.deepEqual(await api.resolveUserJidPair('551182905991@s.whatsapp.net'), {
+        lidJid: '53979165777985@lid',
+        pnJid: '5511982905991@s.whatsapp.net'
+    })
+})
+
+test('resolveUserJidPair degrades to the known form on misses and failures', async () => {
+    const failing = new SignalDeviceSyncApi({
+        logger: createNoopLogger(),
+        query: async () => {
+            throw new Error('usync down')
+        }
+    })
+
+    // usync failure -> pn passthrough, no lid
+    assert.deepEqual(await failing.resolveUserJidPair('5511999999999@s.whatsapp.net'), {
+        lidJid: null,
+        pnJid: '5511999999999@s.whatsapp.net'
+    })
+    // lid input has no reverse lookup; without a cache hit the pn stays null
+    assert.deepEqual(await failing.resolveUserJidPair('123456789@lid'), {
+        lidJid: '123456789@lid',
+        pnJid: null
+    })
+    // neither pn nor lid form
+    assert.deepEqual(await failing.resolveUserJidPair('123-456@g.us'), {
+        lidJid: null,
+        pnJid: null
+    })
+})
+
 test('signal lid sync exposes the server-corrected number (BR 9th digit) via the contact echo', async () => {
     // real captured response: the server collapses the two queried forms into one
     // <user> with the canonical jid (with the 9) and echoes both queried numbers as

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -76,7 +76,8 @@ import {
 } from '@transport/node/builders/prekeys'
 import { buildPresenceNode, buildPresenceSubscribeNode } from '@transport/node/builders/presence'
 import {
-    buildBlocklistChangeIq,
+    buildBlocklistBlockIq,
+    buildBlocklistUnblockIq,
     buildGetBlocklistIq,
     buildGetPrivacyDisallowedListIq,
     buildGetPrivacySettingsIq,
@@ -888,16 +889,55 @@ test('privacy builders generate expected iq payloads', () => {
     assert.equal(blocklist.attrs.xmlns, WA_XMLNS.BLOCKLIST)
     assert.equal(blocklist.content, undefined)
 
-    const block = buildBlocklistChangeIq('5511999999999@s.whatsapp.net', 'block')
-    assert.equal(block.attrs.type, 'set')
-    assert.equal(block.attrs.xmlns, WA_XMLNS.BLOCKLIST)
-    assert.ok(Array.isArray(block.content))
-    if (!Array.isArray(block.content)) {
+    const nonMigratedBlock = buildBlocklistBlockIq({
+        lidJid: null,
+        pnJid: '5511999999999@s.whatsapp.net'
+    })
+    assert.equal(nonMigratedBlock.attrs.type, 'set')
+    assert.equal(nonMigratedBlock.attrs.xmlns, WA_XMLNS.BLOCKLIST)
+    assert.ok(Array.isArray(nonMigratedBlock.content))
+    if (!Array.isArray(nonMigratedBlock.content)) {
         throw new Error('expected blocklist change content array')
     }
-    assert.equal(block.content[0].tag, 'item')
-    assert.equal(block.content[0].attrs.jid, '5511999999999@s.whatsapp.net')
-    assert.equal(block.content[0].attrs.action, 'block')
+    assert.equal(nonMigratedBlock.content[0].tag, 'item')
+    assert.deepEqual(nonMigratedBlock.content[0].attrs, {
+        action: 'block',
+        jid: '5511999999999@s.whatsapp.net'
+    })
+
+    const migratedBlock = buildBlocklistBlockIq({
+        lidJid: '999@lid',
+        pnJid: '5511999999999@s.whatsapp.net'
+    })
+    assert.ok(Array.isArray(migratedBlock.content))
+    if (!Array.isArray(migratedBlock.content)) {
+        throw new Error('expected migrated block content array')
+    }
+    assert.deepEqual(migratedBlock.content[0].attrs, {
+        action: 'block',
+        jid: '999@lid',
+        pn_jid: '5511999999999@s.whatsapp.net'
+    })
+
+    const unknownIdentifierBlock = buildBlocklistBlockIq({ lidJid: '999@lid', pnJid: null })
+    assert.ok(Array.isArray(unknownIdentifierBlock.content))
+    if (!Array.isArray(unknownIdentifierBlock.content)) {
+        throw new Error('expected unknown-identifier block content array')
+    }
+    assert.deepEqual(unknownIdentifierBlock.content[0].attrs, {
+        action: 'block',
+        jid: '999@lid',
+        unknown_identifier: 'true'
+    })
+
+    const unblock = buildBlocklistUnblockIq('999@lid')
+    assert.equal(unblock.attrs.type, 'set')
+    assert.equal(unblock.attrs.xmlns, WA_XMLNS.BLOCKLIST)
+    assert.ok(Array.isArray(unblock.content))
+    if (!Array.isArray(unblock.content)) {
+        throw new Error('expected unblock content array')
+    }
+    assert.deepEqual(unblock.content[0].attrs, { jid: '999@lid', action: 'unblock' })
 })
 
 test('message builders cover group and inbound receipt branches', () => {

--- a/src/transport/node/builders/privacy.ts
+++ b/src/transport/node/builders/privacy.ts
@@ -47,11 +47,50 @@ export function buildGetBlocklistIq(): BinaryNode {
     return buildIqNode(WA_IQ_TYPES.GET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BLOCKLIST)
 }
 
-export function buildBlocklistChangeIq(jid: string, action: 'block' | 'unblock'): BinaryNode {
+/**
+ * Blocklist target in both addressing forms. At least one side is always
+ * present: LID-migrated accounts carry `lidJid` (plus `pnJid` when known),
+ * non-migrated accounts carry only `pnJid`.
+ */
+export type WaBlocklistTarget =
+    | { readonly lidJid: string; readonly pnJid: string | null }
+    | { readonly lidJid: null; readonly pnJid: string }
+
+/**
+ * Builds the blocklist `set` IQ for a block action. LID-migrated targets are
+ * addressed by the LID jid plus an identifier attribute: `pn_jid` when the
+ * phone jid is known, else `unknown_identifier="true"`. Non-migrated targets
+ * are addressed by the phone jid alone. The server rejects a block that
+ * addresses a migrated account by phone jid or omits the identifier
+ * (`400: bad-request`).
+ */
+export function buildBlocklistBlockIq(target: WaBlocklistTarget): BinaryNode {
+    let attrs: Record<string, string>
+    if (target.lidJid !== null) {
+        attrs =
+            target.pnJid !== null
+                ? { action: 'block', jid: target.lidJid, pn_jid: target.pnJid }
+                : { action: 'block', jid: target.lidJid, unknown_identifier: 'true' }
+    } else {
+        attrs = { action: 'block', jid: target.pnJid }
+    }
     return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BLOCKLIST, [
         {
             tag: 'item',
-            attrs: { jid, action }
+            attrs
+        }
+    ])
+}
+
+/**
+ * Builds the blocklist `set` IQ for an unblock action. The server keys
+ * migrated entries by LID, so `jid` must be the LID jid when one exists.
+ */
+export function buildBlocklistUnblockIq(jid: string): BinaryNode {
+    return buildIqNode(WA_IQ_TYPES.SET, WA_DEFAULTS.HOST_DOMAIN, WA_XMLNS.BLOCKLIST, [
+        {
+            tag: 'item',
+            attrs: { jid, action: 'unblock' }
         }
     ])
 }


### PR DESCRIPTION
The server keys blocklist entries by LID for migrated accounts and rejects the legacy single-jid block item with 400: bad-request. Mirror wa-web's update-blocklist request: block addresses the LID jid plus an identifier attribute (pn_jid when known, unknown_identifier otherwise), non-migrated targets keep the plain phone-jid form, and unblock sends the LID jid when one exists.

blockUser/unblockUser now accept a phone jid, LID jid, or bare number and resolve the missing addressing form cache-first via the device-list store with a one-shot usync fallback.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved direct-message recipient addressing by consistently resolving between LID and phone-number identifiers.
  - Enhanced blocking/unblocking by using newer device identifiers with resolution from cached device info and on-demand LID lookup.

- **Bug Fixes**
  - Block and unblock now send the correct identifier format for migrated and non-migrated contacts.
  - Unknown phone identifiers are handled gracefully, and non-user targets are rejected with a clear error.

- **Tests**
  - Expanded coverage for block/unblock IQ payloads and identifier-resolution scenarios, including LID-addressing and unknown cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->