### PR TITLE
feat(messages): recover unavailable messages via placeholder resend

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -851,7 +851,8 @@ export function buildWaClientDependencies(input: {
                 .handleIncomingMessageEvent(event)
                 .catch((err) => runtime.handleError(toError(err)))
         },
-        isMobilePrimary
+        isMobilePrimary,
+        getAbPropNumber: (name) => abPropsCoordinator.getConfigValue<number>(name)
     })
 
     const botCoordinator = createBotCoordinator({
@@ -1035,6 +1036,8 @@ export function buildWaClientDependencies(input: {
         senderKeyManager,
         onDecryptFailure: (context: WaRetryDecryptFailureContext, error: unknown) =>
             retryCoordinator.onDecryptFailure(context, error),
+        requestPlaceholderResend: (context: WaRetryDecryptFailureContext) =>
+            retryCoordinator.onUnavailableMessage(context),
         emitIncomingMessage: (event: WaIncomingMessageEvent) => {
             void runtime
                 .handleIncomingMessageEvent(event)

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -1,3 +1,4 @@
+import type { WaAbPropName } from '@abprops-spec'
 import type { WaAuthCredentials } from '@auth/types'
 import type { WaIncomingMessageEvent } from '@client/types'
 import { toRawPubKey } from '@crypto/core/keys'
@@ -46,8 +47,10 @@ import type { WaSessionStore } from '@store/contracts/session.store'
 import type { WaSignalStore } from '@store/contracts/signal.store'
 import { buildAckNode } from '@transport/node/builders/global'
 import { buildRetryReceiptNode } from '@transport/node/builders/retry'
+import { findNodeChild } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
 import { uint8Equal } from '@util/bytes'
+import { tryAsNumber } from '@util/coercion'
 import { setBoundedMapEntry } from '@util/collections'
 import { toError } from '@util/primitives'
 
@@ -84,6 +87,11 @@ interface WaRetryCoordinatorOptions {
      * or privacy-gated recipients nack them with error 463.
      */
     readonly resolvePrivacyTokenNode?: (recipientJid: string) => Promise<BinaryNode | null>
+    /**
+     * Server-synced AB props. Only `placeholder_message_resend_maximum_days_limit`
+     * is read; falls back to the spec default when unwired.
+     */
+    readonly getAbPropNumber?: (name: WaAbPropName) => number
 }
 
 type RetryAuthorization =
@@ -117,8 +125,9 @@ const DECRYPT_FAILURE_QUEUE_MAX_CONCURRENCY = 8
 const PLACEHOLDER_RESEND_RETRY_THRESHOLD = 3
 const PLACEHOLDER_RESEND_BATCH_SIZE = 32
 const PLACEHOLDER_RESEND_DEBOUNCE_MS = 200
-const PLACEHOLDER_RESEND_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
+const PLACEHOLDER_RESEND_FALLBACK_MAX_AGE_DAYS = 14
 const PLACEHOLDER_RESEND_IN_FLIGHT_MAX = 256
+const DAY_SECONDS = 24 * 60 * 60
 const PLACEHOLDER_RESEND_SKIP_SUBTYPES = new Set<string>([
     'bot_unavailable_fanout',
     'hosted_unavailable_fanout',
@@ -157,6 +166,31 @@ function getRemoteRetryReasonLogFields(reason: number | undefined): {
         remoteRetryReason: reason ?? null,
         remoteRetryReasonName: getRetryReasonName(reason) ?? 'missing_in_retry_receipt'
     }
+}
+
+/**
+ * Returns the placeholder subtype the primary never resends (bot fanout, hosted
+ * account, consumed view-once), or `null` when the message is recoverable.
+ */
+function resolvePlaceholderResendSkipSubtype(node: BinaryNode): string | null {
+    const subtype = node.attrs.subtype
+    if (typeof subtype === 'string' && PLACEHOLDER_RESEND_SKIP_SUBTYPES.has(subtype)) {
+        return subtype
+    }
+    const unavailable = findNodeChild(node, 'unavailable')
+    if (!unavailable) {
+        return null
+    }
+    if (findNodeChild(node, 'bot')) {
+        return 'bot_unavailable_fanout'
+    }
+    if (unavailable.attrs.hosted === 'true') {
+        return 'hosted_unavailable_fanout'
+    }
+    if (unavailable.attrs.type === 'view_once') {
+        return 'view_once_unavailable_fanout'
+    }
+    return null
 }
 
 export class WaRetryCoordinator {
@@ -1091,6 +1125,26 @@ export class WaRetryCoordinator {
         return !!meJid && parseSignalAddressFromJid(meJid).user === senderUser
     }
 
+    /**
+     * Queues a `PLACEHOLDER_MESSAGE_RESEND` peer request for a message the server
+     * delivered as `<unavailable/>` (no `<enc>` to decrypt, so no retry receipt).
+     * Returns `false` when the placeholder is unrecoverable, too old, or this
+     * session is the primary. The payload surfaces later as a `message` event.
+     */
+    public onUnavailableMessage(context: WaRetryDecryptFailureContext): boolean {
+        return this.enqueuePlaceholderResend(context)
+    }
+
+    private getPlaceholderResendMaxAgeSeconds(): number {
+        const days = tryAsNumber(
+            this.deps.getAbPropNumber?.('placeholder_message_resend_maximum_days_limit')
+        )
+        return (
+            (days !== null && days > 0 ? days : PLACEHOLDER_RESEND_FALLBACK_MAX_AGE_DAYS) *
+            DAY_SECONDS
+        )
+    }
+
     private enqueuePlaceholderResend(context: WaRetryDecryptFailureContext): boolean {
         if (!this.deps.peerDataOperation || !this.deps.emitIncomingMessage) {
             return false
@@ -1098,14 +1152,18 @@ export class WaRetryCoordinator {
         if (this.deps.isMobilePrimary?.()) {
             return false
         }
-        const subtype = context.messageNode.attrs.subtype
-        if (typeof subtype === 'string' && PLACEHOLDER_RESEND_SKIP_SUBTYPES.has(subtype)) {
+        const skipSubtype = resolvePlaceholderResendSkipSubtype(context.messageNode)
+        if (skipSubtype !== null) {
+            this.deps.logger.trace('placeholder resend skipped: unrecoverable placeholder', {
+                id: context.stanzaId,
+                subtype: skipSubtype
+            })
             return false
         }
         const timestampSeconds = context.t ? Number(context.t) : Date.now() / 1000
         if (Number.isFinite(timestampSeconds)) {
             const ageSeconds = Date.now() / 1000 - timestampSeconds
-            if (ageSeconds > PLACEHOLDER_RESEND_MAX_AGE_SECONDS) {
+            if (ageSeconds > this.getPlaceholderResendMaxAgeSeconds()) {
                 return false
             }
         }

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -1145,6 +1145,31 @@ export class WaRetryCoordinator {
         )
     }
 
+    /**
+     * Builds the message key the primary indexes the message under: the chat is
+     * the `from`, or the `recipient` for a self-sent 1:1, and both it and the
+     * participant carry no `:device` segment. Asking with the raw device-addressed
+     * `from` matches nothing and the resend comes back empty.
+     */
+    private buildPlaceholderResendKey(
+        context: WaRetryDecryptFailureContext
+    ): PlaceholderResendQueueItem {
+        const fromMe = this.isSenderFromOwnAccount(context)
+        const isGroupOrBroadcast = isGroupOrBroadcastJid(context.from)
+        const chatJid =
+            fromMe && !isGroupOrBroadcast
+                ? (context.messageNode.attrs.recipient ?? context.from)
+                : context.from
+        return {
+            remoteJid: toUserJid(chatJid),
+            id: context.stanzaId,
+            fromMe,
+            ...(isGroupOrBroadcast && context.participant
+                ? { participant: toUserJid(context.participant) }
+                : {})
+        }
+    }
+
     private enqueuePlaceholderResend(context: WaRetryDecryptFailureContext): boolean {
         if (!this.deps.peerDataOperation || !this.deps.emitIncomingMessage) {
             return false
@@ -1178,12 +1203,7 @@ export class WaRetryCoordinator {
             return false
         }
         this.placeholderInFlight.add(context.stanzaId)
-        this.placeholderQueue.push({
-            remoteJid: context.from,
-            id: context.stanzaId,
-            fromMe: this.isSenderFromOwnAccount(context),
-            participant: context.participant
-        })
+        this.placeholderQueue.push(this.buildPlaceholderResendKey(context))
         if (this.placeholderTimer === null) {
             this.placeholderTimer = setTimeout(() => {
                 this.placeholderTimer = null

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -1147,9 +1147,10 @@ export class WaRetryCoordinator {
 
     /**
      * Builds the message key the primary indexes the message under: the chat is
-     * the `from`, or the `recipient` for a self-sent 1:1, and both it and the
-     * participant carry no `:device` segment. Asking with the raw device-addressed
-     * `from` matches nothing and the resend comes back empty.
+     * the `from`, or the `recipient` for a self-sent 1:1, always without the
+     * `:device` segment. The participant rides along only for an incoming
+     * group/broadcast message. Asking with the raw device-addressed `from`
+     * matches nothing and the resend comes back empty.
      */
     private buildPlaceholderResendKey(
         context: WaRetryDecryptFailureContext
@@ -1164,7 +1165,7 @@ export class WaRetryCoordinator {
             remoteJid: toUserJid(chatJid),
             id: context.stanzaId,
             fromMe,
-            ...(isGroupOrBroadcast && context.participant
+            ...(!fromMe && isGroupOrBroadcast && context.participant
                 ? { participant: toUserJid(context.participant) }
                 : {})
         }

--- a/src/client/coordinators/WaRetryCoordinator.ts
+++ b/src/client/coordinators/WaRetryCoordinator.ts
@@ -127,6 +127,7 @@ const PLACEHOLDER_RESEND_BATCH_SIZE = 32
 const PLACEHOLDER_RESEND_DEBOUNCE_MS = 200
 const PLACEHOLDER_RESEND_FALLBACK_MAX_AGE_DAYS = 14
 const PLACEHOLDER_RESEND_IN_FLIGHT_MAX = 256
+const PLACEHOLDER_RESEND_TIMEOUT_MS = 120_000
 const DAY_SECONDS = 24 * 60 * 60
 const PLACEHOLDER_RESEND_SKIP_SUBTYPES = new Set<string>([
     'bot_unavailable_fanout',
@@ -1236,7 +1237,8 @@ export class WaRetryCoordinator {
                                 participant: item.participant
                             }
                         }))
-                    }
+                    },
+                    { timeoutMs: PLACEHOLDER_RESEND_TIMEOUT_MS }
                 )
                 const meJid = this.deps.getCurrentCredentials()?.meJid
                 for (const result of results) {

--- a/src/client/coordinators/__tests__/retry-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/retry-coordinator.test.ts
@@ -352,7 +352,7 @@ test('placeholder resend: keys a self-sent 1:1 message by the recipient chat', a
 })
 
 test('placeholder resend: strips device segments from group keys', async () => {
-    const harness = createPlaceholderHarness()
+    const harness = createPlaceholderHarness({ meJid: '5511999999999@s.whatsapp.net' })
     harness.enqueue(
         buildPlaceholderContext({
             stanzaId: 'grp-1',
@@ -360,12 +360,24 @@ test('placeholder resend: strips device segments from group keys', async () => {
             participant: '5511777777777:5@s.whatsapp.net'
         })
     )
+    harness.enqueue(
+        buildPlaceholderContext({
+            stanzaId: 'grp-2',
+            from: '120363000000000000@g.us',
+            participant: '5511999999999:5@s.whatsapp.net'
+        })
+    )
     const flushPromise = harness.flush()
     harness.resolveNext([])
     await flushPromise
-    const key = (harness.captured[0][0] as { messageKey?: Record<string, unknown> }).messageKey
-    assert.equal(key?.remoteJid, '120363000000000000@g.us')
-    assert.equal(key?.participant, '5511777777777@s.whatsapp.net')
+    const [incoming, own] = harness.captured[0] as Array<{
+        messageKey?: Record<string, unknown>
+    }>
+    assert.equal(incoming.messageKey?.remoteJid, '120363000000000000@g.us')
+    assert.equal(incoming.messageKey?.participant, '5511777777777@s.whatsapp.net')
+    // wa-web omits the participant once the key is from-me.
+    assert.equal(own.messageKey?.fromMe, true)
+    assert.equal(own.messageKey?.participant, undefined)
 })
 
 test('unavailable message: requests a resend for a plain fanout placeholder', async () => {

--- a/src/client/coordinators/__tests__/retry-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/retry-coordinator.test.ts
@@ -180,7 +180,7 @@ function buildPlaceholderContext(
 }
 
 function createPlaceholderHarness(
-    options: { readonly maxAgeDays?: number } = {}
+    options: { readonly maxAgeDays?: number; readonly meJid?: string } = {}
 ): PlaceholderHarness {
     const captured: PlaceholderHarness['captured'] = []
     const emitted: WaIncomingMessageEvent[] = []
@@ -211,7 +211,8 @@ function createPlaceholderHarness(
         signalMissingPreKeysSync: {} as never,
         messageClient: {} as never,
         sendNode: async () => undefined,
-        getCurrentCredentials: () => null,
+        getCurrentCredentials: () =>
+            options.meJid === undefined ? null : ({ meJid: options.meJid } as never),
         peerDataOperation,
         emitIncomingMessage: (event) => emitted.push(event),
         getAbPropNumber: options.maxAgeDays === undefined ? undefined : () => options.maxAgeDays!
@@ -328,6 +329,43 @@ test('placeholder resend: honours the ab-prop age window', async () => {
         (harness.captured[0][0] as { messageKey?: { id?: string } }).messageKey?.id,
         'within-window'
     )
+})
+
+test('placeholder resend: keys a self-sent 1:1 message by the recipient chat', async () => {
+    const harness = createPlaceholderHarness({ meJid: '5511999999999@s.whatsapp.net' })
+    harness.enqueue(
+        buildPlaceholderContext({
+            stanzaId: 'self-1',
+            from: '5511999999999:12@s.whatsapp.net',
+            messageNode: {
+                tag: 'message',
+                attrs: { recipient: '5511777777777@s.whatsapp.net' }
+            }
+        })
+    )
+    const flushPromise = harness.flush()
+    harness.resolveNext([])
+    await flushPromise
+    const key = (harness.captured[0][0] as { messageKey?: Record<string, unknown> }).messageKey
+    assert.equal(key?.remoteJid, '5511777777777@s.whatsapp.net')
+    assert.equal(key?.fromMe, true)
+})
+
+test('placeholder resend: strips device segments from group keys', async () => {
+    const harness = createPlaceholderHarness()
+    harness.enqueue(
+        buildPlaceholderContext({
+            stanzaId: 'grp-1',
+            from: '120363000000000000@g.us',
+            participant: '5511777777777:5@s.whatsapp.net'
+        })
+    )
+    const flushPromise = harness.flush()
+    harness.resolveNext([])
+    await flushPromise
+    const key = (harness.captured[0][0] as { messageKey?: Record<string, unknown> }).messageKey
+    assert.equal(key?.remoteJid, '120363000000000000@g.us')
+    assert.equal(key?.participant, '5511777777777@s.whatsapp.net')
 })
 
 test('unavailable message: requests a resend for a plain fanout placeholder', async () => {

--- a/src/client/coordinators/__tests__/retry-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/retry-coordinator.test.ts
@@ -179,7 +179,9 @@ function buildPlaceholderContext(
     }
 }
 
-function createPlaceholderHarness(): PlaceholderHarness {
+function createPlaceholderHarness(
+    options: { readonly maxAgeDays?: number } = {}
+): PlaceholderHarness {
     const captured: PlaceholderHarness['captured'] = []
     const emitted: WaIncomingMessageEvent[] = []
     const pendingResolvers: Array<
@@ -211,7 +213,8 @@ function createPlaceholderHarness(): PlaceholderHarness {
         sendNode: async () => undefined,
         getCurrentCredentials: () => null,
         peerDataOperation,
-        emitIncomingMessage: (event) => emitted.push(event)
+        emitIncomingMessage: (event) => emitted.push(event),
+        getAbPropNumber: options.maxAgeDays === undefined ? undefined : () => options.maxAgeDays!
     })
     const internals = coordinator as unknown as {
         enqueuePlaceholderResend: (context: WaRetryDecryptFailureContext) => boolean
@@ -304,6 +307,86 @@ test('placeholder resend: drops items older than the max age window', async () =
     await flushPromise
     assert.equal(harness.captured.length, 1)
     assert.equal(harness.captured[0].length, 1)
+})
+
+test('placeholder resend: honours the ab-prop age window', async () => {
+    const harness = createPlaceholderHarness({ maxAgeDays: 1 })
+    const twoDaysAgoSeconds = Math.trunc(Date.now() / 1000) - 2 * 24 * 60 * 60
+    harness.enqueue(
+        buildPlaceholderContext({
+            stanzaId: 'past-window',
+            t: String(twoDaysAgoSeconds)
+        })
+    )
+    harness.enqueue(buildPlaceholderContext({ stanzaId: 'within-window' }))
+    const flushPromise = harness.flush()
+    harness.resolveNext([])
+    await flushPromise
+    assert.equal(harness.captured.length, 1)
+    assert.equal(harness.captured[0].length, 1)
+    assert.equal(
+        (harness.captured[0][0] as { messageKey?: { id?: string } }).messageKey?.id,
+        'within-window'
+    )
+})
+
+test('unavailable message: requests a resend for a plain fanout placeholder', async () => {
+    const harness = createPlaceholderHarness()
+    const queued = harness.coordinator.onUnavailableMessage(
+        buildPlaceholderContext({
+            stanzaId: 'fanout-1',
+            from: '551122223333@s.whatsapp.net',
+            messageNode: {
+                tag: 'message',
+                attrs: { id: 'fanout-1' },
+                content: [{ tag: 'unavailable', attrs: {} }]
+            }
+        })
+    )
+    assert.equal(queued, true)
+    const flushPromise = harness.flush()
+    harness.resolveNext([
+        {
+            placeholderMessageResendResponse: {
+                webMessageInfoBytes: makeWebMessageInfoBytes(
+                    'fanout-1',
+                    '551122223333@s.whatsapp.net'
+                )
+            }
+        }
+    ])
+    await flushPromise
+    assert.equal(harness.captured.length, 1)
+    assert.equal(harness.emitted.length, 1)
+    assert.equal(harness.emitted[0].key.id, 'fanout-1')
+    assert.equal(harness.emitted[0].message?.conversation, 'recovered')
+})
+
+test('unavailable message: skips bot, hosted and view-once placeholders', () => {
+    const harness = createPlaceholderHarness()
+    const buildUnavailable = (unavailableAttrs: Record<string, string>, bot = false) =>
+        buildPlaceholderContext({
+            stanzaId: `skip-${JSON.stringify(unavailableAttrs)}-${String(bot)}`,
+            messageNode: {
+                tag: 'message',
+                attrs: {},
+                content: [
+                    { tag: 'unavailable', attrs: unavailableAttrs },
+                    ...(bot ? [{ tag: 'bot', attrs: { biz_bot: '1' } }] : [])
+                ]
+            }
+        })
+
+    assert.equal(harness.coordinator.onUnavailableMessage(buildUnavailable({}, true)), false)
+    assert.equal(
+        harness.coordinator.onUnavailableMessage(buildUnavailable({ hosted: 'true' })),
+        false
+    )
+    assert.equal(
+        harness.coordinator.onUnavailableMessage(buildUnavailable({ type: 'view_once' })),
+        false
+    )
+    assert.equal(harness.captured.length, 0)
 })
 
 test('placeholder resend: splits queue into batches of 32', async () => {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -945,12 +945,12 @@ export interface WaIncomingUnhandledStanzaEvent extends WaIncomingBaseEvent {
 }
 
 /**
- * Why an incoming message arrived as a content-less placeholder. `view_once`:
- * a view-once already consumed elsewhere. `hosted`: a hosted/bot message that
- * could not be fanned out. `other`: a plain fanout placeholder - the primary
- * device still holds the plaintext, so this one is recoverable.
+ * Why an incoming message arrived as a content-less placeholder. `view_once`: a
+ * view-once already consumed elsewhere. `hosted`: a hosted account whose message
+ * could not be fanned out. `bot`: a bot message whose fanout never ran. `other`:
+ * a plain fanout placeholder – the only kind the primary device resends.
  */
-export type WaUnavailableMessageKind = 'view_once' | 'hosted' | 'other'
+export type WaUnavailableMessageKind = 'view_once' | 'hosted' | 'bot' | 'other'
 
 export interface WaIncomingUnavailableMessageEvent extends Omit<
     WaIncomingBaseEvent,
@@ -959,10 +959,11 @@ export interface WaIncomingUnavailableMessageEvent extends Omit<
     /** Which flavour of content the server signalled as unavailable. */
     readonly kind: WaUnavailableMessageKind
     /**
-     * `true` when a resend was requested from the primary device; the payload
-     * then arrives as a `message` event with the same key. `false` for the
-     * unrecoverable flavours, messages past the server age window, and
-     * mobile-primary sessions.
+     * `true` when a resend was queued for the primary device; the payload then
+     * arrives as a `message` event with the same key. Best-effort, like wa-web:
+     * the request is not persisted, so a failed peer message is not retried.
+     * `false` for the unrecoverable flavours, messages past the server age
+     * window, and mobile-primary sessions.
      */
     readonly resendRequested: boolean
     /**

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -947,8 +947,8 @@ export interface WaIncomingUnhandledStanzaEvent extends WaIncomingBaseEvent {
 /**
  * Why an incoming message arrived as a content-less placeholder. `view_once`:
  * a view-once already consumed elsewhere. `hosted`: a hosted/bot message that
- * could not be fanned out. `other`: an `unavailable` marker the lib does not
- * categorize yet.
+ * could not be fanned out. `other`: a plain fanout placeholder - the primary
+ * device still holds the plaintext, so this one is recoverable.
  */
 export type WaUnavailableMessageKind = 'view_once' | 'hosted' | 'other'
 
@@ -959,9 +959,15 @@ export interface WaIncomingUnavailableMessageEvent extends Omit<
     /** Which flavour of content the server signalled as unavailable. */
     readonly kind: WaUnavailableMessageKind
     /**
+     * `true` when a resend was requested from the primary device; the payload
+     * then arrives as a `message` event with the same key. `false` for the
+     * unrecoverable flavours, messages past the server age window, and
+     * mobile-primary sessions.
+     */
+    readonly resendRequested: boolean
+    /**
      * The message key (chat, stanza id, author, addressing metadata) – same
-     * shape the `message` event carries, so it can be stored or correlated. There
-     * is no decrypted `message`: the payload is unavailable and cannot be fetched.
+     * shape the `message` event carries, so it can be stored or correlated.
      */
     readonly key: WaIncomingMessageKey
     /** Stanza `t` attr (seconds since epoch). */
@@ -1429,11 +1435,11 @@ export interface WaClientEventMap {
      */
     readonly message_protocol: (event: WaIncomingProtocolMessageEvent) => void
     /**
-     * A message the server delivered as a content-less placeholder: the payload
-     * is unavailable and cannot be recovered (a view-once already consumed, or a
-     * hosted/bot message that could not be fanned out). The lib acks it and emits
-     * this instead of a `message` event for the same stanza. Branch on
-     * `event.kind`.
+     * A message the server delivered as a content-less placeholder. The lib acks
+     * it and emits this instead of a `message` event for the same stanza. A plain
+     * fanout placeholder is asked back from the primary device and arrives later
+     * as a `message` event (see `event.resendRequested`); a consumed view-once or
+     * a hosted/bot message that could not be fanned out is never resent.
      */
     readonly message_unavailable: (event: WaIncomingUnavailableMessageEvent) => void
     /**

--- a/src/message/primitives/__tests__/incoming.test.ts
+++ b/src/message/primitives/__tests__/incoming.test.ts
@@ -414,6 +414,33 @@ test('unavailable message asks for a placeholder resend and reports it on the ev
     assert.equal(sentNodes[0].tag, 'ack')
 })
 
+test('bot fanout placeholder is classified as its own kind', async () => {
+    const unavailable: WaIncomingUnavailableMessageEvent[] = []
+
+    await handleIncomingMessageAck(
+        {
+            tag: 'message',
+            attrs: { id: 'msg-bot', from: '5511777777777@s.whatsapp.net', type: 'text' },
+            content: [
+                { tag: 'unavailable', attrs: {} },
+                { tag: 'bot', attrs: { biz_bot: '1' } }
+            ]
+        },
+        {
+            logger: createNoopLogger(),
+            sendNode: async () => undefined,
+            requestPlaceholderResend: () => false,
+            emitUnavailableMessage: (event) => {
+                unavailable.push(event)
+            }
+        }
+    )
+
+    assert.equal(unavailable.length, 1)
+    assert.equal(unavailable[0].kind, 'bot')
+    assert.equal(unavailable[0].resendRequested, false)
+})
+
 test('incoming message ack falls back to retry receipt when decrypt fails', async () => {
     const sentNodes: BinaryNode[] = []
 

--- a/src/message/primitives/__tests__/incoming.test.ts
+++ b/src/message/primitives/__tests__/incoming.test.ts
@@ -5,6 +5,7 @@ import type { WaIncomingMessageEvent, WaIncomingUnavailableMessageEvent } from '
 import { createNoopLogger } from '@infra/log/types'
 import { buildRecoveredIncomingEvent, handleIncomingMessageAck } from '@message/primitives/incoming'
 import { proto } from '@proto'
+import type { WaRetryDecryptFailureContext } from '@retry/types'
 import type { BinaryNode } from '@transport/types'
 
 function createEncryptedMessageNode(): BinaryNode {
@@ -353,6 +354,7 @@ test('view-once-unavailable message acks instead of delivery-receipting and emit
     assert.equal(unavailable.length, 1)
     const event = unavailable[0]
     assert.equal(event.kind, 'view_once')
+    assert.equal(event.resendRequested, false)
     assert.equal(event.key.remoteJid, '53979165777985@lid')
     assert.equal(event.key.id, 'msg-vou')
     assert.equal(event.key.fromMe, false)
@@ -364,6 +366,52 @@ test('view-once-unavailable message acks instead of delivery-receipting and emit
     assert.equal(sentNodes[0].attrs.id, 'msg-vou')
     assert.equal(sentNodes[0].attrs.to, '53979165777985@lid')
     assert.equal(sentNodes[0].attrs.type, 'media')
+})
+
+test('unavailable message asks for a placeholder resend and reports it on the event', async () => {
+    const sentNodes: BinaryNode[] = []
+    const unavailable: WaIncomingUnavailableMessageEvent[] = []
+    const resendContexts: WaRetryDecryptFailureContext[] = []
+
+    const handled = await handleIncomingMessageAck(
+        {
+            tag: 'message',
+            attrs: {
+                id: 'msg-fanout',
+                from: '120363000000000000@g.us',
+                participant: '5511777777777:3@s.whatsapp.net',
+                type: 'text',
+                t: '1781885732'
+            },
+            content: [{ tag: 'unavailable', attrs: {} }]
+        },
+        {
+            logger: createNoopLogger(),
+            sendNode: async (node) => {
+                sentNodes.push(node)
+            },
+            getMeJid: () => '5511999999999@s.whatsapp.net',
+            requestPlaceholderResend: (context) => {
+                resendContexts.push(context)
+                return true
+            },
+            emitUnavailableMessage: (event) => {
+                unavailable.push(event)
+            }
+        }
+    )
+
+    assert.equal(handled, true)
+    assert.equal(resendContexts.length, 1)
+    assert.equal(resendContexts[0].stanzaId, 'msg-fanout')
+    assert.equal(resendContexts[0].from, '120363000000000000@g.us')
+    assert.equal(resendContexts[0].participant, '5511777777777:3@s.whatsapp.net')
+    assert.equal(resendContexts[0].t, '1781885732')
+    assert.equal(unavailable.length, 1)
+    assert.equal(unavailable[0].kind, 'other')
+    assert.equal(unavailable[0].resendRequested, true)
+    assert.equal(sentNodes.length, 1)
+    assert.equal(sentNodes[0].tag, 'ack')
 })
 
 test('incoming message ack falls back to retry receipt when decrypt fails', async () => {

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -667,12 +667,13 @@ export async function handleIncomingMessageAck(
 
     const unavailableNode = findNodeChild(node, 'unavailable')
     if (unavailableNode) {
-        const kind: WaUnavailableMessageKind =
-            unavailableNode.attrs.hosted === 'true'
-                ? 'hosted'
-                : unavailableNode.attrs.type === 'view_once'
-                  ? 'view_once'
-                  : 'other'
+        const kind: WaUnavailableMessageKind = findNodeChild(node, 'bot')
+            ? 'bot'
+            : unavailableNode.attrs.hosted === 'true'
+              ? 'hosted'
+              : unavailableNode.attrs.type === 'view_once'
+                ? 'view_once'
+                : 'other'
         const senderJid = node.attrs.participant ?? node.attrs.from
         const sender = senderJid ? parseJidFull(senderJid) : null
         const { key, pushName } = buildIncomingMessageKey(

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -43,6 +43,11 @@ interface WaIncomingMessageAckHandlerOptions {
         context: WaRetryDecryptFailureContext,
         error: unknown
     ) => Promise<boolean>
+    /**
+     * Asks the primary device for the plaintext of an `<unavailable/>` message.
+     * Returns `true` when the request was queued.
+     */
+    readonly requestPlaceholderResend?: (context: WaRetryDecryptFailureContext) => boolean
     readonly emitIncomingMessage?: (event: WaIncomingMessageEvent) => void
     readonly emitNewsletterMessageUpdate?: (event: WaIncomingNewsletterMessageUpdateEvent) => void
     readonly emitUnavailableMessage?: (event: WaIncomingUnavailableMessageEvent) => void
@@ -675,10 +680,20 @@ export async function handleIncomingMessageAck(
             sender ? { userJid: sender.userJid, device: sender.address.device } : null,
             options
         )
+        const resendRequested =
+            options.requestPlaceholderResend?.({
+                messageNode: node,
+                stanzaId: id,
+                from,
+                participant: node.attrs.participant,
+                recipient: node.attrs.recipient,
+                t: node.attrs.t
+            }) === true
         options.emitUnavailableMessage?.({
             rawNode: buildIncomingEventRawNode(node),
             key,
             kind,
+            resendRequested,
             stanzaType: node.attrs.type,
             offline: node.attrs.offline !== undefined,
             timestampSeconds: parseOptionalInt(node.attrs.t),
@@ -696,7 +711,8 @@ export async function handleIncomingMessageAck(
             to: from,
             type: ackNode.attrs.type,
             participant: ackNode.attrs.participant,
-            unavailableKind: kind
+            unavailableKind: kind,
+            resendRequested
         })
         await options.sendNode(ackNode)
         return true


### PR DESCRIPTION
Messages the server delivers as `<unavailable/>` carry no `<enc>`, so they never reached the placeholder-resend queue that decrypt failures use - the payload was acked and dropped. A plain fanout placeholder is recoverable: the primary still holds the plaintext and resends it on a PLACEHOLDER_MESSAGE_RESEND peer request.

- WaRetryCoordinator.onUnavailableMessage() queues those stanzas
- skip list now derives the unrecoverable flavours from the stanza itself (`<bot>` child, hosted=true, type=view_once) instead of only reading attrs.subtype
- the age window comes from placeholder_message_resend_maximum_days_limit instead of a hardcoded 30 days
- message_unavailable gains resendRequested so consumers know whether to expect a follow-up message event with the same key

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for unavailable group and fanout messages by requesting placeholder resends when possible.
  * Added configurable age limits for retrying older placeholder messages.
  * Prevented resend attempts for unrecoverable content, including consumed view-once messages and certain hosted or bot messages.
  * Improved unavailable-message status reporting to indicate whether a resend was requested.
  * Improved resend handling for direct messages, group participants, and self-sent messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->