### PR TITLE
feat(group-history): send and receive group history bundles

### DIFF
--- a/.changeset/mcp-group-history-bundles.md
+++ b/.changeset/mcp-group-history-bundles.md
@@ -1,0 +1,7 @@
+---
+'@zapo-js/mcp-server': minor
+---
+
+Add `MCP_GROUP_BUNDLES` to opt into downloading the group-history bundles other
+members share, and buffer the resulting `group_history_bundle` events so the
+`events` tool can query them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -872,6 +872,7 @@ After editing source: rebuild → call `restart` with `mode: "process_exit"` →
 | `MCP_EVENT_BUFFER_SIZE`                                                        | `1000`                        | in-memory event ring size                             |
 | `MCP_CAPTURE_TRANSPORT`                                                        | `0`                           | also buffer noisy `transport_*` events                |
 | `MCP_HISTORY_DISABLED`                                                         | `0`                           | disable history sync on connect                       |
+| `MCP_GROUP_BUNDLES`                                                            | `0`                           | download group-history bundles shared by members      |
 | `MCP_TRANSPORT`                                                                | `stdio`                       | `stdio` or `http` (StreamableHTTPServerTransport)     |
 | `MCP_HTTP_HOST` / `MCP_HTTP_PORT` / `MCP_HTTP_PATH`                            | `127.0.0.1` / `3737` / `/mcp` | HTTP listener config                                  |
 | `MCP_FAKE_NOISE_PUBKEY_HEX` + `MCP_FAKE_NOISE_SERIAL` + `MCP_CHAT_SOCKET_URLS` | unset                         | point at `@zapo-js/fake-server` for tests             |

--- a/packages/fake-server/src/__tests__/group-history-share.cross-check.test.ts
+++ b/packages/fake-server/src/__tests__/group-history-share.cross-check.test.ts
@@ -1,0 +1,125 @@
+/** Cross-check: sharing group history uploads a bundle and fans it out only to its receivers. */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { BinaryNode, WaClientEventMap } from 'zapo-js'
+
+import { FakeWaServer } from '../api/FakeWaServer'
+import { parsePairingQrString } from '../protocol/auth/pair-device'
+
+import { createZapoClient } from './helpers/zapo-client'
+
+const GROUP_JID = '120363000000000000@g.us'
+const ALICE = '5511777777777@s.whatsapp.net'
+const BOB = '5511666666666@s.whatsapp.net'
+const ME_DEVICE = '5511999999999:1@s.whatsapp.net'
+const ME_USER = '5511999999999@s.whatsapp.net'
+/** `group_history_send` - WhatsApp gates the sender side on it per account. */
+const GROUP_HISTORY_SEND_CONFIG_CODE = 15313
+
+/** User JIDs the `<participants>` children of a fanout stanza are addressed to. */
+function fanoutUserJids(stanza: BinaryNode): readonly string[] {
+    const content = Array.isArray(stanza.content) ? stanza.content : []
+    const participants = content.find((child) => child.tag === 'participants')
+    const children = Array.isArray(participants?.content) ? participants.content : []
+    const users = new Set<string>()
+    for (const child of children) {
+        const jid = child.attrs.jid
+        if (typeof jid === 'string') {
+            users.add(jid.split(':')[0].split('@')[0])
+        }
+    }
+    return [...users]
+}
+
+test('shareGroupHistory uploads a bundle and addresses only the chosen members', async () => {
+    const server = await FakeWaServer.start()
+    server.setAbProps({
+        props: [{ configCode: GROUP_HISTORY_SEND_CONFIG_CODE, configValue: 'true' }]
+    })
+    const { client } = createZapoClient(server, { sessionId: 'group-history-share' })
+
+    const materialPromise = new Promise<{
+        readonly advSecretKey: Uint8Array
+        readonly identityPublicKey: Uint8Array
+    }>((resolve) => {
+        client.once('auth_qr', (event: Parameters<WaClientEventMap['auth_qr']>[0]) => {
+            const parsed = parsePairingQrString(event.qr)
+            resolve({
+                advSecretKey: parsed.advSecretKey,
+                identityPublicKey: parsed.identityPublicKey
+            })
+        })
+    })
+    const pairedPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('auth_paired timeout')), 60_000)
+        client.once('auth_paired', () => {
+            clearTimeout(timer)
+            resolve()
+        })
+    })
+
+    try {
+        await client.connect()
+        const pipeline = await server.waitForAuthenticatedPipeline()
+        await server.runPairing(pipeline, { deviceJid: ME_DEVICE }, () => materialPromise)
+
+        await pairedPromise
+        const paired = await server
+            .waitForNextAuthenticatedPipeline(5_000)
+            .catch(() => server.waitForAuthenticatedPipeline())
+
+        const alice = await server.createFakePeer({ jid: ALICE }, paired)
+        const bob = await server.createFakePeer({ jid: BOB }, paired)
+        await server.triggerPreKeyUpload(paired)
+        server.createFakeGroup({
+            groupJid: GROUP_JID,
+            subject: 'history share',
+            participants: [alice, bob],
+            creator: ME_USER
+        })
+
+        const bundlePromise = server.expectStanza(
+            { tag: 'message', to: GROUP_JID },
+            { timeoutMs: 15_000 }
+        )
+
+        const result = await client.message.shareGroupHistory(GROUP_JID, {
+            toJids: [ALICE],
+            messages: [
+                {
+                    key: { id: 'HIST-1', remoteJid: GROUP_JID, fromMe: false, participant: BOB },
+                    message: { conversation: 'mensagem antiga' },
+                    messageTimestamp: Math.floor(Date.now() / 1_000) - 60
+                }
+            ]
+        })
+
+        assert.deepEqual(result.historyReceivers, [ALICE])
+        assert.deepEqual(result.nonHistoryReceivers, [BOB])
+        assert.equal(result.messagesCount, 1)
+
+        const bundleStanza = await bundlePromise
+        assert.equal(bundleStanza.attrs.to, GROUP_JID)
+
+        const addressed = fanoutUserJids(bundleStanza)
+        assert.ok(addressed.includes(ALICE.split('@')[0]), `alice missing: ${addressed.join(',')}`)
+        assert.ok(
+            !addressed.includes(BOB.split('@')[0]),
+            `bob was addressed: ${addressed.join(',')}`
+        )
+
+        assert.equal(bundleStanza.attrs.phash, undefined)
+
+        const uploads = server
+            .capturedMediaUploadSnapshot()
+            .filter((upload) => upload.path.startsWith('/mms/group-history/'))
+        assert.equal(uploads.length, 1, `expected 1 bundle upload, got ${uploads.length}`)
+        assert.equal(uploads[0].contentType, 'application/protobuf')
+        assert.ok(uploads[0].encryptedBytes.byteLength > 0)
+    } finally {
+        await client.disconnect().catch(() => undefined)
+        await server.stop()
+    }
+})

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -125,6 +125,7 @@ After editing source: rebuild → call `restart` with `mode: "process_exit"` →
 | `MCP_EVENT_BUFFER_SIZE`                                                        | `1000`                        | In-memory event ring size                             |
 | `MCP_CAPTURE_TRANSPORT`                                                        | `0`                           | Also buffer noisy `transport_*` events                |
 | `MCP_HISTORY_DISABLED`                                                         | `0`                           | Disable history sync on connect                       |
