### PR TITLE
feat(fake-server): interop with non-zapo clients + programmatic server config

### DIFF
--- a/packages/fake-server/README.md
+++ b/packages/fake-server/README.md
@@ -2,6 +2,14 @@
 
 In-process fake WhatsApp Web server that drives the real `zapo-js` `WaClient` end-to-end - full Noise XX/IK handshake, QR pairing, Signal Protocol (X3DH + Double Ratchet), SenderKey for groups, media upload/download over self-signed HTTPS, app-state sync - all without touching WhatsApp servers.
 
+## Install
+
+```bash
+npm i -D @zapo-js/fake-server zapo-js
+```
+
+`zapo-js` is a peer dependency - the fake server reuses the core's binary codec, crypto, and protos. Everything below works from any project; nothing requires this monorepo.
+
 ## Quick start
 
 ```ts
@@ -50,7 +58,7 @@ src/
 │   ├── fake-media-store.ts  # In-memory media blob store
 │   └── fake-app-state-collection.ts  # App-state patch/snapshot provider
 ├── transport/               # Re-exports from zapo-js (codec, crypto, protos)
-└── __tests__/               # Cross-check test suite (147 tests)
+└── __tests__/               # Cross-check test suite
     └── helpers/             # Shared test utilities (zapo-client factory)
 
 bench/
@@ -63,11 +71,27 @@ bench/
 
 ### FakeWaServer
 
-Central facade. Manages the WS listener, noise handshake, IQ router, and all state registries:
+Central facade. Manages the WS listener, noise handshake, IQ router, and all state registries.
+
+Constructor options (`FakeWaServer.start({...})` / `new FakeWaServer({...})`):
+
+```ts
+const server = await FakeWaServer.start({
+    host: '127.0.0.1', // default
+    port: 5222, // default: random free port
+    path: '/ws/chat', // default
+    successNodeAttributes: {
+        // stamped on every post-handshake <success/>
+        lid: '5511999@lid',
+        displayName: 'Fake Display'
+    },
+    defaultIqHandlers: false // start with an empty IQ router (default: true)
+})
+```
 
 - **Peer registry** (`peerRegistry`): maps device JIDs → `FakePeer` instances. The global `usync` + `prekey-fetch` IQ handlers consult this.
 - **Group registry** (`groupRegistry`): maps group JIDs → group metadata + participants. The `w:g2` handler serves it.
-- **IQ router** (`WaFakeIqRouter`): first-match-wins stanza dispatcher with `{ xmlns, type, childTag }` matchers. ~20 global handlers registered in the constructor cover every IQ the lib emits during normal operation.
+- **IQ router** (`WaFakeIqRouter`): first-match-wins stanza dispatcher with `{ xmlns, type, childTag }` matchers. ~27 global handlers registered in the constructor cover every IQ the lib emits during normal operation (disable them with `defaultIqHandlers: false`). `registerIqHandler(matcher, respond)` registers at high priority and shadows the defaults; a responder that returns `null` falls through to the next matching handler, so you can observe an IQ (capture, assert) and still let the default answer it.
 - **Prekey dispenser**: hands out unique one-time prekeys from the lib's upload to FakePeers. Resets on each forced refill (`triggerPreKeyUpload({ force: true })`).
 - **Listener fan-outs**: `onOutboundGroupOp`, `onOutboundPrivacySet`, `onOutboundBlocklistChange`, `onOutboundProfilePictureSet`, `onOutboundStatusSet`, `onLogout`, `onOutboundPrivacyTokenIssue`, `onOutboundDirtyBitsClear`.
 
@@ -101,8 +125,10 @@ Every outbound IQ the lib sends during normal operation is handled:
 | `w:p` / `urn:xmpp:ping` get                                                      | `whatsapp-ping` / `xmpp-ping` | Ack                                     |
 | `encrypt` set                                                                    | `prekey-upload`               | Captures bundle, resets dispenser       |
 | `encrypt` get `<digest>`                                                         | `signal-digest`               | Returns 404 → forces upload             |
+| `encrypt` get `<count>`                                                          | `prekey-count`                | Serves remaining dispenser prekey count |
 | `encrypt` set `<rotate>`                                                         | `signed-prekey-rotate`        | Ack                                     |
 | `encrypt` get `<key>`                                                            | `prekey-fetch`                | Serves peer bundles from registry       |
+| `passive` set                                                                    | `passive-mode`                | Ack                                     |
 | `usync` get                                                                      | `usync`                       | Resolves device IDs from registry       |
 | `w:m` set `<media_conn>`                                                         | `media-conn`                  | Points lib at fake HTTPS server         |
 | `w:sync:app:state` set                                                           | `app-state-sync`              | Serves patches/snapshots from providers |
@@ -118,6 +144,16 @@ Every outbound IQ the lib sends during normal operation is handled:
 | `md` set `<remove-companion-device>`                                             | `remove-companion-device`     | Fires logout listeners                  |
 | `newsletter` get `<my_addons>`                                                   | `newsletter-my-addons`        | Ack                                     |
 | `urn:xmpp:whatsapp:dirty` set                                                    | `dirty-bits-clear`            | Captures cleared bits                   |
+
+## Using with non-zapo-js clients
+
+The fake server speaks the real wire protocol, so other WhatsApp Web libraries (Baileys forks, whatsmeow, ...) can connect to it too. The recipe:
+
+1. **Point the client's WebSocket URL at `server.url`** (the upgrade path is `/ws/chat`, same as production).
+2. **Trust the fake root CA.** The server signs its Noise cert chain with a per-instance random root; clients that verify the cert signature against WhatsApp's pinned production key must be told to trust `server.noiseRootCa.publicKey` instead (exposed via the CLI's `--json` as `noiseRootCa.publicKeyHex`). The chain carries a valid `notBefore`/`notAfter` window, so clients that enforce validity work out of the box.
+3. **Post-connect IQs are answered by default**: the `passive` set IQ and the `encrypt` get `<count>` prekey-count query, which Baileys-family and whatsmeow clients block on before reporting the connection as open.
+4. **Offline drain bulletin**: after every login the server sends `<ib><offline count="0"/></ib>`, which Baileys-family clients require before flushing their buffered events.
+5. **QR pairing**: in-process, use `server.runPairing(...)` with the client's `advSecretKey` + identity public key; from the standalone CLI, use `--pair <device-jid>` and paste the QR payload the client displays when prompted.
 
 ## Benchmarking
 
@@ -161,16 +197,35 @@ node --expose-gc --import tsx packages/fake-server/bench/messaging.bench.ts --cp
 
 ## CLI
 
+The package ships a `fake-wa-server` bin, so the standalone server works from any project (or no project at all):
+
 ```bash
-# Standalone server for manual testing
+# One-off via npx
+npx @zapo-js/fake-server --port 5222 --peer 5511888@s.whatsapp.net --log
+
+# Installed as a dev dependency
+npx fake-wa-server --port 5222 --peer 5511888@s.whatsapp.net --log
+
+# First-time QR pairing: prompts on stdin for the QR payload the client displays
+npx fake-wa-server --port 5222 --pair 5511999:1@s.whatsapp.net
+
+# Print connection info (url + noise root CA hex) as JSON, for scripting
+npx fake-wa-server --json
+```
+
+From inside this monorepo (runs the source, no build needed):
+
+```bash
 npm --workspace=@zapo-js/fake-server run cli -- --port 5222 --peer 5511888@s.whatsapp.net --log
 ```
+
+Run with `--help` for the full flag list.
 
 ## Test suite
 
 ```bash
 npm --workspace=@zapo-js/fake-server test
