### PR TITLE
perf: cut hot-path CPU and allocations across signal, codec, media and appstate

### DIFF
--- a/src/appstate/crypto/WaAppStateCrypto.ts
+++ b/src/appstate/crypto/WaAppStateCrypto.ts
@@ -340,15 +340,13 @@ export class WaAppStateCrypto {
         if (out.byteLength !== left.byteLength) {
             throw new Error('lt hash output length mismatch')
         }
-        const leftView = new DataView(left.buffer, left.byteOffset, left.byteLength)
-        const rightView = new DataView(right.buffer, right.byteOffset, right.byteLength)
-        const outView = new DataView(out.buffer, out.byteOffset, out.byteLength)
         for (let offset = 0; offset < left.byteLength; offset += APP_STATE_POINT_SIZE) {
             const value = combine(
-                leftView.getUint16(offset, true),
-                rightView.getUint16(offset, true)
+                left[offset] | (left[offset + 1] << 8),
+                right[offset] | (right[offset + 1] << 8)
             )
-            outView.setUint16(offset, value & 0xffff, true)
+            out[offset] = value & 0xff
+            out[offset + 1] = (value >>> 8) & 0xff
         }
         return out
     }
@@ -374,10 +372,7 @@ export class WaAppStateCrypto {
     ): Uint8Array {
         const octetLength = new Uint8Array(APP_STATE_MAC_OCTET_LENGTH)
         octetLength[octetLength.length - 1] = associatedData.byteLength & 0xff
-        const full = hmacSha512Sign(
-            valueMacHmacKey,
-            concatBytes([associatedData, iv, cipherText, octetLength])
-        )
+        const full = hmacSha512Sign(valueMacHmacKey, [associatedData, iv, cipherText, octetLength])
         return full.subarray(0, APP_STATE_VALUE_MAC_LENGTH)
     }
 

--- a/src/appstate/crypto/__tests__/appstate-crypto.test.ts
+++ b/src/appstate/crypto/__tests__/appstate-crypto.test.ts
@@ -132,3 +132,68 @@ test('appstate crypto bypasses value and index MAC checks when skipMacVerificati
     assert.equal(decrypted.version, 1)
     assert.equal(crypto.isMacVerificationSkipped, true)
 })
+
+test('lt-hash add/subtract matches a DataView reference implementation', async () => {
+    const { hkdf } = await import('@crypto')
+    const { WA_APP_STATE_KDF_INFO } = await import('@protocol/constants')
+    const crypto = new WaAppStateCrypto()
+
+    const expand = (value: Uint8Array): Uint8Array =>
+        hkdf(value, null, WA_APP_STATE_KDF_INFO.PATCH_INTEGRITY, APP_STATE_EMPTY_LT_HASH.byteLength)
+
+    const referenceApply = (
+        base: Uint8Array,
+        values: readonly Uint8Array[],
+        combine: (left: number, right: number) => number
+    ): Uint8Array => {
+        let current = base
+        for (const value of values) {
+            const expanded = expand(value)
+            const out = new Uint8Array(current.byteLength)
+            const leftView = new DataView(current.buffer, current.byteOffset, current.byteLength)
+            const rightView = new DataView(
+                expanded.buffer,
+                expanded.byteOffset,
+                expanded.byteLength
+            )
+            const outView = new DataView(out.buffer, out.byteOffset, out.byteLength)
+            for (let offset = 0; offset < current.byteLength; offset += 2) {
+                const combined = combine(
+                    leftView.getUint16(offset, true),
+                    rightView.getUint16(offset, true)
+                )
+                outView.setUint16(offset, combined & 0xffff, true)
+            }
+            current = out
+        }
+        return current
+    }
+
+    const values: Uint8Array[] = []
+    for (let i = 0; i < 12; i += 1) {
+        const value = new Uint8Array(32)
+        for (let j = 0; j < value.length; j += 1) {
+            value[j] = (i * 37 + j * 251 + 13) & 0xff
+        }
+        values.push(value)
+    }
+    const base = new Uint8Array(APP_STATE_EMPTY_LT_HASH.byteLength)
+    for (let j = 0; j < base.length; j += 1) {
+        base[j] = (j * 199 + 7) & 0xff
+    }
+
+    const added = await crypto.ltHashAdd(base, values)
+    assert.deepEqual(
+        Array.from(added),
+        Array.from(referenceApply(base, values, (left, right) => left + right))
+    )
+
+    const subtracted = await crypto.ltHashSubtract(added, values.slice(0, 5))
+    assert.deepEqual(
+        Array.from(subtracted),
+        Array.from(referenceApply(added, values.slice(0, 5), (left, right) => left - right))
+    )
+
+    const roundTrip = await crypto.ltHashSubtract(added, values)
+    assert.deepEqual(Array.from(roundTrip), Array.from(base))
+})

--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -40,7 +40,7 @@ import {
     wrapAsViewOnce
 } from '@message/encode/content'
 import { wrapDeviceSentMessage } from '@message/encode/device-sent'