+| `MCP_GROUP_BUNDLES`                                                            | `0`                           | Download group-history bundles shared by members      |
 | `MCP_TRANSPORT`                                                                | `stdio`                       | `stdio` or `http` (StreamableHTTPServerTransport)     |
 | `MCP_HTTP_HOST` / `MCP_HTTP_PORT` / `MCP_HTTP_PATH`                            | `127.0.0.1` / `3737` / `/mcp` | HTTP listener config                                  |
 | `MCP_FAKE_NOISE_PUBKEY_HEX` + `MCP_FAKE_NOISE_SERIAL` + `MCP_CHAT_SOCKET_URLS` | unset                         | Point at `@zapo-js/fake-server` for tests             |

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -321,6 +321,7 @@ const ALL_EVENT_NAMES = [
     'picture',
     'mutation',
     'history_sync_chunk',
+    'group_history_bundle',
     'offline_resume',
     'stream_failure',
     'stanza_error',
@@ -377,6 +378,8 @@ export interface RuntimeConfig {
     readonly deviceBrowser?: string
     readonly deviceOsDisplayName?: string
     readonly historyEnabled: boolean
+    /** Opt into downloading group-history bundles shared by other members. */
+    readonly historyGroupBundles?: boolean
     /** Max log entries kept in memory for the `logs` MCP tool. */
     readonly logBufferSize: number
     /** Optional file path that mirrors every log line as JSONL. */
@@ -419,6 +422,7 @@ export const buildRuntimeConfigFromEnv = (env = process.env): RuntimeConfig => {
     )
     const captureNoisyEvents = env.MCP_CAPTURE_TRANSPORT === '1'
     const historyEnabled = env.MCP_HISTORY_DISABLED !== '1'
+    const historyGroupBundles = env.MCP_GROUP_BUNDLES === '1'
     const chatSocketUrls = parseUrlList(env.MCP_CHAT_SOCKET_URLS)
     const noiseRootCa = parseNoiseRootCa(env.MCP_FAKE_NOISE_PUBKEY_HEX, env.MCP_FAKE_NOISE_SERIAL)
     const logBufferSize = parseEnvPositiveInt(
@@ -441,6 +445,7 @@ export const buildRuntimeConfigFromEnv = (env = process.env): RuntimeConfig => {
         deviceBrowser: env.MCP_DEVICE_BROWSER,
         deviceOsDisplayName: env.MCP_DEVICE_OS_DISPLAY,
         historyEnabled,
+        historyGroupBundles,
         chatSocketUrls,
         noiseRootCa,
         logBufferSize,
@@ -719,7 +724,8 @@ export class McpRuntime {
                 deviceOsDisplayName: this.config.deviceOsDisplayName ?? 'Windows',
                 history: {
                     enabled: this.config.historyEnabled,
-                    requireFullSync: true
+                    requireFullSync: true,
+                    groupBundles: this.config.historyGroupBundles === true
                 },
                 nodeQueryTimeoutMs: 30_000,
                 chatSocketUrls: this.config.chatSocketUrls,

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -17,6 +17,7 @@ import type { WaPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordin
 import type { WaProfileCoordinator } from '@client/coordinators/WaProfileCoordinator'
 import type { WaStatusCoordinator } from '@client/coordinators/WaStatusCoordinator'
 import { createIgnoreKeyFilter, validateIgnoreKey } from '@client/messaging/ignore-key'
+import { runGroupHistoryBundle } from '@client/persistence/group-history'
 import { runHistorySyncNotification } from '@client/persistence/history-sync'
 import { persistIncomingMailboxEntities } from '@client/persistence/mailbox'
 import { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
@@ -42,6 +43,7 @@ import {
 import { ConsoleLogger } from '@infra/log/ConsoleLogger'
 import type { Logger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
+import { unwrapMessage } from '@message/encode/content'
 import { proto, type Proto } from '@proto'
 import { WA_DEFAULTS, WA_MESSAGE_TYPES } from '@protocol/constants'
 import { normalizeDeviceJid } from '@protocol/jid'
@@ -300,6 +302,9 @@ class WaClientImpl extends EventEmitter {
                     })
                 })
             }
+            if (this.options.history?.groupBundles === true && event.message && !event.key.fromMe) {
+                this.tryProcessGroupHistoryBundle(event)
+            }
             const protocolMessage = event.message?.protocolMessage
             if (!protocolMessage) {
                 return
@@ -390,6 +395,38 @@ class WaClientImpl extends EventEmitter {
         } finally {
             this.leaveIncomingHandler()
         }
+    }
+
+    /**
+     * Kicks off the group-history bundle download when the incoming message
+     * carries one. Fire-and-forget: the blob can be large, and the incoming
+     * handler must not stall behind a CDN fetch.
+     */
+    private tryProcessGroupHistoryBundle(event: WaIncomingMessageEvent): void {
+        const bundle = unwrapMessage(event.message ?? {}).messageHistoryBundle
+        const groupJid = event.key.remoteJid
+        if (!bundle || !groupJid) {
+            return
+        }
+        const credentials = this.deps.authClient.getCurrentCredentials()
+        void runGroupHistoryBundle(
+            {
+                logger: this.logger,
+                mediaTransfer: this.mediaTransfer,
+                writeBehind: this.writeBehind,
+                emitEvent: this.emit.bind(this),
+                meJid: credentials?.meJid,
+                meLid: credentials?.meLid,
+                getAbPropNumber: (name) => this.deps.abPropsCoordinator.getConfigValue<number>(name)
+            },
+            {
+                bundle,
+                groupJid,
+                senderJid: event.key.participant ?? undefined,
+                bundleMessageId: event.key.id,
+                sentAtSeconds: event.timestampSeconds
+            }
+        )
     }
 
     private async queryWithContext(

--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -401,11 +401,18 @@ class WaClientImpl extends EventEmitter {
      * Kicks off the group-history bundle download when the incoming message
      * carries one. Fire-and-forget: the blob can be large, and the incoming
      * handler must not stall behind a CDN fetch.
+     *
+     * The download outlives the handler that started it, so it takes a slot of
+     * its own in the drain accounting - `disconnect()` and `clearStoredState()`
+     * must not flush or wipe the stores while a bundle is still writing.
      */
     private tryProcessGroupHistoryBundle(event: WaIncomingMessageEvent): void {
         const bundle = unwrapMessage(event.message ?? {}).messageHistoryBundle
         const groupJid = event.key.remoteJid
         if (!bundle || !groupJid) {
+            return
+        }
+        if (!this.tryEnterIncomingHandler()) {
             return
         }
         const credentials = this.deps.authClient.getCurrentCredentials()
@@ -426,7 +433,9 @@ class WaClientImpl extends EventEmitter {
                 bundleMessageId: event.key.id,
                 sentAtSeconds: event.timestampSeconds
             }
-        )
+        ).finally(() => {
+            this.leaveIncomingHandler()
+        })
     }
 
     private async queryWithContext(

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -819,7 +819,10 @@ export function buildWaClientDependencies(input: {
         trustedContactToken,
         emitAddon: (event) => runtime.emitEvent('message_addon', event),
         mexSocket: { query: runtime.query },
-        peerDataOperation
+        peerDataOperation,
+        isGroupHistorySendEnabled: () =>
+            abPropsCoordinator.getConfigValue<boolean>('group_history_send'),
+        getAbPropNumber: (name) => abPropsCoordinator.getConfigValue<number>(name)
     })
 
     const retryCoordinator = new WaRetryCoordinator({

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -108,16 +108,21 @@ export interface WaShareGroupHistoryInput {
      */
     readonly toJids: readonly string[]
     /**
-     * How many of the most recent messages to include. Defaults to WhatsApp's
-     * `group_history_message_count_limit` (100).
+     * How many of the most recent messages to read from the mailbox store.
+     * Defaults to WhatsApp's `group_history_message_count_limit` (100).
+     * Ignored when {@link messages} is supplied - that list is bundled as-is.
      */
     readonly count?: number
-    /** Only include messages at or after this timestamp (ms). */
+    /**
+     * Only read messages at or after this timestamp (ms) from the mailbox
+     * store. Ignored when {@link messages} is supplied.
+     */
     readonly sinceMs?: number
     /**
-     * Messages to bundle, bypassing the mailbox store. Required when the
-     * `messages` store domain is `'none'` (the default), since there is
-     * nothing to read back in that case.
+     * Messages to bundle, bypassing the mailbox store entirely - {@link count}
+     * and {@link sinceMs} do not apply, so the caller owns the windowing.
+     * Required when the `messages` store domain is `'none'` (the default),
+     * since there is nothing to read back in that case.
      */
     readonly messages?: readonly Proto.IWebMessageInfo[]
     /**
@@ -130,8 +135,12 @@ export interface WaShareGroupHistoryInput {
 export interface WaShareGroupHistoryResult {
     /** Stanza id of the bundle message, fanned out only to `historyReceivers`. */
     readonly bundleMessageId: string
-    /** Stanza id of the notice message, sent to the whole group. */
-    readonly noticeMessageId: string
+    /**
+     * Stanza id of the notice message, sent to the whole group. Absent when the
+     * notice failed to send: the bundle still reached its receivers, so do not
+     * retry the share - it would upload and deliver the history a second time.
+     */
+    readonly noticeMessageId?: string
     readonly messagesCount: number
     readonly historyReceivers: readonly string[]
     readonly nonHistoryReceivers: readonly string[]
@@ -455,9 +464,21 @@ export class WaMessageCoordinator {
             }
         })
 
-        const noticeResult = await this.send(normalizedGroupJid, {
-            messageHistoryNotice: { messageHistoryMetadata: metadata }
-        })
+        let noticeMessageId: string | undefined
+        try {
+            noticeMessageId = (
+                await this.send(normalizedGroupJid, {
+                    messageHistoryNotice: { messageHistoryMetadata: metadata }
+                })
+            ).id
+        } catch (error) {
+            this.logger.warn('group history notice failed after the bundle was delivered', {
+                groupJid: normalizedGroupJid,
+                id: bundleResult.id,
+                receiverCount: audience.historyReceivers.length,
+                message: toError(error).message
+            })
+        }
 
         this.logger.debug('shared group history', {
             groupJid: normalizedGroupJid,
@@ -468,7 +489,7 @@ export class WaMessageCoordinator {
 
         return {
             bundleMessageId: bundleResult.id,
-            noticeMessageId: noticeResult.id,
+            noticeMessageId,
             messagesCount: messages.length,
             historyReceivers: audience.historyReceivers,
             nonHistoryReceivers: audience.nonHistoryReceivers

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -36,6 +36,7 @@ import {
     shouldUseAddonAdditionalData
 } from '@message/crypto/addon-crypto'
 import { unwrapMessage } from '@message/encode/content'
+import { encodeGroupHistoryBundle } from '@message/kinds/group-history'
 import type { PeerDataOperationRequester } from '@message/primitives/peer-data-operation'
 import type {
     WaMessagePublishResult,
@@ -46,13 +47,14 @@ import type {
 } from '@message/types'
 import type { WaMexOperationResponses } from '@mex'
 import { proto, type Proto } from '@proto'
-import { applyDeviceToJid, normalizeRecipientJid } from '@protocol/jid'
+import type { AbPropName } from '@protocol/abprops'
+import { applyDeviceToJid, isGroupJid, normalizeRecipientJid } from '@protocol/jid'
 import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
 import type { WaMessageStore } from '@store/contracts/message.store'
 import { runMexQuery, type WaMexQuerySocket } from '@transport/node/mex/client'
 import { readAllBytes } from '@util/bytes'
 import { tryAsNumber, tryAsString } from '@util/coercion'
-import { toError } from '@util/primitives'
+import { longToNumber, toError } from '@util/primitives'
 
 export interface WaMessageCoordinatorDeps {
     readonly messageDispatch: WaMessageDispatchCoordinator
@@ -66,6 +68,73 @@ export interface WaMessageCoordinatorDeps {
     readonly emitAddon: (event: WaIncomingAddonEvent) => void
     readonly mexSocket: WaMexQuerySocket
     readonly peerDataOperation: PeerDataOperationRequester
+    /**
+     * Server-synced `group_history_send` AB-prop. WhatsApp gates the sender
+     * side per account, and rejects the stanza with SMAX_INVALID when it is
+     * off, so {@link WaMessageCoordinator.shareGroupHistory} checks it before
+     * spending an upload.
+     */
+    readonly isGroupHistorySendEnabled: () => boolean
+    /**
+     * Reads a server-synced numeric AB-prop, falling back to its shipped
+     * default. Sole source for the group-history message-count limit, so a
+     * server-side change takes effect without a release.
+     */
+    readonly getAbPropNumber: (name: AbPropName) => number
+}
+
+/** MIME type the group-history bundle is uploaded and advertised under. */
+const GROUP_HISTORY_BUNDLE_MIMETYPE = 'application/protobuf'
+
+/** Oldest `messageTimestamp` across `messages`, in seconds; `undefined` when none carries one. */
+function oldestTimestampSeconds(messages: readonly Proto.IWebMessageInfo[]): number | undefined {
+    let oldest: number | undefined
+    for (let index = 0; index < messages.length; index += 1) {
+        const timestamp = longToNumber(messages[index].messageTimestamp)
+        if (timestamp > 0 && (oldest === undefined || timestamp < oldest)) {
+            oldest = timestamp
+        }
+    }
+    return oldest
+}
+
+export interface WaShareGroupHistoryInput {
+    /**
+     * Members to share the history with. Must be current members of the group,
+     * written in the group's own addressing mode - a LID-addressed group only
+     * matches `@lid` entries, and a PN one only matches `@s.whatsapp.net`.
+     * Anything else throws, naming the mode the group uses. Read the mode off
+     * `client.group.queryGroupMetadata()`, whose participants carry both forms.
+     */
+    readonly toJids: readonly string[]
+    /**
+     * How many of the most recent messages to include. Defaults to WhatsApp's
+     * `group_history_message_count_limit` (100).
+     */
+    readonly count?: number
+    /** Only include messages at or after this timestamp (ms). */
+    readonly sinceMs?: number
+    /**
+     * Messages to bundle, bypassing the mailbox store. Required when the
+     * `messages` store domain is `'none'` (the default), since there is
+     * nothing to read back in that case.
+     */
+    readonly messages?: readonly Proto.IWebMessageInfo[]
+    /**
+     * Pinned messages older than the shared window. The receiver injects these
+     * regardless of the age cutoff it applies to `messages`.
+     */
+    readonly outOfWindowPinnedMessages?: readonly Proto.IWebMessageInfo[]
+}
+
+export interface WaShareGroupHistoryResult {
+    /** Stanza id of the bundle message, fanned out only to `historyReceivers`. */
+    readonly bundleMessageId: string
+    /** Stanza id of the notice message, sent to the whole group. */
+    readonly noticeMessageId: string
+    readonly messagesCount: number
+    readonly historyReceivers: readonly string[]
+    readonly nonHistoryReceivers: readonly string[]
 }
 
 export interface WaRequestHistorySyncInput {
@@ -209,6 +278,8 @@ export class WaMessageCoordinator {
     private readonly emitAddon: (event: WaIncomingAddonEvent) => void
     private readonly mexSocket: WaMexQuerySocket
     private readonly peerDataOperation: PeerDataOperationRequester
+    private readonly isGroupHistorySendEnabled: () => boolean
+    private readonly getAbPropNumber: (name: AbPropName) => number
 
     public constructor(deps: WaMessageCoordinatorDeps) {
         this.messageDispatch = deps.messageDispatch
@@ -221,6 +292,8 @@ export class WaMessageCoordinator {
         this.emitAddon = deps.emitAddon
         this.mexSocket = deps.mexSocket
         this.peerDataOperation = deps.peerDataOperation
+        this.isGroupHistorySendEnabled = deps.isGroupHistorySendEnabled
+        this.getAbPropNumber = deps.getAbPropNumber
     }
 
     /**
@@ -275,6 +348,169 @@ export class WaMessageCoordinator {
             proto.Message.PeerDataOperationRequestType.HISTORY_SYNC_ON_DEMAND,
             { historySyncOnDemandRequest }
         )
+    }
+
+    /**
+     * Shares recent group history with members who joined after the fact - the
+     * counterpart of the `group_history_bundle` event on the receiving side.
+     *
+     * Sends two messages: the bundle itself, encrypted per device and fanned
+     * out **only** to `toJids` (never to the whole group), followed by a hidden
+     * notice addressed to everyone so other clients can render the "history was
+     * shared" marker.
+     *
+     * WhatsApp gates the sender side per account through the `group_history_send`
+     * AB-prop and rejects the stanza with SMAX_INVALID when it is off, so this
+     * throws up front rather than spending an upload. Admin-only groups
+     * (`memberShareGroupHistoryMode: 'admin_share'`) reject a share from a
+     * regular member server-side - read `client.group.queryGroupMetadata()`
+     * first if you want to check that too.
+     *
+     * @throws when the account is not allowed to share group history, when
+     * `groupJid` is not a group, when any of `toJids` is not a current member
+     * (or is this account), or when there is nothing to bundle.
+     * @example
+     * ```ts
+     * await client.message.shareGroupHistory('12036@g.us', {
+     *     toJids: ['5511999999999@s.whatsapp.net'],
+     *     count: 50
+     * })
+     * ```
+     */
+    public async shareGroupHistory(
+        groupJid: string,
+        input: WaShareGroupHistoryInput
+    ): Promise<WaShareGroupHistoryResult> {
+        const normalizedGroupJid = normalizeRecipientJid(groupJid)
+        if (!isGroupJid(normalizedGroupJid)) {
+            throw new Error(`shareGroupHistory requires a group jid: ${normalizedGroupJid}`)
+        }
+        if (input.toJids.length === 0) {
+            throw new Error('shareGroupHistory requires at least one recipient')
+        }
+        if (!this.isGroupHistorySendEnabled()) {
+            throw new Error(
+                'shareGroupHistory is disabled for this account (group_history_send is off)'
+            )
+        }
+
+        const audience = await this.messageDispatch.resolveGroupHistoryAudience(
+            normalizedGroupJid,
+            input.toJids
+        )
+        if (audience.requestedSelf) {
+            throw new Error('shareGroupHistory cannot share history with this account itself')
+        }
+        if (audience.unknownJids.length > 0) {
+            throw new Error(
+                `shareGroupHistory recipients are not members of the group (addressing mode: ${audience.addressingMode}): ${audience.unknownJids.join(', ')}`
+            )
+        }
+        if (audience.historyReceivers.length === 0) {
+            throw new Error('shareGroupHistory resolved no recipients')
+        }
+
+        const messages =
+            input.messages ??
+            (await this.loadGroupHistoryMessages(normalizedGroupJid, input.count, input.sinceMs))
+        if (messages.length === 0) {
+            throw new Error('shareGroupHistory found no messages to share')
+        }
+
+        const { compressed } = await encodeGroupHistoryBundle(
+            messages,
+            input.outOfWindowPinnedMessages
+        )
+        const upload = await uploadMedia(this.mediaUploadOptions, {
+            source: compressed,
+            cryptoType: 'group-history',
+            uploadPath: MEDIA_UPLOAD_PATHS['group-history'],
+            contentType: GROUP_HISTORY_BUNDLE_MIMETYPE,
+            sidecar: false,
+            logLabel: 'group history bundle upload'
+        })
+
+        const oldestInWindow = oldestTimestampSeconds(messages)
+        const oldestPin = oldestTimestampSeconds(input.outOfWindowPinnedMessages ?? [])
+        const oldestInBundle =
+            oldestPin === undefined
+                ? oldestInWindow
+                : oldestInWindow === undefined
+                  ? oldestPin
+                  : Math.min(oldestInWindow, oldestPin)
+        const metadata: Proto.Message.IMessageHistoryMetadata = {
+            historyReceivers: audience.historyReceivers as string[],
+            nonHistoryReceivers: audience.nonHistoryReceivers as string[],
+            messageCount: messages.length,
+            oldestMessageTimestampInWindow: oldestInWindow,
+            oldestMessageTimestampInBundle: oldestInBundle
+        }
+
+        const bundleResult = await this.send(normalizedGroupJid, {
+            messageHistoryBundle: {
+                mimetype: GROUP_HISTORY_BUNDLE_MIMETYPE,
+                fileSha256: upload.fileSha256,
+                fileEncSha256: upload.fileEncSha256,
+                mediaKey: upload.mediaKey,
+                directPath: upload.directPath,
+                mediaKeyTimestamp: this.mediaUploadOptions.serverClock.nowSeconds(),
+                messageHistoryMetadata: metadata
+            }
+        })
+
+        const noticeResult = await this.send(normalizedGroupJid, {
+            messageHistoryNotice: { messageHistoryMetadata: metadata }
+        })
+
+        this.logger.debug('shared group history', {
+            groupJid: normalizedGroupJid,
+            id: bundleResult.id,
+            messagesCount: messages.length,
+            receiverCount: audience.historyReceivers.length
+        })
+
+        return {
+            bundleMessageId: bundleResult.id,
+            noticeMessageId: noticeResult.id,
+            messagesCount: messages.length,
+            historyReceivers: audience.historyReceivers,
+            nonHistoryReceivers: audience.nonHistoryReceivers
+        }
+    }
+
+    /**
+     * Reads the most recent messages of a group back out of the mailbox store
+     * and rebuilds the `WebMessageInfo` shape a bundle carries. Yields nothing
+     * when the `messages` store domain is `'none'`.
+     */
+    private async loadGroupHistoryMessages(
+        groupJid: string,
+        count?: number,
+        sinceMs?: number
+    ): Promise<readonly Proto.IWebMessageInfo[]> {
+        const limit = count ?? this.getAbPropNumber('group_history_message_count_limit')
+        const records = await this.messageStore.listByThread(groupJid, limit)
+        const messages: Proto.IWebMessageInfo[] = []
+        for (let index = 0; index < records.length; index += 1) {
+            const record = records[index]
+            if (!record.messageBytes) {
+                continue
+            }
+            if (sinceMs !== undefined && (record.timestampMs ?? 0) < sinceMs) {
+                continue
+            }
+            messages[messages.length] = {
+                key: {
+                    id: record.id,
+                    remoteJid: groupJid,
+                    fromMe: record.fromMe,
+                    participant: record.participantJid ?? record.senderJid
+                },
+                message: proto.Message.decode(record.messageBytes),
+                messageTimestamp: Math.floor((record.timestampMs ?? 0) / 1_000)
+            }
+        }
+        return messages
     }
 
     /**

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -53,7 +53,7 @@ import type { WaMessageSecretStore } from '@store/contracts/message-secret.store
 import type { WaMessageStore } from '@store/contracts/message.store'
 import { runMexQuery, type WaMexQuerySocket } from '@transport/node/mex/client'
 import { readAllBytes } from '@util/bytes'
-import { tryAsNumber, tryAsString } from '@util/coercion'
+import { resolveOptionalPositive, resolvePositive, tryAsNumber, tryAsString } from '@util/coercion'
 import { longToNumber, toError } from '@util/primitives'
 
 export interface WaMessageCoordinatorDeps {
@@ -313,15 +313,7 @@ export class WaMessageCoordinator {
         input: WaRequestHistorySyncInput
     ): Promise<{ readonly messageId: string }> {
         const chatJid = normalizeRecipientJid(input.chatJid)
-        if (input.count !== undefined) {
-            if (
-                !Number.isFinite(input.count) ||
-                !Number.isSafeInteger(input.count) ||
-                input.count <= 0
-            ) {
-                throw new Error(`invalid count: ${input.count}`)
-            }
-        }
+        const onDemandMsgCount = resolveOptionalPositive(input.count, 'count')
         if (input.oldestMsgTimestampMs !== undefined) {
             if (
                 !Number.isFinite(input.oldestMsgTimestampMs) ||
@@ -342,7 +334,7 @@ export class WaMessageCoordinator {
                 ...(input.oldestMsgTimestampMs === undefined
                     ? {}
                     : { oldestMsgTimestampMs: input.oldestMsgTimestampMs }),
-                ...(input.count === undefined ? {} : { onDemandMsgCount: input.count })
+                ...(onDemandMsgCount === undefined ? {} : { onDemandMsgCount })
             }
         return this.peerDataOperation.send(
             proto.Message.PeerDataOperationRequestType.HISTORY_SYNC_ON_DEMAND,
@@ -388,6 +380,11 @@ export class WaMessageCoordinator {
         if (input.toJids.length === 0) {
             throw new Error('shareGroupHistory requires at least one recipient')
         }
+        const messageLimit = resolvePositive(
+            input.count,
+            this.getAbPropNumber('group_history_message_count_limit'),
+            'count'
+        )
         if (!this.isGroupHistorySendEnabled()) {
             throw new Error(
                 'shareGroupHistory is disabled for this account (group_history_send is off)'
@@ -412,7 +409,7 @@ export class WaMessageCoordinator {
 
         const messages =
             input.messages ??
-            (await this.loadGroupHistoryMessages(normalizedGroupJid, input.count, input.sinceMs))
+            (await this.loadGroupHistoryMessages(normalizedGroupJid, messageLimit, input.sinceMs))
         if (messages.length === 0) {
             throw new Error('shareGroupHistory found no messages to share')
         }
@@ -485,10 +482,9 @@ export class WaMessageCoordinator {
      */
     private async loadGroupHistoryMessages(
         groupJid: string,
-        count?: number,
+        limit: number,
         sinceMs?: number
     ): Promise<readonly Proto.IWebMessageInfo[]> {
-        const limit = count ?? this.getAbPropNumber('group_history_message_count_limit')
         const records = await this.messageStore.listByThread(groupJid, limit)
         const messages: Proto.IWebMessageInfo[] = []
         for (let index = 0; index < records.length; index += 1) {

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -36,6 +36,7 @@ import {
     resolveEncMediaType,
     resolveMessageTypeAttr,
     resolveMetaAttrs,
+    unwrapMessage,
     wrapAsViewOnce
 } from '@message/encode/content'
 import { wrapDeviceSentMessage } from '@message/encode/device-sent'
@@ -153,6 +154,77 @@ interface GroupSendRetryContext {
     readonly retried?: boolean
     readonly forceRefreshParticipants?: boolean
     readonly forceAddressingMode?: GroupAddressingMode
+}
+
+/** Membership split behind a group-history share, in the group's addressing mode. */
+export interface WaGroupHistoryAudience {
+    /** Members the bundle is addressed to. */
+    readonly historyReceivers: readonly string[]
+    /** Members in the group who are not receiving it. */
+    readonly nonHistoryReceivers: readonly string[]
+    /** Requested JIDs that are not current members of the group. */
+    readonly unknownJids: readonly string[]
+    /** Whether the caller asked to share with this account itself. */
+    readonly requestedSelf: boolean
+    readonly addressingMode: 'pn' | 'lid'
+}
+
+/**
+ * Members a group-history bundle is addressed to. Empty for every other
+ * message, which is what keeps the restricted fanout scoped to bundles.
+ */
+function resolveGroupHistoryReceivers(message: Proto.IMessage): readonly string[] {
+    const metadata = unwrapMessage(message).messageHistoryBundle?.messageHistoryMetadata
+    return metadata?.historyReceivers ?? []
+}
+
+/**
+ * Narrows a group's participant list to the members a group-history bundle is
+ * addressed to, plus the sender so its own devices keep a copy. Receivers are
+ * intersected with the live participant list, so a stale receiver entry cannot
+ * pull a non-member into the fanout. Any other message keeps the full list.
+ *
+ * Receivers must be written in the group's addressing mode - a PN entry for a
+ * LID-addressed group does not match and is reported through `onDropped`.
+ *
+ * @throws when no receiver matches a current member. Sending to the sender's
+ * own devices alone counts as no match: it would look like a delivered share
+ * while nobody received anything.
+ */
+export function restrictGroupHistoryTargets(
+    message: Proto.IMessage,
+    participantUserJids: readonly string[],
+    senderJid: string,
+    onDropped?: (droppedJids: readonly string[], totalExpected: number) => void
+): readonly string[] {
+    const receivers = resolveGroupHistoryReceivers(message)
+    if (receivers.length === 0) {
+        return participantUserJids
+    }
+    const pending = new Set<string>()
+    for (let index = 0; index < receivers.length; index += 1) {
+        pending.add(toUserJid(receivers[index]))
+    }
+    const senderUserJid = toUserJid(senderJid)
+    const targets: string[] = []
+    let matchedReceivers = 0
+    for (let index = 0; index < participantUserJids.length; index += 1) {
+        const participant = participantUserJids[index]
+        const participantUserJid = toUserJid(participant)
+        if (pending.delete(participantUserJid)) {
+            matchedReceivers += 1
+            targets[targets.length] = participant
+        } else if (participantUserJid === senderUserJid) {
+            targets[targets.length] = participant
+        }
+    }
+    if (pending.size > 0 && onDropped) {
+        onDropped([...pending], receivers.length)
+    }
+    if (matchedReceivers === 0) {
+        throw new Error('group history bundle resolved no receivers in the group')
+    }
+    return targets
 }
 
 interface WaOutboundEnvelope {
@@ -845,9 +917,63 @@ export class WaMessageDispatchCoordinator {
         await this.deps.groupMetadataCache.mutateFromGroupEvent(event)
     }
 
-    // noop for now
+    /**
+     * Splits a group's members into the ones a history bundle is being shared
+     * with and the rest, normalizing everything to the group's addressing mode
+     * so the receiver list written into the proto matches what the fanout can
+     * actually resolve. This account is excluded from both lists.
+     *
+     * Requested JIDs that are not current members come back in `unknownJids`
+     * instead of being silently dropped - sharing history with a non-member is
+     * a caller mistake worth surfacing.
+     */
+    public async resolveGroupHistoryAudience(
+        groupJid: string,
+        requestedJids: readonly string[]
+    ): Promise<WaGroupHistoryAudience> {
+        const participants = await this.deps.groupMetadataCache.resolveParticipantUsers(groupJid)
+        const meJid = this.requireCurrentMeJid('shareGroupHistory')
+        const addressingMode = this.resolveGroupAddressingMode(participants, groupJid)
+        const meUserJid = toUserJid(this.resolveSenderForAddressingMode(addressingMode, meJid))
+
+        const pending = new Set<string>()
+        for (let index = 0; index < requestedJids.length; index += 1) {
+            pending.add(toUserJid(normalizeRecipientJid(requestedJids[index])))
+        }
+        const historyReceivers: string[] = []
+        const nonHistoryReceivers: string[] = []
+        for (let index = 0; index < participants.length; index += 1) {
+            const participantUserJid = toUserJid(participants[index])
+            if (participantUserJid === meUserJid) {
+                continue
+            }
+            if (pending.delete(participantUserJid)) {
+                historyReceivers[historyReceivers.length] = participantUserJid
+            } else {
+                nonHistoryReceivers[nonHistoryReceivers.length] = participantUserJid
+            }
+        }
+        const requestedSelf = pending.delete(meUserJid)
+        const unknownJids: string[] = []
+        for (const jid of pending) {
+            unknownJids[unknownJids.length] = jid
+        }
+        return {
+            historyReceivers,
+            nonHistoryReceivers,
+            unknownJids,
+            requestedSelf,
+            addressingMode
+        }
+    }
+
+    /**
+     * A group-history bundle goes to the members named in `historyReceivers`
+     * rather than to the whole group, so it takes the per-device direct fanout
+     * instead of the group sender key.
+     */
     private shouldUseGroupDirectPath(message: Proto.IMessage): boolean {
-        return false
+        return resolveGroupHistoryReceivers(message).length > 0
     }
 
     private async publishGroupDirectMessage(
@@ -863,9 +989,22 @@ export class WaMessageDispatchCoordinator {
         const addressingMode =
             retryContext.forceAddressingMode ??
             this.resolveGroupAddressingMode(participantUserJids, groupJid)
-        const senderForPhash = this.resolveSenderForAddressingMode(addressingMode, meJid)
+        const senderJid = this.resolveSenderForAddressingMode(addressingMode, meJid)
+        const targetUserJids = restrictGroupHistoryTargets(
+            message,
+            participantUserJids,
+            senderJid,
+            (droppedJids, totalExpected) => {
+                this.deps.logger.warn('group history receivers missing from the participant list', {
+                    groupJid,
+                    droppedCount: droppedJids.length,
+                    totalExpected,
+                    sample: droppedJids.slice(0, 3)
+                })
+            }
+        )
         const fanoutDeviceJids =
-            await this.deps.fanoutResolver.resolveGroupParticipantDeviceJids(participantUserJids)
+            await this.deps.fanoutResolver.resolveGroupParticipantDeviceJids(targetUserJids)
         if (fanoutDeviceJids.length === 0) {
             throw new Error('group direct send resolved no target devices')
         }
@@ -931,21 +1070,10 @@ export class WaMessageDispatchCoordinator {
                 break
             }
         }
-        const phashTargets = new Array<string>(resolvedFanoutTargets.length + 1)
-        let phashTargetCount = 0
-        for (let index = 0; index < resolvedFanoutTargets.length; index += 1) {
-            const candidate = resolvedFanoutTargets[index].jid
-            if (isHostedDeviceJid(candidate)) continue
-            phashTargets[phashTargetCount] = candidate
-            phashTargetCount += 1
-        }
-        phashTargets[phashTargetCount] = senderForPhash
-        phashTargets.length = phashTargetCount + 1
-        const localPhash = computePhashV2(phashTargets)
         const reportingArtifacts = await this.tryBuildReportingTokenArtifacts({
             message,
             stanzaId: sendOptions.id,
-            senderUserJid: toUserJid(senderForPhash),
+            senderUserJid: toUserJid(senderJid),
             remoteJid: groupJid,
             context: 'group_direct'
         })
@@ -956,7 +1084,6 @@ export class WaMessageDispatchCoordinator {
             type,
             id: sendOptions.id,
             edit,
-            phash: localPhash,
             addressingMode,
             participants,
             deviceIdentity: shouldAttachDeviceIdentity
@@ -985,7 +1112,7 @@ export class WaMessageDispatchCoordinator {
         const ackError = result.ack.error
         const serverPhash = result.ack.phash
         const serverAddressingMode = result.ack.addressingMode
-        const hasPhashMismatch = !!serverPhash && serverPhash !== localPhash
+        const hasPhashMismatch = !!serverPhash
         const hasAddressingMismatch =
             !!serverAddressingMode && serverAddressingMode !== addressingMode
         const hasAddressingError = ackError === WA_NACK_REASONS.STALE_GROUP_ADDRESSING_MODE
@@ -996,7 +1123,6 @@ export class WaMessageDispatchCoordinator {
             this.deps.logger.warn('group direct publish acknowledged with mismatch metadata', {
                 id: result.id,
                 groupJid,
-                localPhash,
                 serverPhash,
                 localAddressingMode: addressingMode,
                 serverAddressingMode,

--- a/src/client/coordinators/__tests__/group-history-send.test.ts
+++ b/src/client/coordinators/__tests__/group-history-send.test.ts
@@ -180,6 +180,16 @@ test('shareGroupHistory rejects a non-group jid', async () => {
     )
 })
 
+test('shareGroupHistory rejects a count that is not a positive whole number', async () => {
+    const { coordinator } = createShareHarness({})
+    for (const count of [0, -1, 1.5, Number.NaN]) {
+        await assert.rejects(
+            () => coordinator.shareGroupHistory(GROUP, { toJids: [ALICE], count }),
+            /count must be a positive safe integer/
+        )
+    }
+})
+
 test('shareGroupHistory rejects an empty recipient list', async () => {
     const { coordinator } = createShareHarness({})
     await assert.rejects(

--- a/src/client/coordinators/__tests__/group-history-send.test.ts
+++ b/src/client/coordinators/__tests__/group-history-send.test.ts
@@ -1,0 +1,212 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { WaMessageCoordinator } from '@client/coordinators/WaMessageCoordinator'
+import { restrictGroupHistoryTargets } from '@client/coordinators/WaMessageDispatchCoordinator'
+import { createNoopLogger } from '@infra/log/types'
+import type { Proto } from '@proto'
+
+const GROUP = '120363000000000000@g.us'
+const ME = '5511777777777@s.whatsapp.net'
+const ALICE = '5511999999999@s.whatsapp.net'
+const BOB = '5511888888888@s.whatsapp.net'
+const CAROL = '5511666666666@s.whatsapp.net'
+
+function bundleFor(receivers: readonly string[]): Proto.IMessage {
+    return {
+        messageHistoryBundle: {
+            directPath: '/x',
+            messageHistoryMetadata: { historyReceivers: [...receivers] }
+        }
+    }
+}
+
+test('restrictGroupHistoryTargets keeps the full list for a normal message', () => {
+    const participants = [ALICE, BOB, CAROL, ME]
+    assert.deepEqual(
+        restrictGroupHistoryTargets({ conversation: 'hi' }, participants, ME),
+        participants
+    )
+})
+
+test('restrictGroupHistoryTargets narrows a bundle to its receivers plus the sender', () => {
+    const targets = restrictGroupHistoryTargets(bundleFor([ALICE]), [ALICE, BOB, CAROL, ME], ME)
+    assert.deepEqual(targets, [ALICE, ME])
+})
+
+test('restrictGroupHistoryTargets ignores receivers who left the group', () => {
+    const dropped: string[][] = []
+    const targets = restrictGroupHistoryTargets(
+        bundleFor([ALICE, '5511000000000@s.whatsapp.net']),
+        [ALICE, BOB, ME],
+        ME,
+        (jids) => dropped.push([...jids])
+    )
+    assert.deepEqual(targets, [ALICE, ME])
+    assert.deepEqual(dropped, [['5511000000000@s.whatsapp.net']])
+})
+
+test('restrictGroupHistoryTargets matches device-suffixed receivers', () => {
+    const targets = restrictGroupHistoryTargets(
+        bundleFor(['5511999999999:4@s.whatsapp.net']),
+        [ALICE, BOB, ME],
+        ME
+    )
+    assert.deepEqual(targets, [ALICE, ME])
+})
+
+test('restrictGroupHistoryTargets throws rather than broadcasting when nothing matches', () => {
+    assert.throws(
+        () => restrictGroupHistoryTargets(bundleFor([CAROL]), [ALICE, BOB], ME),
+        /no receivers in the group/
+    )
+})
+
+test('restrictGroupHistoryTargets throws when only the sender is left to address', () => {
+    assert.throws(
+        () => restrictGroupHistoryTargets(bundleFor([CAROL]), [ALICE, BOB, ME], ME),
+        /no receivers in the group/
+    )
+})
+
+test('restrictGroupHistoryTargets throws when receivers use the wrong addressing mode', () => {
+    assert.throws(
+        () => restrictGroupHistoryTargets(bundleFor([ALICE]), ['111@lid', '222@lid'], '222@lid'),
+        /no receivers in the group/
+    )
+})
+
+test('restrictGroupHistoryTargets sees through an ephemeral wrapper', () => {
+    const wrapped: Proto.IMessage = {
+        ephemeralMessage: { message: bundleFor([ALICE]) }
+    }
+    assert.deepEqual(restrictGroupHistoryTargets(wrapped, [ALICE, BOB, ME], ME), [ALICE, ME])
+})
+
+interface ShareHarness {
+    readonly coordinator: WaMessageCoordinator
+    readonly sent: { readonly to: string; readonly content: Proto.IMessage }[]
+}
+
+function createShareHarness(options: {
+    readonly audience?: {
+        readonly historyReceivers: readonly string[]
+        readonly nonHistoryReceivers: readonly string[]
+        readonly unknownJids: readonly string[]
+        readonly requestedSelf?: boolean
+        readonly addressingMode?: 'pn' | 'lid'
+    }
+    readonly storedMessages?: readonly unknown[]
+    readonly groupHistorySendEnabled?: boolean
+}): ShareHarness {
+    const sent: { readonly to: string; readonly content: Proto.IMessage }[] = []
+    const coordinator = new WaMessageCoordinator({
+        isGroupHistorySendEnabled: () => options.groupHistorySendEnabled !== false,
+        getAbPropNumber: () => 100,
+        messageDispatch: {
+            resolveGroupHistoryAudience: async () => ({
+                requestedSelf: false,
+                addressingMode: 'pn',
+                ...(options.audience ?? {
+                    historyReceivers: [ALICE],
+                    nonHistoryReceivers: [BOB],
+                    unknownJids: []
+                })
+            }),
+            sendMessage: async (to: string, content: Proto.IMessage) => {
+                sent.push({ to, content })
+                return { id: `sent-${sent.length}` }
+            }
+        },
+        mediaTransfer: {} as never,
+        mediaUploadOptions: {} as never,
+        logger: createNoopLogger(),
+        messageStore: {
+            listByThread: async () => options.storedMessages ?? []
+        },
+        messageSecretStore: {} as never,
+        trustedContactToken: {} as never,
+        emitAddon: () => undefined,
+        mexSocket: {} as never,
+        peerDataOperation: {} as never
+    } as never)
+    return { coordinator, sent }
+}
+
+test('shareGroupHistory refuses to spend an upload when the account is not allowed', async () => {
+    const { coordinator, sent } = createShareHarness({ groupHistorySendEnabled: false })
+    await assert.rejects(
+        () => coordinator.shareGroupHistory(GROUP, { toJids: [ALICE] }),
+        /group_history_send is off/
+    )
+    assert.equal(sent.length, 0)
+})
+
+test('shareGroupHistory rejects sharing with this account itself', async () => {
+    const { coordinator } = createShareHarness({
+        audience: {
+            historyReceivers: [],
+            nonHistoryReceivers: [ALICE, BOB],
+            unknownJids: [],
+            requestedSelf: true
+        }
+    })
+    await assert.rejects(
+        () => coordinator.shareGroupHistory(GROUP, { toJids: [ME] }),
+        /with this account itself/
+    )
+})
+
+test('shareGroupHistory names the addressing mode when a recipient does not match', async () => {
+    const { coordinator } = createShareHarness({
+        audience: {
+            historyReceivers: [],
+            nonHistoryReceivers: ['111@lid'],
+            unknownJids: [ALICE],
+            addressingMode: 'lid'
+        }
+    })
+    await assert.rejects(
+        () => coordinator.shareGroupHistory(GROUP, { toJids: [ALICE] }),
+        /addressing mode: lid/
+    )
+})
+
+test('shareGroupHistory rejects a non-group jid', async () => {
+    const { coordinator } = createShareHarness({})
+    await assert.rejects(
+        () => coordinator.shareGroupHistory(ALICE, { toJids: [BOB] }),
+        /requires a group jid/
+    )
+})
+
+test('shareGroupHistory rejects an empty recipient list', async () => {
+    const { coordinator } = createShareHarness({})
+    await assert.rejects(
+        () => coordinator.shareGroupHistory(GROUP, { toJids: [] }),
+        /at least one recipient/
+    )
+})
+
+test('shareGroupHistory refuses recipients who are not group members', async () => {
+    const { coordinator } = createShareHarness({
+        audience: {
+            historyReceivers: [ALICE],
+            nonHistoryReceivers: [BOB],
+            unknownJids: [CAROL]
+        }
+    })
+    await assert.rejects(
+        () => coordinator.shareGroupHistory(GROUP, { toJids: [ALICE, CAROL] }),
+        /not members of the group/
+    )
+})
+
+test('shareGroupHistory stops before uploading when there is nothing to bundle', async () => {
+    const { coordinator, sent } = createShareHarness({ storedMessages: [] })
+    await assert.rejects(
+        () => coordinator.shareGroupHistory(GROUP, { toJids: [ALICE] }),
+        /no messages to share/
+    )
+    assert.equal(sent.length, 0)
+})

--- a/src/client/coordinators/__tests__/group-history-send.test.ts
+++ b/src/client/coordinators/__tests__/group-history-send.test.ts
@@ -83,6 +83,34 @@ test('restrictGroupHistoryTargets sees through an ephemeral wrapper', () => {
     assert.deepEqual(restrictGroupHistoryTargets(wrapped, [ALICE, BOB, ME], ME), [ALICE, ME])
 })
 
+/**
+ * Just enough of the media-upload wiring to exercise the send path offline: a
+ * pre-warmed media conn skips the IQ, and the fake transfer echoes an upload
+ * response instead of doing HTTP.
+ */
+function createFakeUploadOptions(): never {
+    return {
+        logger: createNoopLogger(),
+        serverClock: { nowSeconds: () => 1_700_000_000 },
+        getMediaConnCache: () => ({
+            auth: 'fake-auth',
+            expiresAtMs: Date.now() + 600_000,
+            hosts: [{ hostname: 'mmg.example', isFallback: false }]
+        }),
+        setMediaConnCache: () => undefined,
+        queryWithContext: async () => {
+            throw new Error('media conn IQ should not be needed')
+        },
+        mediaTransfer: {
+            uploadStream: async () => ({ status: 200 }),
+            readResponseBytes: async () =>
+                new TextEncoder().encode(
+                    JSON.stringify({ url: 'https://mmg.example/x', direct_path: '/mms/x' })
+                )
+        }
+    } as never
+}
+
 interface ShareHarness {
     readonly coordinator: WaMessageCoordinator
     readonly sent: { readonly to: string; readonly content: Proto.IMessage }[]
@@ -98,6 +126,7 @@ function createShareHarness(options: {
     }
     readonly storedMessages?: readonly unknown[]
     readonly groupHistorySendEnabled?: boolean
+    readonly failNoticeSend?: boolean
 }): ShareHarness {
     const sent: { readonly to: string; readonly content: Proto.IMessage }[] = []
     const coordinator = new WaMessageCoordinator({
@@ -114,12 +143,15 @@ function createShareHarness(options: {
                 })
             }),
             sendMessage: async (to: string, content: Proto.IMessage) => {
+                if (options.failNoticeSend && content.messageHistoryNotice) {
+                    throw new Error('notice rejected')
+                }
                 sent.push({ to, content })
                 return { id: `sent-${sent.length}` }
             }
         },
         mediaTransfer: {} as never,
-        mediaUploadOptions: {} as never,
+        mediaUploadOptions: createFakeUploadOptions(),
         logger: createNoopLogger(),
         messageStore: {
             listByThread: async () => options.storedMessages ?? []
@@ -170,6 +202,17 @@ test('shareGroupHistory names the addressing mode when a recipient does not matc
         () => coordinator.shareGroupHistory(GROUP, { toJids: [ALICE] }),
         /addressing mode: lid/
     )
+})
+
+test('shareGroupHistory reports a delivered bundle even when the notice fails', async () => {
+    const { coordinator, sent } = createShareHarness({ failNoticeSend: true })
+    const result = await coordinator.shareGroupHistory(GROUP, {
+        toJids: [ALICE],
+        messages: [{ key: { id: 'M1', remoteJid: GROUP }, message: { conversation: 'x' } }]
+    })
+    assert.equal(result.bundleMessageId, 'sent-1')
+    assert.equal(result.noticeMessageId, undefined)
+    assert.equal(sent.length, 1)
 })
 
 test('shareGroupHistory rejects a non-group jid', async () => {

--- a/src/client/coordinators/__tests__/message-coordinator-upload.test.ts
+++ b/src/client/coordinators/__tests__/message-coordinator-upload.test.ts
@@ -79,7 +79,9 @@ function createUploadCoordinator(mediaUploadOptions: WaMediaMessageOptions): WaM
         trustedContactToken: {} as never,
         emitAddon: () => undefined,
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
-        peerDataOperation: {} as never
+        peerDataOperation: {} as never,
+        isGroupHistorySendEnabled: () => true,
+        getAbPropNumber: () => 100
     })
 }
 

--- a/src/client/coordinators/__tests__/message-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/message-coordinator.test.ts
@@ -95,11 +95,11 @@ test('requestHistorySync rejects invalid count and timestamp inputs', async () =
 
     await assert.rejects(
         () => coordinator.requestHistorySync({ chatJid: 'a@g.us', count: 0 }),
-        /invalid count/
+        /count must be a positive safe integer/
     )
     await assert.rejects(
         () => coordinator.requestHistorySync({ chatJid: 'a@g.us', count: 1.5 }),
-        /invalid count/
+        /count must be a positive safe integer/
     )
     await assert.rejects(
         () =>

--- a/src/client/coordinators/__tests__/message-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/message-coordinator.test.ts
@@ -42,7 +42,9 @@ function createCoordinator(peerDataOperation: PeerDataOperationRequester): WaMes
         trustedContactToken: {} as never,
         emitAddon: () => undefined,
         mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
-        peerDataOperation
+        peerDataOperation,
+        isGroupHistorySendEnabled: () => true,
+        getAbPropNumber: () => 100
     })
 }
 

--- a/src/client/persistence/__tests__/group-history.test.ts
+++ b/src/client/persistence/__tests__/group-history.test.ts
@@ -1,0 +1,225 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    processGroupHistoryBundle,
+    type WaGroupHistoryDeps
+} from '@client/persistence/group-history'
+import { createNoopLogger } from '@infra/log/types'
+import { encodeGroupHistoryBundle } from '@message/kinds/group-history'
+import type { Proto } from '@proto'
+import type { AbPropName } from '@protocol/abprops'
+
+const GROUP_JID = '120363000000000000@g.us'
+const ME_PN = '5511999999999@s.whatsapp.net'
+const ME_LID = '91379841634519@lid'
+const OTHER = '5511888888888@s.whatsapp.net'
+
+const TWO_WEEKS_SECONDS = 1_209_600
+
+function nowSeconds(): number {
+    return Math.floor(Date.now() / 1_000)
+}
+
+function buildMessage(
+    id: string,
+    text: string,
+    overrides: Partial<Proto.IWebMessageInfo> = {}
+): Proto.IWebMessageInfo {
+    return {
+        key: { id, remoteJid: GROUP_JID, fromMe: false, participant: OTHER },
+        message: { conversation: text },
+        messageTimestamp: nowSeconds(),
+        ...overrides
+    }
+}
+
+interface Harness {
+    readonly deps: WaGroupHistoryDeps
+    readonly persisted: { readonly id?: string | null }[]
+    readonly emitted: unknown[]
+    /** Number of CDN fetches the processor actually issued. */
+    readonly downloads: { count: number }
+    /** Sets what the fake CDN returns - called after the bundle is built. */
+    readonly setBlob: (next: Uint8Array) => void
+}
+
+function createHarness(overrides: Partial<WaGroupHistoryDeps> = {}): Harness {
+    const persisted: { readonly id?: string | null }[] = []
+    const emitted: unknown[] = []
+    const downloads = { count: 0 }
+    let blob: Uint8Array = new Uint8Array()
+    const deps = {
+        logger: createNoopLogger(),
+        mediaTransfer: {
+            downloadAndDecrypt: async (request: { readonly mediaType: string }) => {
+                downloads.count += 1
+                assert.equal(request.mediaType, 'group-history')
+                return blob
+            }
+        },
+        writeBehind: {
+            persistMessageAsync: async (record: { readonly id?: string | null }) => {
+                persisted.push(record)
+            }
+        },
+        emitEvent: (_event: string, payload: unknown) => {
+            emitted.push(payload)
+        },
+        meJid: ME_PN,
+        meLid: ME_LID,
+        getAbPropNumber: (_name: AbPropName) => TWO_WEEKS_SECONDS,
+        ...overrides
+    } as unknown as WaGroupHistoryDeps
+    return {
+        deps,
+        persisted,
+        emitted,
+        downloads,
+        setBlob: (next: Uint8Array) => {
+            blob = next
+        }
+    }
+}
+
+function buildBundle(receivers: readonly string[]): Proto.Message.IMessageHistoryBundle {
+    return {
+        directPath: '/v/t62.7119-24/fake',
+        mediaKey: new Uint8Array(32),
+        fileSha256: new Uint8Array(32),
+        fileEncSha256: new Uint8Array(32),
+        mimetype: 'application/protobuf',
+        messageHistoryMetadata: { historyReceivers: [...receivers] }
+    }
+}
+
+test('group history bundle persists messages and emits the event', async () => {
+    const harness = createHarness()
+    const { compressed } = await encodeGroupHistoryBundle(
+        [buildMessage('A', 'primeira'), buildMessage('B', 'segunda')],
+        [buildMessage('P', 'pin antigo', { messageTimestamp: 1 })]
+    )
+    harness.setBlob(compressed)
+
+    await processGroupHistoryBundle(harness.deps, {
+        bundle: buildBundle([ME_LID]),
+        groupJid: GROUP_JID,
+        senderJid: OTHER,
+        bundleMessageId: 'bundle-1',
+        sentAtSeconds: nowSeconds()
+    })
+
+    assert.equal(harness.downloads.count, 1)
+    assert.deepEqual(
+        harness.persisted.map((record) => record.id),
+        ['A', 'B', 'P']
+    )
+    assert.equal(harness.emitted.length, 1)
+    const event = harness.emitted[0] as {
+        messagesCount: number
+        outOfWindowPinsCount: number
+        droppedCount: number
+        groupJid: string
+        senderJid?: string
+    }
+    assert.equal(event.messagesCount, 3)
+    assert.equal(event.outOfWindowPinsCount, 1)
+    assert.equal(event.droppedCount, 0)
+    assert.equal(event.groupJid, GROUP_JID)
+    assert.equal(event.senderJid, OTHER)
+})
+
+test('group history bundle addressed to another member is never downloaded', async () => {
+    const harness = createHarness()
+    const { compressed } = await encodeGroupHistoryBundle([buildMessage('A', 'x')])
+    harness.setBlob(compressed)
+
+    await processGroupHistoryBundle(harness.deps, {
+        bundle: buildBundle([OTHER]),
+        groupJid: GROUP_JID,
+        sentAtSeconds: nowSeconds()
+    })
+
+    assert.equal(harness.downloads.count, 0)
+    assert.equal(harness.persisted.length, 0)
+    assert.equal(harness.emitted.length, 0)
+})
+
+test('group history bundle matches the local identity by PN as well as LID', async () => {
+    const harness = createHarness()
+    const { compressed } = await encodeGroupHistoryBundle([buildMessage('A', 'x')])
+    harness.setBlob(compressed)
+
+    await processGroupHistoryBundle(harness.deps, {
+        bundle: buildBundle(['5511999999999:3@s.whatsapp.net']),
+        groupJid: GROUP_JID,
+        sentAtSeconds: nowSeconds()
+    })
+
+    assert.equal(harness.persisted.length, 1)
+})
+
+test('group history bundle past its receiver window is dropped before download', async () => {
+    const harness = createHarness()
+    const { compressed } = await encodeGroupHistoryBundle([buildMessage('A', 'x')])
+    harness.setBlob(compressed)
+
+    await processGroupHistoryBundle(harness.deps, {
+        bundle: buildBundle([ME_LID]),
+        groupJid: GROUP_JID,
+        sentAtSeconds: nowSeconds() - TWO_WEEKS_SECONDS - 60
+    })
+
+    assert.equal(harness.downloads.count, 0)
+    assert.equal(harness.emitted.length, 0)
+})
+
+test('group history bundle outside a group is ignored', async () => {
+    const harness = createHarness()
+    const { compressed } = await encodeGroupHistoryBundle([buildMessage('A', 'x')])
+    harness.setBlob(compressed)
+
+    await processGroupHistoryBundle(harness.deps, {
+        bundle: buildBundle([ME_LID]),
+        groupJid: OTHER,
+        sentAtSeconds: nowSeconds()
+    })
+
+    assert.equal(harness.downloads.count, 0)
+    assert.equal(harness.emitted.length, 0)
+})
+
+test('group history bundle filters stubs, foreign chats, expired and too-old entries', async () => {
+    const harness = createHarness()
+    const stale = nowSeconds() - 3 * TWO_WEEKS_SECONDS
+    const { compressed } = await encodeGroupHistoryBundle([
+        buildMessage('KEEP', 'ok'),
+        {
+            key: { id: 'STUB', remoteJid: GROUP_JID, fromMe: false },
+            messageTimestamp: nowSeconds()
+        },
+        buildMessage('FOREIGN', 'x', {
+            key: { id: 'FOREIGN', remoteJid: '120363999999999999@g.us', fromMe: false }
+        }),
+        buildMessage('GONE', 'x', {
+            messageTimestamp: nowSeconds() - 120,
+            ephemeralDuration: 60
+        }),
+        buildMessage('ANCIENT', 'x', { messageTimestamp: stale })
+    ])
+    harness.setBlob(compressed)
+
+    await processGroupHistoryBundle(harness.deps, {
+        bundle: buildBundle([ME_LID]),
+        groupJid: GROUP_JID,
+        sentAtSeconds: nowSeconds()
+    })
+
+    assert.deepEqual(
+        harness.persisted.map((record) => record.id),
+        ['KEEP']
+    )
+    const event = harness.emitted[0] as { messagesCount: number; droppedCount: number }
+    assert.equal(event.messagesCount, 1)
+    assert.equal(event.droppedCount, 4)
+})

--- a/src/client/persistence/group-history.ts
+++ b/src/client/persistence/group-history.ts
@@ -1,0 +1,218 @@
+import { downloadHistoryBlob, flushPendingWrites } from '@client/persistence/history-blob'
+import type { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
+import type { WaClientEventMap, WaGroupHistoryBundleEvent } from '@client/types'
+import type { Logger } from '@infra/log/types'
+import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
+import { decodeGroupHistoryBundle } from '@message/kinds/group-history'
+import { proto, type Proto } from '@proto'
+import type { AbPropName } from '@protocol/abprops'
+import { isGroupJid, toUserJid } from '@protocol/jid'
+import { longToNumber, toError } from '@util/primitives'
+
+const GROUP_HISTORY_MAX_PENDING_WRITES = 1_024
+
+export interface WaGroupHistoryBundleInput {
+    /** The `messageHistoryBundle` payload carried by the incoming message. */
+    readonly bundle: Proto.Message.IMessageHistoryBundle
+    /** Group the bundle was shared in - the `remoteJid` of the carrier message. */
+    readonly groupJid: string
+    /** Member who shared the history (carrier message `participant`). */
+    readonly senderJid?: string
+    /** Stanza id of the carrier message. */
+    readonly bundleMessageId?: string
+    /** Carrier message `t` attr, in seconds - drives the bundle expiry check. */
+    readonly sentAtSeconds?: number
+}
+
+export interface WaGroupHistoryDeps {
+    readonly logger: Logger
+    readonly mediaTransfer: WaMediaTransferClient
+    readonly writeBehind: WriteBehindPersistence
+    readonly emitEvent: <K extends keyof WaClientEventMap>(
+        event: K,
+        ...args: Parameters<WaClientEventMap[K]>
+    ) => void
+    readonly meJid?: string | null
+    readonly meLid?: string | null
+    readonly getAbPropNumber: (name: AbPropName) => number
+}
+
+export async function runGroupHistoryBundle(
+    deps: WaGroupHistoryDeps,
+    input: WaGroupHistoryBundleInput
+): Promise<void> {
+    try {
+        await processGroupHistoryBundle(deps, input)
+    } catch (error) {
+        deps.logger.warn('failed to process group history bundle', {
+            groupJid: input.groupJid,
+            id: input.bundleMessageId,
+            message: toError(error).message
+        })
+    }
+}
+
+export async function processGroupHistoryBundle(
+    deps: WaGroupHistoryDeps,
+    input: WaGroupHistoryBundleInput
+): Promise<void> {
+    const logger = deps.logger.child({
+        groupJid: input.groupJid,
+        id: input.bundleMessageId
+    })
+
+    if (!isGroupJid(input.groupJid)) {
+        logger.debug('skipping group history bundle outside a group')
+        return
+    }
+    if (!isHistoryReceiver(deps, input.bundle)) {
+        logger.debug('skipping group history bundle not addressed to this account')
+        return
+    }
+
+    const nowMs = Date.now()
+    const bundleTtlSeconds = deps.getAbPropNumber(
+        'group_history_bundle_time_limit_receiver_enforcement_secs'
+    )
+    if (
+        input.sentAtSeconds !== undefined &&
+        nowMs > (input.sentAtSeconds + bundleTtlSeconds) * 1_000
+    ) {
+        logger.debug('skipping expired group history bundle', {
+            sentAtSeconds: input.sentAtSeconds,
+            bundleTtlSeconds
+        })
+        return
+    }
+
+    const blob = await downloadHistoryBlob(
+        deps.mediaTransfer,
+        input.bundle,
+        'group-history',
+        'group history bundle'
+    )
+    const history = await decodeGroupHistoryBundle(blob)
+
+    const messageTtlSeconds = deps.getAbPropNumber(
+        'group_history_messages_time_limit_receiver_enforcement_secs'
+    )
+    const pendingWrites: Promise<void>[] = []
+    const dropped = { foreignChat: 0, ephemeralExpired: 0, tooOld: 0, stub: 0 }
+
+    let messagesCount = 0
+    let oldestTimestampMs: number | undefined
+    for (const source of [
+        { messages: history.messages, skipAgeCheck: false },
+        { messages: history.outOfWindowPinnedMessages, skipAgeCheck: true }
+    ]) {
+        for (const webMsg of source.messages) {
+            if (!webMsg.key?.id || !webMsg.message) {
+                dropped.stub += 1
+                continue
+            }
+            if (webMsg.key.remoteJid && webMsg.key.remoteJid !== input.groupJid) {
+                dropped.foreignChat += 1
+                continue
+            }
+            const timestampSeconds = longToNumber(webMsg.messageTimestamp)
+            if (isEphemeralExpired(webMsg, timestampSeconds, nowMs)) {
+                dropped.ephemeralExpired += 1
+                continue
+            }
+            if (
+                !source.skipAgeCheck &&
+                timestampSeconds > 0 &&
+                (timestampSeconds + 2 * messageTtlSeconds) * 1_000 < nowMs
+            ) {
+                dropped.tooOld += 1
+                continue
+            }
+
+            const timestampMs = timestampSeconds * 1_000
+            if (
+                timestampMs > 0 &&
+                (oldestTimestampMs === undefined || timestampMs < oldestTimestampMs)
+            ) {
+                oldestTimestampMs = timestampMs
+            }
+            pendingWrites[pendingWrites.length] = deps.writeBehind.persistMessageAsync({
+                id: webMsg.key.id,
+                threadJid: input.groupJid,
+                senderJid: webMsg.key.participant ?? undefined,
+                fromMe: webMsg.key.fromMe === true,
+                timestampMs: timestampMs || undefined,
+                messageBytes: proto.Message.encode(webMsg.message).finish()
+            })
+            if (pendingWrites.length >= GROUP_HISTORY_MAX_PENDING_WRITES) {
+                await flushPendingWrites(pendingWrites)
+            }
+            messagesCount += 1
+        }
+    }
+
+    await flushPendingWrites(pendingWrites)
+
+    const droppedCount =
+        dropped.foreignChat + dropped.ephemeralExpired + dropped.tooOld + dropped.stub
+    logger.debug('processed group history bundle', {
+        messagesCount,
+        outOfWindowPinsCount: history.outOfWindowPinnedMessages.length,
+        droppedCount,
+        dropped
+    })
+
+    const event: WaGroupHistoryBundleEvent = {
+        groupJid: input.groupJid,
+        senderJid: input.senderJid,
+        bundleMessageId: input.bundleMessageId,
+        messagesCount,
+        outOfWindowPinsCount: history.outOfWindowPinnedMessages.length,
+        droppedCount,
+        oldestTimestampMs,
+        historyReceivers: [...(input.bundle.messageHistoryMetadata?.historyReceivers ?? [])]
+    }
+    deps.emitEvent('group_history_bundle', event)
+}
+
+/**
+ * A bundle is only ours to process when this account is listed in
+ * `historyReceivers`. The list may address us by either PN or LID, so both
+ * forms of the local identity are compared.
+ */
+function isHistoryReceiver(
+    deps: WaGroupHistoryDeps,
+    bundle: Proto.Message.IMessageHistoryBundle
+): boolean {
+    const receivers = bundle.messageHistoryMetadata?.historyReceivers
+    if (!receivers || receivers.length === 0) {
+        return false
+    }
+    const meUserJid = deps.meJid ? toUserJid(deps.meJid) : null
+    const meUserLid = deps.meLid ? toUserJid(deps.meLid) : null
+    if (!meUserJid && !meUserLid) {
+        return false
+    }
+    for (let index = 0; index < receivers.length; index += 1) {
+        const receiver = toUserJid(receivers[index])
+        if (receiver === meUserJid || receiver === meUserLid) {
+            return true
+        }
+    }
+    return false
+}
+
+function isEphemeralExpired(
+    webMsg: Proto.IWebMessageInfo,
+    timestampSeconds: number,
+    nowMs: number
+): boolean {
+    const duration = webMsg.ephemeralDuration
+    if (!duration) {
+        return false
+    }
+    const startSeconds = longToNumber(webMsg.ephemeralStartTimestamp) || timestampSeconds
+    if (startSeconds <= 0) {
+        return false
+    }
+    return (startSeconds + duration) * 1_000 <= nowMs
+}

--- a/src/client/persistence/history-blob.ts
+++ b/src/client/persistence/history-blob.ts
@@ -1,0 +1,55 @@
+import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
+import type { MediaCryptoType } from '@media/types'
+import { decodeProtoBytes } from '@util/bytes'
+
+/**
+ * Encrypted-blob fields shared by the history-sync notification and the
+ * group-history bundle: both point at a CDN object plus the key and hashes
+ * needed to decrypt and verify it.
+ */
+export interface WaHistoryBlobSource {
+    readonly directPath?: string | null
+    readonly mediaKey?: Uint8Array | string | null
+    readonly fileSha256?: Uint8Array | string | null
+    readonly fileEncSha256?: Uint8Array | string | null
+}
+
+/**
+ * Fetches and decrypts a history blob. `label` prefixes the field errors so a
+ * failure names which payload was malformed.
+ *
+ * @throws when `directPath` is absent or a key/hash field is missing.
+ */
+export async function downloadHistoryBlob(
+    mediaTransfer: WaMediaTransferClient,
+    source: WaHistoryBlobSource,
+    mediaType: MediaCryptoType,
+    label: string
+): Promise<Uint8Array> {
+    if (!source.directPath) {
+        throw new Error(`${label} missing directPath`)
+    }
+    const mediaKey = decodeProtoBytes(source.mediaKey, `${label} mediaKey`)
+    const fileSha256 = decodeProtoBytes(source.fileSha256, `${label} fileSha256`)
+    const fileEncSha256 = decodeProtoBytes(source.fileEncSha256, `${label} fileEncSha256`)
+    return mediaTransfer.downloadAndDecrypt({
+        directPath: source.directPath,
+        mediaType,
+        mediaKey,
+        fileSha256,
+        fileEncSha256
+    })
+}
+
+/**
+ * Awaits an accumulating write batch and empties it in place, so the caller can
+ * keep filling the same array instead of allocating a new one per chunk.
+ */
+export async function flushPendingWrites(pendingWrites: Promise<void>[]): Promise<void> {
+    if (pendingWrites.length === 0) {
+        return
+    }
+    const settled = Promise.all(pendingWrites)
+    pendingWrites.length = 0
+    await settled
+}

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -1,6 +1,7 @@
 import { promisify } from 'node:util'
 import { unzip } from 'node:zlib'
 
+import { downloadHistoryBlob, flushPendingWrites } from '@client/persistence/history-blob'
 import type { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
 import type { WaClientEventMap, WaHistorySyncChunkEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
@@ -291,15 +292,6 @@ export async function processHistorySyncNotification(
     }
 }
 
-async function flushPendingWrites(pendingWrites: Promise<void>[]): Promise<void> {
-    if (pendingWrites.length === 0) {
-        return
-    }
-    const settled = Promise.all(pendingWrites)
-    pendingWrites.length = 0
-    await settled
-}
-
 async function downloadHistorySyncBlob(
     deps: WaHistorySyncDeps,
     notification: Proto.Message.IHistorySyncNotification
@@ -310,17 +302,5 @@ async function downloadHistorySyncBlob(
             'initialHistBootstrapInlinePayload'
         )
     }
-    if (!notification.directPath) {
-        throw new Error('history sync notification missing directPath')
-    }
-    const mediaKey = decodeProtoBytes(notification.mediaKey, 'history sync mediaKey')
-    const fileSha256 = decodeProtoBytes(notification.fileSha256, 'history sync fileSha256')
-    const fileEncSha256 = decodeProtoBytes(notification.fileEncSha256, 'history sync fileEncSha256')
-    return deps.mediaTransfer.downloadAndDecrypt({
-        directPath: notification.directPath,
-        mediaType: 'history',
-        mediaKey,
-        fileSha256,
-        fileEncSha256
-    })
+    return downloadHistoryBlob(deps.mediaTransfer, notification, 'history', 'history sync')
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -163,7 +163,9 @@ export interface WaClientOptions extends WaAuthClientOptions, WaAuthSocketOption
      * on-demand backfill triggered by `message.requestHistorySync`) are
      * downloaded and emitted as `history_sync_chunk` events. Set
      * `enabled: false` to drop them; `requireFullSync: true` asks the
-     * primary device for a full history download instead of just recent.
+     * primary device for a full history download instead of just recent;
+     * `groupBundles: true` opts into the group-history bundle a member may
+     * share after somebody joins a group.
      */
     readonly history?: WaHistorySyncOptions
     /**
@@ -337,6 +339,14 @@ export interface WaHistorySyncOptions {
      */
     readonly enabled?: boolean
     readonly requireFullSync?: boolean
+    /**
+     * Whether to download and process the group-history bundle a member may
+     * share after somebody joins a group, emitting `group_history_bundle`.
+     * **Off by default** - a bundle is media a third party pushes at this
+     * account unprompted, so fetching it is opt-in. Bundles addressed to
+     * other members are dropped either way.
+     */
+    readonly groupBundles?: boolean
 }
 
 export interface WaSignalMessagePublishInput {
@@ -1248,6 +1258,33 @@ export interface WaHistorySyncChunkEvent {
     readonly progress?: number
 }
 
+/**
+ * A group-history bundle shared with this account after it joined a group,
+ * already downloaded, filtered and persisted. Emitted once per bundle, only
+ * when `history.groupBundles` is enabled.
+ */
+export interface WaGroupHistoryBundleEvent {
+    readonly groupJid: string
+    /** Member who shared the history. */
+    readonly senderJid?: string
+    /** Stanza id of the message that carried the bundle. */
+    readonly bundleMessageId?: string
+    /** Messages persisted from this bundle, after filtering. */
+    readonly messagesCount: number
+    /** Pinned messages older than the shared window, exempt from the age cutoff. */
+    readonly outOfWindowPinsCount: number
+    /** Entries skipped as stubs, foreign-chat, ephemeral-expired or too old. */
+    readonly droppedCount: number
+    /** Oldest persisted message timestamp, in ms. */
+    readonly oldestTimestampMs?: number
+    /**
+     * Members the sender addressed the bundle to (PN or LID form). Copied out
+     * of the decoded payload, so mutating it cannot corrupt the message proto
+     * the `message` event handed to the same listener.
+     */
+    readonly historyReceivers: readonly string[]
+}
+
 export type WaAppStateMutationSource = 'snapshot' | 'patch' | 'local'
 
 type MutationEventBase = {
@@ -1461,6 +1498,13 @@ export interface WaClientEventMap {
      * Skipped only when `history.enabled` is explicitly `false`.
      */
     readonly history_sync_chunk: (event: WaHistorySyncChunkEvent) => void
+    /**
+     * A group-history bundle another member shared with this account after it
+     * joined a group, already downloaded and persisted. Requires
+     * `history.groupBundles: true` - the download is opt-in because a third
+     * party triggers it.
+     */
+    readonly group_history_bundle: (event: WaGroupHistoryBundleEvent) => void
     /**
      * Offline-message queue progress after a reconnect (`'resuming'` ticks
      * with `remainingStanzas`, then `'complete'`). Useful to defer UI updates

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export type {
     WaClientOptions,
     WaClientProxyOptions,
     WaDownloadMediaOptions,
+    WaGroupHistoryBundleEvent,
     WaHistorySyncChunkEvent,
     WaHistorySyncOptions,
     WaWriteBehindOptions
@@ -14,6 +15,8 @@ export type { WaClientPluginContext, WaClientPluginDefinition } from '@client/pl
 export type {
     WaMediaUploadResult,
     WaMessageCoordinator,
+    WaShareGroupHistoryInput,
+    WaShareGroupHistoryResult,
     WaUploadMediaOptions,
     WaUploadMediaType
 } from '@client/coordinators/WaMessageCoordinator'
@@ -259,8 +262,10 @@ export {
     unwrapMessage
 } from '@message/encode/content'
 export { getContextInfo } from '@message/context-info'
+export { decodeGroupHistoryBundle, encodeGroupHistoryBundle } from '@message/kinds/group-history'
 export { resolveMediaPayload } from '@message/encode/media-payload'
 export { unpadPkcs7, writeRandomPadMax16 } from '@message/encode/padding'
+export type { WaGroupHistoryBundleEncoding } from '@message/kinds/group-history'
 export type { WaResolvedMediaPayload } from '@message/encode/media-payload'
 export type { WaSendContextInfo } from '@message/context-info'
 export type {

--- a/src/media/types.ts
+++ b/src/media/types.ts
@@ -9,6 +9,7 @@ export type MediaCryptoType =
     | 'ptt'
     | 'gif'
     | 'history'
+    | 'group-history'
     | 'md-app-state'
     | 'md-msg-hist'
     | 'xma-image'

--- a/src/message/encode/__tests__/content.test.ts
+++ b/src/message/encode/__tests__/content.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+    getContentType,
     isSendMediaMessage,
     resolveButtonAddonKind,
     resolveEditAttr,
@@ -23,6 +24,20 @@ test('content helpers detect media payload and resolve message type', () => {
     assert.equal(resolveMessageTypeAttr({ imageMessage: {} }), 'media')
     assert.equal(resolveMessageTypeAttr({ conversation: 'text' }), 'text')
     assert.equal(resolveMessageTypeAttr({ pollCreationMessage: {} }), 'poll')
+})
+
+test('getContentType picks the payload key, including the unsuffixed ones', () => {
+    assert.equal(getContentType(undefined), undefined)
+    assert.equal(getContentType({}), undefined)
+    assert.equal(getContentType({ conversation: 'hi' }), 'conversation')
+    assert.equal(getContentType({ imageMessage: {} }), 'imageMessage')
+    assert.equal(
+        getContentType({ senderKeyDistributionMessage: {}, imageMessage: {} }),
+        'imageMessage'
+    )
+    // group-history payload keys do not end in `Message`
+    assert.equal(getContentType({ messageHistoryBundle: {} }), 'messageHistoryBundle')
+    assert.equal(getContentType({ messageHistoryNotice: {} }), 'messageHistoryNotice')
 })
 
 test('resolveButtonAddonKind classifies list/interactive incl. documentWithCaption wrap', () => {

--- a/src/message/encode/__tests__/content.test.ts
+++ b/src/message/encode/__tests__/content.test.ts
@@ -40,6 +40,15 @@ test('getContentType picks the payload key, including the unsuffixed ones', () =
     assert.equal(getContentType({ messageHistoryNotice: {} }), 'messageHistoryNotice')
 })
 
+test('getContentType skips keys that are present but hold no payload', () => {
+    assert.equal(
+        getContentType({ messageHistoryBundle: undefined, imageMessage: {} }),
+        'imageMessage'
+    )
+    assert.equal(getContentType({ imageMessage: null, conversation: 'hi' }), 'conversation')
+    assert.equal(getContentType({ imageMessage: undefined }), undefined)
+})
+
 test('resolveButtonAddonKind classifies list/interactive incl. documentWithCaption wrap', () => {
     assert.equal(resolveButtonAddonKind({ listMessage: {} }), 'list')
     assert.equal(resolveButtonAddonKind({ buttonsMessage: {} }), 'interactive')

--- a/src/message/encode/__tests__/media-payload.test.ts
+++ b/src/message/encode/__tests__/media-payload.test.ts
@@ -80,6 +80,22 @@ test('resolveMediaPayload distinguishes video/gif and audio/ptt and ptv', () => 
     assert.equal(sticker?.mediaType, 'sticker')
 })
 
+test('resolveMediaPayload maps the group-history bundle', () => {
+    const bundle = resolveMediaPayload({
+        messageHistoryBundle: {
+            directPath: '/gh',
+            mediaKey: key,
+            fileSha256: sha,
+            fileEncSha256: encSha,
+            mimetype: 'application/protobuf'
+        }
+    })
+    assert.equal(bundle?.mediaType, 'group-history')
+    assert.equal(bundle?.directPath, '/gh')
+    assert.equal(bundle?.mimetype, 'application/protobuf')
+    assert.equal(bundle?.fileLength, undefined)
+})
+
 test('resolveMediaPayload unwraps ephemeral/viewOnce/documentWithCaption wrappers', () => {
     const wrapped = resolveMediaPayload({
         ephemeralMessage: {

--- a/src/message/encode/content.ts
+++ b/src/message/encode/content.ts
@@ -22,10 +22,21 @@ import {
 } from '@protocol/constants'
 
 /**
+ * Content keys that carry a payload but do not end in `Message`, so the
+ * substring match below would miss them.
+ */
+const UNSUFFIXED_CONTENT_KEYS = new Set([
+    'conversation',
+    'messageHistoryBundle',
+    'messageHistoryNotice'
+])
+
+/**
  * Returns the content-type key of a message - `'conversation'`,
- * `'imageMessage'`, `'extendedTextMessage'`, etc. - or `undefined` for an empty
- * message. `senderKeyDistributionMessage` is skipped so group messages report
- * their real payload type rather than the piggy-backed sender-key.
+ * `'imageMessage'`, `'extendedTextMessage'`, `'messageHistoryBundle'`, etc. -
+ * or `undefined` for an empty message. `senderKeyDistributionMessage` is
+ * skipped so group messages report their real payload type rather than the
+ * piggy-backed sender-key.
  */
 export function getContentType(
     content: Proto.IMessage | undefined
@@ -33,7 +44,8 @@ export function getContentType(
     if (!content) return undefined
     const key = Object.keys(content).find(
         (k) =>
-            (k === 'conversation' || k.includes('Message')) && k !== 'senderKeyDistributionMessage'
+            (UNSUFFIXED_CONTENT_KEYS.has(k) || k.includes('Message')) &&
+            k !== 'senderKeyDistributionMessage'
     )
     return key as keyof Proto.IMessage | undefined
 }

--- a/src/message/encode/content.ts
+++ b/src/message/encode/content.ts
@@ -37,6 +37,9 @@ const UNSUFFIXED_CONTENT_KEYS = new Set([
  * or `undefined` for an empty message. `senderKeyDistributionMessage` is
  * skipped so group messages report their real payload type rather than the
  * piggy-backed sender-key.
+ *
+ * A key that is present but holds `null`/`undefined` carries no payload and is
+ * skipped, so an explicitly-cleared field cannot mask the real content.
  */
 export function getContentType(
     content: Proto.IMessage | undefined
@@ -44,6 +47,8 @@ export function getContentType(
     if (!content) return undefined
     const key = Object.keys(content).find(
         (k) =>
+            content[k as keyof Proto.IMessage] !== null &&
+            content[k as keyof Proto.IMessage] !== undefined &&
             (UNSUFFIXED_CONTENT_KEYS.has(k) || k.includes('Message')) &&
             k !== 'senderKeyDistributionMessage'
     )

--- a/src/message/encode/media-payload.ts
+++ b/src/message/encode/media-payload.ts
@@ -10,7 +10,10 @@ import { longToNumber } from '@util/primitives'
  * strings.
  */
 export interface WaResolvedMediaPayload {
-    /** Crypto/HKDF domain for the kind: image, video, gif, audio, ptt, document, sticker, ptv. */
+    /**
+     * Crypto/HKDF domain for the kind: image, video, gif, audio, ptt, document,
+     * sticker, ptv, group-history.
+     */
     readonly mediaType: MediaCryptoType
     /** Server-relative path (or absolute URL) of the encrypted blob on the media CDN. */
     readonly directPath: string
@@ -68,7 +71,7 @@ function buildPayload(
  * lacks the `directPath` / `mediaKey` needed to fetch and decrypt the blob (a
  * non-`Uint8Array` `mediaKey` also yields `null`). Supported kinds: image,
  * video (gif when `gifPlayback`), audio (ptt when `ptt`), document, sticker,
- * ptv.
+ * ptv, and the group-history bundle shared with a member after they join.
  *
  * @example
  * ```ts
@@ -94,5 +97,6 @@ export function resolveMediaPayload(
     if (msg.documentMessage) return buildPayload('document', msg.documentMessage)
     if (msg.stickerMessage) return buildPayload('sticker', msg.stickerMessage)
     if (msg.ptvMessage) return buildPayload('ptv', msg.ptvMessage)
+    if (msg.messageHistoryBundle) return buildPayload('group-history', msg.messageHistoryBundle)
     return null
 }

--- a/src/message/kinds/__tests__/group-history.test.ts
+++ b/src/message/kinds/__tests__/group-history.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { decodeGroupHistoryBundle, encodeGroupHistoryBundle } from '@message/kinds/group-history'
+import type { Proto } from '@proto'
+
+const groupJid = '120363000000000000@g.us'
+
+function buildMessage(id: string, text: string, timestamp: number): Proto.IWebMessageInfo {
+    return {
+        key: {
+            id,
+            remoteJid: groupJid,
+            fromMe: false,
+            participant: '5511999999999@s.whatsapp.net'
+        },
+        message: { conversation: text },
+        messageTimestamp: timestamp
+    }
+}
+
+test('group history bundle round-trips through zlib', async () => {
+    const messages = [buildMessage('A', 'first', 100), buildMessage('B', 'second', 200)]
+    const { compressed, encoded } = await encodeGroupHistoryBundle(messages)
+
+    assert.equal(compressed[0], 0x78)
+    assert.notDeepEqual(compressed, encoded)
+
+    const decoded = await decodeGroupHistoryBundle(compressed)
+    assert.equal(decoded.messages.length, 2)
+    assert.equal(decoded.messages[0].key?.id, 'A')
+    assert.equal(decoded.messages[0].message?.conversation, 'first')
+    assert.equal(decoded.messages[1].key?.id, 'B')
+    assert.equal(decoded.outOfWindowPinnedMessages.length, 0)
+})
+
+test('group history bundle carries out-of-window pins separately', async () => {
+    const { compressed } = await encodeGroupHistoryBundle(
+        [buildMessage('A', 'recent', 300)],
+        [buildMessage('P', 'old pin', 1)]
+    )
+    const decoded = await decodeGroupHistoryBundle(compressed)
+    assert.equal(decoded.messages.length, 1)
+    assert.equal(decoded.outOfWindowPinnedMessages.length, 1)
+    assert.equal(decoded.outOfWindowPinnedMessages[0].key?.id, 'P')
+})
+
+test('encodeGroupHistoryBundle omits out-of-window pins when the list is empty', async () => {
+    const withoutPins = await encodeGroupHistoryBundle([buildMessage('A', 'x', 1)])
+    const withEmptyPins = await encodeGroupHistoryBundle([buildMessage('A', 'x', 1)], [])
+    assert.deepEqual(withEmptyPins.encoded, withoutPins.encoded)
+})
+
+test('decodeGroupHistoryBundle rejects a blob that is not zlib', async () => {
+    await assert.rejects(() => decodeGroupHistoryBundle(new Uint8Array([1, 2, 3, 4])))
+})

--- a/src/message/kinds/group-history.ts
+++ b/src/message/kinds/group-history.ts
@@ -1,0 +1,55 @@
+import { promisify } from 'node:util'
+import { deflate, unzip } from 'node:zlib'
+
+import { proto, type Proto } from '@proto'
+import { toBytesView } from '@util/bytes'
+
+const deflateAsync = promisify(deflate)
+const unzipAsync = promisify(unzip)
+
+/**
+ * Wire form of a group-history bundle: the zlib-compressed blob that is
+ * encrypted and uploaded to the media CDN, plus the uncompressed protobuf
+ * bytes the sender-side reporting token is computed over.
+ */
+export interface WaGroupHistoryBundleEncoding {
+    /** zlib-compressed `GroupHistory` payload - the blob that gets uploaded. */
+    readonly compressed: Uint8Array
+    /** Uncompressed `GroupHistory` protobuf bytes. */
+    readonly encoded: Uint8Array
+}
+
+/**
+ * Serializes the messages shared with a member who just joined a group into a
+ * `GroupHistory` payload, compressed the way the receiver expects.
+ *
+ * `outOfWindowPinnedMessages` carries pinned messages older than the shared
+ * window, which the receiver injects regardless of the age cutoff.
+ *
+ * Both arrays are handed to the encoder as-is. The generated type asks for
+ * mutable arrays, but encoding only reads them, so the assertion avoids
+ * copying every message of the bundle for nothing.
+ */
+export async function encodeGroupHistoryBundle(
+    messages: readonly Proto.IWebMessageInfo[],
+    outOfWindowPinnedMessages?: readonly Proto.IWebMessageInfo[]
+): Promise<WaGroupHistoryBundleEncoding> {
+    const encoded = proto.GroupHistory.encode({
+        messages: messages as Proto.IWebMessageInfo[],
+        outOfWindowPinnedMessages: outOfWindowPinnedMessages?.length
+            ? (outOfWindowPinnedMessages as Proto.IWebMessageInfo[])
+            : undefined
+    }).finish()
+    const compressed = toBytesView(await deflateAsync(encoded))
+    return { compressed, encoded }
+}
+
+/**
+ * Inflates and decodes a downloaded group-history bundle blob.
+ *
+ * @throws when the blob is not valid zlib or does not decode as `GroupHistory`.
+ */
+export async function decodeGroupHistoryBundle(blob: Uint8Array): Promise<Proto.GroupHistory> {
+    const inflated = toBytesView(await unzipAsync(blob))
+    return proto.GroupHistory.decode(inflated)
+}

--- a/src/protocol/__tests__/protocol.test.ts
+++ b/src/protocol/__tests__/protocol.test.ts
@@ -45,6 +45,7 @@ import type {
     WaPrivacyDisallowedListSettingName,
     WaPrivacySettingValueMap
 } from '@protocol/privacy'
+import { TEXT_DECODER } from '@util/bytes'
 
 test('canonicalizeOwnAccountJid maps own PN device JIDs to LID', () => {
     const meJid = '5512988950329:15@s.whatsapp.net'
@@ -188,6 +189,8 @@ test('login identity parsing and protocol constants', () => {
     )
 
     assert.equal(getWaMediaHkdfInfo('image'), WA_MEDIA_HKDF_INFO.image)
+    assert.equal(TEXT_DECODER.decode(getWaMediaHkdfInfo('group-history')), 'Group History')
+    assert.equal(TEXT_DECODER.decode(getWaMediaHkdfInfo('history')), 'WhatsApp History Keys')
     assert.equal(typeof WA_DEFAULTS.HOST_DOMAIN, 'string')
     assert.equal(WA_APPSTATE_SCHEMAS.Star.name, 'star')
     assert.equal(WA_APPSTATE_SCHEMAS.Mute.name, 'mute')

--- a/src/protocol/media.ts
+++ b/src/protocol/media.ts
@@ -17,6 +17,7 @@ export const WA_MEDIA_HKDF_INFO = Object.freeze({
     'md-app-state': TEXT_ENCODER.encode('WhatsApp App State Keys'),
     'md-msg-hist': HISTORY_KEYS,
     history: HISTORY_KEYS,
+    'group-history': TEXT_ENCODER.encode('Group History'),
     'sticker-pack': TEXT_ENCODER.encode('WhatsApp Sticker Pack Keys'),
     'thumbnail-sticker-pack': TEXT_ENCODER.encode('WhatsApp Sticker Pack Thumbnail Keys'),
     'thumbnail-link': TEXT_ENCODER.encode('WhatsApp Link Thumbnail Keys')

--- a/src/util/__tests__/util.test.ts
+++ b/src/util/__tests__/util.test.ts
@@ -31,6 +31,7 @@ import {
     asOptionalNumber,
     asOptionalString,
     asString,
+    resolveOptionalPositive,
     resolvePositive,
     toBoolOrUndef,
     tryAsNumber,
@@ -125,6 +126,10 @@ test('coercion helpers validate primitive and bytes types', () => {
     assert.equal(resolvePositive(2, 1, 'x'), 2)
     assert.equal(resolvePositive(undefined, 3, 'x'), 3)
     assert.throws(() => resolvePositive(0, 3, 'x'), /positive safe integer/)
+    assert.equal(resolveOptionalPositive(2, 'x'), 2)
+    assert.equal(resolveOptionalPositive(undefined, 'x'), undefined)
+    assert.throws(() => resolveOptionalPositive(0, 'x'), /positive safe integer/)
+    assert.throws(() => resolveOptionalPositive(1.5, 'x'), /positive safe integer/)
 })
 
 test('lenient coercion (tryAs*) handles missing, empty and wrong-typed inputs', () => {

--- a/src/util/coercion.ts
+++ b/src/util/coercion.ts
@@ -58,13 +58,25 @@ export function toBoolOrUndef(value: unknown): boolean | undefined {
 }
 
 /**
+ * Returns `value` when it is a positive safe-integer, `undefined` when it is
+ * undefined, and throws otherwise. Use when there is no local default and the
+ * field should stay unset so the server applies its own.
+ */
+export function resolveOptionalPositive(
+    value: number | undefined,
+    name: string
+): number | undefined {
+    if (value === undefined) return undefined
+    if (Number.isSafeInteger(value) && value > 0) return value
+    throw new Error(`${name} must be a positive safe integer`)
+}
+
+/**
  * Returns `value` when it is a positive safe-integer, `fallback` when it is
  * undefined, and throws otherwise.
  */
 export function resolvePositive(value: number | undefined, fallback: number, name: string): number {
-    if (value === undefined) return fallback
-    if (Number.isSafeInteger(value) && value > 0) return value
-    throw new Error(`${name} must be a positive safe integer`)
+    return resolveOptionalPositive(value, name) ?? fallback
 }
 
 /**

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -21,6 +21,7 @@ export {
     asOptionalNumber,
     asOptionalString,
     asString,
+    resolveOptionalPositive,
     resolvePositive,
     toBoolOrUndef
 } from '@util/coercion'


### PR DESCRIPTION
Implements the bundle a member shares with someone who joined a group late, in both directions.

Receiver: `history.groupBundles` (off by default) downloads the bundle a member shared, verifies this account is listed in `historyReceivers` before spending a CDN fetch, drops stubs, foreign-chat entries, ephemeral-expired and over-age messages, persists the rest and emits `group_history_bundle`. Out-of-window pins ride along exempt from the age cutoff. Window limits come from the server-synced AB-props, not from hardcoded defaults.

Sender: `client.message.shareGroupHistory()` resolves the requested members against the live participant list, uploads the zlib-compressed `GroupHistory` payload to `/mms/group-history`, sends the bundle and then the group-wide notice. The bundle takes the per-device direct fanout restricted to its receivers plus this account, so members who are not receiving it never see it. `group_history_send` is checked up front because WhatsApp gates the sender per account and rejects the stanza with SMAX_INVALID, after the upload is spent.

The group-direct path no longer sends a `phash`: it addresses a subset of the group, so a hash over that subset can never match the server's view of the full participant list. WhatsApp Web only sends one on the sender-key path and treats any phash on the ack as the mismatch signal, which this now mirrors.

Bundles derive their media keys from the `Group History` HKDF context, which is distinct from the `WhatsApp History Keys` used by history sync.

Also extracts the blob download and the pending-write flush shared with history sync, which were duplicated verbatim.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in support for downloading and processing shared group-history bundles (including MCP server enablement via `MCP_GROUP_BUNDLES`).
  * Introduced `group_history_bundle` event reporting and enhanced group-history sharing with recipient validation.
  * Added public encoding/decoding support for group-history bundles.
* **Bug Fixes**
  * Improved group-history recipient targeting and bundle eligibility handling (including TTL/window enforcement) to prevent invalid processing.
* **Documentation**
  * Documented `MCP_GROUP_BUNDLES` and its default value in MCP-related guides.
* **Tests**
  * Added new cross-checks and expanded coverage for group-history send/share and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->