-# 147 tests, --test-concurrency=1
+# 163 tests, --test-concurrency=1
 ```
 
 Cross-check tests drive a real `WaClient` against the fake server and assert on both sides (lib emits correct events, peer decrypts correctly). Unit tests validate protocol builders/parsers in isolation.

--- a/packages/fake-server/src/__tests__/bidirectional-1on1.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/bidirectional-1on1.cross-check.test.ts
@@ -55,9 +55,22 @@ test('bidirectional 1:1 ping-pong (peer\u2192client\u2192peer\u2192client\u2192p
 
     const peerJid = '5511777777777@s.whatsapp.net'
 
+    const offlineIbPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('ib.offline timeout')), 60_000)
+        const listener: WaClientEventMap['debug_notification'] = (event) => {
+            if (event.notificationType === 'ib.offline') {
+                clearTimeout(timer)
+                client.off('debug_notification', listener)
+                resolve()
+            }
+        }
+        client.on('debug_notification', listener)
+    })
+
     try {
         await client.connect()
         const pipeline = await server.waitForAuthenticatedPipeline()
+        assert.equal(pipeline.clientPayload?.kind, 'registration')
         await server.runPairing(
             pipeline,
             { deviceJid: '5511999999999:1@s.whatsapp.net' },
@@ -67,6 +80,10 @@ test('bidirectional 1:1 ping-pong (peer\u2192client\u2192peer\u2192client\u2192p
         const pipelineAfterPairPromise = server.waitForNextAuthenticatedPipeline()
         await pairedPromise
         const pipelineAfterPair = await pipelineAfterPairPromise
+        assert.equal(pipelineAfterPair.clientPayload?.kind, 'login')
+
+        // The post-login offline drain bulletin must reach the client.
+        await offlineIbPromise
 
         const peer = await server.createFakePeer({ jid: peerJid }, pipelineAfterPair)
         await server.triggerPreKeyUpload(pipelineAfterPair)
@@ -78,6 +95,8 @@ test('bidirectional 1:1 ping-pong (peer\u2192client\u2192peer\u2192client\u2192p
         await peer.sendConversation('peer-to-client #1')
         const round1Event = await round1ReceivedByLib
         assert.equal(round1Event.message?.conversation, 'peer-to-client #1')
+        // FakePeer default ids must be WA-style hex: no '@', no separators.
+        assert.match(round1Event.key.id, /^3EB0[0-9A-F]+$/)
 
         const round2ReceivedByPeer = peer.expectMessage({ timeoutMs: 8_000 })
         await client.message.send(peerJid, { conversation: 'client-to-peer #1' })

--- a/packages/fake-server/src/__tests__/bidirectional-1on1.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/bidirectional-1on1.cross-check.test.ts
@@ -85,6 +85,14 @@ test('bidirectional 1:1 ping-pong (peer\u2192client\u2192peer\u2192client\u2192p
         // The post-login offline drain bulletin must reach the client.
         await offlineIbPromise
 
+        // The real client sends the passive/active IQ post-login; the default
+        // handler must see it (it answers, so the client never logs a timeout).
+        const passiveIq = await server.expectIq(
+            { xmlns: 'passive', type: 'set' },
+            { timeoutMs: 15_000 }
+        )
+        assert.equal(passiveIq.attrs.xmlns, 'passive')
+
         const peer = await server.createFakePeer({ jid: peerJid }, pipelineAfterPair)
         await server.triggerPreKeyUpload(pipelineAfterPair)
 

--- a/packages/fake-server/src/__tests__/cli.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/cli.cross-check.test.ts
@@ -1,0 +1,282 @@
+import assert from 'node:assert/strict'
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process'
+import { resolve as resolvePath } from 'node:path'
+import test from 'node:test'
+
+import { createNoopLogger, createStore, WaClient, type WaClientEventMap } from 'zapo-js'
+import { hexToBytes } from 'zapo-js/util'
+
+const CLI_ENTRY = resolvePath(__dirname, '../bin.ts')
+const PACKAGE_ROOT = resolvePath(__dirname, '../..')
+
+interface CliExitResult {
+    readonly code: number | null
+    readonly stdout: string
+    readonly stderr: string
+}
+
+interface RunningCli {
+    readonly child: ChildProcessWithoutNullStreams
+    stdoutSnapshot(): string
+    stderrSnapshot(): string
+    waitForStdout(predicate: (stdout: string) => boolean, label: string): Promise<string>
+    writeStdinLine(line: string): void
+    dispose(): Promise<void>
+}
+
+function spawnCli(args: readonly string[]): ChildProcessWithoutNullStreams {
+    return spawn(process.execPath, ['--import', 'tsx', CLI_ENTRY, ...args], {
+        cwd: PACKAGE_ROOT,
+        stdio: 'pipe'
+    })
+}
+
+function runCliUntilExit(args: readonly string[], timeoutMs = 60_000): Promise<CliExitResult> {
+    return new Promise((resolve, reject) => {
+        const child = spawnCli(args)
+        let stdout = ''
+        let stderr = ''
+        const timer = setTimeout(() => {
+            child.kill()
+            reject(new Error(`cli did not exit within ${timeoutMs}ms\nstdout:\n${stdout}`))
+        }, timeoutMs)
+        child.stdout.on('data', (chunk) => {
+            stdout += String(chunk)
+        })
+        child.stderr.on('data', (chunk) => {
+            stderr += String(chunk)
+        })
+        child.on('error', (error) => {
+            clearTimeout(timer)
+            reject(error)
+        })
+        child.on('close', (code) => {
+            clearTimeout(timer)
+            resolve({ code, stdout, stderr })
+        })
+    })
+}
+
+function startCli(args: readonly string[], waitTimeoutMs = 60_000): RunningCli {
+    const child = spawnCli(args)
+    let stdout = ''
+    let stderr = ''
+    const stdoutWaiters = new Set<{
+        readonly predicate: (stdout: string) => boolean
+        readonly resolve: (stdout: string) => void
+    }>()
+    child.stdout.on('data', (chunk) => {
+        stdout += String(chunk)
+        for (const waiter of stdoutWaiters) {
+            if (waiter.predicate(stdout)) {
+                stdoutWaiters.delete(waiter)
+                waiter.resolve(stdout)
+            }
+        }
+    })
+    child.stderr.on('data', (chunk) => {
+        stderr += String(chunk)
+    })
+    return {
+        child,
+        stdoutSnapshot: () => stdout,
+        stderrSnapshot: () => stderr,
+        waitForStdout: (predicate, label) => {
+            if (predicate(stdout)) {
+                return Promise.resolve(stdout)
+            }
+            return new Promise((resolve, reject) => {
+                const waiter = {
+                    predicate,
+                    resolve: (value: string) => {
+                        clearTimeout(timer)
+                        resolve(value)
+                    }
+                }
+                const timer = setTimeout(() => {
+                    stdoutWaiters.delete(waiter)
+                    reject(
+                        new Error(
+                            `timed out waiting for cli stdout: ${label}\nstdout so far:\n${stdout}\nstderr so far:\n${stderr}`
+                        )
+                    )
+                }, waitTimeoutMs)
+                stdoutWaiters.add(waiter)
+            })
+        },
+        writeStdinLine: (line) => {
+            child.stdin.write(`${line}\n`)
+        },
+        dispose: () =>
+            new Promise((resolve) => {
+                if (child.exitCode !== null) {
+                    resolve()
+                    return
+                }
+                child.once('close', () => resolve())
+                child.kill()
+            })
+    }
+}
+
+interface CliStartupJson {
+    readonly url: string
+    readonly host: string
+    readonly port: number
+    readonly path: string
+    readonly noiseRootCa: { readonly serial: number; readonly publicKeyHex: string }
+    readonly peers: readonly string[]
+    readonly groups: readonly { readonly groupJid: string }[]
+    readonly pair: string | null
+}
+
+async function waitForStartupJson(cli: RunningCli): Promise<CliStartupJson> {
+    const stdout = await cli.waitForStdout(
+        (value) => value.includes('{') && value.includes('\n}'),
+        'startup json'
+    )
+    const start = stdout.indexOf('{')
+    const end = stdout.indexOf('\n}', start)
+    return JSON.parse(stdout.slice(start, end + 2)) as CliStartupJson
+}
+
+test('cli --help prints usage and exits 0', async () => {
+    const result = await runCliUntilExit(['--help'])
+    assert.equal(result.code, 0)
+    assert.ok(result.stdout.includes('USAGE'))
+    assert.ok(result.stdout.includes('--peer'))
+    assert.ok(result.stdout.includes('--pair'))
+})
+
+test('cli rejects an unknown flag with exit code 2', async () => {
+    const result = await runCliUntilExit(['--nope'])
+    assert.equal(result.code, 2)
+    assert.ok(result.stderr.includes('unknown flag'))
+})
+
+test('cli rejects an invalid --port with exit code 2', async () => {
+    const result = await runCliUntilExit(['--port', 'not-a-port'])
+    assert.equal(result.code, 2)
+    assert.ok(result.stderr.includes('invalid --port'))
+})
+
+test('cli rejects a --group referencing an undeclared peer with exit code 2', async () => {
+    const result = await runCliUntilExit(['--group', '123@g.us=5511888@s.whatsapp.net'])
+    assert.equal(result.code, 2)
+    assert.ok(result.stderr.includes('not declared via --peer'))
+})
+
+test('cli --json prints connection info with the noise root ca', async () => {
+    const cli = startCli(['--json'])
+    try {
+        const info = await waitForStartupJson(cli)
+        assert.ok(info.url.startsWith('ws://'))
+        assert.equal(info.path, '/ws/chat')
+        assert.ok(info.port > 0)
+        assert.ok(info.url.includes(`:${info.port}`))
+        assert.equal(info.noiseRootCa.serial, 0)
+        assert.match(info.noiseRootCa.publicKeyHex, /^[0-9a-f]{64}$/)
+        assert.deepEqual(info.peers, [])
+        assert.deepEqual(info.groups, [])
+        assert.equal(info.pair, null)
+    } finally {
+        await cli.dispose()
+    }
+})
+
+test('cli banner shows pair mode off by default', async () => {
+    const cli = startCli([])
+    try {
+        const stdout = await cli.waitForStdout(
+            (value) => value.includes('@zapo-js/fake-server is up'),
+            'startup banner'
+        )
+        assert.ok(stdout.includes('pair mode      (off'))
+    } finally {
+        await cli.dispose()
+    }
+})
+
+test('cli --pair drives QR pairing over stdin and then creates peers and groups', async () => {
+    const deviceJid = '5511999999999:1@s.whatsapp.net'
+    const peerJid = '5511777777777@s.whatsapp.net'
+    const groupJid = '123456789@g.us'
+    const cli = startCli([
+        '--json',
+        '--pair',
+        deviceJid,
+        '--peer',
+        peerJid,
+        '--group',
+        `${groupJid}=${peerJid}`
+    ])
+
+    let client: WaClient | null = null
+    try {
+        const info = await waitForStartupJson(cli)
+        assert.equal(info.pair, deviceJid)
+
+        client = new WaClient(
+            {
+                store: createStore({}),
+                sessionId: 'cli-pair-cross-check',
+                chatSocketUrls: [info.url],
+                connectTimeoutMs: 60_000,
+                testHooks: {
+                    noiseRootCa: {
+                        publicKey: hexToBytes(info.noiseRootCa.publicKeyHex),
+                        serial: info.noiseRootCa.serial
+                    }
+                }
+            },
+            createNoopLogger('error')
+        )
+
+        const qrPromise = new Promise<string>((resolve) => {
+            client!.once('auth_qr', (event: Parameters<WaClientEventMap['auth_qr']>[0]) => {
+                resolve(event.qr)
+            })
+        })
+        const pairedPromise = new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(
+                () =>
+                    reject(
+                        new Error(
+                            `auth_paired timeout\ncli stdout:\n${cli.stdoutSnapshot()}\ncli stderr:\n${cli.stderrSnapshot()}`
+                        )
+                    ),
+                60_000
+            )
+            client!.once('auth_paired', () => {
+                clearTimeout(timer)
+                resolve()
+            })
+        })
+
+        await client.connect()
+
+        const promptPromise = cli.waitForStdout(
+            (value) => value.includes('paste the QR payload'),
+            'qr paste prompt'
+        )
+        const [qr] = await Promise.all([qrPromise, promptPromise])
+        cli.writeStdinLine(qr)
+
+        await pairedPromise
+        await cli.waitForStdout(
+            (value) => value.includes(`pair-success sent for ${deviceJid}`),
+            'pair-success confirmation'
+        )
+        await cli.waitForStdout(
+            (value) => value.includes(`created peer ${peerJid}`),
+            'peer creation after login'
+        )
+        await cli.waitForStdout(
+            (value) => value.includes(`created group ${groupJid}`),
+            'group creation after login'
+        )
+    } finally {
+        await client?.disconnect().catch(() => undefined)
+        await cli.dispose()
+    }
+})

--- a/packages/fake-server/src/__tests__/server-options.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/server-options.cross-check.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { WaClientEventMap } from 'zapo-js'
+
+import { FakeWaServer } from '../api/FakeWaServer'
+import type { BinaryNode } from '../transport/codec'
+
+import { createZapoClient } from './helpers/zapo-client'
+
+test('successNodeAttributes reach the client success node and onPipeline fans out', async () => {
+    const server = await FakeWaServer.start({
+        successNodeAttributes: {
+            lid: '5511999999999@lid',
+            displayName: 'Fake Display',
+            abprops: 42
+        }
+    })
+    const pipelineHits: string[] = []
+    server.onPipeline(() => {
+        pipelineHits.push('first')
+    })
+    const unregisterSecond = server.onPipeline(() => {
+        pipelineHits.push('second')
+    })
+
+    const { client } = createZapoClient(server, { sessionId: 'server-options' })
+    const successNodePromise = new Promise<BinaryNode>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('success node timeout')), 15_000)
+        client.once(
+            'debug_connection_success',
+            (event: Parameters<WaClientEventMap['debug_connection_success']>[0]) => {
+                clearTimeout(timer)
+                resolve(event.node)
+            }
+        )
+    })
+
+    try {
+        await client.connect()
+        const successNode = await successNodePromise
+
+        assert.equal(successNode.attrs.lid, '5511999999999@lid')
+        assert.equal(successNode.attrs.display_name, 'Fake Display')
+        assert.equal(successNode.attrs.abprops, '42')
+
+        // Both onPipeline listeners must have seen the same connection.
+        assert.deepEqual(pipelineHits, ['first', 'second'])
+
+        unregisterSecond()
+    } finally {
+        await client.disconnect().catch(() => undefined)
+        await server.stop()
+    }
+})

--- a/packages/fake-server/src/api/FakePeer.ts
+++ b/packages/fake-server/src/api/FakePeer.ts
@@ -817,7 +817,13 @@ export class FakePeer {
 
     private nextId(): string {
         this.nextMessageCounter += 1
-        return `${this.jid}-${Date.now()}-${this.nextMessageCounter}`
+        // WA-style uppercase hex, no '@': strict binary decoders tokenize an
+        // id containing '@' as a JID and reject the stanza. The registration
+        // id keeps ids from colliding across peers created in the same ms.
+        const peerPart = this.keyBundle.registrationId.toString(16).padStart(4, '0')
+        const timePart = Date.now().toString(16)
+        const counterPart = this.nextMessageCounter.toString(16).padStart(4, '0')
+        return `3EB0${peerPart}${timePart}${counterPart}`.toUpperCase()
     }
 }
 

--- a/packages/fake-server/src/api/FakeWaServer.ts
+++ b/packages/fake-server/src/api/FakeWaServer.ts
@@ -775,7 +775,7 @@ export class FakeWaServer {
         })
         for (const listener of this.pipelineListeners) {
             try {
-                listener(pipeline)
+                void Promise.resolve(listener(pipeline)).catch(() => undefined)
             } catch {
                 /* ignore */
             }

--- a/packages/fake-server/src/api/FakeWaServer.ts
+++ b/packages/fake-server/src/api/FakeWaServer.ts
@@ -9,6 +9,7 @@ import {
 import { WaFakeMediaHttpsServer } from '../infra/WaFakeMediaHttpsServer'
 import { WaFakeWsServer, type WaFakeWsServerListenInfo } from '../infra/WaFakeWsServer'
 import { type FakeNoiseRootCa, generateFakeNoiseRootCa } from '../protocol/auth/cert-chain'
+import type { BuildSuccessNodeInput } from '../protocol/auth/success-node'
 import type { BuildAbPropsResultInput } from '../protocol/iq/abprops'
 import {
     type BuildServerSyncNotificationInput,
@@ -67,6 +68,17 @@ export interface FakeWaServerOptions {
     readonly host?: string
     readonly port?: number
     readonly path?: string
+    /**
+     * Attributes stamped on the post-handshake `<success/>` node of every
+     * authenticated connection (lid, display name, props versions, ...).
+     */
+    readonly successNodeAttributes?: BuildSuccessNodeInput
+    /**
+     * Register the built-in IQ auto-handlers that answer everything the lib
+     * emits during normal operation. Default `true`; pass `false` to start
+     * with an empty router and wire every response via `registerIqHandler`.
+     */
+    readonly defaultIqHandlers?: boolean
 }
 
 export interface FakeWaServerNoiseRootCa {
@@ -130,10 +142,11 @@ export class FakeWaServer {
     private readonly authenticatedListeners = new Set<AuthenticatedPipelineListener>()
     private readonly inboundStanzaListeners = new Set<(node: BinaryNode) => void>()
     private readonly capturedStanzaListeners = new Set<(node: BinaryNode) => void>()
+    private readonly options: FakeWaServerOptions
     private rootCa: FakeNoiseRootCa | null = null
     private serverStaticKeyPair: SignalKeyPair | null = null
     private listenInfo: WaFakeWsServerListenInfo | null = null
-    private pipelineListener: FakeWaServerPipelineListener | null = null
+    private readonly pipelineListeners = new Set<FakeWaServerPipelineListener>()
     private rejectMode: { readonly code: number; readonly reason: string } | null = null
     private readonly mediaStore = new FakeMediaStore()
     private readonly mediaHttpsServer = new WaFakeMediaHttpsServer()
@@ -142,9 +155,12 @@ export class FakeWaServer {
     private cachedMediaProxyAgent: HttpsAgent | null = null
 
     public constructor(options: FakeWaServerOptions = {}) {
+        this.options = options
         this.wsServer = new WaFakeWsServer(options)
         this.wsServer.onConnection((connection) => this.handleConnection(connection))
-        registerDefaultIqHandlers(this.iqRouter, this.buildIqHandlerDeps())
+        if (options.defaultIqHandlers !== false) {
+            registerDefaultIqHandlers(this.iqRouter, this.buildIqHandlerDeps())
+        }
     }
 
     private buildIqHandlerDeps(): IqHandlerDeps {
@@ -212,6 +228,7 @@ export class FakeWaServer {
                 }
             },
             capturePreKeyBundle: (bundle) => preKey.captureBundle(bundle),
+            countServerPreKeys: () => preKey.preKeysAvailable(),
             consumeOutboundAppStatePatches: (iq) => appState.consumeOutboundAppStatePatches(iq),
             get appStateCollectionProviders() {
                 return appState.appStateCollectionProviders
@@ -685,8 +702,15 @@ export class FakeWaServer {
         return { publicKey: root.publicKey, serial: root.serial }
     }
 
-    public onPipeline(listener: FakeWaServerPipelineListener): void {
-        this.pipelineListener = listener
+    /**
+     * Subscribes to every new connection pipeline (pre-auth). Listeners
+     * fan out; returns an unsubscribe function.
+     */
+    public onPipeline(listener: FakeWaServerPipelineListener): () => void {
+        this.pipelineListeners.add(listener)
+        return () => {
+            this.pipelineListeners.delete(listener)
+        }
     }
 
     public async listen(): Promise<void> {
@@ -730,7 +754,10 @@ export class FakeWaServer {
             connection,
             rootCa: this.rootCa,
             serverStaticKeyPair: this.serverStaticKeyPair,
-            iqRouter: this.iqRouter
+            iqRouter: this.iqRouter,
+            ...(this.options.successNodeAttributes !== undefined
+                ? { successNodeAttributes: this.options.successNodeAttributes }
+                : {})
         })
         this.pipelines.add(pipeline)
         pipeline.setEvents({
@@ -742,7 +769,9 @@ export class FakeWaServer {
             onStanza: (node) => this.handleCapturedStanza(node),
             onClose: () => this.pipelines.delete(pipeline)
         })
-        this.pipelineListener?.(pipeline)
+        for (const listener of this.pipelineListeners) {
+            listener(pipeline)
+        }
     }
 
     private handleCapturedStanza(node: BinaryNode): void {

--- a/packages/fake-server/src/api/FakeWaServer.ts
+++ b/packages/fake-server/src/api/FakeWaServer.ts
@@ -763,14 +763,22 @@ export class FakeWaServer {
         pipeline.setEvents({
             onAuthenticated: () => {
                 for (const listener of this.authenticatedListeners) {
-                    void listener(pipeline)
+                    try {
+                        void Promise.resolve(listener(pipeline)).catch(() => undefined)
+                    } catch {
+                        /* ignore */
+                    }
                 }
             },
             onStanza: (node) => this.handleCapturedStanza(node),
             onClose: () => this.pipelines.delete(pipeline)
         })
         for (const listener of this.pipelineListeners) {
-            listener(pipeline)
+            try {
+                listener(pipeline)
+            } catch {
+                /* ignore */
+            }
         }
     }
 

--- a/packages/fake-server/src/api/__tests__/iq-handlers.test.ts
+++ b/packages/fake-server/src/api/__tests__/iq-handlers.test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { FAKE_DEFAULT_PRIVACY_SETTINGS } from '../../protocol/iq/privacy'
+import { WaFakeIqRouter } from '../../protocol/iq/router'
+import type { BinaryNode } from '../../transport/codec'
+import { FakeWaServer } from '../FakeWaServer'
+import { type IqHandlerDeps, registerDefaultIqHandlers } from '../iq-handlers'
+
+function createRouterWithDefaults(overrides: Partial<IqHandlerDeps> = {}): WaFakeIqRouter {
+    const router = new WaFakeIqRouter()
+    const deps: IqHandlerDeps = {
+        peerRegistry: new Map(),
+        groupRegistry: new Map(),
+        privacySettings: FAKE_DEFAULT_PRIVACY_SETTINGS,
+        blocklistJids: new Set(),
+        profilePicturesByJid: new Map(),
+        businessProfilesByJid: new Map(),
+        abPropsInput: {},
+        issuedPrivacyTokens: new Map(),
+        latestStatusText: null,
+        setLatestStatusText: () => undefined,
+        lookupDeviceIdsForUser: () => [],
+        notifyGroupOp: () => undefined,
+        mutatePrivacySettings: () => undefined,
+        mutateBlocklist: () => undefined,
+        notifyProfilePictureSet: () => undefined,
+        handleProfilePictureSet: () => undefined,
+        notifyStatusSet: () => undefined,
+        notifyLogout: () => undefined,
+        notifyPrivacyTokenIssue: () => undefined,
+        notifyDirtyBitsClear: () => undefined,
+        notifyPrivacySet: () => undefined,
+        notifyBlocklistChange: () => undefined,
+        capturePreKeyBundle: () => undefined,
+        countServerPreKeys: () => 0,
+        consumeOutboundAppStatePatches: async () => undefined,
+        appStateCollectionProviders: new Map(),
+        requireMediaHttpsInfo: () => ({ host: '127.0.0.1', port: 1 }),
+        ...overrides
+    }
+    registerDefaultIqHandlers(router, deps)
+    return router
+}
+
+test('passive set iq is answered with a plain result from s.whatsapp.net', async () => {
+    const router = createRouterWithDefaults()
+    const inbound: BinaryNode = {
+        tag: 'iq',
+        attrs: { id: 'passive-1', type: 'set', xmlns: 'passive', to: 's.whatsapp.net' },
+        content: [{ tag: 'active', attrs: {} }]
+    }
+
+    const response = await router.route(inbound)
+    assert.ok(response, 'passive iq must be handled by a default handler')
+    assert.equal(response.attrs.type, 'result')
+    assert.equal(response.attrs.id, 'passive-1')
+    assert.equal(response.attrs.from, 's.whatsapp.net')
+})
+
+test('encrypt <count> get iq returns the remaining dispenser prekey count', async () => {
+    const router = createRouterWithDefaults({ countServerPreKeys: () => 812 })
+    const inbound: BinaryNode = {
+        tag: 'iq',
+        attrs: { id: 'count-1', type: 'get', xmlns: 'encrypt', to: 's.whatsapp.net' },
+        content: [{ tag: 'count', attrs: {} }]
+    }
+
+    const response = await router.route(inbound)
+    assert.ok(response, 'count iq must be handled by a default handler')
+    assert.equal(response.attrs.type, 'result')
+    assert.equal(response.attrs.id, 'count-1')
+    const children = Array.isArray(response.content) ? response.content : []
+    assert.equal(children.length, 1)
+    assert.equal(children[0].tag, 'count')
+    assert.equal(children[0].attrs.value, '812')
+})
+
+test('a high-priority responder returning null falls through to the default handler', async () => {
+    const router = createRouterWithDefaults()
+    const observed: string[] = []
+    router.register(
+        {
+            label: 'ping-observer',
+            matcher: { xmlns: 'w:p' },
+            respond: (iq) => {
+                observed.push(iq.attrs.id ?? '')
+                return null
+            }
+        },
+        { priority: 'high' }
+    )
+    const inbound: BinaryNode = {
+        tag: 'iq',
+        attrs: { id: 'ping-1', type: 'get', xmlns: 'w:p', to: 's.whatsapp.net' }
+    }
+
+    const response = await router.route(inbound)
+    assert.deepEqual(observed, ['ping-1'])
+    assert.ok(response, 'default ping handler must still answer after the fallthrough')
+    assert.equal(response.attrs.type, 'result')
+})
+
+test('a responder returning null with no other match leaves the iq unhandled', async () => {
+    const router = new WaFakeIqRouter()
+    const unhandled: BinaryNode[] = []
+    router.setEvents({ onUnhandled: (iq) => unhandled.push(iq) })
+    router.register({ matcher: { xmlns: 'w:p' }, respond: () => null })
+    const inbound: BinaryNode = {
+        tag: 'iq',
+        attrs: { id: 'ping-2', type: 'get', xmlns: 'w:p' }
+    }
+
+    const response = await router.route(inbound)
+    assert.equal(response, null)
+    assert.equal(unhandled.length, 1)
+})
+
+test('defaultIqHandlers: false starts the server with an empty router', async () => {
+    const bare = new FakeWaServer({ defaultIqHandlers: false })
+    const withDefaults = new FakeWaServer()
+    const ping: BinaryNode = {
+        tag: 'iq',
+        attrs: { id: 'ping-3', type: 'get', xmlns: 'w:p', to: 's.whatsapp.net' }
+    }
+
+    assert.equal(await bare.routeIqForTest(ping), null)
+    const answered = await withDefaults.routeIqForTest(ping)
+    assert.equal(answered?.attrs.type, 'result')
+
+    // registerIqHandler is the only routing surface left on a bare server.
+    bare.registerIqHandler({ xmlns: 'w:p' }, (iq) => ({
+        tag: 'iq',
+        attrs: { id: iq.attrs.id ?? '', type: 'result' }
+    }))
+    const custom = await bare.routeIqForTest(ping)
+    assert.equal(custom?.attrs.type, 'result')
+})
+
+test('encrypt <count> does not shadow the <digest> 404 handler', async () => {
+    const router = createRouterWithDefaults()
+    const inbound: BinaryNode = {
+        tag: 'iq',
+        attrs: { id: 'digest-1', type: 'get', xmlns: 'encrypt', to: 's.whatsapp.net' },
+        content: [{ tag: 'digest', attrs: {} }]
+    }
+
+    const response = await router.route(inbound)
+    assert.ok(response)
+    assert.equal(response.attrs.type, 'error')
+})

--- a/packages/fake-server/src/api/iq-handlers.ts
+++ b/packages/fake-server/src/api/iq-handlers.ts
@@ -83,6 +83,7 @@ export interface IqHandlerDeps {
     notifyPrivacySet(change: CapturedPrivacySet): void
     notifyBlocklistChange(change: CapturedBlocklistChange): void
     capturePreKeyBundle(bundle: ClientPreKeyBundle): void
+    countServerPreKeys(): number
     consumeOutboundAppStatePatches(iq: BinaryNode): Promise<void>
     readonly appStateCollectionProviders: ReadonlyMap<
         string,
@@ -162,6 +163,31 @@ export function registerDefaultIqHandlers(router: WaFakeIqRouter, deps: IqHandle
         label: 'signal-digest',
         matcher: { xmlns: 'encrypt', type: 'get', childTag: 'digest' },
         respond: (iq) => buildIqError(iq, { code: 404, text: 'item-not-found' })
+    })
+
+    // Baileys-family and whatsmeow clients block on this query before
+    // reporting the connection as open; zapo-js uses <digest> instead.
+    router.register({
+        label: 'prekey-count',
+        matcher: { xmlns: 'encrypt', type: 'get', childTag: 'count' },
+        respond: (iq) => {
+            const result = buildIqResult(iq)
+            return {
+                ...result,
+                content: [
+                    {
+                        tag: 'count',
+                        attrs: { value: String(deps.countServerPreKeys()) }
+                    }
+                ]
+            }
+        }
+    })
+
+    router.register({
+        label: 'passive-mode',
+        matcher: { xmlns: 'passive', type: 'set' },
+        respond: (iq) => buildIqResult(iq)
     })
 
     router.register({

--- a/packages/fake-server/src/bin.ts
+++ b/packages/fake-server/src/bin.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 /** Standalone CLI for `@zapo-js/fake-server`. */
 
+import { createInterface } from 'node:readline'
+
 import { FakeWaServer } from './api/FakeWaServer'
+import { parsePairingQrString } from './protocol/auth/pair-device'
 
 interface CliArgs {
     readonly host: string
@@ -9,6 +12,7 @@ interface CliArgs {
     readonly path: string
     readonly peerJids: readonly string[]
     readonly groupSpecs: readonly string[]
+    readonly pairJid: string | null
     readonly log: boolean
     readonly quiet: boolean
     readonly json: boolean
@@ -21,6 +25,7 @@ function parseArgs(argv: readonly string[]): CliArgs {
     let path = '/ws/chat'
     const peerJids: string[] = []
     const groupSpecs: string[] = []
+    let pairJid: string | null = null
     let log = false
     let quiet = false
     let json = false
@@ -59,6 +64,9 @@ function parseArgs(argv: readonly string[]): CliArgs {
             case '--group':
                 groupSpecs.push(next())
                 break
+            case '--pair':
+                pairJid = next()
+                break
             case '--log':
                 log = true
                 break
@@ -72,7 +80,7 @@ function parseArgs(argv: readonly string[]): CliArgs {
                 throw new Error(`unknown flag: ${arg}`)
         }
     }
-    return { host, port, path, peerJids, groupSpecs, log, quiet, json, help }
+    return { host, port, path, peerJids, groupSpecs, pairJid, log, quiet, json, help }
 }
 
 function printHelp(): void {
@@ -89,6 +97,12 @@ FLAGS
   --group <spec>      Pre-create a fake group; spec format
                       <group-jid>=<peer-jid>,<peer-jid>,...
                       All peers must already be passed via --peer.
+  --pair <jid>        Drive QR pairing for unregistered clients: the server
+                      sends pair-device refs, then prompts on stdin for the
+                      QR payload the client displays
+                      (ref,noisePubB64,identityPubB64,advSecretB64,platform)
+                      and answers pair-success assigning <jid> as the device
+                      jid. Without this flag the CLI is login-only.
   --log               Print every captured inbound stanza
   --quiet             Suppress the startup info banner
   --json              Print connection info as JSON
@@ -155,10 +169,41 @@ async function main(): Promise<void> {
         path: args.path
     })
 
+    if (args.pairJid !== null) {
+        const pairJid = args.pairJid
+        let pairingStarted = false
+        server.onAuthenticatedPipeline(async (pipeline) => {
+            if (pairingStarted) return
+            if (pipeline.clientPayload?.kind !== 'registration') return
+            pairingStarted = true
+            try {
+                await server.runPairing(pipeline, { deviceJid: pairJid }, async () => {
+                    const qr = await readStdinLine(
+                        '[fake-server] paste the QR payload displayed by the client and press Enter:\n'
+                    )
+                    const parsed = parsePairingQrString(qr.trim())
+                    return {
+                        advSecretKey: parsed.advSecretKey,
+                        identityPublicKey: parsed.identityPublicKey
+                    }
+                })
+                process.stdout.write(
+                    `[fake-server] pair-success sent for ${pairJid}; the client will now reconnect and log in\n`
+                )
+            } catch (error) {
+                pairingStarted = false
+                process.stderr.write(
+                    `pairing failed: ${error instanceof Error ? error.message : String(error)}\n`
+                )
+            }
+        })
+    }
+
     let setupComplete = false
     const setupPromise = new Promise<void>((resolve, reject) => {
         server.onAuthenticatedPipeline(async (pipeline) => {
             if (setupComplete) return
+            if (pipeline.clientPayload?.kind !== 'login') return
             setupComplete = true
             try {
                 const peers = new Map<string, Awaited<ReturnType<typeof server.createFakePeer>>>()
@@ -197,14 +242,13 @@ async function main(): Promise<void> {
     })
 
     if (args.log) {
-        server.onPipeline((pipeline) => {
-            pipeline.setEvents({
-                onStanza: (node) => {
-                    process.stdout.write(
-                        `[wire] ${node.tag}${node.attrs.id ? ` id=${node.attrs.id}` : ''}${node.attrs.type ? ` type=${node.attrs.type}` : ''}\n`
-                    )
-                }
-            })
+        // onCapturedStanza taps the server's own capture stream; overriding
+        // pipeline.setEvents here would replace the server's handlers and
+        // silently break --peer setup and stanza capture.
+        server.onCapturedStanza((node) => {
+            process.stdout.write(
+                `[wire] ${node.tag}${node.attrs.id ? ` id=${node.attrs.id}` : ''}${node.attrs.type ? ` type=${node.attrs.type}` : ''}\n`
+            )
         })
     }
 
@@ -223,7 +267,8 @@ async function main(): Promise<void> {
                             publicKeyHex: bytesToHex(noiseRoot.publicKey)
                         },
                         peers: args.peerJids,
-                        groups: parsedGroups
+                        groups: parsedGroups,
+                        pair: args.pairJid
                     },
                     null,
                     2
@@ -242,6 +287,7 @@ async function main(): Promise<void> {
                 `│ noise root ca  serial=${noiseRoot.serial} pub=${bytesToHex(noiseRoot.publicKey).slice(0, 32)}…`,
                 `│ peers          ${args.peerJids.length === 0 ? '(none)' : args.peerJids.join(', ')}`,
                 `│ groups         ${parsedGroups.length === 0 ? '(none)' : parsedGroups.map((g) => g.groupJid).join(', ')}`,
+                `│ pair mode      ${args.pairJid ?? '(off – login only)'}`,
                 '├─────────────────────────────────────────────────────────────',
                 '│ Wire your WaClient with:',
                 '│   chatSocketUrls: [server.url]',
@@ -274,6 +320,20 @@ async function main(): Promise<void> {
     process.on('SIGTERM', () => void shutdown('SIGTERM'))
 
     await new Promise<void>(() => undefined)
+}
+
+function readStdinLine(prompt: string): Promise<string> {
+    process.stdout.write(prompt)
+    return new Promise((resolve, reject) => {
+        const rl = createInterface({ input: process.stdin })
+        // resolve before close(): rl.close() emits 'close' synchronously,
+        // which would otherwise reject the still-pending promise first.
+        rl.once('line', (line) => {
+            resolve(line)
+            rl.close()
+        })
+        rl.once('close', () => reject(new Error('stdin closed before a QR payload was provided')))
+    })
 }
 
 function bytesToHex(bytes: Uint8Array): string {

--- a/packages/fake-server/src/bin.ts
+++ b/packages/fake-server/src/bin.ts
@@ -5,6 +5,7 @@ import { createInterface } from 'node:readline'
 
 import { FakeWaServer } from './api/FakeWaServer'
 import { parsePairingQrString } from './protocol/auth/pair-device'
+import { bytesToHex, toError } from './transport/util'
 
 interface CliArgs {
     readonly host: string
@@ -141,7 +142,7 @@ async function main(): Promise<void> {
     try {
         args = parseArgs(process.argv.slice(2))
     } catch (error) {
-        process.stderr.write(`error: ${error instanceof Error ? error.message : String(error)}\n`)
+        process.stderr.write(`error: ${toError(error).message}\n`)
         process.stderr.write('run with --help to see usage.\n')
         process.exit(2)
     }
@@ -192,9 +193,7 @@ async function main(): Promise<void> {
                 )
             } catch (error) {
                 pairingStarted = false
-                process.stderr.write(
-                    `pairing failed: ${error instanceof Error ? error.message : String(error)}\n`
-                )
+                process.stderr.write(`pairing failed: ${toError(error).message}\n`)
             }
         })
     }
@@ -232,7 +231,7 @@ async function main(): Promise<void> {
                 }
                 resolve()
             } catch (error) {
-                reject(error instanceof Error ? error : new Error(String(error)))
+                reject(toError(error))
             }
         })
     })
@@ -310,9 +309,7 @@ async function main(): Promise<void> {
             process.stdout.write('[fake-server] stopped cleanly\n')
             process.exit(0)
         } catch (error) {
-            process.stderr.write(
-                `error during shutdown: ${error instanceof Error ? error.message : String(error)}\n`
-            )
+            process.stderr.write(`error during shutdown: ${toError(error).message}\n`)
             process.exit(1)
         }
     }
@@ -336,18 +333,8 @@ function readStdinLine(prompt: string): Promise<string> {
     })
 }
 
-function bytesToHex(bytes: Uint8Array): string {
-    let out = ''
-    for (let index = 0; index < bytes.byteLength; index += 1) {
-        const value = bytes[index]
-        out += value < 16 ? `0${value.toString(16)}` : value.toString(16)
-    }
-    return out
-}
-
 main().catch((error) => {
-    process.stderr.write(
-        `fatal: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`
-    )
+    const normalized = toError(error)
+    process.stderr.write(`fatal: ${normalized.stack ?? normalized.message}\n`)
     process.exit(1)
 })

--- a/packages/fake-server/src/infra/WaFakeConnectionPipeline.ts
+++ b/packages/fake-server/src/infra/WaFakeConnectionPipeline.ts
@@ -62,6 +62,7 @@ export class WaFakeConnectionPipeline {
     private events: WaFakeConnectionPipelineEvents = {}
     private state: State = { kind: 'awaiting_prologue' }
     private chain: Promise<void> = Promise.resolve()
+    private authenticatedPayload: ParsedClientPayload | null = null
 
     public constructor(config: WaFakeConnectionPipelineConfig) {
         this.config = config
@@ -83,6 +84,11 @@ export class WaFakeConnectionPipeline {
 
     public isAuthenticated(): boolean {
         return this.state.kind === 'authenticated'
+    }
+
+    /** Parsed ClientPayload of the authenticated connection; null before auth. */
+    public get clientPayload(): ParsedClientPayload | null {
+        return this.authenticatedPayload
     }
 
     public async sendStanza(node: BinaryNode): Promise<void> {
@@ -235,15 +241,7 @@ export class WaFakeConnectionPipeline {
 
         this.frameSocket.sendFrame(serverHello)
 
-        const keys = handshake.finish()
-        const transport = new WaFakeTransport({
-            recvKey: keys.recvKey,
-            sendKey: keys.sendKey
-        })
-        this.state = { kind: 'authenticated', transport }
-
-        await this.sendStanza(buildSuccessNode(this.config.successNodeAttributes))
-        this.events.onAuthenticated?.({ clientPayload, clientStaticKey })
+        await this.completeAuthentication(handshake, clientPayload, clientStaticKey)
     }
 
     private async handleClientFinish(
@@ -263,14 +261,33 @@ export class WaFakeConnectionPipeline {
         const clientPayloadBytes = handshake.decrypt(clientFinish.payload)
         const clientPayload = parseClientPayload(clientPayloadBytes)
 
+        await this.completeAuthentication(handshake, clientPayload, clientStaticKey)
+    }
+
+    private async completeAuthentication(
+        handshake: WaFakeNoiseHandshake,
+        clientPayload: ParsedClientPayload,
+        clientStaticKey: Uint8Array
+    ): Promise<void> {
         const keys = handshake.finish()
         const transport = new WaFakeTransport({
             recvKey: keys.recvKey,
             sendKey: keys.sendKey
         })
         this.state = { kind: 'authenticated', transport }
+        this.authenticatedPayload = clientPayload
 
         await this.sendStanza(buildSuccessNode(this.config.successNodeAttributes))
+        if (clientPayload.kind === 'login') {
+            // Real WA drains offline messages after login and closes the
+            // drain with this bulletin. Baileys-family clients buffer their
+            // events until it arrives, so send it eagerly with count=0.
+            await this.sendStanza({
+                tag: 'ib',
+                attrs: { from: 's.whatsapp.net' },
+                content: [{ tag: 'offline', attrs: { count: '0' } }]
+            })
+        }
         this.events.onAuthenticated?.({ clientPayload, clientStaticKey })
     }
 

--- a/packages/fake-server/src/protocol/auth/__tests__/cert-chain.test.ts
+++ b/packages/fake-server/src/protocol/auth/__tests__/cert-chain.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import { verifyNoiseCertificateChain, type WaNoiseRootCa } from '../../../transport/codec'
 import { X25519 } from '../../../transport/crypto'
+import { proto } from '../../../transport/protos'
 import { buildFakeCertChain, generateFakeNoiseRootCa } from '../cert-chain'
 
 test('fake cert chain passes the lib verification using the matching root CA', async () => {
@@ -20,6 +21,31 @@ test('fake cert chain passes the lib verification using the matching root CA', a
     }
 
     await verifyNoiseCertificateChain(encoded, serverStaticKeyPair.pubKey, trustedRootCa)
+})
+
+test('fake cert chain carries a currently-valid notBefore/notAfter window', async () => {
+    const root = await generateFakeNoiseRootCa()
+    const serverStaticKeyPair = await X25519.generateKeyPair()
+
+    const { encoded } = await buildFakeCertChain({
+        root,
+        leafKey: serverStaticKeyPair.pubKey
+    })
+
+    const chain = proto.CertChain.decode(encoded)
+    const nowSeconds = Math.floor(Date.now() / 1_000)
+    const toSeconds = (value: number | { toNumber(): number } | null | undefined): number => {
+        if (value === null || value === undefined) return 0
+        return typeof value === 'number' ? value : value.toNumber()
+    }
+    for (const certificate of [chain.intermediate, chain.leaf]) {
+        assert.ok(certificate?.details)
+        const details = proto.CertChain.NoiseCertificate.Details.decode(certificate.details)
+        const notBefore = toSeconds(details.notBefore)
+        const notAfter = toSeconds(details.notAfter)
+        assert.ok(notBefore > 0 && notBefore <= nowSeconds)
+        assert.ok(notAfter > nowSeconds)
+    }
 })
 
 test('cert chain verification rejects when leaf key does not match server static', async () => {

--- a/packages/fake-server/src/protocol/auth/cert-chain.ts
+++ b/packages/fake-server/src/protocol/auth/cert-chain.ts
@@ -24,8 +24,8 @@ export interface BuildFakeCertChainInput {
     readonly notAfter?: number
 }
 
-const CERT_NOT_BEFORE_BACKDATE_SECONDS = 86_400
-const CERT_NOT_AFTER_LIFETIME_SECONDS = 315_360_000
+const WA_CERT_NOT_BEFORE_BACKDATE_SECONDS = 86_400
+const WA_CERT_NOT_AFTER_LIFETIME_SECONDS = 315_360_000
 
 export async function generateFakeNoiseRootCa(): Promise<FakeNoiseRootCa> {
     const keyPair = await X25519.generateKeyPair()
@@ -45,8 +45,8 @@ export async function buildFakeCertChain(
     // Strict clients (e.g. whatsmeow) enforce the validity window; leaving
     // notBefore/notAfter unset decodes as 0 (1970) and reads as expired.
     const nowSeconds = Math.floor(Date.now() / 1_000)
-    const notBefore = input.notBefore ?? nowSeconds - CERT_NOT_BEFORE_BACKDATE_SECONDS
-    const notAfter = input.notAfter ?? nowSeconds + CERT_NOT_AFTER_LIFETIME_SECONDS
+    const notBefore = input.notBefore ?? nowSeconds - WA_CERT_NOT_BEFORE_BACKDATE_SECONDS
+    const notAfter = input.notAfter ?? nowSeconds + WA_CERT_NOT_AFTER_LIFETIME_SECONDS
 
     const intermediateKeyPair = await X25519.generateKeyPair()
 

--- a/packages/fake-server/src/protocol/auth/cert-chain.ts
+++ b/packages/fake-server/src/protocol/auth/cert-chain.ts
@@ -18,7 +18,14 @@ export interface BuildFakeCertChainInput {
     readonly leafKey: Uint8Array
     readonly intermediateSerial?: number
     readonly leafSerial?: number
+    /** Unix seconds. Defaults to 24h before build time. */
+    readonly notBefore?: number
+    /** Unix seconds. Defaults to 10 years after build time. */
+    readonly notAfter?: number
 }
+
+const CERT_NOT_BEFORE_BACKDATE_SECONDS = 86_400
+const CERT_NOT_AFTER_LIFETIME_SECONDS = 315_360_000
 
 export async function generateFakeNoiseRootCa(): Promise<FakeNoiseRootCa> {
     const keyPair = await X25519.generateKeyPair()
@@ -35,19 +42,29 @@ export async function buildFakeCertChain(
     const intermediateSerial = input.intermediateSerial ?? 1
     const leafSerial = input.leafSerial ?? 2
 
+    // Strict clients (e.g. whatsmeow) enforce the validity window; leaving
+    // notBefore/notAfter unset decodes as 0 (1970) and reads as expired.
+    const nowSeconds = Math.floor(Date.now() / 1_000)
+    const notBefore = input.notBefore ?? nowSeconds - CERT_NOT_BEFORE_BACKDATE_SECONDS
+    const notAfter = input.notAfter ?? nowSeconds + CERT_NOT_AFTER_LIFETIME_SECONDS
+
     const intermediateKeyPair = await X25519.generateKeyPair()
 
     const intermediateDetails = proto.CertChain.NoiseCertificate.Details.encode({
         serial: intermediateSerial,
         issuerSerial: input.root.serial,
-        key: intermediateKeyPair.pubKey
+        key: intermediateKeyPair.pubKey,
+        notBefore,
+        notAfter
     }).finish()
     const intermediateSignature = await xeddsaSign(input.root.privateKey, intermediateDetails)
 
     const leafDetails = proto.CertChain.NoiseCertificate.Details.encode({
         serial: leafSerial,
         issuerSerial: intermediateSerial,
-        key: input.leafKey
+        key: input.leafKey,
+        notBefore,
+        notAfter
     }).finish()
     const leafSignature = await xeddsaSign(intermediateKeyPair.privKey, leafDetails)
 

--- a/packages/fake-server/src/protocol/iq/router.ts
+++ b/packages/fake-server/src/protocol/iq/router.ts
@@ -11,7 +11,13 @@ export interface WaFakeIqMatcher {
     readonly childTag?: string
 }
 
-export type WaFakeIqResponder = (iq: BinaryNode) => BinaryNode | Promise<BinaryNode>
+/**
+ * Returns the response stanza, or `null` to fall through: the router keeps
+ * scanning lower-priority handlers as if this one had not matched. Lets a
+ * high-priority handler observe an IQ (capture, log, assert) while the
+ * default handler still answers it.
+ */
+export type WaFakeIqResponder = (iq: BinaryNode) => BinaryNode | null | Promise<BinaryNode | null>
 
 export interface WaFakeIqHandler {
     readonly matcher: WaFakeIqMatcher
@@ -53,12 +59,18 @@ export class WaFakeIqRouter {
         }
         for (const handler of this.highPriorityHandlers) {
             if (matches(iq, handler.matcher)) {
-                return handler.respond(iq)
+                const response = await handler.respond(iq)
+                if (response !== null) {
+                    return response
+                }
             }
         }
         for (const handler of this.handlers) {
             if (matches(iq, handler.matcher)) {
-                return handler.respond(iq)
+                const response = await handler.respond(iq)
+                if (response !== null) {
+                    return response
+                }
             }
         }
         this.events.onUnhandled?.(iq)

--- a/packages/fake-server/src/transport/util.ts
+++ b/packages/fake-server/src/transport/util.ts
@@ -5,6 +5,12 @@
  * server can use them without importing zapo-js directly.
  */
 
-export { bytesToBase64, bytesToBase64UrlSafe, bytesToHex, decodeBase64Url } from 'zapo-js/util'
+export {
+    bytesToBase64,
+    bytesToBase64UrlSafe,
+    bytesToHex,
+    decodeBase64Url,
+    toError
+} from 'zapo-js/util'
 
 export const TEXT_ENCODER = new TextEncoder()


### PR DESCRIPTION
Interop fixes so strict WhatsApp Web clients (Baileys forks, whatsmeow) can run against the fake server:

- set notBefore/notAfter on the fake noise cert chain; the unset fields decoded as 0 (1970) and validity-checking clients rejected the cert as expired
- answer the passive set IQ and the encrypt <count> prekey-count query by default; non-zapo clients block on both before reporting the connection as open
- send <ib><offline count="0"/></ib> after every login; buffered-event clients require it before flushing
- default FakePeer message ids to WA-style hex; the old jid-based id contained '@' and strict binary decoders tokenized it as a JID

CLI:

- new --pair <jid> mode drives QR pairing by prompting on stdin for the QR payload the client displays (the CLI was login-only before)
- --log no longer replaces the server's pipeline events, which broke --peer setup and stanza capture when combined

Programmatic API:

- FakeWaServerOptions accepts successNodeAttributes (previously dead config on the pipeline) and defaultIqHandlers: false for an empty IQ router
- IQ responders may return null to fall through to the next matching handler (observe-then-delegate)
- onPipeline fans out to multiple listeners and returns an unsubscribe function
- WaFakeConnectionPipeline exposes the parsed clientPayload

Docs cover install/CLI usage outside the monorepo and the non-zapo client recipe. New unit tests for the default handlers and router fallthrough, CLI tests spawning the real bin (including a stdin-driven pairing E2E), and cross-check assertions for the offline bulletin, message-id format, and success-node attributes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added QR-based device pairing to the fake-server CLI (with `--pair`).
  - Added configurable success-node attributes and a `defaultIqHandlers` option to disable built-in IQ handling.
  - Added support for `passive` and `prekey-count` IQ handling.
  - Improved authenticated flow to emit login offline notifications.
  - Enabled fall-through behavior for custom IQ handlers.
- **Bug Fixes**
  - Updated generated stanza IDs to WhatsApp-style hex format.
  - Populated certificate validity windows with correct timestamps.
- **Documentation**
  - Expanded installation, integration, CLI/pairing, and test-suite documentation.
- **Tests**
  - Added/expanded cross-check and IQ-routing coverage, including CLI validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->