### PR TITLE
fix(newsletter): carry the plaintext mediatype so link previews render

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -649,6 +649,16 @@ export function buildWaClientDependencies(input: {
         generateStanzaId: () => messageDispatch.generateOutgoingMessageId(),
         mediaTransfer,
         getMediaConn: () => getClientMediaConn(mediaMessageBuildOptions),
+        linkPreviewResolver: (content) =>
+            resolveLinkPreview(content.text, content.linkPreview, {
+                logger,
+                mediaTransfer,
+                getMediaConn: () => getClientMediaConn(mediaMessageBuildOptions),
+                fetcher: linkPreviewFetcher,
+                options: linkPreviewOptions,
+                serverClock,
+                surface: 'newsletter'
+            }),
         getAbPropString: (name) => abPropsCoordinator.getConfigValue<string>(name),
         logger
     })

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -66,7 +66,7 @@ import { parsePrivacyTokenNotification } from '@client/events/privacy-token'
 import { createDeviceFanoutResolver } from '@client/messaging/fanout'
 import { createGroupMetadataCache } from '@client/messaging/group-metadata'
 import { createAppStateSyncKeyProtocol } from '@client/messaging/key-protocol'
-import { resolveLinkPreview } from '@client/messaging/link-preview'
+import { resolveLinkPreview, type WaLinkPreviewSurface } from '@client/messaging/link-preview'
 import {
     buildMediaMessageContent,
     getMediaConn as getClientMediaConn,
@@ -90,6 +90,7 @@ import {
     createPeerDataOperationRequester,
     type PeerDataOperationRequester
 } from '@message/primitives/peer-data-operation'
+import type { WaSendTextMessage } from '@message/types'
 import { WaMessageClient } from '@message/WaMessageClient'
 import {
     resolveWaDeviceIdentity,
@@ -503,6 +504,17 @@ export function buildWaClientDependencies(input: {
             allowPrivateHosts: linkPreviewOptions.allowPrivateHosts,
             proxy: linkPreviewOptions.proxy ?? options.proxy?.linkPreview
         })
+    const createLinkPreviewResolver =
+        (surface?: WaLinkPreviewSurface) => (content: WaSendTextMessage) =>
+            resolveLinkPreview(content.text, content.linkPreview, {
+                logger,
+                mediaTransfer,
+                getMediaConn: () => getClientMediaConn(mediaMessageBuildOptions),
+                fetcher: linkPreviewFetcher,
+                options: linkPreviewOptions,
+                serverClock,
+                surface
+            })
     const mediaMessageBuildOptions: WaMediaMessageOptions = {
         logger,
         mediaTransfer,
@@ -520,15 +532,7 @@ export function buildWaClientDependencies(input: {
         },
         serverClock,
         media: options.media,
-        linkPreviewResolver: (content) =>
-            resolveLinkPreview(content.text, content.linkPreview, {
-                logger,
-                mediaTransfer,
-                getMediaConn: () => getClientMediaConn(mediaMessageBuildOptions),
-                fetcher: linkPreviewFetcher,
-                options: linkPreviewOptions,
-                serverClock
-            })
+        linkPreviewResolver: createLinkPreviewResolver()
     }
 
     const messageClient = new WaMessageClient({
@@ -649,16 +653,7 @@ export function buildWaClientDependencies(input: {
         generateStanzaId: () => messageDispatch.generateOutgoingMessageId(),
         mediaTransfer,
         getMediaConn: () => getClientMediaConn(mediaMessageBuildOptions),
-        linkPreviewResolver: (content) =>
-            resolveLinkPreview(content.text, content.linkPreview, {
-                logger,
-                mediaTransfer,
-                getMediaConn: () => getClientMediaConn(mediaMessageBuildOptions),
-                fetcher: linkPreviewFetcher,
-                options: linkPreviewOptions,
-                serverClock,
-                surface: 'newsletter'
-            }),
+        linkPreviewResolver: createLinkPreviewResolver('newsletter'),
         getAbPropString: (name) => abPropsCoordinator.getConfigValue<string>(name),
         logger
     })

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -1140,6 +1140,10 @@ test('buildNewsletterMessageContent applies the resolved link preview to a text 
     assert.equal(decoded.extendedTextMessage?.matchedText, 'https://example.com')
     assert.equal(decoded.extendedTextMessage?.title, 'Example')
     assert.equal(decoded.extendedTextMessage?.thumbnailDirectPath, '/v/newsletter/thumb')
+    assert.deepEqual(
+        Uint8Array.from(decoded.extendedTextMessage?.thumbnailSha256 ?? []),
+        new Uint8Array(32).fill(7)
+    )
     assert.equal(decoded.extendedTextMessage?.mediaKey?.length ?? 0, 0)
     assert.equal(decoded.extendedTextMessage?.thumbnailEncSha256?.length ?? 0, 0)
 })

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -1079,3 +1079,119 @@ test('uploadNewsletterMedia builds plaintext URL and parses response', async () 
     assert.equal(result.fileLength, 4)
     assert.equal(result.fileSha256.byteLength, 32)
 })
+
+test('buildNewsletterMessageContent resolves the plaintext mediatype for raw payloads', async () => {
+    const { buildNewsletterMessageContent } = await import('@client/newsletter/content')
+    const options = { logger: createNoopLogger() }
+
+    const linkPreview = await buildNewsletterMessageContent(options, {
+        extendedTextMessage: {
+            text: 'look at https://example.com',
+            matchedText: 'https://example.com',
+            title: 'Example',
+            previewType: proto.Message.ExtendedTextMessage.PreviewType.NONE
+        }
+    })
+    assert.equal(linkPreview.kind, 'media')
+    assert.equal(linkPreview.mediaType, 'url')
+
+    const vcard = await buildNewsletterMessageContent(options, {
+        contactMessage: { displayName: 'Ada', vcard: 'BEGIN:VCARD\nEND:VCARD' }
+    })
+    assert.equal(vcard.kind, 'media')
+    assert.equal(vcard.mediaType, 'vcard')
+
+    const plain = await buildNewsletterMessageContent(options, {
+        extendedTextMessage: { text: 'no link here' }
+    })
+    assert.equal(plain.kind, 'text')
+    assert.equal(plain.mediaType, null)
+
+    const location = await buildNewsletterMessageContent(options, {
+        locationMessage: { degreesLatitude: 1, degreesLongitude: 2 }
+    })
+    assert.equal(location.kind, 'text')
+    assert.equal(location.mediaType, null)
+})
+
+test('buildNewsletterMessageContent applies the resolved link preview to a text send', async () => {
+    const { buildNewsletterMessageContent } = await import('@client/newsletter/content')
+    const built = await buildNewsletterMessageContent(
+        {
+            logger: createNoopLogger(),
+            linkPreviewResolver: async () => ({
+                resolved: {
+                    matchedText: 'https://example.com',
+                    previewType: proto.Message.ExtendedTextMessage.PreviewType.NONE,
+                    title: 'Example'
+                },
+                thumbnailFields: {
+                    thumbnailDirectPath: '/v/newsletter/thumb',
+                    thumbnailSha256: new Uint8Array(32).fill(7)
+                }
+            })
+        },
+        { type: 'text', text: 'see https://example.com', linkPreview: true }
+    )
+
+    assert.equal(built.kind, 'media')
+    assert.equal(built.mediaType, 'url')
+    const decoded = proto.Message.decode(built.plaintext)
+    assert.equal(decoded.extendedTextMessage?.matchedText, 'https://example.com')
+    assert.equal(decoded.extendedTextMessage?.title, 'Example')
+    assert.equal(decoded.extendedTextMessage?.thumbnailDirectPath, '/v/newsletter/thumb')
+    assert.equal(decoded.extendedTextMessage?.mediaKey?.length ?? 0, 0)
+    assert.equal(decoded.extendedTextMessage?.thumbnailEncSha256?.length ?? 0, 0)
+})
+
+test('buildNewsletterMessageContent falls back to plain text when the resolver throws', async () => {
+    const { buildNewsletterMessageContent } = await import('@client/newsletter/content')
+    const built = await buildNewsletterMessageContent(
+        {
+            logger: createNoopLogger(),
+            linkPreviewResolver: async () => {
+                throw new Error('fetch exploded')
+            }
+        },
+        { type: 'text', text: 'see https://example.com' }
+    )
+
+    assert.equal(built.kind, 'text')
+    assert.equal(built.mediaType, null)
+    const decoded = proto.Message.decode(built.plaintext)
+    assert.equal(decoded.extendedTextMessage?.text, 'see https://example.com')
+    assert.equal(decoded.extendedTextMessage?.matchedText ?? '', '')
+})
+
+test('newsletter send publishes a link preview as type=media with mediatype=url', async () => {
+    const { createMessagingOps } = await import('@client/newsletter/messaging')
+    const published: BinaryNode[] = []
+    const ops = createMessagingOps({
+        logger: createNoopLogger(),
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: {} }) },
+        sendNode: async () => undefined,
+        publishMessageNode: async (node: BinaryNode) => {
+            published.push(node)
+            return { id: node.attrs.id ?? '', ack: 0 }
+        },
+        generateStanzaId: async () => 'STANZA-1'
+    } as unknown as Parameters<typeof createMessagingOps>[0])
+
+    await ops.send('123@newsletter', {
+        extendedTextMessage: {
+            text: 'look at https://example.com',
+            matchedText: 'https://example.com'
+        }
+    })
+
+    const node = published[0]
+    assert.equal(node.tag, 'message')
+    assert.equal(node.attrs.to, '123@newsletter')
+    assert.equal(node.attrs.id, 'STANZA-1')
+    assert.equal(node.attrs.type, 'media')
+    assert.equal(node.attrs.media_id, undefined)
+    const plaintext = (node.content as BinaryNode[])[0]
+    assert.equal(plaintext.tag, 'plaintext')
+    assert.equal(plaintext.attrs.mediatype, 'url')
+    assert.ok(plaintext.content instanceof Uint8Array)
+})