-import { writeRandomPadMax16 } from '@message/encode/padding'
+import { unpadPkcs7, writeRandomPadMax16 } from '@message/encode/padding'
 import { buildBotInvokeProtoCopy, extractInvokedBotJid, genBotMsgSecret } from '@message/kinds/bot'
 import type {
     WaEncryptedMessageInput,
@@ -1174,6 +1174,7 @@ export class WaMessageDispatchCoordinator {
         }
         const reportingArtifacts = await this.tryBuildReportingTokenArtifacts({
             message,
+            messageBytes: unpadPkcs7(plaintext),
             stanzaId: sendOptions.id,
             senderUserJid: toUserJid(senderJid),
             remoteJid: groupJid,
@@ -1364,6 +1365,7 @@ export class WaMessageDispatchCoordinator {
         const localPhash = computePhashV2(phashTargets)
         const reportingArtifacts = await this.tryBuildReportingTokenArtifacts({
             message,
+            messageBytes: unpadPkcs7(plaintext),
             stanzaId: sendOptions.id,
             senderUserJid: toUserJid(senderJid),
             remoteJid: groupJid,
@@ -1842,6 +1844,7 @@ export class WaMessageDispatchCoordinator {
             : undefined
         const reportingArtifacts = await this.tryBuildReportingTokenArtifacts({
             message,
+            messageBytes: unpadPkcs7(plaintext),
             stanzaId: sendOptions.id,
             senderUserJid: meUserJid,
             remoteJid: recipientUserJid,
@@ -1958,6 +1961,7 @@ export class WaMessageDispatchCoordinator {
 
     private async tryBuildReportingTokenArtifacts(input: {
         readonly message: Proto.IMessage
+        readonly messageBytes?: Uint8Array
         readonly stanzaId?: string
         readonly senderUserJid: string
         readonly remoteJid: string
@@ -1970,6 +1974,7 @@ export class WaMessageDispatchCoordinator {
         try {
             return await buildReportingTokenArtifacts({
                 message: input.message,
+                messageBytes: input.messageBytes,
                 stanzaId: input.stanzaId,
                 senderUserJid: input.senderUserJid,
                 remoteJid: input.remoteJid

--- a/src/crypto/core/xeddsa.ts
+++ b/src/crypto/core/xeddsa.ts
@@ -64,6 +64,31 @@ export async function xeddsaVerify(
     }
 }
 
+interface XeddsaPublicDerivation {
+    readonly privateScalar: bigint
+    readonly encodedPublic: Uint8Array
+    readonly pubKeySignBit: number
+}
+
+const publicDerivationCache = new WeakMap<Uint8Array, XeddsaPublicDerivation>()
+
+function derivePublicForSigning(privateKey: Uint8Array): XeddsaPublicDerivation {
+    const cached = publicDerivationCache.get(privateKey)
+    if (cached) {
+        return cached
+    }
+    const clampedPrivateKey = clampCurvePrivateKeyInPlace(privateKey)
+    const privateScalar = bytesToBigIntLE(clampedPrivateKey)
+    const encodedPublic = encodeExtendedPoint(scalarMultBase(privateScalar))
+    const derivation: XeddsaPublicDerivation = {
+        privateScalar,
+        encodedPublic,
+        pubKeySignBit: encodedPublic[31] & 0x80
+    }
+    publicDerivationCache.set(privateKey, derivation)
+    return derivation
+}
+
 /**
  * Signs `message` with an X25519 (Montgomery) private key using the XEdDSA
  * construction. Returns a 64-byte signature.
@@ -75,10 +100,8 @@ export async function xeddsaSign(privateKey: Uint8Array, message: Uint8Array): P
         return toBytesView(nativeBinding.xeddsaSign(privateKey, message))
     }
 
-    const clampedPrivateKey = clampCurvePrivateKeyInPlace(privateKey)
-    const privateScalar = bytesToBigIntLE(clampedPrivateKey)
-    const encodedPublic = encodeExtendedPoint(scalarMultBase(privateScalar))
-    const pubKeySignBit = encodedPublic[31] & 0x80
+    const { privateScalar, encodedPublic, pubKeySignBit } = derivePublicForSigning(privateKey)
+    const clampedPrivateKey = privateKey
 
     const randomSuffix = await randomBytesAsync(64)
     const r = modGroup(

--- a/src/crypto/curves/X25519.ts
+++ b/src/crypto/curves/X25519.ts
@@ -113,20 +113,35 @@ export function montgomeryToEdwardsPublic(curvePublicKey: Uint8Array, signBit: n
     return encoded
 }
 
-function x25519PrivateKeyObject(privKey: Uint8Array) {
-    return createPrivateKey({
+const privateKeyObjectCache = new WeakMap<Uint8Array, KeyObject>()
+const publicKeyObjectCache = new WeakMap<Uint8Array, KeyObject>()
+
+function x25519PrivateKeyObject(privKey: Uint8Array): KeyObject {
+    const cached = privateKeyObjectCache.get(privKey)
+    if (cached) {
+        return cached
+    }
+    const keyObject = createPrivateKey({
         key: pkcs8FromRawPrivate(X25519_PKCS8_PREFIX, privKey) as Buffer,
         format: 'der',
         type: 'pkcs8'
     })
+    privateKeyObjectCache.set(privKey, keyObject)
+    return keyObject
 }
 
-function x25519PublicKeyObject(pubKey: Uint8Array) {
-    return createPublicKey({
+function x25519PublicKeyObject(pubKey: Uint8Array): KeyObject {
+    const cached = publicKeyObjectCache.get(pubKey)
+    if (cached) {
+        return cached
+    }
+    const keyObject = createPublicKey({
         key: concatBytes([X25519_SPKI_PREFIX, pubKey]) as Buffer,
         format: 'der',
         type: 'spki'
     })
+    publicKeyObjectCache.set(pubKey, keyObject)
+    return keyObject
 }
 
 /**

--- a/src/media/crypto/WaMediaCrypto.ts
+++ b/src/media/crypto/WaMediaCrypto.ts
@@ -33,7 +33,6 @@ import { getWaMediaHkdfInfo, WA_APP_STATE_KEY_TYPES } from '@protocol/constants'
 import {
     assertByteLength,
     concatBytes,
-    EMPTY_BYTES,
     toBytesView,
     toChunkBytes,
     uint8TimingSafeEqual
@@ -455,7 +454,18 @@ async function pumpDecryption(
     const plainHash = createHash('sha256')
     const encHash = createHash('sha256')
     const hmac = createHmac('sha256', keys.macKey)
-    let trailing: Uint8Array = EMPTY_BYTES
+    const trailingScratch = new Uint8Array(HMAC_TRUNCATED_SIZE)
+    let trailingLength = 0
+
+    const consumeCiphertext = async (part: Uint8Array): Promise<void> => {
+        hmac.update(part)
+        const dec = decipher.update(part)
+        if (dec.byteLength > 0) {
+            const decBytes = toBytesView(dec)
+            plainHash.update(decBytes)
+            await writeChunkToWritable(plaintext, decBytes)
+        }
+    }
 
     hmac.update(keys.iv)
     try {
@@ -465,31 +475,37 @@ async function pumpDecryption(
                 continue
             }
             encHash.update(bytes)
-            const merged = trailing.byteLength === 0 ? bytes : concatBytes([trailing, bytes])
-            if (merged.byteLength <= HMAC_TRUNCATED_SIZE) {
-                trailing = merged
+            const total = trailingLength + bytes.byteLength
+            if (total <= HMAC_TRUNCATED_SIZE) {
+                trailingScratch.set(bytes, trailingLength)
+                trailingLength = total
                 continue
             }
 
-            const ciphertextChunk = merged.subarray(0, merged.byteLength - HMAC_TRUNCATED_SIZE)
-            trailing = toBytesView(merged.subarray(merged.byteLength - HMAC_TRUNCATED_SIZE))
-            hmac.update(ciphertextChunk)
-
-            const dec = decipher.update(ciphertextChunk)
-            if (dec.byteLength > 0) {
-                const decBytes = toBytesView(dec)
-                plainHash.update(decBytes)
-                await writeChunkToWritable(plaintext, decBytes)
+            const cipherLength = total - HMAC_TRUNCATED_SIZE
+            const fromTrailing = Math.min(trailingLength, cipherLength)
+            if (fromTrailing > 0) {
+                await consumeCiphertext(trailingScratch.subarray(0, fromTrailing))
             }
+            const fromBytes = cipherLength - fromTrailing
+            if (fromBytes > 0) {
+                await consumeCiphertext(bytes.subarray(0, fromBytes))
+            }
+            const keepFromTrailing = trailingLength - fromTrailing
+            if (keepFromTrailing > 0) {
+                trailingScratch.copyWithin(0, fromTrailing, trailingLength)
+            }
+            trailingScratch.set(bytes.subarray(fromBytes), keepFromTrailing)
+            trailingLength = HMAC_TRUNCATED_SIZE
         }
 
-        if (trailing.byteLength !== HMAC_TRUNCATED_SIZE) {
-            throw new Error(`ciphertext too short: ${trailing.byteLength}`)
+        if (trailingLength !== HMAC_TRUNCATED_SIZE) {
+            throw new Error(`ciphertext too short: ${trailingLength}`)
         }
 
         if (!options.skipMacVerification) {
             const signature = hmac.digest().subarray(0, HMAC_TRUNCATED_SIZE)
-            if (!uint8TimingSafeEqual(signature, trailing)) {
+            if (!uint8TimingSafeEqual(signature, trailingScratch)) {
                 throw new Error('media MAC mismatch')
             }
         }

--- a/src/message/crypto/__tests__/reporting-token.test.ts
+++ b/src/message/crypto/__tests__/reporting-token.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildReportingTokenArtifacts } from '@message/crypto/reporting-token'
+import { unpadPkcs7, writeRandomPadMax16 } from '@message/encode/padding'
+import { proto, type Proto } from '@proto'
+import { bytesToHex } from '@util/bytes'
+
+const message: Proto.IMessage = {
+    extendedTextMessage: {
+        text: 'mensagem de teste com reporting token',
+        contextInfo: {
+            mentionedJid: ['5511999998888@s.whatsapp.net']
+        }
+    },
+    messageContextInfo: {
+        messageSecret: new Uint8Array(32).fill(7)
+    }
+}
+
+const input = {
+    message,
+    stanzaId: '3EB0AABBCCDD',
+    senderUserJid: '5511888887777@s.whatsapp.net',
+    remoteJid: '5511999998888@s.whatsapp.net'
+}
+
+test('reporting token from caller-supplied bytes matches the self-encoded path', async () => {
+    const fromMessage = await buildReportingTokenArtifacts(input)
+    assert.ok(fromMessage)
+
+    const messageBytes = proto.Message.encode(message).finish()
+    const fromBytes = await buildReportingTokenArtifacts({ ...input, messageBytes })
+    assert.ok(fromBytes)
+
+    assert.equal(bytesToHex(fromBytes.reportingToken), bytesToHex(fromMessage.reportingToken))
+    assert.equal(
+        bytesToHex(fromBytes.reportingTokenContent),
+        bytesToHex(fromMessage.reportingTokenContent)
+    )
+    assert.equal(fromBytes.version, fromMessage.version)
+})
+
+test('unpadded envelope plaintext yields the same reporting token as a fresh encode', async () => {
+    const padded = await writeRandomPadMax16(proto.Message.encode(message).finish())
+    const fromEnvelope = await buildReportingTokenArtifacts({
+        ...input,
+        messageBytes: unpadPkcs7(padded)
+    })
+    const fromMessage = await buildReportingTokenArtifacts(input)
+    assert.ok(fromEnvelope)
+    assert.ok(fromMessage)
+    assert.equal(bytesToHex(fromEnvelope.reportingToken), bytesToHex(fromMessage.reportingToken))
+})

--- a/src/message/crypto/reporting-token.ts
+++ b/src/message/crypto/reporting-token.ts
@@ -63,6 +63,8 @@ interface ExtractedFieldSet {
 
 export interface BuildReportingTokenNodeInput {
     readonly message: Proto.IMessage
+    /** Unpadded `proto.Message.encode(message)` bytes, when the caller already has them. */
+    readonly messageBytes?: Uint8Array
     readonly stanzaId: string
     readonly senderUserJid: string
     readonly remoteJid: string
@@ -95,7 +97,7 @@ export async function buildReportingTokenArtifacts(
     }
 
     const reportingTokenContent = computeReportingTokenContent(
-        proto.Message.encode(input.message).finish(),
+        input.messageBytes ?? proto.Message.encode(input.message).finish(),
         input.version ?? WA_REPORTING_TOKEN_VERSION
     )
     if (reportingTokenContent.byteLength === 0) {

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -440,7 +440,7 @@ async function decryptAndProcessEncNode(
     options: WaIncomingMessageAckHandlerOptions,
     decrypt: (ciphertext: Uint8Array, senderAddress: SignalAddress) => Promise<Uint8Array>
 ): Promise<DecryptEncNodeResult> {
-    const log = options.logger.child({
+    const logContext = (): { id?: string; from?: string; participant?: string } => ({
         id: node.attrs.id,
         from: node.attrs.from,
         participant: node.attrs.participant
@@ -462,11 +462,13 @@ async function decryptAndProcessEncNode(
                     senderAddress,
                     senderKeyDistribution.payload
                 )
-                log.trace('processed incoming sender key distribution', {
+                options.logger.trace('processed incoming sender key distribution', {
+                    ...logContext(),
                     groupId: senderKeyDistribution.groupId
                 })
             } catch (error) {
-                log.warn('failed to process incoming sender key distribution', {
+                options.logger.warn('failed to process incoming sender key distribution', {
+                    ...logContext(),
                     groupId: senderKeyDistribution.groupId,
                     message: toError(error).message
                 })
@@ -496,7 +498,8 @@ async function decryptAndProcessEncNode(
         }
         return { success: true, encType }
     } catch (error) {
-        log.warn('failed to decrypt incoming message', {
+        options.logger.warn('failed to decrypt incoming message', {
+            ...logContext(),
             encType,
             message: toError(error).message
         })

--- a/src/protocol/jid.ts
+++ b/src/protocol/jid.ts
@@ -1,26 +1,28 @@
 import { WA_DEFAULTS } from '@protocol/constants'
 import type { SignalAddress } from '@signal/types'
 
-const KNOWN_SERVERS: Record<string, string> = {
-    [WA_DEFAULTS.HOST_DOMAIN]: WA_DEFAULTS.HOST_DOMAIN,
-    [WA_DEFAULTS.GROUP_SERVER]: WA_DEFAULTS.GROUP_SERVER,
-    [WA_DEFAULTS.BROADCAST_SERVER]: WA_DEFAULTS.BROADCAST_SERVER,
-    [WA_DEFAULTS.LID_SERVER]: WA_DEFAULTS.LID_SERVER,
-    [WA_DEFAULTS.HOSTED_SERVER]: WA_DEFAULTS.HOSTED_SERVER,
-    [WA_DEFAULTS.HOSTED_LID_SERVER]: WA_DEFAULTS.HOSTED_LID_SERVER,
-    [WA_DEFAULTS.MSGR_SERVER]: WA_DEFAULTS.MSGR_SERVER,
-    [WA_DEFAULTS.INTEROP_SERVER]: WA_DEFAULTS.INTEROP_SERVER,
-    [WA_DEFAULTS.NEWSLETTER_SERVER]: WA_DEFAULTS.NEWSLETTER_SERVER,
-    [WA_DEFAULTS.BOT_SERVER]: WA_DEFAULTS.BOT_SERVER
-}
+const KNOWN_SERVERS: ReadonlyMap<string, string> = new Map([
+    [WA_DEFAULTS.HOST_DOMAIN, WA_DEFAULTS.HOST_DOMAIN],
+    [WA_DEFAULTS.GROUP_SERVER, WA_DEFAULTS.GROUP_SERVER],
+    [WA_DEFAULTS.BROADCAST_SERVER, WA_DEFAULTS.BROADCAST_SERVER],
+    [WA_DEFAULTS.LID_SERVER, WA_DEFAULTS.LID_SERVER],
+    [WA_DEFAULTS.HOSTED_SERVER, WA_DEFAULTS.HOSTED_SERVER],
+    [WA_DEFAULTS.HOSTED_LID_SERVER, WA_DEFAULTS.HOSTED_LID_SERVER],
+    [WA_DEFAULTS.MSGR_SERVER, WA_DEFAULTS.MSGR_SERVER],
+    [WA_DEFAULTS.INTEROP_SERVER, WA_DEFAULTS.INTEROP_SERVER],
+    [WA_DEFAULTS.NEWSLETTER_SERVER, WA_DEFAULTS.NEWSLETTER_SERVER],
+    [WA_DEFAULTS.BOT_SERVER, WA_DEFAULTS.BOT_SERVER]
+])
 
 /**
  * Returns the canonical reference for known server strings, avoiding
  * thousands of duplicate sliced copies (e.g. "lid", "s.whatsapp.net")
- * that would otherwise be created by repeated JID parsing.
+ * that would otherwise be created by repeated JID parsing. A `Map` keeps
+ * untrusted server strings like "toString" from resolving through the
+ * object prototype chain.
  */
 function internServer(server: string): string {
-    return KNOWN_SERVERS[server] ?? server
+    return KNOWN_SERVERS.get(server) ?? server
 }
 
 function extractDigits(input: string): string {

--- a/src/signal/session/SignalProtocol.ts
+++ b/src/signal/session/SignalProtocol.ts
@@ -45,6 +45,11 @@ function signalAddressLockKey(address: SignalAddress): string {
 interface EstablishOutgoingSessionOptions {
     readonly reuseExisting?: boolean
     readonly knownAbsent?: boolean
+    /**
+     * Preloaded local identity for batch session setup. Must come from
+     * {@link SignalProtocol.loadLocalIdentity} on the same store; when
+     * absent the identity is read from the store per call.
+     */
     readonly localIdentity?: LocalIdentityContext
 }
 

--- a/src/signal/session/SignalProtocol.ts
+++ b/src/signal/session/SignalProtocol.ts
@@ -22,6 +22,7 @@ import {
     generateSerializedKeyPair,
     initiateSessionIncoming,
     initiateSessionOutgoing,
+    type LocalIdentityContext,
     requireLocalIdentity,
     toSerializedKeyPair
 } from '@signal/session/SignalSession'
@@ -44,6 +45,7 @@ function signalAddressLockKey(address: SignalAddress): string {
 interface EstablishOutgoingSessionOptions {
     readonly reuseExisting?: boolean
     readonly knownAbsent?: boolean
+    readonly localIdentity?: LocalIdentityContext
 }
 
 export interface SignalProtocolStores {
@@ -70,6 +72,15 @@ export class SignalProtocol {
     }
 
     /**
+     * Loads the local registration identity once so batch callers can share
+     * it across many `prepareOutgoingSession` calls via
+     * `options.localIdentity` instead of re-reading the store per address.
+     */
+    public async loadLocalIdentity(): Promise<LocalIdentityContext> {
+        return requireLocalIdentity(this.stores.signal)
+    }
+
+    /**
      * Builds an outgoing Signal session against a remote prekey bundle. Set
      * `options.reuseExisting` to skip the handshake when a session already
      * exists for the same remote identity. Set `options.knownAbsent` only
@@ -93,7 +104,7 @@ export class SignalProtocol {
                 }
             }
             const [local, localOneTimeBase] = await Promise.all([
-                requireLocalIdentity(this.stores.signal),
+                options.localIdentity ?? requireLocalIdentity(this.stores.signal),
                 generateSerializedKeyPair()
             ])
             const session = await initiateSessionOutgoing(local, remoteBundle, localOneTimeBase)
@@ -135,7 +146,7 @@ export class SignalProtocol {
                 }
             }
             const [local, localOneTimeBase] = await Promise.all([
-                requireLocalIdentity(this.stores.signal),
+                options.localIdentity ?? requireLocalIdentity(this.stores.signal),
                 generateSerializedKeyPair()
             ])
             const session = await initiateSessionOutgoing(local, remoteBundle, localOneTimeBase)
@@ -264,32 +275,25 @@ export class SignalProtocol {
                 }
             }
 
-            const uniqueAddressKeys = new Array<string>(requests.length)
-            const uniqueAddresses = new Array<SignalAddress>(requests.length)
-            let uniqueAddressCount = 0
+            const addressKeys = new Array<string>(requests.length)
+            const seenAddressKeys = new Set<string>()
+            const uniqueAddressKeys: string[] = []
+            const uniqueAddresses: SignalAddress[] = []
             for (let index = 0; index < requests.length; index += 1) {
                 const address = requests[index].address
                 const addressKey = signalAddressKey(address)
-                let isDuplicate = false
-                for (let dedupIndex = 0; dedupIndex < uniqueAddressCount; dedupIndex += 1) {
-                    if (uniqueAddressKeys[dedupIndex] === addressKey) {
-                        isDuplicate = true
-                        break
-                    }
-                }
-                if (isDuplicate) {
+                addressKeys[index] = addressKey
+                if (seenAddressKeys.has(addressKey)) {
                     continue
                 }
-                uniqueAddressKeys[uniqueAddressCount] = addressKey
-                uniqueAddresses[uniqueAddressCount] = address
-                uniqueAddressCount += 1
+                seenAddressKeys.add(addressKey)
+                uniqueAddressKeys.push(addressKey)
+                uniqueAddresses.push(address)
             }
-            uniqueAddressKeys.length = uniqueAddressCount
-            uniqueAddresses.length = uniqueAddressCount
 
             const currentSessions = await this.stores.session.getSessionsBatch(uniqueAddresses)
             const latestSessionByAddress = new Map<string, SignalSessionRecord>()
-            for (let index = 0; index < uniqueAddressCount; index += 1) {
+            for (let index = 0; index < uniqueAddresses.length; index += 1) {
                 const addressKey = uniqueAddressKeys[index]
                 const current = currentSessions[index]
                 if (current) {
@@ -318,7 +322,7 @@ export class SignalProtocol {
             for (let index = 0; index < requests.length; index += 1) {
                 const request = requests[index]
                 const address = request.address
-                const addressKey = signalAddressKey(address)
+                const addressKey = addressKeys[index]
                 const session = latestSessionByAddress.get(addressKey)
                 if (!session) {
                     throw new Error('signal session not found')

--- a/src/signal/session/SignalRatchet.ts
+++ b/src/signal/session/SignalRatchet.ts
@@ -36,7 +36,7 @@ import type {
     SignalRecvChain,
     SignalSessionRecord
 } from '@signal/types'
-import { concatBytes, removeAt, uint8Equal, uint8TimingSafeEqual } from '@util/bytes'
+import { removeAt, uint8Equal, uint8TimingSafeEqual } from '@util/bytes'
 import { toError } from '@util/primitives'
 
 const MAX_TRACKED_RECV_CHAINS = 4
@@ -178,16 +178,19 @@ export async function encryptMsg(
         previousCounter: session.prevSendChainHighestIndex,
         ciphertext
     }).finish()
-    const versionedSignalPayload = prependVersion(signalPayload, SIGNAL_VERSION)
+    const versionedLength = 1 + signalPayload.length
+    const signalMessage = new Uint8Array(versionedLength + SIGNAL_MAC_SIZE)
+    signalMessage[0] = ((SIGNAL_VERSION << 4) | SIGNAL_VERSION) & 0xff
+    signalMessage.set(signalPayload, 1)
     const mac = hmacSha256Sign(messageKey.macKey, [
         session.local.pubKey,
         session.remote.pubKey,
-        versionedSignalPayload
+        signalMessage.subarray(0, versionedLength)
     ])
-    const signalMessage = concatBytes([versionedSignalPayload, mac.subarray(0, SIGNAL_MAC_SIZE)])
+    signalMessage.set(mac.subarray(0, SIGNAL_MAC_SIZE), versionedLength)
 
     let type: 'msg' | 'pkmsg' = 'msg'
-    let output = signalMessage
+    let output: Uint8Array = signalMessage
     if (session.initialExchangeInfo) {
         const preKeyPayload = proto.PreKeySignalMessage.encode({
             registrationId: session.local.regId,

--- a/src/signal/session/SignalSession.ts
+++ b/src/signal/session/SignalSession.ts
@@ -11,6 +11,13 @@ import type {
 import type { WaSignalStore } from '@store/contracts/signal.store'
 import { concatBytes, uint8Equal } from '@util/bytes'
 
+/**
+ * Local registration identity used to initiate outgoing Signal sessions.
+ *
+ * @sensitive `staticKeyPair.privKey` is the account's Signal identity
+ * private key. Do not `JSON.stringify`, log, or persist instances; the
+ * store layer is responsible for encryption at rest.
+ */
 export interface LocalIdentityContext {
     readonly regId: number
     readonly staticKeyPair: SignalSerializedKeyPair

--- a/src/signal/session/SignalSession.ts
+++ b/src/signal/session/SignalSession.ts
@@ -11,7 +11,7 @@ import type {
 import type { WaSignalStore } from '@store/contracts/signal.store'
 import { concatBytes, uint8Equal } from '@util/bytes'
 
-interface LocalIdentityContext {
+export interface LocalIdentityContext {
     readonly regId: number
     readonly staticKeyPair: SignalSerializedKeyPair
 }

--- a/src/signal/session/__tests__/record-encoding.test.ts
+++ b/src/signal/session/__tests__/record-encoding.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { proto, type Proto } from '@proto'
+import {
+    decodeSignalSessionRecord,
+    encodeSignalSessionRecord,
+    encodeSignalSessionSnapshot
+} from '@signal/session/encoding'
+import { bytesToHex } from '@util/bytes'
+
+function bytes(length: number, fill: number): Uint8Array {
+    return new Uint8Array(length).fill(fill)
+}
+
+function chain(seed: number): Proto.SessionStructure.IChain {
+    return {
+        senderRatchetKey: bytes(33, seed),
+        senderRatchetKeyPrivate: bytes(32, seed + 1),
+        chainKey: { index: 10 + seed, key: bytes(32, seed + 2) },
+        messageKeys: [
+            {
+                index: 1,
+                cipherKey: bytes(32, seed + 3),
+                macKey: bytes(32, seed + 4),
+                iv: bytes(16, seed + 5)
+            },
+            {
+                index: 2,
+                cipherKey: bytes(32, seed + 6),
+                macKey: bytes(32, seed + 7),
+                iv: bytes(16, seed + 8)
+            }
+        ]
+    }
+}
+
+function sessionStructure(seed: number): Proto.ISessionStructure {
+    return {
+        sessionVersion: 3,
+        localIdentityPublic: bytes(33, seed),
+        remoteIdentityPublic: bytes(33, seed + 1),
+        localRegistrationId: 1000 + seed,
+        remoteRegistrationId: 2000 + seed,
+        rootKey: bytes(32, seed + 2),
+        previousCounter: 7,
+        senderChain: chain(seed + 3),
+        receiverChains: [chain(seed + 10)],
+        aliceBaseKey: bytes(33, seed + 20)
+    }
+}
+
+function referenceEncode(record: ReturnType<typeof decodeSignalSessionRecord>): Uint8Array {
+    return proto.RecordStructure.encode({
+        currentSession: encodeSignalSessionSnapshot(record),
+        previousSessions: record.prevSessions as Proto.ISessionStructure[]
+    }).finish()
+}
+
+function buildRecord(prevCount: number): ReturnType<typeof decodeSignalSessionRecord> {
+    const raw = proto.RecordStructure.encode({
+        currentSession: sessionStructure(1),
+        previousSessions: Array.from({ length: prevCount }, (_, i) => sessionStructure(i + 30))
+    }).finish()
+    return decodeSignalSessionRecord(raw)
+}
+
+test('encodeSignalSessionRecord matches the monolithic encode byte for byte', () => {
+    for (const prevCount of [0, 1, 5, 40]) {
+        const record = buildRecord(prevCount)
+        const expected = bytesToHex(referenceEncode(record))
+        assert.equal(
+            bytesToHex(encodeSignalSessionRecord(record)),
+            expected,
+            `cold encode, prevSessions=${prevCount}`
+        )
+        assert.equal(
+            bytesToHex(encodeSignalSessionRecord(record)),
+            expected,
+            `cached encode, prevSessions=${prevCount}`
+        )
+    }
+})
+
+test('cached prevSessions suffix follows current-session mutations and prevSessions replacement', () => {
+    const record = buildRecord(3)
+    encodeSignalSessionRecord(record)
+
+    const advanced = {
+        ...record,
+        sendChain: {
+            ...record.sendChain,
+            nextMsgIndex: record.sendChain.nextMsgIndex + 5
+        }
+    }
+    assert.equal(
+        bytesToHex(encodeSignalSessionRecord(advanced)),
+        bytesToHex(referenceEncode(advanced)),
+        'current-session mutation with shared prevSessions array'
+    )
+
+    const archived = {
+        ...record,
+        prevSessions: record.prevSessions.slice(1)
+    }
+    assert.equal(
+        bytesToHex(encodeSignalSessionRecord(archived)),
+        bytesToHex(referenceEncode(archived)),
+        'replaced prevSessions array'
+    )
+
+    const decoded = decodeSignalSessionRecord(encodeSignalSessionRecord(record))
+    assert.equal(decoded.prevSessions.length, 3)
+    assert.equal(
+        bytesToHex(encodeSignalSessionRecord(decoded)),
+        bytesToHex(encodeSignalSessionRecord(record)),
+        'decode/re-encode stability'
+    )
+})

--- a/src/signal/session/__tests__/resolver.test.ts
+++ b/src/signal/session/__tests__/resolver.test.ts
@@ -389,3 +389,41 @@ test('signal session resolver keeps stricter identity checks for concurrent call
     assert.match(String(results[1].reason), /identity mismatch/)
     assert.equal(syncIdentityCalls, 1)
 })
+
+test('signal session resolver degrades per-target when the local identity load fails', async () => {
+    const jid = '5511999999999:2@s.whatsapp.net'
+
+    const resolver = createSignalSessionResolver({
+        signalProtocol: {
+            hasSession: async () => false,
+            establishOutgoingSession: async () => {
+                throw new Error('unexpected establish call')
+            },
+            loadLocalIdentity: async () => {
+                throw new Error('registration info not found')
+            },
+            prepareOutgoingSession: async () => {
+                throw new Error('unexpected prepare call')
+            },
+            persistOutgoingSessionsBatch: async () => ({ resolved: [], skipped: [] })
+        } as never,
+        sessionStore: {
+            hasSession: async () => false,
+            getSessionsBatch: async () => [null]
+        } as never,
+        identityStore: {
+            getRemoteIdentity: async () => null
+        } as never,
+        signalIdentitySync: {
+            syncIdentityKeys: async () => undefined
+        } as never,
+        signalSessionSync: {
+            fetchKeyBundles: async () => [{ jid, bundle: buildBundle(8) }],
+            fetchKeyBundle: async () => ({ jid, bundle: buildBundle(8) })
+        } as never,
+        logger: createNoopLogger()
+    })
+
+    const resolved = await resolver.ensureSessionsBatch([jid])
+    assert.equal(resolved.length, 0)
+})

--- a/src/signal/session/__tests__/resolver.test.ts
+++ b/src/signal/session/__tests__/resolver.test.ts
@@ -95,6 +95,10 @@ test('signal session resolver batch does not fallback to single fetch for partia
                 sessionsByAddress.set(key, session)
                 return session
             },
+            loadLocalIdentity: async () => ({
+                regId: 1,
+                staticKeyPair: { pubKey: new Uint8Array(33), privKey: new Uint8Array(32) }
+            }),
             prepareOutgoingSession: async (address: {
                 readonly user: string
                 readonly device: number
@@ -253,6 +257,10 @@ test('signal session resolver shares dedup between ensureSession and ensureSessi
                 hasSession = true
                 return sessionRecord
             },
+            loadLocalIdentity: async () => ({
+                regId: 1,
+                staticKeyPair: { pubKey: new Uint8Array(33), privKey: new Uint8Array(32) }
+            }),
             prepareOutgoingSession: async () => {
                 prepareCalls += 1
                 return {

--- a/src/signal/session/encoding.ts
+++ b/src/signal/session/encoding.ts
@@ -226,15 +226,38 @@ export function decodeSignalSessionSnapshot(
     }
 }
 
+const prevSessionsSuffixCache = new WeakMap<object, Uint8Array>()
+
 /**
  * Serializes a {@link SignalSessionRecord} (current + previous sessions) into
  * the Signal `RecordStructure` protobuf encoding used by the session stores.
+ *
+ * The `previousSessions` segment only depends on the `prevSessions` array,
+ * which every mutation path replaces wholesale (never edits in place), so its
+ * encoded bytes are cached per array instance and only the current session is
+ * re-encoded on the per-message write path.
  */
 export function encodeSignalSessionRecord(record: SignalSessionRecord): Uint8Array {
-    return proto.RecordStructure.encode({
-        currentSession: encodeSignalSessionSnapshot(record),
-        previousSessions: record.prevSessions as Proto.ISessionStructure[]
+    const prevSessions = record.prevSessions
+    if (prevSessions.length === 0) {
+        return proto.RecordStructure.encode({
+            currentSession: encodeSignalSessionSnapshot(record)
+        }).finish()
+    }
+    let suffix = prevSessionsSuffixCache.get(prevSessions)
+    if (!suffix) {
+        suffix = proto.RecordStructure.encode({
+            previousSessions: prevSessions as Proto.ISessionStructure[]
+        }).finish()
+        prevSessionsSuffixCache.set(prevSessions, suffix)
+    }
+    const current = proto.RecordStructure.encode({
+        currentSession: encodeSignalSessionSnapshot(record)
     }).finish()
+    const out = new Uint8Array(current.length + suffix.length)
+    out.set(current, 0)
+    out.set(suffix, current.length)
+    return out
 }
 
 /**

--- a/src/signal/session/resolver.ts
+++ b/src/signal/session/resolver.ts
@@ -288,7 +288,7 @@ export function createSignalSessionResolver(options: {
         >(missingIndices.length)
         let prepareCount = 0
         const missingBundleTargets: { jid: string; reason: string }[] = []
-        const localIdentity = await signalProtocol.loadLocalIdentity()
+        let localIdentityPromise: ReturnType<typeof signalProtocol.loadLocalIdentity> | null = null
         for (let index = 0; index < missingIndices.length; index += 1) {
             const targetIndex = missingIndices[index]
             const targetJid = normalizedTargetJids[targetIndex]
@@ -322,12 +322,15 @@ export function createSignalSessionResolver(options: {
             const targetAddress = normalizedTargetAddresses[targetIndex]
             const bundle = batchResult.bundle
             prepareTargetIndices[prepareCount] = targetIndex
-            preparePromises[prepareCount] = signalProtocol
-                .prepareOutgoingSession(targetAddress, bundle, {
-                    reuseExisting: true,
-                    knownAbsent: true,
-                    localIdentity
-                })
+            localIdentityPromise ??= signalProtocol.loadLocalIdentity()
+            preparePromises[prepareCount] = localIdentityPromise
+                .then((localIdentity) =>
+                    signalProtocol.prepareOutgoingSession(targetAddress, bundle, {
+                        reuseExisting: true,
+                        knownAbsent: true,
+                        localIdentity
+                    })
+                )
                 .then((prep) => ({
                     session: prep.session,
                     remoteIdentity: prep.remoteIdentity

--- a/src/signal/session/resolver.ts
+++ b/src/signal/session/resolver.ts
@@ -288,6 +288,7 @@ export function createSignalSessionResolver(options: {
         >(missingIndices.length)
         let prepareCount = 0
         const missingBundleTargets: { jid: string; reason: string }[] = []
+        const localIdentity = await signalProtocol.loadLocalIdentity()
         for (let index = 0; index < missingIndices.length; index += 1) {
             const targetIndex = missingIndices[index]
             const targetJid = normalizedTargetJids[targetIndex]
@@ -324,7 +325,8 @@ export function createSignalSessionResolver(options: {
             preparePromises[prepareCount] = signalProtocol
                 .prepareOutgoingSession(targetAddress, bundle, {
                     reuseExisting: true,
-                    knownAbsent: true
+                    knownAbsent: true,
+                    localIdentity
                 })
                 .then((prep) => ({
                     session: prep.session,
@@ -353,6 +355,7 @@ export function createSignalSessionResolver(options: {
         }[] = []
         const entryToTargetIndex: number[] = []
         const fallbackIndices: number[] = []
+        const fallbackIndexSet = new Set<number>()
         for (let i = 0; i < prepareTargetIndices.length; i += 1) {
             const targetIndex = prepareTargetIndices[i]
             const result = prepareResults[i]
@@ -387,6 +390,7 @@ export function createSignalSessionResolver(options: {
                 message: normalized.message
             })
             for (let i = 0; i < entryToTargetIndex.length; i += 1) {
+                fallbackIndexSet.add(entryToTargetIndex[i])
                 fallbackIndices.push(entryToTargetIndex[i])
             }
             persistResult = { resolved: [], skipped: [] }
@@ -415,7 +419,8 @@ export function createSignalSessionResolver(options: {
             if (skippedByAddressKey.has(addrKey)) {
                 continue
             }
-            if (!fallbackIndices.includes(targetIndex)) {
+            if (!fallbackIndexSet.has(targetIndex)) {
+                fallbackIndexSet.add(targetIndex)
                 fallbackIndices.push(targetIndex)
             }
         }

--- a/src/transport/binary/__tests__/codec-golden.json
+++ b/src/transport/binary/__tests__/codec-golden.json
@@ -1,0 +1,3435 @@
+[
+    {
+        "name": "single-byte tokens as attr values",
+        "node": {
+            "tag": "iq",
+            "attrs": {
+                "a0": "xmlstreamstart",
+                "a1": "xmlstreamend",
+                "a2": "s.whatsapp.net",
+                "a3": "type",
+                "a4": "participant",
+                "a5": "from",
+                "a6": "receipt",
+                "a7": "id",
+                "a8": "notification",
+                "a9": "disappearing_mode",
+                "a10": "status",
+                "a11": "jid",
+                "a12": "broadcast",
+                "a13": "user",
+                "a14": "devices",
+                "a15": "device_hash",
+                "a16": "to",
+                "a17": "offline",
+                "a18": "message",
+                "a19": "result",
+                "a20": "class",
+                "a21": "xmlns",
+                "a22": "duration",
+                "a23": "notify",
+                "a24": "iq",
+                "a25": "t",
+                "a26": "ack",
+                "a27": "g.us",
+                "a28": "enc",
+                "a29": "urn:xmpp:whatsapp:push",
+                "a30": "presence",
+                "a31": "config_value",
+                "a32": "picture",
+                "a33": "verified_name",
+                "a34": "config_code",
+                "a35": "key-index-list",
+                "a36": "contact",
+                "a37": "mediatype",
+                "a38": "routing_info",
+                "a39": "edge_routing",
+                "a40": "get",
+                "a41": "read",
+                "a42": "urn:xmpp:ping",
+                "a43": "fallback_hostname",
+                "a44": "0",
+                "a45": "chatstate",
+                "a46": "business_hours_config",
+                "a47": "unavailable",
+                "a48": "download_buckets",
+                "a49": "skmsg",
+                "a50": "verified_level",
+                "a51": "composing",
+                "a52": "handshake",
+                "a53": "device-list",
+                "a54": "media",
+                "a55": "text",
+                "a56": "fallback_ip4",
+                "a57": "media_conn",
+                "a58": "device",
+                "a59": "creation",
+                "a60": "location",
+                "a61": "config",
+                "a62": "item",
+                "a63": "fallback_ip6",
+                "a64": "count",
+                "a65": "w:profile:picture",
+                "a66": "image",
+                "a67": "business",
+                "a68": "2",
+                "a69": "hostname",
+                "a70": "call-creator",
+                "a71": "display_name",
+                "a72": "relaylatency",
+                "a73": "platform",
+                "a74": "abprops",
+                "a75": "success",
+                "a76": "msg",
+                "a77": "offline_preview",
+                "a78": "prop",
+                "a79": "key-index",
+                "a80": "v",
+                "a81": "day_of_week",
+                "a82": "pkmsg",
+                "a83": "version",
+                "a84": "1",
+                "a85": "ping",
+                "a86": "w:p",
+                "a87": "download",
+                "a88": "video",
+                "a89": "set",
+                "a90": "specific_hours",
+                "a91": "props",
+                "a92": "primary",
+                "a93": "unknown",
+                "a94": "hash",
+                "a95": "commerce_experience",
+                "a96": "last",
+                "a97": "subscribe",
+                "a98": "max_buckets",
+                "a99": "call",
+                "a100": "profile",
+                "a101": "member_since_text",
+                "a102": "close_time",
+                "a103": "call-id",
+                "a104": "sticker",
+                "a105": "mode",
+                "a106": "participants",
+                "a107": "value",
+                "a108": "query",
+                "a109": "profile_options",
+                "a110": "open_time",
+                "a111": "code",
+                "a112": "list",
+                "a113": "host",
+                "a114": "ts",
+                "a115": "contacts",
+                "a116": "upload",
+                "a117": "lid",
+                "a118": "preview",
+                "a119": "update",
+                "a120": "usync",
+                "a121": "w:stats",
+                "a122": "delivery",
+                "a123": "auth_ttl",
+                "a124": "context",
+                "a125": "fail",
+                "a126": "cart_enabled",
+                "a127": "appdata",
+                "a128": "category",
+                "a129": "atn",
+                "a130": "direct_connection",
+                "a131": "decrypt-fail",
+                "a132": "relay_id",
+                "a133": "mmg-fallback.whatsapp.net",
+                "a134": "target",
+                "a135": "available",
+                "a136": "name",
+                "a137": "last_id",
+                "a138": "mmg.whatsapp.net",
+                "a139": "categories",
+                "a140": "401",
+                "a141": "is_new",
+                "a142": "index",
+                "a143": "tctoken",
+                "a144": "ip4",
+                "a145": "token_id",
+                "a146": "latency",
+                "a147": "recipient",
+                "a148": "edit",
+                "a149": "ip6",
+                "a150": "add",
+                "a151": "thumbnail-document",
+                "a152": "26",
+                "a153": "paused",
+                "a154": "true",
+                "a155": "identity",
+                "a156": "stream:error",
+                "a157": "key",
+                "a158": "sidelist",
+                "a159": "background",
+                "a160": "audio",
+                "a161": "3",
+                "a162": "thumbnail-image",
+                "a163": "biz-cover-photo",
+                "a164": "cat",
+                "a165": "gcm",
+                "a166": "thumbnail-video",
+                "a167": "error",
+                "a168": "auth",
+                "a169": "deny",
+                "a170": "serial",
+                "a171": "in",
+                "a172": "registration",
+                "a173": "thumbnail-link",
+                "a174": "remove",
+                "a175": "00",
+                "a176": "gif",
+                "a177": "thumbnail-gif",
+                "a178": "tag",
+                "a179": "capability",
+                "a180": "multicast",
+                "a181": "item-not-found",
+                "a182": "description",
+                "a183": "business_hours",
+                "a184": "config_expo_key",
+                "a185": "md-app-state",
+                "a186": "expiration",
+                "a187": "fallback",
+                "a188": "ttl",
+                "a189": "300",
+                "a190": "md-msg-hist",
+                "a191": "device_orientation",
+                "a192": "out",
+                "a193": "w:m",
+                "a194": "open_24h",
+                "a195": "side_list",
+                "a196": "token",
+                "a197": "inactive",
+                "a198": "01",
+                "a199": "document",
+                "a200": "te2",
+                "a201": "played",
+                "a202": "encrypt",
+                "a203": "msgr",
+                "a204": "hide",
+                "a205": "direct_path",
+                "a206": "12",
+                "a207": "state",
+                "a208": "not-authorized",
+                "a209": "url",
+                "a210": "terminate",
+                "a211": "signature",
+                "a212": "status-revoke-delay",
+                "a213": "02",
+                "a214": "te",
+                "a215": "linked_accounts",
+                "a216": "trusted_contact",
+                "a217": "timezone",
+                "a218": "ptt",
+                "a219": "kyc-id",
+                "a220": "privacy_token",
+                "a221": "readreceipts",
+                "a222": "appointment_only",
+                "a223": "address",
+                "a224": "expected_ts",
+                "a225": "privacy",
+                "a226": "7",
+                "a227": "android",
+                "a228": "interactive",
+                "a229": "device-identity",
+                "a230": "enabled",
+                "a231": "attribute_padding",
+                "a232": "1080",
+                "a233": "03",
+                "a234": "screen_height"
+            }
+        },
+        "hex": "f901d719fc02613001fc02613102fc02613203fc02613304fc02613405fc02613506fc02613607fc02613708fc02613809fc0261390afc036131300bfc036131310cfc036131320dfc036131330efc036131340ffc0361313510fc0361313611fc0361313712fc0361313813fc0361313914fc0361323015fc0361323116fc0361323217fc0361323318fc0361323419fc036132351afc036132361bfc036132371cfc036132381dfc036132391efc036133301ffc0361333120fc0361333221fc0361333322fc0361333423fc0361333524fc0361333625fc0361333726fc0361333827fc0361333928fc0361343029fc036134312afc036134322bfc036134332cfc036134342dfc036134352efc036134362ffc0361343730fc0361343831fc0361343932fc0361353033fc0361353134fc0361353235fc0361353336fc0361353437fc0361353538fc0361353639fc036135373afc036135383bfc036135393cfc036136303dfc036136313efc036136323ffc0361363340fc0361363441fc0361363542fc0361363643fc0361363744fc0361363845fc0361363946fc0361373047fc0361373148fc0361373249fc036137334afc036137344bfc036137354cfc036137364dfc036137374efc036137384ffc0361373950fc0361383051fc0361383152fc0361383253fc0361383354fc0361383455fc0361383556fc0361383657fc0361383758fc0361383859fc036138395afc036139305bfc036139315cfc036139325dfc036139335efc036139345ffc0361393560fc0361393661fc0361393762fc0361393863fc0361393964fc046131303065fc046131303166fc046131303267fc046131303368fc046131303469fc04613130356afc04613130366bfc04613130376cfc04613130386dfc04613130396efc04613131306ffc046131313170fc046131313271fc046131313372fc046131313473fc046131313574fc046131313675fc046131313776fc046131313877fc046131313978fc046131323079fc04613132317afc04613132327bfc04613132337cfc04613132347dfc04613132357efc04613132367ffc046131323780fc046131323881fc046131323982fc046131333083fc046131333184fc046131333285fc046131333386fc046131333487fc046131333588fc046131333689fc04613133378afc04613133388bfc04613133398cfc04613134308dfc04613134318efc04613134328ffc046131343390fc046131343491fc046131343592fc046131343693fc046131343794fc046131343895fc046131343996fc046131353097fc046131353198fc046131353299fc04613135339afc04613135349bfc04613135359cfc04613135369dfc04613135379efc04613135389ffc0461313539a0fc0461313630a1fc0461313631a2fc0461313632a3fc0461313633a4fc0461313634a5fc0461313635a6fc0461313636a7fc0461313637a8fc0461313638a9fc0461313639aafc0461313730abfc0461313731acfc0461313732adfc0461313733aefc0461313734affc0461313735b0fc0461313736b1fc0461313737b2fc0461313738b3fc0461313739b4fc0461313830b5fc0461313831b6fc0461313832b7fc0461313833b8fc0461313834b9fc0461313835bafc0461313836bbfc0461313837bcfc0461313838bdfc0461313839befc0461313930bffc0461313931c0fc0461313932c1fc0461313933c2fc0461313934c3fc0461313935c4fc0461313936c5fc0461313937c6fc0461313938c7fc0461313939c8fc0461323030c9fc0461323031cafc0461323032cbfc0461323033ccfc0461323034cdfc0461323035cefc0461323036cffc0461323037d0fc0461323038d1fc0461323039d2fc0461323130d3fc0461323131d4fc0461323132d5fc0461323133d6fc0461323134d7fc0461323135d8fc0461323136d9fc0461323137dafc0461323138dbfc0461323139dcfc0461323230ddfc0461323231defc0461323232dffc0461323233e0fc0461323234e1fc0461323235e2fc0461323236e3fc0461323237e4fc0461323238e5fc0461323239e6fc0461323330e7fc0461323331e8fc0461323332e9fc0461323333eafc0461323334eb"
+    },
+    {
+        "name": "dictionary 0 tokens as attr values",
+        "node": {
+            "tag": "iq",
+            "attrs": {
+                "d0": "read-self",
+                "d1": "active",
+                "d2": "fbns",
+                "d3": "protocol",
+                "d4": "reaction",
+                "d5": "screen_width",
+                "d6": "heartbeat",
+                "d7": "deviceid",
+                "d8": "2:47DEQpj8",
+                "d9": "uploadfieldstat",
+                "d10": "voip_settings",
+                "d11": "retry",
+                "d12": "priority",
+                "d13": "longitude",
+                "d14": "conflict",
+                "d15": "false",
+                "d16": "ig_professional",
+                "d17": "replaced",
+                "d18": "preaccept",
+                "d19": "cover_photo",
+                "d20": "uncompressed",
+                "d21": "encopt",
+                "d22": "ppic",
+                "d23": "04",
+                "d24": "passive",
+                "d25": "status-revoke-drop",
+                "d26": "keygen",
+                "d27": "540",
+                "d28": "offer",
+                "d29": "rate",
+                "d30": "opus",
+                "d31": "latitude",
+                "d32": "w:gp2",
+                "d33": "ver",
+                "d34": "4",
+                "d35": "business_profile",
+                "d36": "medium",
+                "d37": "sender",
+                "d38": "prev_v_id",
+                "d39": "email",
+                "d40": "website",
+                "d41": "invited",
+                "d42": "sign_credential",
+                "d43": "05",
+                "d44": "transport",
+                "d45": "skey",
+                "d46": "reason",
+                "d47": "peer_abtest_bucket",
+                "d48": "America/Sao_Paulo",
+                "d49": "appid",
+                "d50": "refresh",
+                "d51": "100",
+                "d52": "06",
+                "d53": "404",
+                "d54": "101",
+                "d55": "104",
+                "d56": "107",
+                "d57": "102",
+                "d58": "109",
+                "d59": "103",
+                "d60": "member_add_mode",
+                "d61": "105",
+                "d62": "transaction-id",
+                "d63": "110",
+                "d64": "106",
+                "d65": "outgoing",
+                "d66": "108",
+                "d67": "111",
+                "d68": "tokens",
+                "d69": "followers",
+                "d70": "ig_handle",
+                "d71": "self_pid",
+                "d72": "tue",
+                "d73": "dec",
+                "d74": "thu",
+                "d75": "joinable",
+                "d76": "peer_pid",
+                "d77": "mon",
+                "d78": "features",
+                "d79": "wed",
+                "d80": "peer_device_presence",
+                "d81": "pn",
+                "d82": "delete",
+                "d83": "07",
+                "d84": "fri",
+                "d85": "audio_duration",
+                "d86": "admin",
+                "d87": "connected",
+                "d88": "delta",
+                "d89": "rcat",
+                "d90": "disable",
+                "d91": "collection",
+                "d92": "08",
+                "d93": "480",
+                "d94": "sat",
+                "d95": "phash",
+                "d96": "all",
+                "d97": "invite",
+                "d98": "accept",
+                "d99": "critical_unblock_low",
+                "d100": "group_update",
+                "d101": "signed_credential",
+                "d102": "blinded_credential",
+                "d103": "eph_setting",
+                "d104": "net",
+                "d105": "09",
+                "d106": "background_location",
+                "d107": "refresh_id",
+                "d108": "Asia/Kolkata",
+                "d109": "privacy_mode_ts",
+                "d110": "account_sync",
+                "d111": "voip_payload_type",
+                "d112": "service_areas",
+                "d113": "acs_public_key",
+                "d114": "v_id",
+                "d115": "0a",
+                "d116": "fallback_class",
+                "d117": "relay",
+                "d118": "actual_actors",
+                "d119": "metadata",
+                "d120": "w:biz",
+                "d121": "5",
+                "d122": "connected-limit",
+                "d123": "notice",
+                "d124": "0b",
+                "d125": "host_storage",
+                "d126": "fb_page",
+                "d127": "subject",
+                "d128": "privatestats",
+                "d129": "invis",
+                "d130": "groupadd",
+                "d131": "010",
+                "d132": "note.m4r",
+                "d133": "uuid",
+                "d134": "0c",
+                "d135": "8000",
+                "d136": "sun",
+                "d137": "372",
+                "d138": "1020",
+                "d139": "stage",
+                "d140": "1200",
+                "d141": "720",
+                "d142": "canonical",
+                "d143": "fb",
+                "d144": "011",
+                "d145": "video_duration",
+                "d146": "0d",
+                "d147": "1140",
+                "d148": "superadmin",
+                "d149": "012",
+                "d150": "Opening.m4r",
+                "d151": "keystore_attestation",
+                "d152": "dleq_proof",
+                "d153": "013",
+                "d154": "timestamp",
+                "d155": "ab_key",
+                "d156": "w:sync:app:state",
+                "d157": "0e",
+                "d158": "vertical",
+                "d159": "600",
+                "d160": "p_v_id",
+                "d161": "6",
+                "d162": "likes",
+                "d163": "014",
+                "d164": "500",
+                "d165": "1260",
+                "d166": "creator",
+                "d167": "0f",
+                "d168": "rte",
+                "d169": "destination",
+                "d170": "group",
+                "d171": "group_info",
+                "d172": "syncd_anti_tampering_fatal_exception_enabled",
+                "d173": "015",
+                "d174": "dl_bw",
+                "d175": "Asia/Jakarta",
+                "d176": "vp8/h.264",
+                "d177": "online",
+                "d178": "1320",
+                "d179": "fb:multiway",
+                "d180": "10",
+                "d181": "timeout",
+                "d182": "016",
+                "d183": "nse_retry",
+                "d184": "urn:xmpp:whatsapp:dirty",
+                "d185": "017",
+                "d186": "a_v_id",
+                "d187": "web_shops_chat_header_button_enabled",
+                "d188": "nse_call",
+                "d189": "inactive-upgrade",
+                "d190": "none",
+                "d191": "web",
+                "d192": "groups",
+                "d193": "2250",
+                "d194": "mms_hot_content_timespan_in_seconds",
+                "d195": "contact_blacklist",
+                "d196": "nse_read",
+                "d197": "suspended_group_deletion_notification",
+                "d198": "binary_version",
+                "d199": "018",
+                "d200": "https://www.whatsapp.com/otp/copy/",
+                "d201": "reg_push",
+                "d202": "shops_hide_catalog_attachment_entrypoint",
+                "d203": "server_sync",
+                "d204": ".",
+                "d205": "ephemeral_messages_allowed_values",
+                "d206": "019",
+                "d207": "mms_vcache_aggregation_enabled",
+                "d208": "iphone",
+                "d209": "America/Argentina/Buenos_Aires",
+                "d210": "01a",
+                "d211": "mms_vcard_autodownload_size_kb",
+                "d212": "nse_ver",
+                "d213": "shops_header_dropdown_menu_item",
+                "d214": "dhash",
+                "d215": "catalog_status",
+                "d216": "communities_mvp_new_iqs_serverprop",
+                "d217": "blocklist",
+                "d218": "default",
+                "d219": "11",
+                "d220": "ephemeral_messages_enabled",
+                "d221": "01b",
+                "d222": "original_dimensions",
+                "d223": "8",
+                "d224": "mms4_media_retry_notification_encryption_enabled",
+                "d225": "mms4_server_error_receipt_encryption_enabled",
+                "d226": "original_image_url",
+                "d227": "sync",
+                "d228": "multiway",
+                "d229": "420",
+                "d230": "companion_enc_static",
+                "d231": "shops_profile_drawer_entrypoint",
+                "d232": "01c",
+                "d233": "vcard_as_document_size_kb",
+                "d234": "status_video_max_duration",
+                "d235": "request_image_url",
+                "d236": "01d",
+                "d237": "regular_high",
+                "d238": "s_t",
+                "d239": "abt",
+                "d240": "share_ext_min_preliminary_image_quality",
+                "d241": "01e",
+                "d242": "32",
+                "d243": "syncd_key_rotation_enabled",
+                "d244": "data_namespace",
+                "d245": "md_downgrade_read_receipts2",
+                "d246": "patch",
+                "d247": "polltype",
+                "d248": "ephemeral_messages_setting",
+                "d249": "userrate",
+                "d250": "15",
+                "d251": "partial_pjpeg_bw_threshold",
+                "d252": "played-self",
+                "d253": "catalog_exists",
+                "d254": "01f",
+                "d255": "mute_v2"
+            }
+        },
+        "hex": "f9020119fc026430ec00fc026431ec01fc026432ec02fc026433ec03fc026434ec04fc026435ec05fc026436ec06fc026437ec07fc026438ec08fc026439ec09fc03643130ec0afc03643131ec0bfc03643132ec0cfc03643133ec0dfc03643134ec0efc03643135ec0ffc03643136ec10fc03643137ec11fc03643138ec12fc03643139ec13fc03643230ec14fc03643231ec15fc03643232ec16fc03643233ec17fc03643234ec18fc03643235ec19fc03643236ec1afc03643237ec1bfc03643238ec1cfc03643239ec1dfc03643330ec1efc03643331ec1ffc03643332ec20fc03643333ec21fc03643334ec22fc03643335ec23fc03643336ec24fc03643337ec25fc03643338ec26fc03643339ec27fc03643430ec28fc03643431ec29fc03643432ec2afc03643433ec2bfc03643434ec2cfc03643435ec2dfc03643436ec2efc03643437ec2ffc03643438ec30fc03643439ec31fc03643530ec32fc03643531ec33fc03643532ec34fc03643533ec35fc03643534ec36fc03643535ec37fc03643536ec38fc03643537ec39fc03643538ec3afc03643539ec3bfc03643630ec3cfc03643631ec3dfc03643632ec3efc03643633ec3ffc03643634ec40fc03643635ec41fc03643636ec42fc03643637ec43fc03643638ec44fc03643639ec45fc03643730ec46fc03643731ec47fc03643732ec48fc03643733ec49fc03643734ec4afc03643735ec4bfc03643736ec4cfc03643737ec4dfc03643738ec4efc03643739ec4ffc03643830ec50fc03643831ec51fc03643832ec52fc03643833ec53fc03643834ec54fc03643835ec55fc03643836ec56fc03643837ec57fc03643838ec58fc03643839ec59fc03643930ec5afc03643931ec5bfc03643932ec5cfc03643933ec5dfc03643934ec5efc03643935ec5ffc03643936ec60fc03643937ec61fc03643938ec62fc03643939ec63fc0464313030ec64fc0464313031ec65fc0464313032ec66fc0464313033ec67fc0464313034ec68fc0464313035ec69fc0464313036ec6afc0464313037ec6bfc0464313038ec6cfc0464313039ec6dfc0464313130ec6efc0464313131ec6ffc0464313132ec70fc0464313133ec71fc0464313134ec72fc0464313135ec73fc0464313136ec74fc0464313137ec75fc0464313138ec76fc0464313139ec77fc0464313230ec78fc0464313231ec79fc0464313232ec7afc0464313233ec7bfc0464313234ec7cfc0464313235ec7dfc0464313236ec7efc0464313237ec7ffc0464313238ec80fc0464313239ec81fc0464313330ec82fc0464313331ec83fc0464313332ec84fc0464313333ec85fc0464313334ec86fc0464313335ec87fc0464313336ec88fc0464313337ec89fc0464313338ec8afc0464313339ec8bfc0464313430ec8cfc0464313431ec8dfc0464313432ec8efc0464313433ec8ffc0464313434ec90fc0464313435ec91fc0464313436ec92fc0464313437ec93fc0464313438ec94fc0464313439ec95fc0464313530ec96fc0464313531ec97fc0464313532ec98fc0464313533ec99fc0464313534ec9afc0464313535ec9bfc0464313536ec9cfc0464313537ec9dfc0464313538ec9efc0464313539ec9ffc0464313630eca0fc0464313631eca1fc0464313632eca2fc0464313633eca3fc0464313634eca4fc0464313635eca5fc0464313636eca6fc0464313637eca7fc0464313638eca8fc0464313639eca9fc0464313730ecaafc0464313731ecabfc0464313732ecacfc0464313733ecadfc0464313734ecaefc0464313735ecaffc0464313736ecb0fc0464313737ecb1fc0464313738ecb2fc0464313739ecb3fc0464313830ecb4fc0464313831ecb5fc0464313832ecb6fc0464313833ecb7fc0464313834ecb8fc0464313835ecb9fc0464313836ecbafc0464313837ecbbfc0464313838ecbcfc0464313839ecbdfc0464313930ecbefc0464313931ecbffc0464313932ecc0fc0464313933ecc1fc0464313934ecc2fc0464313935ecc3fc0464313936ecc4fc0464313937ecc5fc0464313938ecc6fc0464313939ecc7fc0464323030ecc8fc0464323031ecc9fc0464323032eccafc0464323033eccbfc0464323034ecccfc0464323035eccdfc0464323036eccefc0464323037eccffc0464323038ecd0fc0464323039ecd1fc0464323130ecd2fc0464323131ecd3fc0464323132ecd4fc0464323133ecd5fc0464323134ecd6fc0464323135ecd7fc0464323136ecd8fc0464323137ecd9fc0464323138ecdafc0464323139ecdbfc0464323230ecdcfc0464323231ecddfc0464323232ecdefc0464323233ecdffc0464323234ece0fc0464323235ece1fc0464323236ece2fc0464323237ece3fc0464323238ece4fc0464323239ece5fc0464323330ece6fc0464323331ece7fc0464323332ece8fc0464323333ece9fc0464323334eceafc0464323335ecebfc0464323336ececfc0464323337ecedfc0464323338eceefc0464323339eceffc0464323430ecf0fc0464323431ecf1fc0464323432ecf2fc0464323433ecf3fc0464323434ecf4fc0464323435ecf5fc0464323436ecf6fc0464323437ecf7fc0464323438ecf8fc0464323439ecf9fc0464323530ecfafc0464323531ecfbfc0464323532ecfcfc0464323533ecfdfc0464323534ecfefc0464323535ecff"
+    },
+    {
+        "name": "dictionary 1 tokens as attr values",
+        "node": {
+            "tag": "iq",
+            "attrs": {
+                "d0": "reject",
+                "d1": "dirty",
+                "d2": "announcement",
+                "d3": "020",
+                "d4": "13",
+                "d5": "9",
+                "d6": "status_video_max_bitrate",
+                "d7": "fb:thrift_iq",
+                "d8": "offline_batch",
+                "d9": "022",
+                "d10": "full",
+                "d11": "ctwa_first_business_reply_logging",
+                "d12": "h.264",
+                "d13": "smax_id",
+                "d14": "group_description_length",
+                "d15": "https://www.whatsapp.com/otp/code",
+                "d16": "status_image_max_edge",
+                "d17": "smb_upsell_business_profile_enabled",
+                "d18": "021",
+                "d19": "web_upgrade_to_md_modal",
+                "d20": "14",
+                "d21": "023",
+                "d22": "s_o",
+                "d23": "smaller_video_thumbs_status_enabled",
+                "d24": "media_max_autodownload",
+                "d25": "960",
+                "d26": "blocking_status",
+                "d27": "peer_msg",
+                "d28": "joinable_group_call_client_version",
+                "d29": "group_call_video_maximization_enabled",
+                "d30": "return_snapshot",
+                "d31": "high",
+                "d32": "America/Mexico_City",
+                "d33": "entry_point_block_logging_enabled",
+                "d34": "pop",
+                "d35": "024",
+                "d36": "1050",
+                "d37": "16",
+                "d38": "1380",
+                "d39": "one_tap_calling_in_group_chat_size",
+                "d40": "regular_low",
+                "d41": "inline_joinable_education_enabled",
+                "d42": "hq_image_max_edge",
+                "d43": "locked",
+                "d44": "America/Bogota",
+                "d45": "smb_biztools_deeplink_enabled",
+                "d46": "status_image_quality",
+                "d47": "1088",
+                "d48": "025",
+                "d49": "payments_upi_intent_transaction_limit",
+                "d50": "voip",
+                "d51": "w:g2",
+                "d52": "027",
+                "d53": "md_pin_chat_enabled",
+                "d54": "026",
+                "d55": "multi_scan_pjpeg_download_enabled",
+                "d56": "shops_product_grid",
+                "d57": "transaction_id",
+                "d58": "ctwa_context_enabled",
+                "d59": "20",
+                "d60": "fna",
+                "d61": "hq_image_quality",
+                "d62": "alt_jpeg_doc_detection_quality",
+                "d63": "group_call_max_participants",
+                "d64": "pkey",
+                "d65": "America/Belem",
+                "d66": "image_max_kbytes",
+                "d67": "web_cart_v1_1_order_message_changes_enabled",
+                "d68": "ctwa_context_enterprise_enabled",
+                "d69": "urn:xmpp:whatsapp:account",
+                "d70": "840",
+                "d71": "Asia/Kuala_Lumpur",
+                "d72": "max_participants",
+                "d73": "video_remux_after_repair_enabled",
+                "d74": "stella_addressbook_restriction_type",
+                "d75": "660",
+                "d76": "900",
+                "d77": "780",
+                "d78": "context_menu_ios13_enabled",
+                "d79": "mute-state",
+                "d80": "ref",
+                "d81": "payments_request_messages",
+                "d82": "029",
+                "d83": "frskmsg",
+                "d84": "vcard_max_size_kb",
+                "d85": "sample_buffer_gif_player_enabled",
+                "d86": "match_last_seen",
+                "d87": "510",
+                "d88": "4983",
+                "d89": "video_max_bitrate",
+                "d90": "028",
+                "d91": "w:comms:chat",
+                "d92": "17",
+                "d93": "frequently_forwarded_max",
+                "d94": "groups_privacy_blacklist",
+                "d95": "Asia/Karachi",
+                "d96": "02a",
+                "d97": "web_download_document_thumb_mms_enabled",
+                "d98": "02b",
+                "d99": "hist_sync",
+                "d100": "biz_block_reasons_version",
+                "d101": "1024",
+                "d102": "18",
+                "d103": "web_is_direct_connection_for_plm_transparent",
+                "d104": "view_once_write",
+                "d105": "file_max_size",
+                "d106": "paid_convo_id",
+                "d107": "online_privacy_setting",
+                "d108": "video_max_edge",
+                "d109": "view_once_read",
+                "d110": "enhanced_storage_management",
+                "d111": "multi_scan_pjpeg_encoding_enabled",
+                "d112": "ctwa_context_forward_enabled",
+                "d113": "video_transcode_downgrade_enable",
+                "d114": "template_doc_mime_types",
+                "d115": "hq_image_bw_threshold",
+                "d116": "30",
+                "d117": "body",
+                "d118": "u_aud_limit_sil_restarts_ctrl",
+                "d119": "other",
+                "d120": "participating",
+                "d121": "w:biz:directory",
+                "d122": "1110",
+                "d123": "vp8",
+                "d124": "4018",
+                "d125": "meta",
+                "d126": "doc_detection_image_max_edge",
+                "d127": "image_quality",
+                "d128": "1170",
+                "d129": "02c",
+                "d130": "smb_upsell_chat_banner_enabled",
+                "d131": "key_expiry_time_second",
+                "d132": "pid",
+                "d133": "stella_interop_enabled",
+                "d134": "19",
+                "d135": "linked_device_max_count",
+                "d136": "md_device_sync_enabled",
+                "d137": "02d",
+                "d138": "02e",
+                "d139": "360",
+                "d140": "enhanced_block_enabled",
+                "d141": "ephemeral_icon_in_forwarding",
+                "d142": "paid_convo_status",
+                "d143": "gif_provider",
+                "d144": "project_name",
+                "d145": "server-error",
+                "d146": "canonical_url_validation_enabled",
+                "d147": "wallpapers_v2",
+                "d148": "syncd_clear_chat_delete_chat_enabled",
+                "d149": "medianotify",
+                "d150": "02f",
+                "d151": "shops_required_tos_version",
+                "d152": "vote",
+                "d153": "reset_skey_on_id_change",
+                "d154": "030",
+                "d155": "image_max_edge",
+                "d156": "multicast_limit_global",
+                "d157": "ul_bw",
+                "d158": "21",
+                "d159": "25",
+                "d160": "5000",
+                "d161": "poll",
+                "d162": "570",
+                "d163": "22",
+                "d164": "031",
+                "d165": "1280",
+                "d166": "WhatsApp",
+                "d167": "032",
+                "d168": "bloks_shops_enabled",
+                "d169": "50",
+                "d170": "upload_host_switching_enabled",
+                "d171": "web_ctwa_context_compose_enabled",
+                "d172": "ptt_forwarded_features_enabled",
+                "d173": "unblocked",
+                "d174": "partial_pjpeg_enabled",
+                "d175": "fbid:devices",
+                "d176": "height",
+                "d177": "ephemeral_group_query_ts",
+                "d178": "group_join_permissions",
+                "d179": "order",
+                "d180": "033",
+                "d181": "alt_jpeg_status_quality",
+                "d182": "migrate",
+                "d183": "popular-bank",
+                "d184": "win_uwp_deprecation_killswitch_enabled",
+                "d185": "web_download_status_thumb_mms_enabled",
+                "d186": "blocking",
+                "d187": "url_text",
+                "d188": "035",
+                "d189": "web_forwarding_limit_to_groups",
+                "d190": "1600",
+                "d191": "val",
+                "d192": "1000",
+                "d193": "syncd_msg_date_enabled",
+                "d194": "bank-ref-id",
+                "d195": "max_subject",
+                "d196": "payments_web_enabled",
+                "d197": "web_upload_document_thumb_mms_enabled",
+                "d198": "size",
+                "d199": "request",
+                "d200": "ephemeral",
+                "d201": "24",
+                "d202": "receipt_agg",
+                "d203": "ptt_remember_play_position",
+                "d204": "sampling_weight",
+                "d205": "enc_rekey",
+                "d206": "mute_always",
+                "d207": "037",
+                "d208": "034",
+                "d209": "23",
+                "d210": "036",
+                "d211": "action",
+                "d212": "click_to_chat_qr_enabled",
+                "d213": "width",
+                "d214": "disabled",
+                "d215": "038",
+                "d216": "md_blocklist_v2",
+                "d217": "played_self_enabled",
+                "d218": "web_buttons_message_enabled",
+                "d219": "flow_id",
+                "d220": "clear",
+                "d221": "450",
+                "d222": "fbid:thread",
+                "d223": "bloks_session_state",
+                "d224": "America/Lima",
+                "d225": "attachment_picker_refresh",
+                "d226": "download_host_switching_enabled",
+                "d227": "1792",
+                "d228": "u_aud_limit_sil_restarts_test2",
+                "d229": "custom_urls",
+                "d230": "device_fanout",
+                "d231": "optimistic_upload",
+                "d232": "2000",
+                "d233": "key_cipher_suite",
+                "d234": "web_smb_upsell_in_biz_profile_enabled",
+                "d235": "e",
+                "d236": "039",
+                "d237": "siri_post_status_shortcut",
+                "d238": "pair-device",
+                "d239": "lg",
+                "d240": "lc",
+                "d241": "stream_attribution_url",
+                "d242": "model",
+                "d243": "mspjpeg_phash_gen",
+                "d244": "catalog_send_all",
+                "d245": "new_multi_vcards_ui",
+                "d246": "share_biz_vcard_enabled",
+                "d247": "-",
+                "d248": "clean",
+                "d249": "200",
+                "d250": "md_blocklist_v2_server",
+                "d251": "03b",
+                "d252": "03a",
+                "d253": "web_md_migration_experience",
+                "d254": "ptt_conversation_waveform",
+                "d255": "u_aud_limit_sil_restarts_test1"
+            }
+        },
+        "hex": "f9020119fc026430ed00fc026431ed01fc026432ed02fc026433ed03fc026434ed04fc026435ed05fc026436ed06fc026437ed07fc026438ed08fc026439ed09fc03643130ed0afc03643131ed0bfc03643132ed0cfc03643133ed0dfc03643134ed0efc03643135ed0ffc03643136ed10fc03643137ed11fc03643138ed12fc03643139ed13fc03643230ed14fc03643231ed15fc03643232ed16fc03643233ed17fc03643234ed18fc03643235ed19fc03643236ed1afc03643237ed1bfc03643238ed1cfc03643239ed1dfc03643330ed1efc03643331ed1ffc03643332ed20fc03643333ed21fc03643334ed22fc03643335ed23fc03643336ed24fc03643337ed25fc03643338ed26fc03643339ed27fc03643430ed28fc03643431ed29fc03643432ed2afc03643433ed2bfc03643434ed2cfc03643435ed2dfc03643436ed2efc03643437ed2ffc03643438ed30fc03643439ed31fc03643530ed32fc03643531ed33fc03643532ed34fc03643533ed35fc03643534ed36fc03643535ed37fc03643536ed38fc03643537ed39fc03643538ed3afc03643539ed3bfc03643630ed3cfc03643631ed3dfc03643632ed3efc03643633ed3ffc03643634ed40fc03643635ed41fc03643636ed42fc03643637ed43fc03643638ed44fc03643639ed45fc03643730ed46fc03643731ed47fc03643732ed48fc03643733ed49fc03643734ed4afc03643735ed4bfc03643736ed4cfc03643737ed4dfc03643738ed4efc03643739ed4ffc03643830ed50fc03643831ed51fc03643832ed52fc03643833ed53fc03643834ed54fc03643835ed55fc03643836ed56fc03643837ed57fc03643838ed58fc03643839ed59fc03643930ed5afc03643931ed5bfc03643932ed5cfc03643933ed5dfc03643934ed5efc03643935ed5ffc03643936ed60fc03643937ed61fc03643938ed62fc03643939ed63fc0464313030ed64fc0464313031ed65fc0464313032ed66fc0464313033ed67fc0464313034ed68fc0464313035ed69fc0464313036ed6afc0464313037ed6bfc0464313038ed6cfc0464313039ed6dfc0464313130ed6efc0464313131ed6ffc0464313132ed70fc0464313133ed71fc0464313134ed72fc0464313135ed73fc0464313136ed74fc0464313137ed75fc0464313138ed76fc0464313139ed77fc0464313230ed78fc0464313231ed79fc0464313232ed7afc0464313233ed7bfc0464313234ed7cfc0464313235ed7dfc0464313236ed7efc0464313237ed7ffc0464313238ed80fc0464313239ed81fc0464313330ed82fc0464313331ed83fc0464313332ed84fc0464313333ed85fc0464313334ed86fc0464313335ed87fc0464313336ed88fc0464313337ed89fc0464313338ed8afc0464313339ed8bfc0464313430ed8cfc0464313431ed8dfc0464313432ed8efc0464313433ed8ffc0464313434ed90fc0464313435ed91fc0464313436ed92fc0464313437ed93fc0464313438ed94fc0464313439ed95fc0464313530ed96fc0464313531ed97fc0464313532ed98fc0464313533ed99fc0464313534ed9afc0464313535ed9bfc0464313536ed9cfc0464313537ed9dfc0464313538ed9efc0464313539ed9ffc0464313630eda0fc0464313631eda1fc0464313632eda2fc0464313633eda3fc0464313634eda4fc0464313635eda5fc0464313636eda6fc0464313637eda7fc0464313638eda8fc0464313639eda9fc0464313730edaafc0464313731edabfc0464313732edacfc0464313733edadfc0464313734edaefc0464313735edaffc0464313736edb0fc0464313737edb1fc0464313738edb2fc0464313739edb3fc0464313830edb4fc0464313831edb5fc0464313832edb6fc0464313833edb7fc0464313834edb8fc0464313835edb9fc0464313836edbafc0464313837edbbfc0464313838edbcfc0464313839edbdfc0464313930edbefc0464313931edbffc0464313932edc0fc0464313933edc1fc0464313934edc2fc0464313935edc3fc0464313936edc4fc0464313937edc5fc0464313938edc6fc0464313939edc7fc0464323030edc8fc0464323031edc9fc0464323032edcafc0464323033edcbfc0464323034edccfc0464323035edcdfc0464323036edcefc0464323037edcffc0464323038edd0fc0464323039edd1fc0464323130edd2fc0464323131edd3fc0464323132edd4fc0464323133edd5fc0464323134edd6fc0464323135edd7fc0464323136edd8fc0464323137edd9fc0464323138eddafc0464323139eddbfc0464323230eddcfc0464323231edddfc0464323232eddefc0464323233eddffc0464323234ede0fc0464323235ede1fc0464323236ede2fc0464323237ede3fc0464323238ede4fc0464323239ede5fc0464323330ede6fc0464323331ede7fc0464323332ede8fc0464323333ede9fc0464323334edeafc0464323335edebfc0464323336edecfc0464323337ededfc0464323338edeefc0464323339edeffc0464323430edf0fc0464323431edf1fc0464323432edf2fc0464323433edf3fc0464323434edf4fc0464323435edf5fc0464323436edf6fc0464323437edf7fc0464323438edf8fc0464323439edf9fc0464323530edfafc0464323531edfbfc0464323532edfcfc0464323533edfdfc0464323534edfefc0464323535edff"
+    },
+    {
+        "name": "dictionary 2 tokens as attr values",
+        "node": {
+            "tag": "iq",
+            "attrs": {
+                "d0": "64",
+                "d1": "ptt_playback_speed_enabled",
+                "d2": "web_product_list_message_enabled",
+                "d3": "paid_convo_ts",
+                "d4": "27",
+                "d5": "manufacturer",
+                "d6": "psp-routing",
+                "d7": "grp_uii_cleanup",
+                "d8": "ptt_draft_enabled",
+                "d9": "03c",
+                "d10": "business_initiated",
+                "d11": "web_catalog_products_onoff",
+                "d12": "web_upload_link_thumb_mms_enabled",
+                "d13": "03e",
+                "d14": "mediaretry",
+                "d15": "35",
+                "d16": "hfm_string_changes",
+                "d17": "28",
+                "d18": "America/Fortaleza",
+                "d19": "max_keys",
+                "d20": "md_mhfs_days",
+                "d21": "streaming_upload_chunk_size",
+                "d22": "5541",
+                "d23": "040",
+                "d24": "03d",
+                "d25": "2675",
+                "d26": "03f",
+                "d27": "...",
+                "d28": "512",
+                "d29": "mute",
+                "d30": "48",
+                "d31": "041",
+                "d32": "alt_jpeg_quality",
+                "d33": "60",
+                "d34": "042",
+                "d35": "md_smb_quick_reply",
+                "d36": "5183",
+                "d37": "c",
+                "d38": "1343",
+                "d39": "40",
+                "d40": "1230",
+                "d41": "043",
+                "d42": "044",
+                "d43": "mms_cat_v1_forward_hot_override_enabled",
+                "d44": "user_notice",
+                "d45": "ptt_waveform_send",
+                "d46": "047",
+                "d47": "Asia/Calcutta",
+                "d48": "250",
+                "d49": "md_privacy_v2",
+                "d50": "31",
+                "d51": "29",
+                "d52": "128",
+                "d53": "md_messaging_enabled",
+                "d54": "046",
+                "d55": "crypto",
+                "d56": "690",
+                "d57": "045",
+                "d58": "enc_iv",
+                "d59": "75",
+                "d60": "failure",
+                "d61": "ptt_oot_playback",
+                "d62": "AIzaSyDR5yfaG7OG8sMTUj8kfQEb8T9pN8BM6Lk",
+                "d63": "w",
+                "d64": "048",
+                "d65": "2201",
+                "d66": "web_large_files_ui",
+                "d67": "Asia/Makassar",
+                "d68": "812",
+                "d69": "status_collapse_muted",
+                "d70": "1334",
+                "d71": "257",
+                "d72": "2HP4dm",
+                "d73": "049",
+                "d74": "patches",
+                "d75": "1290",
+                "d76": "43cY6T",
+                "d77": "America/Caracas",
+                "d78": "web_sticker_maker",
+                "d79": "campaign",
+                "d80": "ptt_pausable_enabled",
+                "d81": "33",
+                "d82": "42",
+                "d83": "attestation",
+                "d84": "biz",
+                "d85": "04b",
+                "d86": "query_linked",
+                "d87": "s",
+                "d88": "125",
+                "d89": "04a",
+                "d90": "810",
+                "d91": "availability",
+                "d92": "1411",
+                "d93": "responsiveness_v2_m1",
+                "d94": "catalog_not_created",
+                "d95": "34",
+                "d96": "America/Santiago",
+                "d97": "1465",
+                "d98": "enc_p",
+                "d99": "04d",
+                "d100": "status_info",
+                "d101": "04f",
+                "d102": "key_version",
+                "d103": "..",
+                "d104": "04c",
+                "d105": "04e",
+                "d106": "md_group_notification",
+                "d107": "1598",
+                "d108": "1215",
+                "d109": "web_cart_enabled",
+                "d110": "37",
+                "d111": "630",
+                "d112": "1920",
+                "d113": "2394",
+                "d114": "-1",
+                "d115": "vcard",
+                "d116": "38",
+                "d117": "elapsed",
+                "d118": "36",
+                "d119": "828",
+                "d120": "peer",
+                "d121": "pricing_category",
+                "d122": "1245",
+                "d123": "invalid",
+                "d124": "stella_ios_enabled",
+                "d125": "2687",
+                "d126": "45",
+                "d127": "1528",
+                "d128": "39",
+                "d129": "u_is_redial_audio_1104_ctrl",
+                "d130": "1025",
+                "d131": "1455",
+                "d132": "58",
+                "d133": "2524",
+                "d134": "2603",
+                "d135": "054",
+                "d136": "bsp_system_message_enabled",
+                "d137": "web_pip_redesign",
+                "d138": "051",
+                "d139": "verify_apps",
+                "d140": "1974",
+                "d141": "1272",
+                "d142": "1322",
+                "d143": "1755",
+                "d144": "052",
+                "d145": "70",
+                "d146": "050",
+                "d147": "1063",
+                "d148": "1135",
+                "d149": "1361",
+                "d150": "80",
+                "d151": "1096",
+                "d152": "1828",
+                "d153": "1851",
+                "d154": "1251",
+                "d155": "1921",
+                "d156": "key_config_id",
+                "d157": "1254",
+                "d158": "1566",
+                "d159": "1252",
+                "d160": "2525",
+                "d161": "critical_block",
+                "d162": "1669",
+                "d163": "max_available",
+                "d164": "w:auth:backup:token",
+                "d165": "product",
+                "d166": "2530",
+                "d167": "870",
+                "d168": "1022",
+                "d169": "participant_uuid",
+                "d170": "web_cart_on_off",
+                "d171": "1255",
+                "d172": "1432",
+                "d173": "1867",
+                "d174": "41",
+                "d175": "1415",
+                "d176": "1440",
+                "d177": "240",
+                "d178": "1204",
+                "d179": "1608",
+                "d180": "1690",
+                "d181": "1846",
+                "d182": "1483",
+                "d183": "1687",
+                "d184": "1749",
+                "d185": "69",
+                "d186": "url_number",
+                "d187": "053",
+                "d188": "1325",
+                "d189": "1040",
+                "d190": "365",
+                "d191": "59",
+                "d192": "Asia/Riyadh",
+                "d193": "1177",
+                "d194": "test_recommended",
+                "d195": "057",
+                "d196": "1612",
+                "d197": "43",
+                "d198": "1061",
+                "d199": "1518",
+                "d200": "1635",
+                "d201": "055",
+                "d202": "1034",
+                "d203": "1375",
+                "d204": "750",
+                "d205": "1430",
+                "d206": "event_code",
+                "d207": "1682",
+                "d208": "503",
+                "d209": "55",
+                "d210": "865",
+                "d211": "78",
+                "d212": "1309",
+                "d213": "1365",
+                "d214": "44",
+                "d215": "America/Guayaquil",
+                "d216": "535",
+                "d217": "LIMITED",
+                "d218": "1377",
+                "d219": "1613",
+                "d220": "1420",
+                "d221": "1599",
+                "d222": "1822",
+                "d223": "05a",
+                "d224": "1681",
+                "d225": "password",
+                "d226": "1111",
+                "d227": "1214",
+                "d228": "1376",
+                "d229": "1478",
+                "d230": "47",
+                "d231": "1082",
+                "d232": "4282",
+                "d233": "Europe/Istanbul",
+                "d234": "1307",
+                "d235": "46",
+                "d236": "058",
+                "d237": "1124",
+                "d238": "256",
+                "d239": "rate-overlimit",
+                "d240": "retail",
+                "d241": "u_a_socket_err_fix_succ_test",
+                "d242": "1292",
+                "d243": "1370",
+                "d244": "1388",
+                "d245": "520",
+                "d246": "861",
+                "d247": "psa",
+                "d248": "regular",
+                "d249": "1181",
+                "d250": "1766",
+                "d251": "05b",
+                "d252": "1183",
+                "d253": "1213",
+                "d254": "1304",
+                "d255": "1537"
+            }
+        },
+        "hex": "f9020119fc026430ee00fc026431ee01fc026432ee02fc026433ee03fc026434ee04fc026435ee05fc026436ee06fc026437ee07fc026438ee08fc026439ee09fc03643130ee0afc03643131ee0bfc03643132ee0cfc03643133ee0dfc03643134ee0efc03643135ee0ffc03643136ee10fc03643137ee11fc03643138ee12fc03643139ee13fc03643230ee14fc03643231ee15fc03643232ee16fc03643233ee17fc03643234ee18fc03643235ee19fc03643236ee1afc03643237ee1bfc03643238ee1cfc03643239ee1dfc03643330ee1efc03643331ee1ffc03643332ee20fc03643333ee21fc03643334ee22fc03643335ee23fc03643336ee24fc03643337ee25fc03643338ee26fc03643339ee27fc03643430ee28fc03643431ee29fc03643432ee2afc03643433ee2bfc03643434ee2cfc03643435ee2dfc03643436ee2efc03643437ee2ffc03643438ee30fc03643439ee31fc03643530ee32fc03643531ee33fc03643532ee34fc03643533ee35fc03643534ee36fc03643535ee37fc03643536ee38fc03643537ee39fc03643538ee3afc03643539ee3bfc03643630ee3cfc03643631ee3dfc03643632ee3efc03643633ee3ffc03643634ee40fc03643635ee41fc03643636ee42fc03643637ee43fc03643638ee44fc03643639ee45fc03643730ee46fc03643731ee47fc03643732ee48fc03643733ee49fc03643734ee4afc03643735ee4bfc03643736ee4cfc03643737ee4dfc03643738ee4efc03643739ee4ffc03643830ee50fc03643831ee51fc03643832ee52fc03643833ee53fc03643834ee54fc03643835ee55fc03643836ee56fc03643837ee57fc03643838ee58fc03643839ee59fc03643930ee5afc03643931ee5bfc03643932ee5cfc03643933ee5dfc03643934ee5efc03643935ee5ffc03643936ee60fc03643937ee61fc03643938ee62fc03643939ee63fc0464313030ee64fc0464313031ee65fc0464313032ee66fc0464313033ee67fc0464313034ee68fc0464313035ee69fc0464313036ee6afc0464313037ee6bfc0464313038ee6cfc0464313039ee6dfc0464313130ee6efc0464313131ee6ffc0464313132ee70fc0464313133ee71fc0464313134ee72fc0464313135ee73fc0464313136ee74fc0464313137ee75fc0464313138ee76fc0464313139ee77fc0464313230ee78fc0464313231ee79fc0464313232ee7afc0464313233ee7bfc0464313234ee7cfc0464313235ee7dfc0464313236ee7efc0464313237ee7ffc0464313238ee80fc0464313239ee81fc0464313330ee82fc0464313331ee83fc0464313332ee84fc0464313333ee85fc0464313334ee86fc0464313335ee87fc0464313336ee88fc0464313337ee89fc0464313338ee8afc0464313339ee8bfc0464313430ee8cfc0464313431ee8dfc0464313432ee8efc0464313433ee8ffc0464313434ee90fc0464313435ee91fc0464313436ee92fc0464313437ee93fc0464313438ee94fc0464313439ee95fc0464313530ee96fc0464313531ee97fc0464313532ee98fc0464313533ee99fc0464313534ee9afc0464313535ee9bfc0464313536ee9cfc0464313537ee9dfc0464313538ee9efc0464313539ee9ffc0464313630eea0fc0464313631eea1fc0464313632eea2fc0464313633eea3fc0464313634eea4fc0464313635eea5fc0464313636eea6fc0464313637eea7fc0464313638eea8fc0464313639eea9fc0464313730eeaafc0464313731eeabfc0464313732eeacfc0464313733eeadfc0464313734eeaefc0464313735eeaffc0464313736eeb0fc0464313737eeb1fc0464313738eeb2fc0464313739eeb3fc0464313830eeb4fc0464313831eeb5fc0464313832eeb6fc0464313833eeb7fc0464313834eeb8fc0464313835eeb9fc0464313836eebafc0464313837eebbfc0464313838eebcfc0464313839eebdfc0464313930eebefc0464313931eebffc0464313932eec0fc0464313933eec1fc0464313934eec2fc0464313935eec3fc0464313936eec4fc0464313937eec5fc0464313938eec6fc0464313939eec7fc0464323030eec8fc0464323031eec9fc0464323032eecafc0464323033eecbfc0464323034eeccfc0464323035eecdfc0464323036eecefc0464323037eecffc0464323038eed0fc0464323039eed1fc0464323130eed2fc0464323131eed3fc0464323132eed4fc0464323133eed5fc0464323134eed6fc0464323135eed7fc0464323136eed8fc0464323137eed9fc0464323138eedafc0464323139eedbfc0464323230eedcfc0464323231eeddfc0464323232eedefc0464323233eedffc0464323234eee0fc0464323235eee1fc0464323236eee2fc0464323237eee3fc0464323238eee4fc0464323239eee5fc0464323330eee6fc0464323331eee7fc0464323332eee8fc0464323333eee9fc0464323334eeeafc0464323335eeebfc0464323336eeecfc0464323337eeedfc0464323338eeeefc0464323339eeeffc0464323430eef0fc0464323431eef1fc0464323432eef2fc0464323433eef3fc0464323434eef4fc0464323435eef5fc0464323436eef6fc0464323437eef7fc0464323438eef8fc0464323439eef9fc0464323530eefafc0464323531eefbfc0464323532eefcfc0464323533eefdfc0464323534eefefc0464323535eeff"
+    },
+    {
+        "name": "dictionary 3 tokens as attr values",
+        "node": {
+            "tag": "iq",
+            "attrs": {
+                "d0": "1724",
+                "d1": "profile_picture",
+                "d2": "1071",
+                "d3": "1314",
+                "d4": "1605",
+                "d5": "407",
+                "d6": "990",
+                "d7": "1710",
+                "d8": "746",
+                "d9": "pricing_model",
+                "d10": "056",
+                "d11": "059",
+                "d12": "061",
+                "d13": "1119",
+                "d14": "6027",
+                "d15": "65",
+                "d16": "877",
+                "d17": "1607",
+                "d18": "05d",
+                "d19": "917",
+                "d20": "seen",
+                "d21": "1516",
+                "d22": "49",
+                "d23": "470",
+                "d24": "973",
+                "d25": "1037",
+                "d26": "1350",
+                "d27": "1394",
+                "d28": "1480",
+                "d29": "1796",
+                "d30": "keys",
+                "d31": "794",
+                "d32": "1536",
+                "d33": "1594",
+                "d34": "2378",
+                "d35": "1333",
+                "d36": "1524",
+                "d37": "1825",
+                "d38": "116",
+                "d39": "309",
+                "d40": "52",
+                "d41": "808",
+                "d42": "827",
+                "d43": "909",
+                "d44": "495",
+                "d45": "1660",
+                "d46": "361",
+                "d47": "957",
+                "d48": "google",
+                "d49": "1357",
+                "d50": "1565",
+                "d51": "1967",
+                "d52": "996",
+                "d53": "1775",
+                "d54": "586",
+                "d55": "736",
+                "d56": "1052",
+                "d57": "1670",
+                "d58": "bank",
+                "d59": "177",
+                "d60": "1416",
+                "d61": "2194",
+                "d62": "2222",
+                "d63": "1454",
+                "d64": "1839",
+                "d65": "1275",
+                "d66": "53",
+                "d67": "997",
+                "d68": "1629",
+                "d69": "6028",
+                "d70": "smba",
+                "d71": "1378",
+                "d72": "1410",
+                "d73": "05c",
+                "d74": "1849",
+                "d75": "727",
+                "d76": "create",
+                "d77": "1559",
+                "d78": "536",
+                "d79": "1106",
+                "d80": "1310",
+                "d81": "1944",
+                "d82": "670",
+                "d83": "1297",
+                "d84": "1316",
+                "d85": "1762",
+                "d86": "en",
+                "d87": "1148",
+                "d88": "1295",
+                "d89": "1551",
+                "d90": "1853",
+                "d91": "1890",
+                "d92": "1208",
+                "d93": "1784",
+                "d94": "7200",
+                "d95": "05f",
+                "d96": "178",
+                "d97": "1283",
+                "d98": "1332",
+                "d99": "381",
+                "d100": "643",
+                "d101": "1056",
+                "d102": "1238",
+                "d103": "2024",
+                "d104": "2387",
+                "d105": "179",
+                "d106": "981",
+                "d107": "1547",
+                "d108": "1705",
+                "d109": "05e",
+                "d110": "290",
+                "d111": "903",
+                "d112": "1069",
+                "d113": "1285",
+                "d114": "2436",
+                "d115": "062",
+                "d116": "251",
+                "d117": "560",
+                "d118": "582",
+                "d119": "719",
+                "d120": "56",
+                "d121": "1700",
+                "d122": "2321",
+                "d123": "325",
+                "d124": "448",
+                "d125": "613",
+                "d126": "777",
+                "d127": "791",
+                "d128": "51",
+                "d129": "488",
+                "d130": "902",
+                "d131": "Asia/Almaty",
+                "d132": "is_hidden",
+                "d133": "1398",
+                "d134": "1527",
+                "d135": "1893",
+                "d136": "1999",
+                "d137": "2367",
+                "d138": "2642",
+                "d139": "237",
+                "d140": "busy",
+                "d141": "065",
+                "d142": "067",
+                "d143": "233",
+                "d144": "590",
+                "d145": "993",
+                "d146": "1511",
+                "d147": "54",
+                "d148": "723",
+                "d149": "860",
+                "d150": "363",
+                "d151": "487",
+                "d152": "522",
+                "d153": "605",
+                "d154": "995",
+                "d155": "1321",
+                "d156": "1691",
+                "d157": "1865",
+                "d158": "2447",
+                "d159": "2462",
+                "d160": "NON_TRANSACTIONAL",
+                "d161": "433",
+                "d162": "871",
+                "d163": "432",
+                "d164": "1004",
+                "d165": "1207",
+                "d166": "2032",
+                "d167": "2050",
+                "d168": "2379",
+                "d169": "2446",
+                "d170": "279",
+                "d171": "636",
+                "d172": "703",
+                "d173": "904",
+                "d174": "248",
+                "d175": "370",
+                "d176": "691",
+                "d177": "700",
+                "d178": "1068",
+                "d179": "1655",
+                "d180": "2334",
+                "d181": "060",
+                "d182": "063",
+                "d183": "364",
+                "d184": "533",
+                "d185": "534",
+                "d186": "567",
+                "d187": "1191",
+                "d188": "1210",
+                "d189": "1473",
+                "d190": "1827",
+                "d191": "069",
+                "d192": "701",
+                "d193": "2531",
+                "d194": "514",
+                "d195": "prev_dhash",
+                "d196": "064",
+                "d197": "496",
+                "d198": "790",
+                "d199": "1046",
+                "d200": "1139",
+                "d201": "1505",
+                "d202": "1521",
+                "d203": "1108",
+                "d204": "207",
+                "d205": "544",
+                "d206": "637",
+                "d207": "final",
+                "d208": "1173",
+                "d209": "1293",
+                "d210": "1694",
+                "d211": "1939",
+                "d212": "1951",
+                "d213": "1993",
+                "d214": "2353",
+                "d215": "2515",
+                "d216": "504",
+                "d217": "601",
+                "d218": "857",
+                "d219": "modify",
+                "d220": "spam_request",
+                "d221": "p_121_aa_1101_test4",
+                "d222": "866",
+                "d223": "1427",
+                "d224": "1502",
+                "d225": "1638",
+                "d226": "1744",
+                "d227": "2153",
+                "d228": "068",
+                "d229": "382",
+                "d230": "725",
+                "d231": "1704",
+                "d232": "1864",
+                "d233": "1990",
+                "d234": "2003",
+                "d235": "Asia/Dubai",
+                "d236": "508",
+                "d237": "531",
+                "d238": "1387",
+                "d239": "1474",
+                "d240": "1632",
+                "d241": "2307",
+                "d242": "2386",
+                "d243": "819",
+                "d244": "2014",
+                "d245": "066",
+                "d246": "387",
+                "d247": "1468",
+                "d248": "1706",
+                "d249": "2186",
+                "d250": "2261",
+                "d251": "471",
+                "d252": "728",
+                "d253": "1147",
+                "d254": "1372",
+                "d255": "1961"
+            }
+        },
+        "hex": "f9020119fc026430ef00fc026431ef01fc026432ef02fc026433ef03fc026434ef04fc026435ef05fc026436ef06fc026437ef07fc026438ef08fc026439ef09fc03643130ef0afc03643131ef0bfc03643132ef0cfc03643133ef0dfc03643134ef0efc03643135ef0ffc03643136ef10fc03643137ef11fc03643138ef12fc03643139ef13fc03643230ef14fc03643231ef15fc03643232ef16fc03643233ef17fc03643234ef18fc03643235ef19fc03643236ef1afc03643237ef1bfc03643238ef1cfc03643239ef1dfc03643330ef1efc03643331ef1ffc03643332ef20fc03643333ef21fc03643334ef22fc03643335ef23fc03643336ef24fc03643337ef25fc03643338ef26fc03643339ef27fc03643430ef28fc03643431ef29fc03643432ef2afc03643433ef2bfc03643434ef2cfc03643435ef2dfc03643436ef2efc03643437ef2ffc03643438ef30fc03643439ef31fc03643530ef32fc03643531ef33fc03643532ef34fc03643533ef35fc03643534ef36fc03643535ef37fc03643536ef38fc03643537ef39fc03643538ef3afc03643539ef3bfc03643630ef3cfc03643631ef3dfc03643632ef3efc03643633ef3ffc03643634ef40fc03643635ef41fc03643636ef42fc03643637ef43fc03643638ef44fc03643639ef45fc03643730ef46fc03643731ef47fc03643732ef48fc03643733ef49fc03643734ef4afc03643735ef4bfc03643736ef4cfc03643737ef4dfc03643738ef4efc03643739ef4ffc03643830ef50fc03643831ef51fc03643832ef52fc03643833ef53fc03643834ef54fc03643835ef55fc03643836ef56fc03643837ef57fc03643838ef58fc03643839ef59fc03643930ef5afc03643931ef5bfc03643932ef5cfc03643933ef5dfc03643934ef5efc03643935ef5ffc03643936ef60fc03643937ef61fc03643938ef62fc03643939ef63fc0464313030ef64fc0464313031ef65fc0464313032ef66fc0464313033ef67fc0464313034ef68fc0464313035ef69fc0464313036ef6afc0464313037ef6bfc0464313038ef6cfc0464313039ef6dfc0464313130ef6efc0464313131ef6ffc0464313132ef70fc0464313133ef71fc0464313134ef72fc0464313135ef73fc0464313136ef74fc0464313137ef75fc0464313138ef76fc0464313139ef77fc0464313230ef78fc0464313231ef79fc0464313232ef7afc0464313233ef7bfc0464313234ef7cfc0464313235ef7dfc0464313236ef7efc0464313237ef7ffc0464313238ef80fc0464313239ef81fc0464313330ef82fc0464313331ef83fc0464313332ef84fc0464313333ef85fc0464313334ef86fc0464313335ef87fc0464313336ef88fc0464313337ef89fc0464313338ef8afc0464313339ef8bfc0464313430ef8cfc0464313431ef8dfc0464313432ef8efc0464313433ef8ffc0464313434ef90fc0464313435ef91fc0464313436ef92fc0464313437ef93fc0464313438ef94fc0464313439ef95fc0464313530ef96fc0464313531ef97fc0464313532ef98fc0464313533ef99fc0464313534ef9afc0464313535ef9bfc0464313536ef9cfc0464313537ef9dfc0464313538ef9efc0464313539ef9ffc0464313630efa0fc0464313631efa1fc0464313632efa2fc0464313633efa3fc0464313634efa4fc0464313635efa5fc0464313636efa6fc0464313637efa7fc0464313638efa8fc0464313639efa9fc0464313730efaafc0464313731efabfc0464313732efacfc0464313733efadfc0464313734efaefc0464313735efaffc0464313736efb0fc0464313737efb1fc0464313738efb2fc0464313739efb3fc0464313830efb4fc0464313831efb5fc0464313832efb6fc0464313833efb7fc0464313834efb8fc0464313835efb9fc0464313836efbafc0464313837efbbfc0464313838efbcfc0464313839efbdfc0464313930efbefc0464313931efbffc0464313932efc0fc0464313933efc1fc0464313934efc2fc0464313935efc3fc0464313936efc4fc0464313937efc5fc0464313938efc6fc0464313939efc7fc0464323030efc8fc0464323031efc9fc0464323032efcafc0464323033efcbfc0464323034efccfc0464323035efcdfc0464323036efcefc0464323037efcffc0464323038efd0fc0464323039efd1fc0464323130efd2fc0464323131efd3fc0464323132efd4fc0464323133efd5fc0464323134efd6fc0464323135efd7fc0464323136efd8fc0464323137efd9fc0464323138efdafc0464323139efdbfc0464323230efdcfc0464323231efddfc0464323232efdefc0464323233efdffc0464323234efe0fc0464323235efe1fc0464323236efe2fc0464323237efe3fc0464323238efe4fc0464323239efe5fc0464323330efe6fc0464323331efe7fc0464323332efe8fc0464323333efe9fc0464323334efeafc0464323335efebfc0464323336efecfc0464323337efedfc0464323338efeefc0464323339efeffc0464323430eff0fc0464323431eff1fc0464323432eff2fc0464323433eff3fc0464323434eff4fc0464323435eff5fc0464323436eff6fc0464323437eff7fc0464323438eff8fc0464323439eff9fc0464323530effafc0464323531effbfc0464323532effcfc0464323533effdfc0464323534effefc0464323535efff"
+    },
+    {
+        "name": "tokens as tags",
+        "node": {
+            "tag": "message",
+            "attrs": {},
+            "content": [
+                {
+                    "tag": "xmlstreamstart",
+                    "attrs": {}
+                },
+                {
+                    "tag": "xmlstreamend",
+                    "attrs": {}
+                },
+                {
+                    "tag": "s.whatsapp.net",
+                    "attrs": {}
+                },
+                {
+                    "tag": "type",
+                    "attrs": {}
+                },
+                {
+                    "tag": "participant",
+                    "attrs": {}
+                },
+                {
+                    "tag": "from",
+                    "attrs": {}
+                },
+                {
+                    "tag": "receipt",
+                    "attrs": {}
+                },
+                {
+                    "tag": "id",
+                    "attrs": {}
+                },
+                {
+                    "tag": "notification",
+                    "attrs": {}
+                },
+                {
+                    "tag": "disappearing_mode",
+                    "attrs": {}
+                },
+                {
+                    "tag": "status",
+                    "attrs": {}
+                },
+                {
+                    "tag": "jid",
+                    "attrs": {}
+                },
+                {
+                    "tag": "broadcast",
+                    "attrs": {}
+                },
+                {
+                    "tag": "user",
+                    "attrs": {}
+                },
+                {
+                    "tag": "devices",
+                    "attrs": {}
+                },
+                {
+                    "tag": "device_hash",
+                    "attrs": {}
+                },
+                {
+                    "tag": "to",
+                    "attrs": {}
+                },
+                {
+                    "tag": "offline",
+                    "attrs": {}
+                },
+                {
+                    "tag": "message",
+                    "attrs": {}
+                },
+                {
+                    "tag": "result",
+                    "attrs": {}
+                },
+                {
+                    "tag": "class",
+                    "attrs": {}
+                },
+                {
+                    "tag": "xmlns",
+                    "attrs": {}
+                },
+                {
+                    "tag": "duration",
+                    "attrs": {}
+                },
+                {
+                    "tag": "notify",
+                    "attrs": {}
+                },
+                {
+                    "tag": "iq",
+                    "attrs": {}
+                },
+                {
+                    "tag": "t",
+                    "attrs": {}
+                },
+                {
+                    "tag": "ack",
+                    "attrs": {}
+                },
+                {
+                    "tag": "g.us",
+                    "attrs": {}
+                },
+                {
+                    "tag": "enc",
+                    "attrs": {}
+                },
+                {
+                    "tag": "urn:xmpp:whatsapp:push",
+                    "attrs": {}
+                },
+                {
+                    "tag": "presence",
+                    "attrs": {}
+                },
+                {
+                    "tag": "config_value",
+                    "attrs": {}
+                },
+                {
+                    "tag": "picture",
+                    "attrs": {}
+                },
+                {
+                    "tag": "verified_name",
+                    "attrs": {}
+                },
+                {
+                    "tag": "config_code",
+                    "attrs": {}
+                },
+                {
+                    "tag": "key-index-list",
+                    "attrs": {}
+                },
+                {
+                    "tag": "contact",
+                    "attrs": {}
+                },
+                {
+                    "tag": "mediatype",
+                    "attrs": {}
+                },
+                {
+                    "tag": "routing_info",
+                    "attrs": {}
+                },
+                {
+                    "tag": "edge_routing",
+                    "attrs": {}
+                }
+            ]
+        },
+        "hex": "f80213f828f80101f80102f80103f80104f80105f80106f80107f80108f80109f8010af8010bf8010cf8010df8010ef8010ff80110f80111f80112f80113f80114f80115f80116f80117f80118f80119f8011af8011bf8011cf8011df8011ef8011ff80120f80121f80122f80123f80124f80125f80126f80127f80128"
+    },
+    {
+        "name": "packed nibble strings",
+        "node": {
+            "tag": "iq",
+            "attrs": {
+                "even": "5511999998888",
+                "odd": "551199999888",
+                "dashes": "5511-9999.8888",
+                "single": "7",
+                "long127": "9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999",
+                "over128": "99999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999"
+            }
+        },
+        "hex": "f80d19fc046576656eff875511999998888ffc036f6464ff06551199999888fc06646173686573ff075511a9999b8888fc0673696e676c65e3fc076c6f6e67313237ffc09999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999ffc076f766572313238fc803939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939393939"
+    },
+    {
+        "name": "packed hex strings",
+        "node": {
+            "tag": "iq",
+            "attrs": {
+                "even": "3EB0F4A1B2C3D4E5",
+                "odd": "3EB0F4A1B2C3D4E",
+                "mixedcase": "3eb0F4A1",
+                "allcaps": "ABCDEF0123456789"
+            }
+        },
+        "hex": "f80919fc046576656efb083eb0f4a1b2c3d4e5fc036f6464fb883eb0f4a1b2c3d4effc096d6978656463617365fc083365623046344131fc07616c6c63617073fb08abcdef0123456789"
+    },
+    {
+        "name": "jids all domain types",
+        "node": {
+            "tag": "message",
+            "attrs": {
+                "pn": "5511999998888@s.whatsapp.net",
+                "pnDevice": "5511999998888:12@s.whatsapp.net",
+                "pnDevice255": "5511999998888:255@s.whatsapp.net",
+                "lid": "123456789012345@lid",
+                "lidDevice": "123456789012345:3@lid",
+                "hosted": "5511888887777@hosted",
+                "hostedDevice": "5511888887777:1@hosted",
+                "hostedLid": "98765@hosted.lid",
+                "hostedLidDevice": "98765:2@hosted.lid",
+                "group": "120363042123456789@g.us",
+                "broadcast": "status@broadcast",
+                "newsletter": "120363154211234567@newsletter",
+                "bot": "13135550002@bot",
+                "weird": "someone@unknown.example.com",
+                "deviceZero": "5511999998888:0@s.whatsapp.net",
+                "colonNoDigit": "user:abc@s.whatsapp.net",
+                "multiAt": "a@b@c",
+                "trailingAt": "user@",
+                "leadingAt": "@server"
+            }
+        },
+        "hex": "f82713ec51faff875511999998888f03fc08706e446576696365f7000cff875511999998888ffc0b706e446576696365323535f700ffff875511999998888f76faff88123456789012345f76fc096c6964446576696365f70103ff88123456789012345ffc06686f73746564faff875511888887777ffc06686f73746564fc0c686f73746564446576696365f78001ff875511888887777ffc09686f737465644c6964faff8398765ffc0a686f737465642e6c6964fc0f686f737465644c6964446576696365f78102ff8398765fecaafaff091203630421234567891c0dfa0b0dfc0a6e6577736c6574746572faff09120363154211234567fc0a6e6577736c6574746572fc03626f74faff8613135550002ffc03626f74fc057765697264fafc07736f6d656f6e65fc13756e6b6e6f776e2e6578616d706c652e636f6dfc0a6465766963655a65726ffaff875511999998888f03fc0c636f6c6f6e4e6f4469676974fc17757365723a61626340732e77686174736170702e6e6574fc076d756c74694174fc056140624063fc0a747261696c696e674174fc057573657240fc096c656164696e674174fc0740736572766572"
+    },
+    {
+        "name": "non-token strings short and long",
+        "node": {
+            "tag": "iq",
+            "attrs": {
+                "short": "hello-world_x",
+                "base64": "dGVzdGJhc2U2NA==",
+                "url": "https://mmg.whatsapp.net/v/t62.7118-24/abc_n.enc?ccb=11-4",
+                "exactly85": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                "exactly86": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                "len255bytes": "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+                "len256bytes": "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+                "unicode": "olá çãé アイウ 😀😀 débora",
+                "emoji": "😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀"
+            }
+        },
+        "hex": "f81319fc0573686f7274fc0d68656c6c6f2d776f726c645f78fc06626173653634fc106447567a64474a68633255324e413d3dd2fc3968747470733a2f2f6d6d672e77686174736170702e6e65742f762f7436322e373131382d32342f6162635f6e2e656e633f6363623d31312d34fc0965786163746c793835fc5578787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878fc0965786163746c793836fc567878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878fc0b6c656e3235356279746573fcff797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979fc0b6c656e3235366279746573fd00010079797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979797979fc07756e69636f6465fc266f6cc3a120c3a7c3a3c3a920e382a2e382a4e382a620f09f9880f09f98802064c3a9626f7261fc05656d6f6a69fcc8f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880f09f9880"
+    },
+    {
+        "name": "string content",
+        "node": {
+            "tag": "body",
+            "attrs": {},
+            "content": "conteúdo de texto com acentos é 😀"
+        },
+        "hex": "f802ed75fc26636f6e7465c3ba646f20646520746578746f20636f6d206163656e746f7320c3a920f09f9880"
+    },
+    {
+        "name": "long string content",
+        "node": {
+            "tag": "body",
+            "attrs": {},
+            "content": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+        },
+        "hex": "f802ed75fd000fa07a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a"
+    },
+    {
+        "name": "bytes content",
+        "node": {
+            "tag": "enc",
+            "attrs": {
+                "v": "2",
+                "type": "msg"
+            },
+            "content": {
+                "$bytes": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b"
+            }
+        },
+        "hex": "f8061d5145044dfd00012c000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b"
+    },
+    {
+        "name": "nested children",
+        "node": {
+            "tag": "iq",
+            "attrs": {
+                "id": "3EB0AAAA",
+                "type": "set",
+                "to": "s.whatsapp.net",
+                "xmlns": "encrypt"
+            },
+            "content": [
+                {
+                    "tag": "key",
+                    "attrs": {
+                        "jid": "5511999998888@s.whatsapp.net"
+                    },
+                    "content": [
+                        {
+                            "tag": "value",
+                            "attrs": {},
+                            "content": {
+                                "$bytes": "010203"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "tag": "empty",
+                    "attrs": {}
+                }
+            ]
+        },
+        "hex": "f80a1908fb043eb0aaaa045a110316cbf802f8049e0cfaff875511999998888f03f801f8026cfc03010203f801fc05656d707479"
+    },
+    {
+        "name": "empty attrs empty content list",
+        "node": {
+            "tag": "presence",
+            "attrs": {},
+            "content": []
+        },
+        "hex": "f8021ff800"
+    },
+    {
+        "name": "list16 children",
+        "node": {
+            "tag": "list",
+            "attrs": {},
+            "content": [
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "0"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "1"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "2"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "3"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "4"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "5"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "6"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "7"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "8"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "9"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "10"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "11"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "12"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "13"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "14"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "15"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "16"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "17"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "18"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "19"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "20"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "21"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "22"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "23"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "24"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "25"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "26"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "27"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "28"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "29"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "30"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "31"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "32"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "33"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "34"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "35"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "36"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "37"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "38"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "39"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "40"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "41"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "42"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "43"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "44"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "45"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "46"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "47"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "48"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "49"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "50"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "51"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "52"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "53"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "54"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "55"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "56"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "57"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "58"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "59"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "60"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "61"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "62"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "63"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "64"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "65"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "66"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "67"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "68"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "69"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "70"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "71"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "72"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "73"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "74"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "75"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "76"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "77"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "78"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "79"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "80"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "81"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "82"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "83"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "84"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "85"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "86"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "87"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "88"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "89"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "90"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "91"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "92"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "93"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "94"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "95"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "96"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "97"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "98"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "99"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "100"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "101"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "102"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "103"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "104"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "105"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "106"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "107"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "108"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "109"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "110"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "111"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "112"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "113"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "114"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "115"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "116"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "117"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "118"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "119"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "120"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "121"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "122"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "123"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "124"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "125"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "126"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "127"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "128"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "129"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "130"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "131"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "132"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "133"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "134"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "135"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "136"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "137"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "138"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "139"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "140"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "141"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "142"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "143"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "144"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "145"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "146"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "147"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "148"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "149"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "150"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "151"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "152"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "153"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "154"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "155"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "156"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "157"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "158"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "159"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "160"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "161"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "162"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "163"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "164"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "165"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "166"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "167"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "168"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "169"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "170"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "171"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "172"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "173"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "174"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "175"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "176"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "177"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "178"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "179"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "180"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "181"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "182"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "183"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "184"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "185"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "186"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "187"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "188"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "189"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "190"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "191"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "192"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "193"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "194"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "195"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "196"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "197"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "198"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "199"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "200"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "201"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "202"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "203"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "204"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "205"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "206"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "207"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "208"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "209"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "210"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "211"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "212"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "213"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "214"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "215"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "216"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "217"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "218"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "219"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "220"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "221"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "222"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "223"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "224"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "225"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "226"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "227"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "228"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "229"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "230"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "231"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "232"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "233"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "234"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "235"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "236"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "237"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "238"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "239"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "240"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "241"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "242"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "243"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "244"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "245"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "246"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "247"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "248"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "249"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "250"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "251"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "252"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "253"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "254"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "255"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "256"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "257"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "258"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "259"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "260"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "261"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "262"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "263"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "264"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "265"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "266"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "267"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "268"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "269"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "270"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "271"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "272"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "273"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "274"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "275"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "276"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "277"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "278"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "279"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "280"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "281"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "282"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "283"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "284"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "285"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "286"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "287"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "288"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "289"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "290"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "291"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "292"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "293"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "294"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "295"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "296"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "297"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "298"
+                    }
+                },
+                {
+                    "tag": "item",
+                    "attrs": {
+                        "n": "299"
+                    }
+                }
+            ]
+        },
+        "hex": "f80271f9012cf8033ffc016e2df8033ffc016e55f8033ffc016e45f8033ffc016ea2f8033ffc016eec22f8033ffc016eec79f8033ffc016eeca1f8033ffc016ee3f8033ffc016eecdff8033ffc016eed05f8033ffc016eecb4f8033ffc016eecdbf8033ffc016ecff8033ffc016eed04f8033ffc016eed14f8033ffc016eecfaf8033ffc016eed25f8033ffc016eed5cf8033ffc016eed66f8033ffc016eed86f8033ffc016eed3bf8033ffc016eed9ef8033ffc016eeda3f8033ffc016eedd1f8033ffc016eedc9f8033ffc016eed9ff8033ffc016e99f8033ffc016eee04f8033ffc016eee11f8033ffc016eee33f8033ffc016eed74f8033ffc016eee32f8033ffc016eecf2f8033ffc016eee51f8033ffc016eee5ff8033ffc016eee0ff8033ffc016eee76f8033ffc016eee6ef8033ffc016eee74f8033ffc016eee80f8033ffc016eee27f8033ffc016eeeaef8033ffc016eee52f8033ffc016eeec5f8033ffc016eeed6f8033ffc016eee7ef8033ffc016eeeebf8033ffc016eeee6f8033ffc016eee1ef8033ffc016eef16f8033ffc016eeda9f8033ffc016eef80f8033ffc016eef28f8033ffc016eef42f8033ffc016eef93f8033ffc016eeed1f8033ffc016eef78f8033ffc016eff0157f8033ffc016eee84f8033ffc016eeebff8033ffc016eee21f8033ffc016eff0161f8033ffc016eff0162f8033ffc016eff0163f8033ffc016eee00f8033ffc016eef0ff8033ffc016eff0166f8033ffc016eff0167f8033ffc016eff0168f8033ffc016eeeb9f8033ffc016eee91f8033ffc016eff0171f8033ffc016eff0172f8033ffc016eff0173f8033ffc016eff0174f8033ffc016eee3bf8033ffc016eff0176f8033ffc016eff0177f8033ffc016eeed3f8033ffc016eff0179f8033ffc016eee96f8033ffc016eff0181f8033ffc016eff0182f8033ffc016eff0183f8033ffc016eff0184f8033ffc016eff0185f8033ffc016eff0186f8033ffc016eff0187f8033ffc016eff0188f8033ffc016eff0189f8033ffc016eff0190f8033ffc016eff0191f8033ffc016eff0192f8033ffc016eff0193f8033ffc016eff0194f8033ffc016eff0195f8033ffc016eff0196f8033ffc016eff0197f8033ffc016eff0198f8033ffc016eff0199f8033ffc016eec33f8033ffc016eec36f8033ffc016eec39f8033ffc016eec3bf8033ffc016eec37f8033ffc016eec3df8033ffc016eec40f8033ffc016eec38f8033ffc016eec42f8033ffc016eec3af8033ffc016eec3ff8033ffc016eec43f8033ffc016eff82112ff8033ffc016eff82113ff8033ffc016eff82114ff8033ffc016eff82115ff8033ffc016eef26f8033ffc016eff82117ff8033ffc016eff82118ff8033ffc016eff82119ff8033ffc016eff82120ff8033ffc016eff82121ff8033ffc016eff82122ff8033ffc016eff82123ff8033ffc016eff82124ff8033ffc016eee58f8033ffc016eff82126ff8033ffc016eff82127ff8033ffc016eee34f8033ffc016eff82129ff8033ffc016eff82130ff8033ffc016eff82131ff8033ffc016eff82132ff8033ffc016eff82133ff8033ffc016eff82134ff8033ffc016eff82135ff8033ffc016eff82136ff8033ffc016eff82137ff8033ffc016eff82138ff8033ffc016eff82139ff8033ffc016eff82140ff8033ffc016eff82141ff8033ffc016eff82142ff8033ffc016eff82143ff8033ffc016eff82144ff8033ffc016eff82145ff8033ffc016eff82146ff8033ffc016eff82147ff8033ffc016eff82148ff8033ffc016eff82149ff8033ffc016eff82150ff8033ffc016eff82151ff8033ffc016eff82152ff8033ffc016eff82153ff8033ffc016eff82154ff8033ffc016eff82155ff8033ffc016eff82156ff8033ffc016eff82157ff8033ffc016eff82158ff8033ffc016eff82159ff8033ffc016eff82160ff8033ffc016eff82161ff8033ffc016eff82162ff8033ffc016eff82163ff8033ffc016eff82164ff8033ffc016eff82165ff8033ffc016eff82166ff8033ffc016eff82167ff8033ffc016eff82168ff8033ffc016eff82169ff8033ffc016eff82170ff8033ffc016eff82171ff8033ffc016eff82172ff8033ffc016eff82173ff8033ffc016eff82174ff8033ffc016eff82175ff8033ffc016eff82176ff8033ffc016eef3bf8033ffc016eef60f8033ffc016eef69f8033ffc016eff82180ff8033ffc016eff82181ff8033ffc016eff82182ff8033ffc016eff82183ff8033ffc016eff82184ff8033ffc016eff82185ff8033ffc016eff82186ff8033ffc016eff82187ff8033ffc016eff82188ff8033ffc016eff82189ff8033ffc016eff82190ff8033ffc016eff82191ff8033ffc016eff82192ff8033ffc016eff82193ff8033ffc016eff82194ff8033ffc016eff82195ff8033ffc016eff82196ff8033ffc016eff82197ff8033ffc016eff82198ff8033ffc016eff82199ff8033ffc016eedf9f8033ffc016eff82201ff8033ffc016eff82202ff8033ffc016eff82203ff8033ffc016eff82204ff8033ffc016eff82205ff8033ffc016eff82206ff8033ffc016eefccf8033ffc016eff82208ff8033ffc016eff82209ff8033ffc016eff82210ff8033ffc016eff82211ff8033ffc016eff82212ff8033ffc016eff82213ff8033ffc016eff82214ff8033ffc016eff82215ff8033ffc016eff82216ff8033ffc016eff82217ff8033ffc016eff82218ff8033ffc016eff82219ff8033ffc016eff82220ff8033ffc016eff82221ff8033ffc016eff82222ff8033ffc016eff82223ff8033ffc016eff82224ff8033ffc016eff82225ff8033ffc016eff82226ff8033ffc016eff82227ff8033ffc016eff82228ff8033ffc016eff82229ff8033ffc016eff82230ff8033ffc016eff82231ff8033ffc016eff82232ff8033ffc016eef8ff8033ffc016eff82234ff8033ffc016eff82235ff8033ffc016eff82236ff8033ffc016eef8bf8033ffc016eff82238ff8033ffc016eff82239ff8033ffc016eeeb1f8033ffc016eff82241ff8033ffc016eff82242ff8033ffc016eff82243ff8033ffc016eff82244ff8033ffc016eff82245ff8033ffc016eff82246ff8033ffc016eff82247ff8033ffc016eefaef8033ffc016eff82249ff8033ffc016eee30f8033ffc016eef74f8033ffc016eff82252ff8033ffc016eff82253ff8033ffc016eff82254ff8033ffc016eff82255ff8033ffc016eeeeef8033ffc016eee47f8033ffc016eff82258ff8033ffc016eff82259ff8033ffc016eff82260ff8033ffc016eff82261ff8033ffc016eff82262ff8033ffc016eff82263ff8033ffc016eff82264ff8033ffc016eff82265ff8033ffc016eff82266ff8033ffc016eff82267ff8033ffc016eff82268ff8033ffc016eff82269ff8033ffc016eff82270ff8033ffc016eff82271ff8033ffc016eff82272ff8033ffc016eff82273ff8033ffc016eff82274ff8033ffc016eff82275ff8033ffc016eff82276ff8033ffc016eff82277ff8033ffc016eff82278ff8033ffc016eefaaf8033ffc016eff82280ff8033ffc016eff82281ff8033ffc016eff82282ff8033ffc016eff82283ff8033ffc016eff82284ff8033ffc016eff82285ff8033ffc016eff82286ff8033ffc016eff82287ff8033ffc016eff82288ff8033ffc016eff82289ff8033ffc016eef6ef8033ffc016eff82291ff8033ffc016eff82292ff8033ffc016eff82293ff8033ffc016eff82294ff8033ffc016eff82295ff8033ffc016eff82296ff8033ffc016eff82297ff8033ffc016eff82298ff8033ffc016eff82299f"
+    }
+]

--- a/src/transport/binary/__tests__/codec-golden.test.ts
+++ b/src/transport/binary/__tests__/codec-golden.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import { decodeBinaryNode, encodeBinaryNode } from '@transport/binary'
+import type { BinaryNode } from '@transport/types'
+import { bytesToHex, hexToBytes } from '@util/bytes'
+
+interface GoldenNodeSpec {
+    readonly tag: string
+    readonly attrs: Record<string, string>
+    readonly content?: string | GoldenNodeSpec[] | { readonly $bytes: string }
+}
+
+interface GoldenFixture {
+    readonly name: string
+    readonly node: GoldenNodeSpec
+    readonly hex: string
+}
+
+const fixtures = JSON.parse(
+    readFileSync(join(__dirname, 'codec-golden.json'), 'utf8')
+) as GoldenFixture[]
+
+function toNode(spec: GoldenNodeSpec): BinaryNode {
+    if (spec.content === undefined) {
+        return { tag: spec.tag, attrs: spec.attrs }
+    }
+    if (typeof spec.content === 'string') {
+        return { tag: spec.tag, attrs: spec.attrs, content: spec.content }
+    }
+    if (Array.isArray(spec.content)) {
+        return { tag: spec.tag, attrs: spec.attrs, content: spec.content.map(toNode) }
+    }
+    return { tag: spec.tag, attrs: spec.attrs, content: hexToBytes(spec.content.$bytes) }
+}
+
+test('binary encoder matches golden fixtures byte for byte', () => {
+    assert.ok(fixtures.length >= 16)
+    for (const fixture of fixtures) {
+        const encoded = encodeBinaryNode(toNode(fixture.node))
+        assert.equal(bytesToHex(encoded), fixture.hex, `fixture: ${fixture.name}`)
+    }
+})
+
+test('golden fixtures survive a decode/re-encode round-trip unchanged', () => {
+    for (const fixture of fixtures) {
+        const decoded = decodeBinaryNode(hexToBytes(fixture.hex))
+        const reEncoded = encodeBinaryNode(decoded)
+        assert.equal(bytesToHex(reEncoded), fixture.hex, `fixture: ${fixture.name}`)
+    }
+})

--- a/src/transport/binary/constants.ts
+++ b/src/transport/binary/constants.ts
@@ -77,3 +77,24 @@ export const DICTIONARY_TOKEN_MAPS: readonly ReadonlyMap<string, number>[] = DIC
         return map
     }
 )
+
+export const MERGED_TOKEN_DICTIONARY_FLAG = 0x1_0000
+
+/**
+ * Single lookup table for the encoder: single-byte tokens map to their code
+ * (< 256), dictionary tokens to `MERGED_TOKEN_DICTIONARY_FLAG | (dict << 8) |
+ * token`. Built dictionary-last-to-first then single-byte so precedence
+ * matches the sequential lookup order (single byte, then dictionary 0..3).
+ */
+export const MERGED_TOKEN_MAP: ReadonlyMap<string, number> = (() => {
+    const map = new Map<string, number>()
+    for (let i = DICTIONARY_TOKEN_MAPS.length - 1; i >= 0; i -= 1) {
+        for (const [value, token] of DICTIONARY_TOKEN_MAPS[i]) {
+            map.set(value, MERGED_TOKEN_DICTIONARY_FLAG | (i << 8) | token)
+        }
+    }
+    for (const [value, token] of SINGLE_BYTE_TOKEN_MAP) {
+        map.set(value, token)
+    }
+    return map
+})()

--- a/src/transport/binary/decoder.ts
+++ b/src/transport/binary/decoder.ts
@@ -84,12 +84,20 @@ class ByteReader {
     }
 }
 
-// Reusable scratch buffer for nibble/hex unpack. Max output is
-// `(0x7f) * 2 = 254` bytes (length byte holds the packed-byte count in
-// its low 7 bits, each byte unpacks to ≤2 chars). Single-threaded JS +
-// non-reentrant decoder makes module-level reuse safe – `TextDecoder`
-// copies into the returned string before we touch the buffer again.
-const PACKED_SCRATCH = new Uint8Array(256)
+const PACKED_PAIR_TABLES = new WeakMap<readonly string[], readonly string[]>()
+
+function packedPairTable(alphabet: readonly string[]): readonly string[] {
+    let pairs = PACKED_PAIR_TABLES.get(alphabet)
+    if (!pairs) {
+        const built = new Array<string>(256)
+        for (let i = 0; i < 256; i += 1) {
+            built[i] = alphabet[(i >>> 4) & 0x0f] + alphabet[i & 0x0f]
+        }
+        PACKED_PAIR_TABLES.set(alphabet, built)
+        pairs = built
+    }
+    return pairs
+}
 
 function parsePacked(reader: ByteReader, alphabet: readonly string[]): string {
     const lengthByte = reader.readUint8()
@@ -100,23 +108,12 @@ function parsePacked(reader: ByteReader, alphabet: readonly string[]): string {
         throw new Error(`invalid packed length byte 0x${lengthByte.toString(16)}`)
     }
 
-    let outIndex = 0
+    const pairs = packedPairTable(alphabet)
+    let out = ''
     for (let i = 0; i < byteCount; i += 1) {
-        const packed = reader.readUint8()
-        const high = (packed >>> 4) & 0x0f
-        const low = packed & 0x0f
-
-        if (outIndex < outLength) {
-            PACKED_SCRATCH[outIndex] = alphabet[high].charCodeAt(0)
-            outIndex += 1
-        }
-        if (outIndex < outLength) {
-            PACKED_SCRATCH[outIndex] = alphabet[low].charCodeAt(0)
-            outIndex += 1
-        }
+        out += pairs[reader.readUint8()]
     }
-
-    return TEXT_DECODER.decode(PACKED_SCRATCH.subarray(0, outLength))
+    return odd ? out.slice(0, outLength) : out
 }
 
 function readBinary(reader: ByteReader, token: number): Uint8Array {

--- a/src/transport/binary/encoder.ts
+++ b/src/transport/binary/encoder.ts
@@ -4,7 +4,6 @@ import {
     BINARY_32,
     BINARY_8,
     DICTIONARY_0,
-    DICTIONARY_TOKEN_MAPS,
     HEX_8,
     JID_PAIR,
     JID_U,
@@ -15,8 +14,9 @@ import {
     LIST_16,
     LIST_8,
     LIST_EMPTY,
-    NIBBLE_8,
-    SINGLE_BYTE_TOKEN_MAP
+    MERGED_TOKEN_DICTIONARY_FLAG,
+    MERGED_TOKEN_MAP,
+    NIBBLE_8
 } from '@transport/binary/constants'
 import type { BinaryNode } from '@transport/types'
 import { TEXT_ENCODER } from '@util/bytes'
@@ -56,6 +56,24 @@ class ByteWriter {
         this.ensure(value.length)
         this.buffer.set(value, this.offset)
         this.offset += value.length
+    }
+
+    public reserveUint8(): number {
+        this.ensure(1)
+        const at = this.offset
+        this.offset += 1
+        return at
+    }
+
+    public patchUint8(at: number, value: number): void {
+        this.buffer[at] = value & 0xff
+    }
+
+    public writeUtf8(value: string, maxBytes: number): number {
+        this.ensure(maxBytes)
+        const result = TEXT_ENCODER.encodeInto(value, this.buffer.subarray(this.offset))
+        this.offset += result.written
+        return result.written
     }
 
     public toUint8Array(): Uint8Array {
@@ -165,24 +183,29 @@ function writeBinaryLength(length: number, writer: ByteWriter): void {
     writer.writeUint32(length)
 }
 
-function writeString(value: string, writer: ByteWriter): void {
-    const singleToken = SINGLE_BYTE_TOKEN_MAP.get(value)
-    if (singleToken !== undefined) {
-        writer.writeUint8(singleToken)
+function writeUtf8WithLength(value: string, writer: ByteWriter): void {
+    if (value.length < 86) {
+        writer.writeUint8(BINARY_8)
+        const lengthAt = writer.reserveUint8()
+        const written = writer.writeUtf8(value, value.length * 3)
+        writer.patchUint8(lengthAt, written)
         return
     }
+    const encoded = TEXT_ENCODER.encode(value)
+    writeBinaryLength(encoded.length, writer)
+    writer.writeBytes(encoded)
+}
 
-    for (
-        let dictionaryIndex = 0;
-        dictionaryIndex < DICTIONARY_TOKEN_MAPS.length;
-        dictionaryIndex += 1
-    ) {
-        const dictToken = DICTIONARY_TOKEN_MAPS[dictionaryIndex].get(value)
-        if (dictToken !== undefined) {
-            writer.writeUint8(DICTIONARY_0 + dictionaryIndex)
-            writer.writeUint8(dictToken)
-            return
+function writeString(value: string, writer: ByteWriter): void {
+    const token = MERGED_TOKEN_MAP.get(value)
+    if (token !== undefined) {
+        if (token < MERGED_TOKEN_DICTIONARY_FLAG) {
+            writer.writeUint8(token)
+        } else {
+            writer.writeUint8(DICTIONARY_0 + ((token >>> 8) & 0xff))
+            writer.writeUint8(token & 0xff)
         }
+        return
     }
 
     const packed = classifyPackedString(value)
@@ -195,9 +218,31 @@ function writeString(value: string, writer: ByteWriter): void {
         return
     }
 
-    const encoded = TEXT_ENCODER.encode(value)
-    writeBinaryLength(encoded.length, writer)
-    writer.writeBytes(encoded)
+    writeUtf8WithLength(value, writer)
+}
+
+const KNOWN_JID_SERVERS: readonly string[] = [
+    WA_DEFAULTS.HOST_DOMAIN,
+    WA_DEFAULTS.LID_SERVER,
+    WA_DEFAULTS.GROUP_SERVER,
+    WA_DEFAULTS.NEWSLETTER_SERVER,
+    WA_DEFAULTS.BROADCAST_SERVER,
+    WA_DEFAULTS.HOSTED_LID_SERVER,
+    WA_DEFAULTS.HOSTED_SERVER,
+    WA_DEFAULTS.BOT_SERVER,
+    WA_DEFAULTS.MSGR_SERVER,
+    WA_DEFAULTS.INTEROP_SERVER
+]
+
+function matchKnownServer(value: string, from: number): string | null {
+    const length = value.length - from
+    for (let i = 0; i < KNOWN_JID_SERVERS.length; i += 1) {
+        const server = KNOWN_JID_SERVERS[i]
+        if (server.length === length && value.startsWith(server, from)) {
+            return server
+        }
+    }
+    return null
 }
 
 function tryWriteJid(value: string, writer: ByteWriter): boolean {
@@ -229,7 +274,7 @@ function tryWriteJid(value: string, writer: ByteWriter): boolean {
         userEnd = colonIndex
     }
 
-    const server = value.slice(atIndex + 1)
+    const server = matchKnownServer(value, atIndex + 1) ?? value.slice(atIndex + 1)
     let domainType = -1
     if (server === WA_DEFAULTS.LID_SERVER) {
         domainType = JID_U_DOMAIN_TYPE_LID
@@ -299,9 +344,7 @@ function writeNodeInternal(node: BinaryNode, writer: ByteWriter): void {
 
     const content = node.content
     if (typeof content === 'string') {
-        const encoded = TEXT_ENCODER.encode(content)
-        writeBinaryLength(encoded.length, writer)
-        writer.writeBytes(encoded)
+        writeUtf8WithLength(content, writer)
         return
     }
     if (content instanceof Uint8Array) {

--- a/src/transport/noise/WaFrameCodec.ts
+++ b/src/transport/noise/WaFrameCodec.ts
@@ -149,7 +149,7 @@ export class WaFrameCodec {
             this.tailScratch.set(remainingChunk.subarray(offset))
             this.buffered = this.tailScratch
         } else {
-            this.buffered = remainingChunk.slice(offset)
+            this.buffered = new Uint8Array(remainingChunk.subarray(offset))
         }
         this.bufferedLength = restLength
         return frames

--- a/src/transport/noise/WaFrameCodec.ts
+++ b/src/transport/noise/WaFrameCodec.ts
@@ -8,6 +8,7 @@ function frameLength(header: Uint8Array): number {
 export class WaFrameCodec {
     private readonly introFrame: Uint8Array | null
     private readonly maxFrameLength: number
+    private readonly tailScratch: Uint8Array = new Uint8Array(4096)
     private introSent: boolean
     private buffered: Uint8Array
     private bufferedLength: number
@@ -113,7 +114,7 @@ export class WaFrameCodec {
                     return frames
                 }
                 if (missingPayloadBytes === 0) {
-                    frames.push(this.buffered.subarray(3, 3 + length))
+                    frames.push(this.buffered.slice(3, 3 + length))
                 } else if (bufferedPayloadLength === 0) {
                     frames.push(chunk.subarray(0, missingPayloadBytes))
                 } else {
@@ -141,9 +142,16 @@ export class WaFrameCodec {
             frames.push(remainingChunk.subarray(start, end))
             offset = end
         }
-        this.buffered =
-            offset >= remainingChunk.length ? EMPTY_BYTES : remainingChunk.subarray(offset)
-        this.bufferedLength = this.buffered.length
+        const restLength = remainingChunk.length - offset
+        if (restLength === 0) {
+            this.buffered = EMPTY_BYTES
+        } else if (restLength <= this.tailScratch.length) {
+            this.tailScratch.set(remainingChunk.subarray(offset))
+            this.buffered = this.tailScratch
+        } else {
+            this.buffered = remainingChunk.slice(offset)
+        }
+        this.bufferedLength = restLength
         return frames
     }
 }

--- a/src/transport/noise/__tests__/frame-codec.test.ts
+++ b/src/transport/noise/__tests__/frame-codec.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { WaFrameCodec } from '@transport/noise/WaFrameCodec'
+import { bytesToHex, concatBytes } from '@util/bytes'
+
+function frame(length: number, seed: number): Uint8Array {
+    const out = new Uint8Array(length)
+    for (let i = 0; i < length; i += 1) {
+        out[i] = (seed * 31 + i * 7 + 3) & 0xff
+    }
+    return out
+}
+
+test('frame codec reassembles frames identically across every chunking pattern', () => {
+    const frames = [
+        frame(1, 1),
+        frame(3, 2),
+        frame(10, 3),
+        frame(100, 4),
+        frame(4095, 5),
+        frame(4096, 6),
+        frame(5000, 7),
+        frame(100_000, 8)
+    ]
+    const encoder = new WaFrameCodec()
+    const wire = concatBytes(frames.map((f) => encoder.encodeFrame(f)))
+
+    for (const chunkSize of [1, 2, 3, 5, 7, 13, 64, 4096, 8192, wire.length]) {
+        const codec = new WaFrameCodec()
+        const received: Uint8Array[] = []
+        for (let repeat = 0; repeat < 2; repeat += 1) {
+            for (let offset = 0; offset < wire.length; offset += chunkSize) {
+                const chunk = wire.subarray(offset, Math.min(offset + chunkSize, wire.length))
+                for (const out of codec.pushWireChunk(chunk)) {
+                    received.push(out.slice())
+                }
+            }
+        }
+        assert.equal(received.length, frames.length * 2, `chunkSize=${chunkSize}`)
+        for (let i = 0; i < received.length; i += 1) {
+            assert.equal(
+                bytesToHex(received[i]),
+                bytesToHex(frames[i % frames.length]),
+                `chunkSize=${chunkSize} frame=${i}`
+            )
+        }
+    }
+})


### PR DESCRIPTION
Validated per-change with microbenchmarks and end-to-end via the fake-server messaging bench: send/recv 1:1 +43%/+56% msgs/s, send/recv group +27%/+36% on the JS crypto path, no regression with the wasm backend (send group +6.7%).

- signal: cache parsed X25519 KeyObjects and the XEdDSA public-point derivation per key buffer (WeakMap, lifetime bound to the key); read the local identity once per fanout batch instead of once per device; dedup encrypt-batch addresses with a Set and compute each address key once; build the SignalMessage envelope in a single pre-sized buffer; cache the serialized previousSessions suffix per record array so the per-message persist only re-encodes the current session
- transport/binary: single merged token lookup map (5 map probes -> 1), encodeInto for short non-token strings, packed decode via a 256-entry pair table, known-server match without slicing, and a bounded tail scratch in WaFrameCodec so a partial frame no longer retains the whole socket chunk buffer
- protocol: intern known JID servers through a Map, which also stops prototype-chain names like "toString" from resolving to functions
- media: streaming download decrypt feeds HMAC/decipher with subarrays instead of concatenating every chunk
- appstate: LT-hash lanes read/written directly on bytes instead of three DataViews per call; value MAC fed as multi-part HMAC input
- client: reporting token reuses the already-encoded envelope bytes via unpadPkcs7; per-enc-node logger.child removed from the incoming path

Regression tests pin the byte-sensitive changes: golden fixtures for the binary codec captured from the previous implementation, session record suffix parity against the monolithic encode, an LT-hash reference implementation, frame reassembly across chunking patterns, and reporting-token equivalence for caller-supplied bytes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved efficiency for message encryption, media decryption, binary encoding, and frame processing.
  * Reduced repeated cryptographic calculations and memory allocations.

* **Reliability**
  * Improved reporting-token generation for direct and group messages.
  * Strengthened session handling and identity reuse.
  * Preserved binary protocol compatibility across diverse content and payload sizes.

* **Bug Fixes**
  * Improved handling of partial network frames, packed text, server identifiers, and streaming media verification.

* **Tests**
  * Expanded coverage for cryptography, session encoding, reporting tokens, binary codecs, and frame reassembly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->