### PR TITLE
feat(store): let backends declare partial domain coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -479,6 +479,25 @@ Default providers (when no `providers` entry is set):
 - cache domains (`retry`, `groupMetadata`, `deviceList`, `messageSecret`)
   → `'memory'`
 
+A backend does not have to cover the whole matrix. `WaStoreBackend<S, C>`
+defaults both parameters to "every domain" (what the in-tree `store-*`
+packages ship), and a partial backend names its own:
+
+```ts
+const vault = {
+    stores: { auth: (sessionId: string) => new MyAuthStore(sessionId) },
+    caches: {}
+} satisfies WaStoreBackend<'auth', never>
+```
+
+`createStore()` infers the backend map, so each domain only accepts the
+backends that declare it – naming `vault` on `signal` is a compile error
+instead of the `does not provide stores.signal` throw on first `session()`.
+Coverage of `providers` itself is unchanged: with any backend registered,
+all 11 persistence domains stay mandatory. Use `WaAnyStoreBackend` only as
+a constraint for an unknown backend; as an annotation it vouches for no
+domain, so nothing can name it.
+
 SQLite provider rules (live in [`@zapo-js/store-sqlite`](packages/store-sqlite)):
 
 - subclasses `BaseSqliteStore` (exported from the package)

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,12 +319,15 @@ export type {
 } from '@abprops-spec'
 export { createStore, WaAuthMemoryStore } from '@store'
 export type {
+    WaAnyStoreBackend,
     WaAppStateCollectionStoreState,
     WaAppStateStore,
     WaAuthStore,
+    WaCacheDomain,
     WaContactStore,
     WaCreateStoreOptions,
     WaCreateStoreOptionsStrict,
+    WaCreateStoreOptionsStrictFor,
     WaDeviceListSnapshot,
     WaDeviceListStore,
     WaChatMetadataSnapshot,
@@ -343,6 +346,8 @@ export type {
     WaStoredThreadRecord,
     WaStore,
     WaStoreBackend,
+    WaStoreBackendMap,
+    WaStoreDomain,
     WaStoreSession,
     WaThreadStore
 } from '@store'

--- a/src/store/__tests__/create-store-typing.test.ts
+++ b/src/store/__tests__/create-store-typing.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { WaAppStateStore } from '@store/contracts/appstate.store'
+import type { WaAuthStore } from '@store/contracts/auth.store'
+import type { WaChatMetadataStore } from '@store/contracts/chat-metadata.store'
+import type { WaContactStore } from '@store/contracts/contact.store'
+import type { WaDeviceListStore } from '@store/contracts/device-list.store'
+import type { WaGroupMetadataStore } from '@store/contracts/group-metadata.store'
+import type { WaIdentityStore } from '@store/contracts/identity.store'
+import type { WaMessageSecretStore } from '@store/contracts/message-secret.store'
+import type { WaMessageStore } from '@store/contracts/message.store'
+import type { WaPreKeyStore } from '@store/contracts/pre-key.store'
+import type { WaPrivacyTokenStore } from '@store/contracts/privacy-token.store'
+import type { WaRetryStore } from '@store/contracts/retry.store'
+import type { WaSenderKeyStore } from '@store/contracts/sender-key.store'
+import type { WaSessionStore } from '@store/contracts/session.store'
+import type { WaSignalStore } from '@store/contracts/signal.store'
+import type { WaThreadStore } from '@store/contracts/thread.store'
+import { createStore } from '@store/createStore'
+import type { WaCreateStoreOptions, WaStoreBackend } from '@store/types'
+
+const authFactory = (): WaAuthStore => ({
+    async load() {
+        return null
+    },
+    async save() {},
+    async clear() {}
+})
+
+const unusedFactory =
+    <T>() =>
+    (): T => {
+        throw new Error('not expected')
+    }
+
+const fullBackend = {
+    stores: {
+        auth: authFactory,
+        signal: unusedFactory<WaSignalStore>(),
+        preKey: unusedFactory<WaPreKeyStore>(),
+        session: unusedFactory<WaSessionStore>(),
+        identity: unusedFactory<WaIdentityStore>(),
+        senderKey: unusedFactory<WaSenderKeyStore>(),
+        appState: unusedFactory<WaAppStateStore>(),
+        messages: unusedFactory<WaMessageStore>(),
+        threads: unusedFactory<WaThreadStore>(),
+        contacts: unusedFactory<WaContactStore>(),
+        privacyToken: unusedFactory<WaPrivacyTokenStore>()
+    },
+    caches: {
+        retry: unusedFactory<WaRetryStore>(),
+        groupMetadata: unusedFactory<WaGroupMetadataStore>(),
+        chatMetadata: unusedFactory<WaChatMetadataStore>(),
+        deviceList: unusedFactory<WaDeviceListStore>(),
+        messageSecret: unusedFactory<WaMessageSecretStore>()
+    }
+} satisfies WaStoreBackend
+
+/** Credentials-only backend: one persistent domain, no caches. */
+const authOnlyBackend = {
+    stores: { auth: authFactory },
+    caches: {}
+} satisfies WaStoreBackend<'auth', never>
+
+const MEMORY_REST = {
+    signal: 'memory',
+    preKey: 'memory',
+    session: 'memory',
+    identity: 'memory',
+    senderKey: 'memory',
+    appState: 'memory',
+    privacyToken: 'memory',
+    messages: 'none',
+    threads: 'none',
+    contacts: 'none'
+} as const
+
+test('full backend is nameable on every domain', () => {
+    const store = createStore({
+        backends: { sql: fullBackend },
+        providers: {
+            auth: 'sql',
+            signal: 'sql',
+            preKey: 'sql',
+            session: 'sql',
+            identity: 'sql',
+            senderKey: 'sql',
+            appState: 'sql',
+            privacyToken: 'sql',
+            messages: 'sql',
+            threads: 'sql',
+            contacts: 'sql'
+        },
+        cacheProviders: { retry: 'sql' }
+    })
+
+    assert.ok(store)
+})
+
+test('partial backend serves what it declares and leaves the session total', async () => {
+    const store = createStore({
+        backends: { vault: authOnlyBackend },
+        providers: { auth: 'vault', ...MEMORY_REST }
+    })
+
+    const session = store.session('typing-partial')
+
+    assert.equal(await session.auth.load(), null)
+    // 'none' keeps the domain on the session - it resolves to the noop store,
+    // it does not disappear from the bundle.
+    assert.equal(await session.messages.getById('missing'), null)
+    assert.equal(await session.contacts.getByJid('missing@lid'), null)
+
+    await store.destroy()
+})
+
+test('domains a backend does not declare are rejected at compile time', () => {
+    createStore({
+        backends: { vault: authOnlyBackend },
+        providers: {
+            auth: 'vault',
+            // @ts-expect-error - vault declares no stores.signal factory
+            signal: 'vault',
+            preKey: 'memory',
+            session: 'memory',
+            identity: 'memory',
+            senderKey: 'memory',
+            appState: 'memory',
+            privacyToken: 'memory',
+            messages: 'none',
+            threads: 'none',
+            contacts: 'none'
+        }
+    })
+
+    createStore({
+        backends: { vault: authOnlyBackend },
+        providers: { auth: 'vault', ...MEMORY_REST },
+        // @ts-expect-error - vault declares no caches.retry factory
+        cacheProviders: { retry: 'vault' }
+    })
+
+    createStore({
+        backends: { sql: fullBackend },
+        providers: {
+            // @ts-expect-error - 'sqlite' is not a registered backend name
+            auth: 'sqlite',
+            ...MEMORY_REST
+        }
+    })
+
+    assert.ok(true)
+})
+
+test('every persistence domain stays mandatory once a backend is registered', () => {
+    // Both layers guard this: the compiler rejects the partial `providers`,
+    // and the runtime check still fires for JS callers with no types.
+    assert.throws(
+        () =>
+            createStore({
+                backends: { sql: fullBackend },
+                // @ts-expect-error - providers.auth is missing
+                providers: MEMORY_REST
+            }),
+        /Missing: providers\.auth/
+    )
+})
+
+test('name-keyed options still compile without the backend values in scope', () => {
+    const options: WaCreateStoreOptions<'sqlite'> = {
+        providers: { auth: 'sqlite', ...MEMORY_REST },
+        cacheProviders: { retry: 'sqlite' }
+    }
+
+    assert.equal(options.providers?.auth, 'sqlite')
+})

--- a/src/store/__tests__/create-store-typing.test.ts
+++ b/src/store/__tests__/create-store-typing.test.ts
@@ -18,7 +18,13 @@ import type { WaSessionStore } from '@store/contracts/session.store'
 import type { WaSignalStore } from '@store/contracts/signal.store'
 import type { WaThreadStore } from '@store/contracts/thread.store'
 import { createStore } from '@store/createStore'
-import type { WaCreateStoreOptions, WaStoreBackend } from '@store/types'
+import type {
+    WaCreateStoreOptions,
+    WaCreateStoreOptionsStrict,
+    WaCreateStoreOptionsStrictFor,
+    WaStoreBackend,
+    WaStoreBackendMap
+} from '@store/types'
 
 const authFactory = (): WaAuthStore => ({
     async load() {
@@ -174,4 +180,46 @@ test('name-keyed options still compile without the backend values in scope', () 
     }
 
     assert.equal(options.providers?.auth, 'sqlite')
+})
+
+test('name-keyed options demand full backends, having no way to verify coverage', () => {
+    // Partial backends belong to the inferred shape, which sees the values.
+    // This one only sees names, so its `providers` let any name serve any
+    // domain - taking a partial backend here would compile `signal: 'vault'`
+    // and move the failure back to the first session(). Reach for
+    // `WaCreateStoreOptionsStrictFor<typeof backends>` instead.
+    const options: WaCreateStoreOptionsStrict<'vault'> = {
+        // @ts-expect-error - vault implements only stores.auth
+        backends: { vault: authOnlyBackend },
+        providers: { auth: 'vault', ...MEMORY_REST }
+    }
+
+    assert.equal(options.providers.auth, 'vault')
+})
+
+test('the inferred shape annotates a partial backend just fine', () => {
+    const backends = { vault: authOnlyBackend }
+    const options: WaCreateStoreOptionsStrictFor<typeof backends> = {
+        backends,
+        providers: { auth: 'vault', ...MEMORY_REST }
+    }
+
+    assert.equal(options.providers.auth, 'vault')
+})
+
+test('annotating the backend map erases coverage', () => {
+    // WaStoreBackendMap is a constraint, not an annotation - it optionalises
+    // every factory, so no backend vouches for any domain any more.
+    const backends: WaStoreBackendMap = { vault: authOnlyBackend }
+
+    createStore({
+        backends,
+        providers: {
+            // @ts-expect-error - the annotation collapsed auth to 'memory'
+            auth: 'vault',
+            ...MEMORY_REST
+        }
+    })
+
+    assert.ok(backends)
 })

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -61,9 +61,9 @@ import {
 } from '@store/noop.store'
 import type {
     WaCreateStoreOptions,
-    WaCreateStoreOptionsStrict,
+    WaCreateStoreOptionsStrictFor,
     WaStore,
-    WaStoreBackend,
+    WaStoreBackendMap,
     WaStoreMemoryLimitSelection,
     WaStoreSession
 } from '@store/types'
@@ -116,7 +116,7 @@ function usesBackend(provider: string | undefined): boolean {
 
 function resolveStore<T>(
     sessionId: string,
-    backends: Readonly<Record<string, WaStoreBackend>>,
+    backends: WaStoreBackendMap,
     provider: string | undefined,
     domain: string,
     kind: 'stores' | 'caches',
@@ -155,6 +155,14 @@ function resolveStore<T>(
  *   messageSecret) stay opt-in and default to memory - they are small,
  *   hot, and cheap to rebuild.
  *
+ * **Domain coverage:** the backend map is inferred, so each domain only
+ * accepts the backends whose bundle actually declares it. A backend that
+ * covers part of the matrix (`WaStoreBackend<'auth', never>`, say) can only
+ * be named on the domains it implements - the rest fall back to `'memory'`
+ * / `'none'`, checked by the compiler rather than by the
+ * `backend '<name>' does not provide <kind>.<domain>` throw on first
+ * `session()`.
+ *
  * @example
  * ```ts
  * // Persistent setup with @zapo-js/store-sqlite (recommended for production)
@@ -190,10 +198,12 @@ export function createStore(
         readonly providers?: undefined
     }
 ): WaStore
-export function createStore<B extends string>(options: WaCreateStoreOptionsStrict<B>): WaStore
-export function createStore<B extends string>(options?: WaCreateStoreOptions<B>): WaStore {
+export function createStore<TBackends extends WaStoreBackendMap>(
+    options: WaCreateStoreOptionsStrictFor<TBackends>
+): WaStore
+export function createStore(options?: WaCreateStoreOptions): WaStore {
     options = options ?? {}
-    const backends = (options.backends ?? {}) as Readonly<Record<string, WaStoreBackend>>
+    const backends: WaStoreBackendMap = options.backends ?? {}
     const providers = options.providers ?? {}
     const cacheProviders = options.cacheProviders ?? {}
     const cacheLayer = options.cacheLayer ?? {}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,10 +1,16 @@
 export type {
+    WaAnyStoreBackend,
+    WaBackendsProviding,
     WaCreateStoreOptions,
     WaCreateStoreOptionsStrict,
+    WaCreateStoreOptionsStrictFor,
     WaStore,
     WaStoreBackend,
+    WaStoreBackendMap,
     WaCacheDomain,
+    WaCacheDomainContracts,
     WaStoreDomain,
+    WaStoreDomainContracts,
     WaStoreMemoryLimitSelection,
     WaStoreSession
 } from '@store/types'

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -76,40 +76,160 @@ export interface WaStore {
     destroy(): Promise<void>
 }
 
-export interface WaStoreBackend {
+/**
+ * Domain → contract map for the persistent store domains. Single source of
+ * truth: {@link WaStoreDomain}, {@link WaStoreBackend} and the per-domain
+ * provider selection are all derived from it.
+ */
+export interface WaStoreDomainContracts {
+    readonly auth: WaAuthStore
+    readonly signal: WaSignalStore
+    readonly preKey: WaPreKeyStore
+    readonly session: WaSessionStore
+    readonly identity: WaIdentityStore
+    readonly senderKey: WaSenderKeyStore
+    readonly appState: WaAppStateStore
+    readonly messages: WaMessageStore
+    readonly threads: WaThreadStore
+    readonly contacts: WaContactStore
+    readonly privacyToken: WaPrivacyTokenStore
+}
+
+/** Domain → contract map for the bounded cache domains. */
+export interface WaCacheDomainContracts {
+    readonly retry: WaRetryStore
+    readonly groupMetadata: WaGroupMetadataStore
+    readonly chatMetadata: WaChatMetadataStore
+    readonly deviceList: WaDeviceListStore
+    readonly messageSecret: WaMessageSecretStore
+}
+
+export type WaStoreDomain = keyof WaStoreDomainContracts
+export type WaCacheDomain = keyof WaCacheDomainContracts
+
+/**
+ * A backend bundle: one factory per domain it implements.
+ *
+ * Both parameters default to *every* domain, so a bare `WaStoreBackend`
+ * keeps meaning a full backend – all 11 persistent domains plus all 4
+ * cache domains – which is what every in-tree `@zapo-js/store-*` package
+ * ships.
+ *
+ * A backend covering only part of the matrix names its domains explicitly.
+ * `createStore()` then refuses, at compile time, to route a domain it
+ * doesn't implement to it:
+ *
+ * ```ts
+ * const vault = {
+ *     stores: { auth: (sessionId: string) => new MyAuthStore(sessionId) },
+ *     caches: {}
+ * } satisfies WaStoreBackend<'auth', never>
+ *
+ * createStore({
+ *     backends: { vault },
+ *     providers: { auth: 'vault', signal: 'vault', ... }
+ * })
+ * ```
+ *
+ * where `signal: 'vault'` is rejected because `vault.stores` has no
+ * `signal` factory – the union for that domain is `'memory'` alone.
+ */
+export type WaStoreBackend<
+    S extends WaStoreDomain = WaStoreDomain,
+    C extends WaCacheDomain = WaCacheDomain
+> = {
     readonly stores: {
-        readonly auth: (sessionId: string) => WaAuthStore
-        readonly signal: (sessionId: string) => WaSignalStore
-        readonly preKey: (sessionId: string) => WaPreKeyStore
-        readonly session: (sessionId: string) => WaSessionStore
-        readonly identity: (sessionId: string) => WaIdentityStore
-        readonly senderKey: (sessionId: string) => WaSenderKeyStore
-        readonly appState: (sessionId: string) => WaAppStateStore
-        readonly messages: (sessionId: string) => WaMessageStore
-        readonly threads: (sessionId: string) => WaThreadStore
-        readonly contacts: (sessionId: string) => WaContactStore
-        readonly privacyToken: (sessionId: string) => WaPrivacyTokenStore
+        readonly [K in S]: (sessionId: string) => WaStoreDomainContracts[K]
     }
     readonly caches: {
-        readonly retry: (sessionId: string) => WaRetryStore
-        readonly groupMetadata: (sessionId: string) => WaGroupMetadataStore
-        readonly chatMetadata: (sessionId: string) => WaChatMetadataStore
-        readonly deviceList: (sessionId: string) => WaDeviceListStore
-        readonly messageSecret: (sessionId: string) => WaMessageSecretStore
+        readonly [K in C]: (sessionId: string) => WaCacheDomainContracts[K]
     }
 }
 
-export type WaStoreDomain = keyof WaStoreBackend['stores']
-export type WaCacheDomain = keyof WaStoreBackend['caches']
+/**
+ * Structural upper bound for any backend, full or partial – the constraint
+ * to use when accepting an unknown backend, since `WaStoreBackend` on its
+ * own means *all* domains.
+ *
+ * Every factory is optional here, which is also what makes it useless as
+ * an annotation on a concrete backend: a value declared as this type
+ * vouches for no domain, so no domain can name it in `providers`. Annotate
+ * concrete backends with `WaStoreBackend<S, C>` (or let inference do it)
+ * to keep the per-domain guarantees.
+ */
+export type WaAnyStoreBackend = {
+    readonly stores: {
+        readonly [K in WaStoreDomain]?: (sessionId: string) => WaStoreDomainContracts[K]
+    }
+    readonly caches: {
+        readonly [K in WaCacheDomain]?: (sessionId: string) => WaCacheDomainContracts[K]
+    }
+}
 
-export interface WaCreateStoreOptions<B extends string = string> {
+/** Named backend map, as passed to `createStore({ backends })`. */
+export type WaStoreBackendMap = Readonly<Record<string, WaAnyStoreBackend>>
+
+/**
+ * The backend names in `TBackends` whose `stores`/`caches` bundle actually
+ * declares `D`. Domains a backend doesn't implement never enter the union,
+ * so routing one to it is a compile error instead of the
+ * `backend '<name>' does not provide <kind>.<domain>` throw that would
+ * otherwise surface on the first `store.session(...)`.
+ */
+export type WaBackendsProviding<
+    TBackends extends WaStoreBackendMap,
+    Kind extends 'stores' | 'caches',
+    D extends WaStoreDomain | WaCacheDomain
+> = {
+    [K in keyof TBackends]: D extends keyof TBackends[K][Kind]
+        ? undefined extends TBackends[K][Kind][D]
+            ? never
+            : K & string
+        : never
+}[keyof TBackends]
+
+/**
+ * Backend map implied by a bare name union: every name is assumed to cover
+ * the full matrix, which is the pre-inference behaviour kept for
+ * {@link WaCreateStoreOptions} and {@link WaCreateStoreOptionsStrict}.
+ */
+type WaNamedBackends<B extends string> = Readonly<Record<B, WaStoreBackend>>
+
+/** Provider union for a persistent domain: any backend declaring it, or memory. */
+type WaProviderFor<TBackends extends WaStoreBackendMap, D extends WaStoreDomain> =
+    | WaBackendsProviding<TBackends, 'stores', D>
+    | 'memory'
+
+/** Provider union for a mailbox domain – same, plus the `'none'` opt-out. */
+type WaMailboxProviderFor<TBackends extends WaStoreBackendMap, D extends WaStoreDomain> =
+    | WaProviderFor<TBackends, D>
+    | 'none'
+
+/** Provider union for a cache domain. */
+type WaCacheProviderFor<TBackends extends WaStoreBackendMap, D extends WaCacheDomain> =
+    | WaBackendsProviding<TBackends, 'caches', D>
+    | 'memory'
+    | 'none'
+
+/**
+ * @typeParam B         Registered backend names.
+ * @typeParam TBackends The backend map itself. Defaults to "every name in
+ *                      `B` covers the full domain matrix", which is what a
+ *                      bare `WaCreateStoreOptions<'sqlite'>` still means.
+ *                      `createStore()` infers the real map instead, so each
+ *                      domain only accepts backends that declare it.
+ */
+export interface WaCreateStoreOptions<
+    B extends string = string,
+    TBackends extends WaStoreBackendMap = WaNamedBackends<B>
+> {
     /**
      * Named persistent backends (e.g. `{ sqlite: createSqliteStore(...) }`).
      * Each key here is a backend id you can reference under {@link providers}
      * and {@link cacheProviders}. The literal strings `'memory'` and `'none'`
      * are reserved and don't need a backend entry.
      */
-    readonly backends?: Readonly<Record<B, WaStoreBackend>>
+    readonly backends?: Readonly<Record<B, WaAnyStoreBackend>>
     /**
      * Per-domain provider selection for the persistent (non-cache) stores.
      * Every domain falls back to `'memory'` (or `'none'` for the mailbox
@@ -126,7 +246,7 @@ export interface WaCreateStoreOptions<B extends string = string> {
          * (e.g. `@zapo-js/store-sqlite`) in production so the device
          * survives a process restart.
          */
-        readonly auth?: B | 'memory'
+        readonly auth?: WaProviderFor<TBackends, 'auth'>
         /**
          * Signal protocol identities and the meta row (`server_has_prekeys`,
          * `next_prekey_id`, signed-prekey rotation timestamp). Splits with
@@ -135,27 +255,27 @@ export interface WaCreateStoreOptions<B extends string = string> {
          * `'memory'` – fine for short-lived sessions; persist it in
          * production so re-keying / digest checks survive restarts.
          */
-        readonly signal?: B | 'memory'
+        readonly signal?: WaProviderFor<TBackends, 'signal'>
         /**
          * Signal one-time prekey pool. The server hands these out to peers
          * starting fresh sessions with you. Losing them forces fallback to
          * the signed-prekey-only flow (slower / less forward-secret per
          * session). Default: `'memory'`.
          */
-        readonly preKey?: B | 'memory'
+        readonly preKey?: WaProviderFor<TBackends, 'preKey'>
         /**
          * Signal sessions (the per-peer Double Ratchet state). Losing this
          * forces a transparent re-handshake on the next message to/from that
          * peer – your identity key doesn't change, so no "security code
          * changed" notice fires on the peer. Default: `'memory'`.
          */
-        readonly session?: B | 'memory'
+        readonly session?: WaProviderFor<TBackends, 'session'>
         /**
          * Remote identity keys per peer device. The library compares the
          * stored key against the server-reported one on every send to detect
          * device-takeover (`identity mismatch`). Default: `'memory'`.
          */
-        readonly identity?: B | 'memory'
+        readonly identity?: WaProviderFor<TBackends, 'identity'>
         /**
          * Sender-key state for group encryption: your own outgoing sender
          * key per group + incoming sender keys from other participants + the
@@ -163,7 +283,7 @@ export interface WaCreateStoreOptions<B extends string = string> {
          * sender key to every member on the next group send. Default:
          * `'memory'`.
          */
-        readonly senderKey?: B | 'memory'
+        readonly senderKey?: WaProviderFor<TBackends, 'senderKey'>
         /**
          * App-state sync keys + per-collection version/hash/index map
          * (mute, archive, pin, contacts, labels, ...). This is what lets
@@ -171,7 +291,7 @@ export interface WaCreateStoreOptions<B extends string = string> {
          * Wiping it triggers a full re-sync on next connect (slow, lots of
          * traffic). Default: `'memory'`.
          */
-        readonly appState?: B | 'memory'
+        readonly appState?: WaProviderFor<TBackends, 'appState'>
         /**
          * Optional archive of every message you received/sent. Required if
          * you want to call `client.message.send(..., { quote })` later for
@@ -179,27 +299,27 @@ export interface WaCreateStoreOptions<B extends string = string> {
          * secrets for addon decryption after a restart. Default: `'none'`
          * (no archive – events fire but aren't stored).
          */
-        readonly messages?: B | 'memory' | 'none'
+        readonly messages?: WaMailboxProviderFor<TBackends, 'messages'>
         /**
          * Per-chat thread metadata (last message id/time, unread count,
          * disappearing-mode setting). Used by some UIs to render a chat
          * list; not required for messaging. Default: `'none'`.
          */
-        readonly threads?: B | 'memory' | 'none'
+        readonly threads?: WaMailboxProviderFor<TBackends, 'threads'>
         /**
          * Contact book mirror (push names, phone numbers, business labels).
          * Populated by app-state mutations and history sync. Not required
          * for messaging but useful for display names without an extra
          * profile fetch. Default: `'none'`.
          */
-        readonly contacts?: B | 'memory' | 'none'
+        readonly contacts?: WaMailboxProviderFor<TBackends, 'contacts'>
         /**
          * Trusted-contact-token cache – short-lived tokens the lib issues
          * to peers so they can verify that messages from you are authentic.
          * Persisting avoids re-issuing on every reconnect (saves IQs).
          * Default: `'memory'`.
          */
-        readonly privacyToken?: B | 'memory'
+        readonly privacyToken?: WaProviderFor<TBackends, 'privacyToken'>
     }
     /**
      * Provider selection for the bounded cache domains – TTL-evicted state
@@ -218,7 +338,7 @@ export interface WaCreateStoreOptions<B extends string = string> {
          * arrive after restart get dropped (peer falls back to a placeholder
          * message). Default: `'memory'`.
          */
-        readonly retry?: B | 'memory' | 'none'
+        readonly retry?: WaCacheProviderFor<TBackends, 'retry'>
         /**
          * Group metadata (subject, participants, settings) keyed by group
          * JID. Populated by `client.group.queryGroupMetadata`/server pushes
@@ -228,21 +348,21 @@ export interface WaCreateStoreOptions<B extends string = string> {
          * will get throttled (or temporarily blocked) without a cache.
          * Default: `'memory'`.
          */
-        readonly groupMetadata?: B | 'memory' | 'none'
+        readonly groupMetadata?: WaCacheProviderFor<TBackends, 'groupMetadata'>
         /**
          * Protocol-derived per-chat state (disappearing-message settings).
          * Read on every 1:1 send to stamp `contextInfo`; rebuilt from history
          * sync, `EPHEMERAL_SETTING` messages and incoming `ContextInfo`, so
          * losing it costs freshness rather than data. Default: `'memory'`.
          */
-        readonly chatMetadata?: B | 'memory' | 'none'
+        readonly chatMetadata?: WaCacheProviderFor<TBackends, 'chatMetadata'>
         /**
          * Per-user device list (which `:device` JIDs each contact has online).
          * Populated by usync queries; consumed on every send to pick the
          * fan-out set. Disabling forces a usync round-trip per recipient on
          * every send. Default: `'memory'`.
          */
-        readonly deviceList?: B | 'memory' | 'none'
+        readonly deviceList?: WaCacheProviderFor<TBackends, 'deviceList'>
         /**
          * Message-secret cache: maps `stanzaId → { senderJid, secret }` so
          * addon decryption (poll votes, reactions, encrypted edits, ...) can
@@ -251,7 +371,7 @@ export interface WaCreateStoreOptions<B extends string = string> {
          * – otherwise addon auto-decrypt loses parents after restart.
          * Default: `'memory'`.
          */
-        readonly messageSecret?: B | 'memory' | 'none'
+        readonly messageSecret?: WaCacheProviderFor<TBackends, 'messageSecret'>
     }
     /**
      * Opt-in in-process read-through cache in front of a *persistent* backend
@@ -382,17 +502,40 @@ export interface WaCreateStoreOptions<B extends string = string> {
 }
 
 /**
- * Strict overload shape for {@link createStore} when at least one backend
- * is registered. Every persistence domain in `providers` is `Required` -
- * the compiler refuses partial coverage and the IDE highlights the missing
- * keys. Cache domains stay opt-in (default `'memory'`).
+ * Strict options keyed by backend *name*. Every persistence domain in
+ * `providers` is `Required` - the compiler refuses partial coverage and the
+ * IDE highlights the missing keys. Cache domains stay opt-in (default
+ * `'memory'`).
+ *
+ * Each name is assumed to cover the full domain matrix. `createStore()`
+ * itself infers the backend map and uses
+ * {@link WaCreateStoreOptionsStrictFor}, which additionally rejects routing
+ * a domain to a backend that doesn't implement it; annotate with this one
+ * only when the backend values aren't in scope.
  */
 export interface WaCreateStoreOptionsStrict<B extends string> extends Omit<
     WaCreateStoreOptions<B>,
     'backends' | 'providers'
 > {
-    readonly backends: Readonly<Record<B, WaStoreBackend>>
+    readonly backends: Readonly<Record<B, WaAnyStoreBackend>>
     readonly providers: Required<NonNullable<WaCreateStoreOptions<B>['providers']>>
+}
+
+/**
+ * Strict options resolved against the backend map itself - the shape
+ * {@link createStore} infers when `backends` is set.
+ *
+ * Same `Required` coverage rule as {@link WaCreateStoreOptionsStrict}, with
+ * one addition: each domain only accepts the backends whose bundle actually
+ * declares it, so a typo or a partial backend fails to compile instead of
+ * throwing on the first `store.session(...)`.
+ */
+export interface WaCreateStoreOptionsStrictFor<TBackends extends WaStoreBackendMap> extends Omit<
+    WaCreateStoreOptions<string, TBackends>,
+    'backends' | 'providers'
+> {
+    readonly backends: TBackends
+    readonly providers: Required<NonNullable<WaCreateStoreOptions<string, TBackends>['providers']>>
 }
 
 export interface WaStoreMemoryLimitSelection {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -111,9 +111,9 @@ export type WaCacheDomain = keyof WaCacheDomainContracts
  * A backend bundle: one factory per domain it implements.
  *
  * Both parameters default to *every* domain, so a bare `WaStoreBackend`
- * keeps meaning a full backend – all 11 persistent domains plus all 4
- * cache domains – which is what every in-tree `@zapo-js/store-*` package
- * ships.
+ * keeps meaning a full backend – the whole of {@link WaStoreDomainContracts}
+ * plus the whole of {@link WaCacheDomainContracts} – which is what every
+ * in-tree `@zapo-js/store-*` package ships.
  *
  * A backend covering only part of the matrix names its domains explicitly.
  * `createStore()` then refuses, at compile time, to route a domain it
@@ -166,7 +166,23 @@ export type WaAnyStoreBackend = {
     }
 }
 
-/** Named backend map, as passed to `createStore({ backends })`. */
+/**
+ * Named backend map, as passed to `createStore({ backends })`.
+ *
+ * This is a *constraint*, not an annotation. Declaring the map as this type
+ * erases each backend's coverage the same way {@link WaAnyStoreBackend} does
+ * on a single backend, and every domain then collapses to `'memory'` /
+ * `'none'`:
+ *
+ * ```ts
+ * const backends: WaStoreBackendMap = { vault }
+ * createStore({ backends, providers: { auth: 'vault', ... } })
+ * ```
+ *
+ * where `auth: 'vault'` no longer compiles. Pass the object literal straight
+ * to `createStore()`, or bind it with `satisfies WaStoreBackendMap`, so
+ * inference keeps the per-backend factories.
+ */
 export type WaStoreBackendMap = Readonly<Record<string, WaAnyStoreBackend>>
 
 /**
@@ -228,8 +244,14 @@ export interface WaCreateStoreOptions<
      * Each key here is a backend id you can reference under {@link providers}
      * and {@link cacheProviders}. The literal strings `'memory'` and `'none'`
      * are reserved and don't need a backend entry.
+     *
+     * Full backends only while `TBackends` is left at its default: this shape
+     * knows names, not coverage, so `providers` assumes every name implements
+     * every domain. Partial backends go through the inferred shape
+     * ({@link WaCreateStoreOptionsStrictFor}), which checks coverage per
+     * domain.
      */
-    readonly backends?: Readonly<Record<B, WaAnyStoreBackend>>
+    readonly backends?: Readonly<Record<B, WaStoreBackend>>
     /**
      * Per-domain provider selection for the persistent (non-cache) stores.
      * Every domain falls back to `'memory'` (or `'none'` for the mailbox
@@ -507,17 +529,18 @@ export interface WaCreateStoreOptions<
  * IDE highlights the missing keys. Cache domains stay opt-in (default
  * `'memory'`).
  *
- * Each name is assumed to cover the full domain matrix. `createStore()`
- * itself infers the backend map and uses
- * {@link WaCreateStoreOptionsStrictFor}, which additionally rejects routing
- * a domain to a backend that doesn't implement it; annotate with this one
- * only when the backend values aren't in scope.
+ * Each name is assumed to cover the full domain matrix, so `backends` takes
+ * full {@link WaStoreBackend}s here - nothing in this shape could verify a
+ * partial one against the `providers` it accepts. `createStore()` itself
+ * infers the backend map and uses {@link WaCreateStoreOptionsStrictFor},
+ * which does check coverage per domain; annotate with this one only when the
+ * backend values aren't in scope.
  */
 export interface WaCreateStoreOptionsStrict<B extends string> extends Omit<
     WaCreateStoreOptions<B>,
     'backends' | 'providers'
 > {
-    readonly backends: Readonly<Record<B, WaAnyStoreBackend>>
+    readonly backends: Readonly<Record<B, WaStoreBackend>>
     readonly providers: Required<NonNullable<WaCreateStoreOptions<B>['providers']>>
 }
 


### PR DESCRIPTION
WaStoreBackend takes optional S/C parameters naming the domains a backend implements. Both default to the full matrix, so a bare WaStoreBackend keeps meaning all 11 persistent + 4 cache domains and every in-tree store-* package is unaffected. A partial backend writes `satisfies WaStoreBackend<'auth', never>`.

createStore() now infers the backend map instead of only the backend names, so each domain accepts only the backends whose bundle actually declares it. Routing an undeclared domain - or misspelling a backend name - fails to compile instead of throwing "does not provide <kind>.<domain>" on the first session().

Type layer only, no runtime change. The mandatory coverage of all 11 persistence domains once a backend is registered stays as is, and 'none' still resolves to the noop store rather than dropping the domain from the session bundle.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for stores backed by selected domains.
  - `createStore()` now infers backend coverage and validates provider compatibility at compile time.
  - Added public types for store domains, backend maps, cache domains, and strict store options.
  - Unsupported domain assignments and invalid provider selections are rejected before runtime.

- **Documentation**
  - Documented partial backend coverage and compile-time validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->