--- a/src/client/messaging/link-preview.ts
+++ b/src/client/messaging/link-preview.ts
@@ -4,10 +4,12 @@ import {
     assertMediaUploadStatus,
     buildMediaUploadUrl,
     parseMediaUploadJsonBody,
-    selectMediaUploadHost
+    performPlaintextMediaUpload,
+    selectMediaUploadHost,
+    type WaUploadMediaSource
 } from '@client/media'
 import type { Logger } from '@infra/log/types'
-import { MEDIA_UPLOAD_PATHS } from '@media/constants'
+import { MEDIA_UPLOAD_PATHS, NEWSLETTER_MEDIA_UPLOAD_PATHS } from '@media/constants'
 import { WaMediaCrypto } from '@media/crypto/WaMediaCrypto'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import type { WaMediaConn } from '@media/types'
@@ -28,6 +30,12 @@ import { toError } from '@util/primitives'
 
 const INLINE_THUMBNAIL_MAX_BYTES = 64 * 1024
 
+/**
+ * Where the preview is published. `chat` uploads the HQ thumbnail encrypted;
+ * `newsletter` uploads it in the clear, since channel media is not encrypted.
+ */
+export type WaLinkPreviewSurface = 'chat' | 'newsletter'
+
 export interface ResolveLinkPreviewDeps {
     readonly logger: Logger
     readonly mediaTransfer: WaMediaTransferClient
@@ -35,6 +43,8 @@ export interface ResolveLinkPreviewDeps {
     readonly fetcher: WaLinkPreviewFetcher
     readonly options: WaLinkPreviewOptions
     readonly serverClock: ServerClock
+    /** Defaults to `chat`. */
+    readonly surface?: WaLinkPreviewSurface
 }
 
 export interface ResolvedLinkPreviewResult {
@@ -147,6 +157,9 @@ async function uploadHqFromBytes(
     deps: ResolveLinkPreviewDeps,
     thumbnail: WaLinkPreviewThumbnailBytes
 ): Promise<WaLinkPreviewThumbnailFields> {
+    if (deps.surface === 'newsletter') {
+        return uploadPlaintextHq(deps, thumbnail.bytes, thumbnail)
+    }
     const mediaKey = await WaMediaCrypto.generateMediaKey()
     const encrypted = await WaMediaCrypto.encryptBytes(
         'thumbnail-link',
@@ -175,6 +188,9 @@ async function uploadHqFromStream(
     deps: ResolveLinkPreviewDeps,
     thumbnail: WaLinkPreviewThumbnailStream
 ): Promise<WaLinkPreviewThumbnailFields> {
+    if (deps.surface === 'newsletter') {
+        return uploadPlaintextHq(deps, thumbnail.stream, thumbnail)
+    }
     const mediaKey = await WaMediaCrypto.generateMediaKey()
     const encrypted = await WaMediaCrypto.encryptToFile(
         'thumbnail-link',
@@ -208,6 +224,38 @@ async function uploadHqFromStream(
             })
         }
         await WaMediaCrypto.cleanupEncryptedFile(encrypted.filePath)
+    }
+}
+
+/** Uploads the HQ thumbnail unencrypted, so no `mediaKey` / `thumbnailEncSha256`. */
+async function uploadPlaintextHq(
+    deps: ResolveLinkPreviewDeps,
+    source: WaUploadMediaSource,
+    dimensions: { readonly width?: number; readonly height?: number }
+): Promise<WaLinkPreviewThumbnailFields> {
+    const mediaConn = await deps.getMediaConn()
+    const upload = await performPlaintextMediaUpload(
+        { mediaTransfer: deps.mediaTransfer, mediaConn, logger: deps.logger },
+        {
+            source,
+            path: NEWSLETTER_MEDIA_UPLOAD_PATHS['thumbnail-link'],
+            mimetype: 'image/jpeg',
+            logLabel: 'uploading newsletter link preview thumbnail'
+        }
+    )
+    assertMediaUploadStatus(upload.status, 'newsletter thumbnail-link upload')
+    const parsed = parseMediaUploadJsonBody<{ readonly direct_path?: string }>(
+        upload.responseBytes,
+        'newsletter thumbnail-link upload'
+    )
+    if (!parsed.direct_path) {
+        throw new Error('newsletter thumbnail-link upload response missing direct_path')
+    }
+    return {
+        thumbnailDirectPath: parsed.direct_path,
+        thumbnailSha256: upload.fileSha256,
+        ...(dimensions.width !== undefined ? { thumbnailWidth: dimensions.width } : {}),
+        ...(dimensions.height !== undefined ? { thumbnailHeight: dimensions.height } : {})
     }
 }
 

--- a/src/client/newsletter/content.ts
+++ b/src/client/newsletter/content.ts
@@ -6,11 +6,13 @@ import {
     performPlaintextMediaUpload,
     type WaUploadMediaSource
 } from '@client/media'
+import type { ResolvedLinkPreviewResult } from '@client/messaging/link-preview'
 import type { Logger } from '@infra/log/types'
 import { NEWSLETTER_MEDIA_UPLOAD_PATHS, type NewsletterMediaKind } from '@media/constants'
 import { createStickerPackZipStream } from '@media/sticker/sticker-pack'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import type { WaMediaConn } from '@media/types'
+import { buildExtendedTextWithPreview } from '@message/addons/link-preview/builder'
 import { applyContextInfo, type WaSendContextInfo } from '@message/context-info'
 import {
     isSendEventMessage,
@@ -23,6 +25,7 @@ import {
     isSendReactionMessage,
     isSendRevokeMessage,
     isSendTextMessage,
+    resolveEncMediaType,
     resolveMessageTypeAttr,
     unwrapMessage
 } from '@message/encode/content'
@@ -34,11 +37,13 @@ import {
 import type {
     WaSendMediaMessage,
     WaSendMessageContent,
-    WaSendStickerPackMessage
+    WaSendStickerPackMessage,
+    WaSendTextMessage
 } from '@message/types'
 import { proto, type Proto } from '@proto'
 import { WA_ENC_MEDIA_TYPES } from '@protocol/message'
 import { base64ToBytes } from '@util/bytes'
+import { toError } from '@util/primitives'
 
 export type WaNewsletterUploadMedia = WaUploadMediaSource
 
@@ -128,6 +133,10 @@ export interface BuildNewsletterContentOptions {
     readonly logger: Logger
     readonly mediaTransfer?: WaMediaTransferClient
     readonly getMediaConn?: () => Promise<WaMediaConn>
+    /** Must be bound to the `newsletter` surface (unencrypted thumbnail upload). */
+    readonly linkPreviewResolver?: (
+        content: WaSendTextMessage
+    ) => Promise<ResolvedLinkPreviewResult | null>
 }
 
 function resolveSendMediaKind(content: WaSendMediaMessage): NewsletterMediaKind {
@@ -136,17 +145,44 @@ function resolveSendMediaKind(content: WaSendMediaMessage): NewsletterMediaKind 
     return content.type
 }
 
+/** Enc media types a channel publish accepts; anything else ships as text. */
+const NEWSLETTER_MEDIA_TYPES: ReadonlySet<string> = new Set([
+    WA_ENC_MEDIA_TYPES.AUDIO,
+    WA_ENC_MEDIA_TYPES.DOCUMENT,
+    WA_ENC_MEDIA_TYPES.GIF,
+    WA_ENC_MEDIA_TYPES.IMAGE,
+    WA_ENC_MEDIA_TYPES.PTT,
+    WA_ENC_MEDIA_TYPES.PTV,
+    WA_ENC_MEDIA_TYPES.STICKER,
+    WA_ENC_MEDIA_TYPES.STICKER_PACK,
+    WA_ENC_MEDIA_TYPES.URL,
+    WA_ENC_MEDIA_TYPES.VCARD,
+    WA_ENC_MEDIA_TYPES.VIDEO
+])
+
+/**
+ * Resolves the `plaintext` node `mediatype`. Shares the encrypted send path's
+ * resolver so media without an upload still gets it - a link preview publishes
+ * as `url`, a contact card as `vcard`; without it the channel drops the card.
+ */
 function pickMediaTypeFromMessage(message: Proto.IMessage): string | null {
-    if (message.imageMessage) return WA_ENC_MEDIA_TYPES.IMAGE
-    if (message.videoMessage)
-        return message.videoMessage.gifPlayback ? WA_ENC_MEDIA_TYPES.GIF : WA_ENC_MEDIA_TYPES.VIDEO
-    if (message.audioMessage)
-        return message.audioMessage.ptt ? WA_ENC_MEDIA_TYPES.PTT : WA_ENC_MEDIA_TYPES.AUDIO
-    if (message.documentMessage) return WA_ENC_MEDIA_TYPES.DOCUMENT
-    if (message.stickerMessage) return WA_ENC_MEDIA_TYPES.STICKER
-    if (message.stickerPackMessage) return WA_ENC_MEDIA_TYPES.STICKER_PACK
-    if (message.ptvMessage) return WA_ENC_MEDIA_TYPES.PTV
-    return null
+    const mediaType = resolveEncMediaType(message)
+    return mediaType !== null && NEWSLETTER_MEDIA_TYPES.has(mediaType) ? mediaType : null
+}
+
+async function resolveTextLinkPreview(
+    options: BuildNewsletterContentOptions,
+    content: WaSendTextMessage
+): Promise<ResolvedLinkPreviewResult | null> {
+    if (!options.linkPreviewResolver) return null
+    try {
+        return await options.linkPreviewResolver(content)
+    } catch (error) {
+        options.logger.warn('link preview resolver failed, sending plain text', {
+            message: toError(error).message
+        })
+        return null
+    }
 }
 
 function buildMediaProtoMessage(
@@ -243,11 +279,22 @@ export async function buildNewsletterMessageContent(
     }
 
     if (isSendTextMessage(content)) {
-        const message = applyContextInfo({ extendedTextMessage: { text: content.text } }, ctx)
+        const preview = await resolveTextLinkPreview(options, content)
+        const message = applyContextInfo(
+            preview !== null
+                ? buildExtendedTextWithPreview(
+                      content.text,
+                      preview.resolved,
+                      preview.thumbnailFields
+                  )
+                : { extendedTextMessage: { text: content.text } },
+            ctx
+        )
+        const mediaType = pickMediaTypeFromMessage(message)
         return {
-            kind: 'text',
+            kind: mediaType !== null ? 'media' : 'text',
             plaintext: proto.Message.encode(message).finish(),
-            mediaType: null,
+            mediaType,
             upload: null
         }
     }

--- a/src/client/newsletter/messaging.ts
+++ b/src/client/newsletter/messaging.ts
@@ -1,4 +1,5 @@
 import {
+    type BuildNewsletterContentOptions,
     buildNewsletterMessageContent,
     type WaNewsletterBuiltContent
 } from '@client/newsletter/content'
@@ -42,6 +43,7 @@ export interface WaNewsletterMessagingDeps extends WaNewsletterMexDeps {
     readonly generateStanzaId: () => Promise<string>
     readonly mediaTransfer?: WaMediaTransferClient
     readonly getMediaConn?: () => Promise<WaMediaConn>
+    readonly linkPreviewResolver?: BuildNewsletterContentOptions['linkPreviewResolver']
 }
 
 /** Newsletter messaging operations (send, react, fetch, follow). */
@@ -108,7 +110,8 @@ async function buildContent(
         {
             logger: deps.logger,
             mediaTransfer: deps.mediaTransfer,
-            getMediaConn: deps.getMediaConn
+            getMediaConn: deps.getMediaConn,
+            linkPreviewResolver: deps.linkPreviewResolver
         },
         content,
         ctx


### PR DESCRIPTION
A channel publish resolved its `mediatype` with a local duplicate of the enc-media resolver that only knew uploadable media, so an extendedTextMessage carrying a link preview went out as `type=text` with a bare `<plaintext>` node. WhatsApp needs `type=media` + `mediatype=url` there, and without it the channel drops the preview card and renders plain text.

Resolve it with the shared resolver instead, gated by the media types a channel publish accepts. Contact cards (`vcard`) were missing for the same reason and now work too.

Wire the link preview resolver into the channel text path as well - it was silently dropped, so `{ type: 'text', linkPreview }` never produced a card. Channel media is not encrypted, so the HQ thumbnail uploads in the clear to /newsletter/newsletter-thumbnail-link and carries thumbnailDirectPath plus a plaintext thumbnailSha256, with no mediaKey or thumbnailEncSha256.

Closes #214

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added link previews to newsletter text messages, including matched link text, titles, and thumbnails.
  - Newsletter link-preview thumbnails now use a newsletter-specific upload format.
- **Bug Fixes**
  - Newsletter message classification now more reliably distinguishes supported media vs text content.
  - If link-preview resolution fails, newsletter messages safely fall back to plain text (no previews).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->