### PR TITLE
fix(store): reacquirable session after destroy + non-terminal destroyCaches

### DIFF
--- a/src/store/__tests__/create-store.test.ts
+++ b/src/store/__tests__/create-store.test.ts
@@ -125,7 +125,9 @@ test('createStore session destroy releases the id for a fresh reacquire', async 
     const first = store.session('repair')
     await first.senderKey.getGroupSenderKeyList('123@g.us')
 
-    await first.destroy()
+    const firstDestroy = first.destroy()
+    assert.strictEqual(first.destroy(), firstDestroy)
+    await firstDestroy
     await assert.rejects(
         first.senderKey.getGroupSenderKeyList('123@g.us'),
         /shared-exclusive gate is closed/
@@ -150,7 +152,7 @@ test('createStore destroyCaches keeps the session bundle usable', async () => {
     })
     const staleGroupMetadata = session.groupMetadata
 
-    await session.destroyCaches()
+    await Promise.all([session.destroyCaches(), session.destroyCaches()])
 
     assert.strictEqual(store.session('caches'), session)
     await assert.rejects(
@@ -166,6 +168,22 @@ test('createStore destroyCaches keeps the session bundle usable', async () => {
     assert.ok(await session.groupMetadata.getGroupMetadata('123@g.us'))
     await session.senderKey.getGroupSenderKeyList('123@g.us')
 
+    await store.destroy()
+})
+
+test('createStore defaults the deviceList cache to memory when cacheProviders is unset', async () => {
+    const store = createStore({})
+    const session = store.session('devices')
+    await session.deviceList.upsertUserDevicesBatch([
+        {
+            userJid: '555@s.whatsapp.net',
+            deviceJids: ['555:1@s.whatsapp.net'],
+            updatedAtMs: Date.now()
+        }
+    ])
+    const [snapshot] = await session.deviceList.getUserDevicesBatch(['555@s.whatsapp.net'])
+    assert.ok(snapshot)
+    assert.deepEqual(snapshot.deviceJids, ['555:1@s.whatsapp.net'])
     await store.destroy()
 })
 

--- a/src/store/__tests__/create-store.test.ts
+++ b/src/store/__tests__/create-store.test.ts
@@ -120,6 +120,55 @@ test('createStore session lifecycle with backend + memory', async () => {
     assert.throws(() => store.session('x'), /store has been destroyed/)
 })
 
+test('createStore session destroy releases the id for a fresh reacquire', async () => {
+    const store = createStore({})
+    const first = store.session('repair')
+    await first.senderKey.getGroupSenderKeyList('123@g.us')
+
+    await first.destroy()
+    await assert.rejects(
+        first.senderKey.getGroupSenderKeyList('123@g.us'),
+        /shared-exclusive gate is closed/
+    )
+
+    const second = store.session('repair')
+    assert.notStrictEqual(second, first)
+    await second.senderKey.getGroupSenderKeyList('123@g.us')
+    await second.deviceList.getUserDevicesBatch(['555@s.whatsapp.net'])
+    await second.groupMetadata.getGroupMetadata('123@g.us')
+
+    await store.destroy()
+})
+
+test('createStore destroyCaches keeps the session bundle usable', async () => {
+    const store = createStore({})
+    const session = store.session('caches')
+    await session.groupMetadata.upsertGroupMetadata({
+        groupJid: '123@g.us',
+        participants: ['555@s.whatsapp.net'],
+        updatedAtMs: Date.now()
+    })
+    const staleGroupMetadata = session.groupMetadata
+
+    await session.destroyCaches()
+
+    assert.strictEqual(store.session('caches'), session)
+    await assert.rejects(
+        staleGroupMetadata.getGroupMetadata('123@g.us'),
+        /shared-exclusive gate is closed/
+    )
+    assert.equal(await session.groupMetadata.getGroupMetadata('123@g.us'), null)
+    await session.groupMetadata.upsertGroupMetadata({
+        groupJid: '123@g.us',
+        participants: ['555@s.whatsapp.net'],
+        updatedAtMs: Date.now()
+    })
+    assert.ok(await session.groupMetadata.getGroupMetadata('123@g.us'))
+    await session.senderKey.getGroupSenderKeyList('123@g.us')
+
+    await store.destroy()
+})
+
 test('createStore rejects unknown backend name', () => {
     assert.throws(
         () =>

--- a/src/store/__tests__/create-store.test.ts
+++ b/src/store/__tests__/create-store.test.ts
@@ -127,14 +127,15 @@ test('createStore session destroy releases the id for a fresh reacquire', async 
 
     const firstDestroy = first.destroy()
     assert.strictEqual(first.destroy(), firstDestroy)
+
+    const second = store.session('repair')
+    assert.notStrictEqual(second, first)
+
     await firstDestroy
     await assert.rejects(
         first.senderKey.getGroupSenderKeyList('123@g.us'),
         /shared-exclusive gate is closed/
     )
-
-    const second = store.session('repair')
-    assert.notStrictEqual(second, first)
     await second.senderKey.getGroupSenderKeyList('123@g.us')
     await second.deviceList.getUserDevicesBatch(['555@s.whatsapp.net'])
     await second.groupMetadata.getGroupMetadata('123@g.us')
@@ -169,6 +170,54 @@ test('createStore destroyCaches keeps the session bundle usable', async () => {
     await session.senderKey.getGroupSenderKeyList('123@g.us')
 
     await store.destroy()
+})
+
+test('createStore destroyCaches rejects on teardown failure but still swaps fresh caches', async () => {
+    let clearCalls = 0
+    const failingBackend = {
+        ...mockAuthBackend,
+        caches: {
+            ...mockAuthBackend.caches,
+            groupMetadata: () => ({
+                upsertGroupMetadata: async () => {},
+                getGroupMetadata: async () => null,
+                deleteGroupMetadata: async () => 0,
+                cleanupExpired: async () => 0,
+                clear: async () => {
+                    clearCalls += 1
+                    throw new Error('clear boom')
+                }
+            })
+        }
+    }
+    const store = createStore({
+        backends: { failing: failingBackend },
+        providers: {
+            auth: 'memory',
+            signal: 'memory',
+            preKey: 'memory',
+            session: 'memory',
+            identity: 'memory',
+            senderKey: 'memory',
+            appState: 'memory',
+            privacyToken: 'memory',
+            messages: 'none',
+            threads: 'none',
+            contacts: 'none'
+        },
+        cacheProviders: { groupMetadata: 'failing' }
+    })
+    const session = store.session('x')
+
+    await assert.rejects(session.destroyCaches(), /teardown failure/)
+    assert.equal(clearCalls, 1)
+
+    assert.strictEqual(store.session('x'), session)
+    assert.equal(await session.groupMetadata.getGroupMetadata('123@g.us'), null)
+    await session.retry.clear()
+
+    await store.destroy()
+    assert.equal(clearCalls, 2)
 })
 
 test('createStore defaults the deviceList cache to memory when cacheProviders is unset', async () => {

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -236,6 +236,7 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
         )
     } as const)
     const sessions = new Map<string, WaStoreSession>()
+    const pendingSessionDestroys = new Set<Promise<void>>()
     let storeDestroyed = false
 
     return {
@@ -477,7 +478,7 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
 
             const teardownCaches = async (
                 target: ReturnType<typeof buildCaches>
-            ): Promise<void> => {
+            ): Promise<number> => {
                 const cleared = await Promise.allSettled([
                     target.retry.clear(),
                     target.groupMetadata.clear(),
@@ -501,13 +502,20 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
                         sample: toError(failures[0].reason).message
                     })
                 }
+                return failures.length
             }
 
             const destroyCaches = (): Promise<void> => {
                 const run = cacheLifecycle.then(async () => {
                     if (sessionDestroyed) return
-                    await teardownCaches(caches)
+                    const failureCount = await teardownCaches(caches)
                     caches = buildCaches()
+                    if (failureCount > 0) {
+                        throw new Error(
+                            `cache reset finished with ${failureCount} teardown failure(s); ` +
+                                'fresh caches are in place but old persistent entries may remain'
+                        )
+                    }
                 })
                 cacheLifecycle = run.then(
                     () => undefined,
@@ -517,25 +525,28 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
             }
 
             const destroy = (): Promise<void> => {
-                destroyPromise ??= destroyInternal()
+                if (!destroyPromise) {
+                    const pending: Promise<void> = destroyInternal().finally(() =>
+                        pendingSessionDestroys.delete(pending)
+                    )
+                    destroyPromise = pending
+                    pendingSessionDestroys.add(pending)
+                }
                 return destroyPromise
             }
 
             const destroyInternal = async (): Promise<void> => {
                 sessionDestroyed = true
-                try {
-                    await cacheLifecycle
-                    await teardownCaches(caches)
-                    await destroyPersistentStores()
-                } finally {
-                    if (sessions.get(id) === storeSession) {
-                        sessions.delete(id)
-                    }
+                if (sessions.get(id) === storeSession) {
+                    sessions.delete(id)
                 }
+                await cacheLifecycle
+                await teardownCaches(caches)
+                await destroyPersistentStores()
             }
 
-            const destroyPersistentStores = (): Promise<unknown> =>
-                Promise.all([
+            const destroyPersistentStores = async (): Promise<void> => {
+                const results = await Promise.allSettled([
                     destroyIfSupported(authStore),
                     destroyIfSupported(signalStore),
                     destroyIfSupported(preKeyStore),
@@ -548,6 +559,18 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
                     destroyIfSupported(contactStore),
                     destroyIfSupported(privacyTokenStore)
                 ])
+                const failures = results.filter(
+                    (result): result is PromiseRejectedResult => result.status === 'rejected'
+                )
+                if (failures.length > 0) {
+                    storeLogger?.warn('persistent store teardown had failures', {
+                        sessionId: id,
+                        droppedCount: failures.length,
+                        totalExpected: results.length,
+                        sample: toError(failures[0].reason).message
+                    })
+                }
+            }
 
             const storeSession: WaStoreSession = {
                 auth: authStore,
@@ -592,6 +615,7 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
             const list = Array.from(sessions.values())
             sessions.clear()
             await Promise.all(list.map((s) => s.destroy()))
+            await Promise.all(Array.from(pendingSessionDestroys))
             const uniqueBackends = new Set(Object.values(backends))
             await Promise.all(Array.from(uniqueBackends, (backend) => destroyIfSupported(backend)))
         }

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -65,6 +65,7 @@ import type {
     WaStoreSession
 } from '@store/types'
 import { resolvePositive } from '@util/coercion'
+import { toError } from '@util/primitives'
 
 interface Destroyable {
     destroy: () => void | Promise<void>
@@ -408,7 +409,7 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
                         'deviceList',
                         'caches',
                         () =>
-                            cacheProviders.deviceList === 'memory'
+                            cacheProviders.deviceList === 'memory' || !cacheProviders.deviceList
                                 ? new WaDeviceListMemoryStore(cacheTtlsMs.deviceList, {
                                       maxUsers: ml.deviceListUsers,
                                       logger: memoryLogger?.child({
@@ -471,39 +472,70 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
             )
 
             let sessionDestroyed = false
+            let destroyPromise: Promise<void> | null = null
+            let cacheLifecycle: Promise<void> = Promise.resolve()
 
             const teardownCaches = async (
                 target: ReturnType<typeof buildCaches>
             ): Promise<void> => {
-                await Promise.all([
+                const cleared = await Promise.allSettled([
                     target.retry.clear(),
                     target.groupMetadata.clear(),
                     target.deviceList.clear(),
                     target.messageSecret.clear()
                 ])
-                await Promise.all([
+                const destroyed = await Promise.allSettled([
                     destroyIfSupported(target.retry),
                     destroyIfSupported(target.groupMetadata),
                     destroyIfSupported(target.deviceList),
                     destroyIfSupported(target.messageSecret)
                 ])
-            }
-
-            const destroyCaches = async (): Promise<void> => {
-                if (sessionDestroyed) return
-                const previous = caches
-                caches = buildCaches()
-                await teardownCaches(previous)
-            }
-
-            const destroy = async (): Promise<void> => {
-                if (sessionDestroyed) return
-                sessionDestroyed = true
-                if (sessions.get(id) === storeSession) {
-                    sessions.delete(id)
+                const failures = [...cleared, ...destroyed].filter(
+                    (result): result is PromiseRejectedResult => result.status === 'rejected'
+                )
+                if (failures.length > 0) {
+                    storeLogger?.warn('cache teardown had failures', {
+                        sessionId: id,
+                        droppedCount: failures.length,
+                        totalExpected: cleared.length + destroyed.length,
+                        sample: toError(failures[0].reason).message
+                    })
                 }
-                await teardownCaches(caches)
-                await Promise.all([
+            }
+
+            const destroyCaches = (): Promise<void> => {
+                const run = cacheLifecycle.then(async () => {
+                    if (sessionDestroyed) return
+                    await teardownCaches(caches)
+                    caches = buildCaches()
+                })
+                cacheLifecycle = run.then(
+                    () => undefined,
+                    () => undefined
+                )
+                return run
+            }
+
+            const destroy = (): Promise<void> => {
+                destroyPromise ??= destroyInternal()
+                return destroyPromise
+            }
+
+            const destroyInternal = async (): Promise<void> => {
+                sessionDestroyed = true
+                try {
+                    await cacheLifecycle
+                    await teardownCaches(caches)
+                    await destroyPersistentStores()
+                } finally {
+                    if (sessions.get(id) === storeSession) {
+                        sessions.delete(id)
+                    }
+                }
+            }
+
+            const destroyPersistentStores = (): Promise<unknown> =>
+                Promise.all([
                     destroyIfSupported(authStore),
                     destroyIfSupported(signalStore),
                     destroyIfSupported(preKeyStore),
@@ -516,7 +548,6 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
                     destroyIfSupported(contactStore),
                     destroyIfSupported(privacyTokenStore)
                 ])
-            }
 
             const storeSession: WaStoreSession = {
                 auth: authStore,

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -359,69 +359,88 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
                 'stores',
                 () => new WaPrivacyTokenMemoryStore(ml.privacyTokens)
             )
-            const rawRetry = resolveStore<WaRetryStore>(
-                id,
-                backends,
-                cacheProviders.retry ?? 'memory',
-                'retry',
-                'caches',
-                () =>
-                    cacheProviders.retry === 'memory' || !cacheProviders.retry
-                        ? new WaRetryMemoryStore(cacheTtlsMs.retry, {
-                              maxOutboundMessages: ml.retryOutboundMessages,
-                              maxInboundCounters: ml.retryInboundCounters,
-                              logger: memoryLogger?.child({ domain: 'retry', sessionId: id })
-                          })
-                        : NOOP_RETRY_STORE
-            )
-            const rawGroupMetadata = resolveStore<WaGroupMetadataStore>(
-                id,
-                backends,
-                cacheProviders.groupMetadata ?? 'memory',
-                'groupMetadata',
-                'caches',
-                () =>
-                    cacheProviders.groupMetadata === 'memory' || !cacheProviders.groupMetadata
-                        ? new WaGroupMetadataMemoryStore(cacheTtlsMs.groupMetadata, {
-                              maxGroups: ml.groupMetadataGroups,
-                              logger: memoryLogger?.child({
-                                  domain: 'groupMetadata',
-                                  sessionId: id
-                              })
-                          })
-                        : NOOP_GROUP_METADATA_STORE
-            )
-            const rawDeviceList = resolveStore<WaDeviceListStore>(
-                id,
-                backends,
-                cacheProviders.deviceList ?? 'memory',
-                'deviceList',
-                'caches',
-                () =>
-                    cacheProviders.deviceList === 'memory'
-                        ? new WaDeviceListMemoryStore(cacheTtlsMs.deviceList, {
-                              maxUsers: ml.deviceListUsers,
-                              logger: memoryLogger?.child({ domain: 'deviceList', sessionId: id })
-                          })
-                        : NOOP_DEVICE_LIST_STORE
-            )
-            const rawMessageSecret = resolveStore<WaMessageSecretStore>(
-                id,
-                backends,
-                cacheProviders.messageSecret ?? 'memory',
-                'messageSecret',
-                'caches',
-                () =>
-                    cacheProviders.messageSecret === 'memory' || !cacheProviders.messageSecret
-                        ? new WaMessageSecretMemoryStore(cacheTtlsMs.messageSecret, {
-                              maxSecrets: ml.messageSecrets,
-                              logger: memoryLogger?.child({
-                                  domain: 'messageSecret',
-                                  sessionId: id
-                              })
-                          })
-                        : NOOP_MESSAGE_SECRET_STORE
-            )
+            const buildCaches = () => ({
+                retry: withRetryLock(
+                    resolveStore<WaRetryStore>(
+                        id,
+                        backends,
+                        cacheProviders.retry ?? 'memory',
+                        'retry',
+                        'caches',
+                        () =>
+                            cacheProviders.retry === 'memory' || !cacheProviders.retry
+                                ? new WaRetryMemoryStore(cacheTtlsMs.retry, {
+                                      maxOutboundMessages: ml.retryOutboundMessages,
+                                      maxInboundCounters: ml.retryInboundCounters,
+                                      logger: memoryLogger?.child({
+                                          domain: 'retry',
+                                          sessionId: id
+                                      })
+                                  })
+                                : NOOP_RETRY_STORE
+                    )
+                ),
+                groupMetadata: withGroupMetadataLock(
+                    resolveStore<WaGroupMetadataStore>(
+                        id,
+                        backends,
+                        cacheProviders.groupMetadata ?? 'memory',
+                        'groupMetadata',
+                        'caches',
+                        () =>
+                            cacheProviders.groupMetadata === 'memory' ||
+                            !cacheProviders.groupMetadata
+                                ? new WaGroupMetadataMemoryStore(cacheTtlsMs.groupMetadata, {
+                                      maxGroups: ml.groupMetadataGroups,
+                                      logger: memoryLogger?.child({
+                                          domain: 'groupMetadata',
+                                          sessionId: id
+                                      })
+                                  })
+                                : NOOP_GROUP_METADATA_STORE
+                    )
+                ),
+                deviceList: withDeviceListLock(
+                    resolveStore<WaDeviceListStore>(
+                        id,
+                        backends,
+                        cacheProviders.deviceList ?? 'memory',
+                        'deviceList',
+                        'caches',
+                        () =>
+                            cacheProviders.deviceList === 'memory'
+                                ? new WaDeviceListMemoryStore(cacheTtlsMs.deviceList, {
+                                      maxUsers: ml.deviceListUsers,
+                                      logger: memoryLogger?.child({
+                                          domain: 'deviceList',
+                                          sessionId: id
+                                      })
+                                  })
+                                : NOOP_DEVICE_LIST_STORE
+                    )
+                ),
+                messageSecret: withMessageSecretLock(
+                    resolveStore<WaMessageSecretStore>(
+                        id,
+                        backends,
+                        cacheProviders.messageSecret ?? 'memory',
+                        'messageSecret',
+                        'caches',
+                        () =>
+                            cacheProviders.messageSecret === 'memory' ||
+                            !cacheProviders.messageSecret
+                                ? new WaMessageSecretMemoryStore(cacheTtlsMs.messageSecret, {
+                                      maxSecrets: ml.messageSecrets,
+                                      logger: memoryLogger?.child({
+                                          domain: 'messageSecret',
+                                          sessionId: id
+                                      })
+                                  })
+                                : NOOP_MESSAGE_SECRET_STORE
+                    )
+                )
+            })
+            let caches = buildCaches()
 
             const authStore = withAuthLock(rawAuth)
             const signalStore = withSignalLock(rawSignal)
@@ -442,11 +461,7 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
                     : rawSenderKey
             )
             const appStateStore = withAppStateLock(rawAppState)
-            const retryStore = withRetryLock(rawRetry)
-            const groupMetadataStore = withGroupMetadataLock(rawGroupMetadata)
-            const deviceListStore = withDeviceListLock(rawDeviceList)
             const messageStore = withMessageLock(rawMessages)
-            const messageSecretStore = withMessageSecretLock(rawMessageSecret)
             const threadStore = withThreadLock(rawThreads)
             const contactStore = withContactLock(rawContacts)
             const privacyTokenStore = withPrivacyTokenLock(
@@ -455,30 +470,39 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
                     : rawPrivacyToken
             )
 
-            let cachesDestroyed = false
             let sessionDestroyed = false
 
+            const teardownCaches = async (
+                target: ReturnType<typeof buildCaches>
+            ): Promise<void> => {
+                await Promise.all([
+                    target.retry.clear(),
+                    target.groupMetadata.clear(),
+                    target.deviceList.clear(),
+                    target.messageSecret.clear()
+                ])
+                await Promise.all([
+                    destroyIfSupported(target.retry),
+                    destroyIfSupported(target.groupMetadata),
+                    destroyIfSupported(target.deviceList),
+                    destroyIfSupported(target.messageSecret)
+                ])
+            }
+
             const destroyCaches = async (): Promise<void> => {
-                if (cachesDestroyed) return
-                cachesDestroyed = true
-                await Promise.all([
-                    retryStore.clear(),
-                    groupMetadataStore.clear(),
-                    deviceListStore.clear(),
-                    messageSecretStore.clear()
-                ])
-                await Promise.all([
-                    destroyIfSupported(retryStore),
-                    destroyIfSupported(groupMetadataStore),
-                    destroyIfSupported(deviceListStore),
-                    destroyIfSupported(messageSecretStore)
-                ])
+                if (sessionDestroyed) return
+                const previous = caches
+                caches = buildCaches()
+                await teardownCaches(previous)
             }
 
             const destroy = async (): Promise<void> => {
                 if (sessionDestroyed) return
                 sessionDestroyed = true
-                await destroyCaches()
+                if (sessions.get(id) === storeSession) {
+                    sessions.delete(id)
+                }
+                await teardownCaches(caches)
                 await Promise.all([
                     destroyIfSupported(authStore),
                     destroyIfSupported(signalStore),
@@ -502,11 +526,19 @@ export function createStore<B extends string>(options?: WaCreateStoreOptions<B>)
                 identity: identityStore,
                 senderKey: senderKeyStore,
                 appState: appStateStore,
-                retry: retryStore,
-                groupMetadata: groupMetadataStore,
-                deviceList: deviceListStore,
+                get retry() {
+                    return caches.retry
+                },
+                get groupMetadata() {
+                    return caches.groupMetadata
+                },
+                get deviceList() {
+                    return caches.deviceList
+                },
                 messages: messageStore,
-                messageSecret: messageSecretStore,
+                get messageSecret() {
+                    return caches.messageSecret
+                },
                 threads: threadStore,
                 contacts: contactStore,
                 privacyToken: privacyTokenStore,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -42,14 +42,18 @@ export interface WaStoreSession {
      * operations issued while the reset is in flight may reject. References
      * to the old cache stores captured before the call (e.g. by a live
      * client) reject afterwards - recreate the client to pick up the fresh
-     * stores.
+     * stores. Rejects when the old generation's teardown had failures - the
+     * fresh caches are still in place, but stale entries may remain in a
+     * persistent cache backend.
      */
     destroyCaches(): Promise<void>
     /**
      * Final teardown of every domain store in this bundle. The bundle is
      * single-shot: every operation on it rejects afterwards. The sessionId
-     * is released once teardown completes, so the next `store.session(id)`
-     * builds a fresh bundle. Repeat calls return the same in-flight promise.
+     * is released as soon as destruction starts, so a concurrent
+     * `store.session(id)` builds a fresh bundle instead of returning this
+     * one. Repeat calls return the same in-flight promise. Teardown
+     * failures are logged (warn), never thrown.
      */
     destroy(): Promise<void>
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -33,13 +33,35 @@ export interface WaStoreSession {
     readonly threads: WaThreadStore
     readonly contacts: WaContactStore
     readonly privacyToken: WaPrivacyTokenStore
+    /**
+     * Tears down the cache domains (retry/groupMetadata/deviceList/
+     * messageSecret) and swaps fresh, empty ones into this bundle. The
+     * session stays usable; the caches rebuild on demand. References to the
+     * old cache stores captured before the call (e.g. by a live client)
+     * reject afterwards - recreate the client to pick up the fresh stores.
+     */
     destroyCaches(): Promise<void>
+    /**
+     * Final teardown of every domain store in this bundle. The bundle is
+     * single-shot: every operation on it rejects afterwards. The sessionId
+     * is released, so the next `store.session(id)` builds a fresh bundle.
+     */
     destroy(): Promise<void>
 }
 
 export interface WaStore {
+    /**
+     * Returns the lock-wrapped per-domain store bundle for `sessionId`,
+     * building it on first use and caching it until its `destroy()` (or the
+     * store-wide `destroy()`) releases it.
+     */
     session(sessionId: string): WaStoreSession
+    /** Runs {@link WaStoreSession.destroyCaches} on every live session. */
     destroyCaches(): Promise<void>
+    /**
+     * Destroys every live session bundle and the registered backends. The
+     * store is single-shot: `session()` throws afterwards.
+     */
     destroy(): Promise<void>
 }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -36,15 +36,20 @@ export interface WaStoreSession {
     /**
      * Tears down the cache domains (retry/groupMetadata/deviceList/
      * messageSecret) and swaps fresh, empty ones into this bundle. The
-     * session stays usable; the caches rebuild on demand. References to the
-     * old cache stores captured before the call (e.g. by a live client)
-     * reject afterwards - recreate the client to pick up the fresh stores.
+     * session stays usable; the caches rebuild on demand. The swap happens
+     * after the old stores finish tearing down (so a persistent cache
+     * backend is never cleared under the fresh stores), which means cache
+     * operations issued while the reset is in flight may reject. References
+     * to the old cache stores captured before the call (e.g. by a live
+     * client) reject afterwards - recreate the client to pick up the fresh
+     * stores.
      */
     destroyCaches(): Promise<void>
     /**
      * Final teardown of every domain store in this bundle. The bundle is
      * single-shot: every operation on it rejects afterwards. The sessionId
-     * is released, so the next `store.session(id)` builds a fresh bundle.
+     * is released once teardown completes, so the next `store.session(id)`
+     * builds a fresh bundle. Repeat calls return the same in-flight promise.
      */
     destroy(): Promise<void>
 }


### PR DESCRIPTION
WaStoreSession.destroy() left the destroyed bundle cached in the createStore session map, so a new client for the same sessionId in the same process silently got a bundle whose SharedExclusiveGates were permanently closed - every store op rejected with "shared-exclusive gate is closed" (first visible on group sends via
deviceList/groupMetadata/senderKey lookups).

- destroy() now removes the bundle from the session map (guarded so a late destroy on a stale reference cannot evict a newer bundle), so the next store.session(id) builds a fresh working bundle
- destroyCaches() now swaps in freshly built cache stores instead of permanently closing them; the bundle exposes cache domains via getters so recreated clients pick up the new stores
- document the lifecycle semantics on WaStoreSession/WaStore

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Session destruction now reliably gates cache-backed operations, and later requests for the same session ID create a fresh, working session.
  - Cache reset (`destroyCaches`) keeps the session usable, while stale cached accessors become invalid and in-flight operations fail safely; cache teardown failures are handled without preventing cache refresh.
  - Restores default in-memory caching for `deviceList` when no cache providers are configured.

- **Documentation**
  - Expanded lifecycle docs for session `destroy()` and `destroyCaches()` to clarify reuse, teardown, and failure behavior.

- **Tests**
  - Added/updated coverage for session/cache lifecycle, rebuild semantics, and default `deviceList` caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->