### PR TITLE
perf: single-pass outbound attrs and sync signal hot-path helpers

### DIFF
--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -30,12 +30,7 @@ import {
     isSendMediaMessage,
     isSendTextMessage,
     needsSecretPersistence,
-    resolveButtonAddonKind,
-    resolveDecryptFailAttr,
-    resolveEditAttr,
-    resolveEncMediaType,
-    resolveMessageTypeAttr,
-    resolveMetaAttrs,
+    resolveOutboundMessageAttrs,
     unwrapMessage,
     wrapAsViewOnce
 } from '@message/encode/content'
@@ -637,17 +632,16 @@ export class WaMessageDispatchCoordinator {
         )
 
         const plaintext = await writeRandomPadMax16(proto.Message.encode(messageWithIcdc).finish())
-        const buttonAddonKind = resolveButtonAddonKind(messageWithIcdc)
+        const outboundAttrs = resolveOutboundMessageAttrs(messageWithIcdc)
+        const buttonAddonKind = outboundAttrs.buttonAddonKind
         const buttonAddonNode = buttonAddonKind ? buildButtonAddonNode(buttonAddonKind) : undefined
         // when a <biz> companion is attached the stanza must advertise type=text and
         // omit enc.mediatype; sending type=media + mediatype=list/button alongside the
         // companion is rejected by the server as SMAX_INVALID (479).
-        const type = buttonAddonKind ? 'text' : resolveMessageTypeAttr(messageWithIcdc)
-        const edit = resolveEditAttr(messageWithIcdc) ?? undefined
-        const mediatype = buttonAddonKind
-            ? undefined
-            : (resolveEncMediaType(messageWithIcdc) ?? undefined)
-        const metaAttrs = resolveMetaAttrs(messageWithIcdc)
+        const type = buttonAddonKind ? 'text' : outboundAttrs.typeAttr
+        const edit = outboundAttrs.edit ?? undefined
+        const mediatype = buttonAddonKind ? undefined : (outboundAttrs.mediatype ?? undefined)
+        const metaAttrs = outboundAttrs.metaAttrs
         const metaNode = metaAttrs ? buildMetaNode(metaAttrs as Record<string, string>) : undefined
         const customNodes: BinaryNode[] = []
         if (metaNode) customNodes.push(metaNode)
@@ -658,7 +652,7 @@ export class WaMessageDispatchCoordinator {
             }
         }
 
-        const decryptFail = resolveDecryptFailAttr(messageWithIcdc)
+        const decryptFail = outboundAttrs.decryptFail
         const envelope: WaOutboundEnvelope = {
             message: messageWithIcdc,
             plaintext,
@@ -798,7 +792,7 @@ export class WaMessageDispatchCoordinator {
             replayStatusSetting: statusSetting,
             // Bare `<to jid=user>` ack hints route the skmsg through primary
             // devices that already hold the sender key.
-            customize: async ({
+            customize: ({
                 fanoutDeviceJids,
                 distributionParticipants,
                 messageWithSecret,
@@ -822,7 +816,7 @@ export class WaMessageDispatchCoordinator {
                     seenAck.add(userJid)
                     ackHints.push({ jid: userJid })
                 }
-                const reportingArtifacts = await this.tryBuildReportingTokenArtifacts({
+                const reportingArtifacts = this.tryBuildReportingTokenArtifacts({
                     message: messageWithSecret,
                     stanzaId: sendOptions.id,
                     senderUserJid: toUserJid(senderJid),
@@ -891,11 +885,17 @@ export class WaMessageDispatchCoordinator {
             }[]
             readonly messageWithSecret: Proto.IMessage
             readonly sendOptions: WaSendMessageOptions
-        }) => Promise<{
-            readonly extraParticipants?: readonly { readonly jid: string }[]
-            readonly customNodes?: readonly BinaryNode[]
-            readonly phash?: string
-        }>
+        }) =>
+            | Promise<{
+                  readonly extraParticipants?: readonly { readonly jid: string }[]
+                  readonly customNodes?: readonly BinaryNode[]
+                  readonly phash?: string
+              }>
+            | {
+                  readonly extraParticipants?: readonly { readonly jid: string }[]
+                  readonly customNodes?: readonly BinaryNode[]
+                  readonly phash?: string
+              }
     }): Promise<WaMessagePublishResult> {
         const sendOptions = await this.withResolvedMessageId(input.options)
         const sender = parseSignalAddressFromJid(input.senderJid)
@@ -948,14 +948,15 @@ export class WaMessageDispatchCoordinator {
                 participants.push(entry)
             }
         }
+        const outboundAttrs = resolveOutboundMessageAttrs(messageWithSecret)
         const messageNode = buildGroupSenderKeyMessageNode({
             to: input.groupJid,
-            type: resolveMessageTypeAttr(messageWithSecret),
+            type: outboundAttrs.typeAttr,
             id: sendOptions.id,
             phash: extras.phash,
-            edit: resolveEditAttr(messageWithSecret) ?? undefined,
-            mediatype: resolveEncMediaType(messageWithSecret) ?? undefined,
-            decryptFail: resolveDecryptFailAttr(messageWithSecret),
+            edit: outboundAttrs.edit ?? undefined,
+            mediatype: outboundAttrs.mediatype ?? undefined,
+            decryptFail: outboundAttrs.decryptFail,
             groupCiphertext: groupCiphertext.ciphertext,
             participants,
             deviceIdentity: shouldAttachDeviceIdentity
@@ -1172,7 +1173,7 @@ export class WaMessageDispatchCoordinator {
                 break
             }
         }
-        const reportingArtifacts = await this.tryBuildReportingTokenArtifacts({
+        const reportingArtifacts = this.tryBuildReportingTokenArtifacts({
             message,
             messageBytes: unpadPkcs7(plaintext),
             stanzaId: sendOptions.id,
@@ -1363,7 +1364,7 @@ export class WaMessageDispatchCoordinator {
         phashTargets[phashTargetCount] = senderJid
         phashTargets.length = phashTargetCount + 1
         const localPhash = computePhashV2(phashTargets)
-        const reportingArtifacts = await this.tryBuildReportingTokenArtifacts({
+        const reportingArtifacts = this.tryBuildReportingTokenArtifacts({
             message,
             messageBytes: unpadPkcs7(plaintext),
             stanzaId: sendOptions.id,
@@ -1842,7 +1843,7 @@ export class WaMessageDispatchCoordinator {
         const deviceIdentity = shouldAttachDeviceIdentity
             ? this.getEncodedSignedDeviceIdentity()
             : undefined
-        const reportingArtifacts = await this.tryBuildReportingTokenArtifacts({
+        const reportingArtifacts = this.tryBuildReportingTokenArtifacts({
             message,
             messageBytes: unpadPkcs7(plaintext),
             stanzaId: sendOptions.id,
@@ -1959,20 +1960,20 @@ export class WaMessageDispatchCoordinator {
         }
     }
 
-    private async tryBuildReportingTokenArtifacts(input: {
+    private tryBuildReportingTokenArtifacts(input: {
         readonly message: Proto.IMessage
         readonly messageBytes?: Uint8Array
         readonly stanzaId?: string
         readonly senderUserJid: string
         readonly remoteJid: string
         readonly context: string
-    }): Promise<BuildReportingTokenArtifactsResult | null> {
+    }): BuildReportingTokenArtifactsResult | null {
         if (!input.stanzaId) {
             return null
         }
 
         try {
-            return await buildReportingTokenArtifacts({
+            return buildReportingTokenArtifacts({
                 message: input.message,
                 messageBytes: input.messageBytes,
                 stanzaId: input.stanzaId,

--- a/src/message/__tests__/message.test.ts
+++ b/src/message/__tests__/message.test.ts
@@ -387,13 +387,13 @@ test('reporting token helpers cover secret injection and deterministic token gen
             messageSecret: new Uint8Array(32).fill(7)
         }
     }
-    const first = await buildReportingTokenArtifacts({
+    const first = buildReportingTokenArtifacts({
         message: baseMessage,
         stanzaId: 'msg-1',
         senderUserJid: '551100000000@s.whatsapp.net',
         remoteJid: '551188888888@s.whatsapp.net'
     })
-    const second = await buildReportingTokenArtifacts({
+    const second = buildReportingTokenArtifacts({
         message: baseMessage,
         stanzaId: 'msg-1',
         senderUserJid: '551100000000@s.whatsapp.net',
@@ -410,7 +410,7 @@ test('reporting token helpers cover secret injection and deterministic token gen
     assert.equal((firstTokenNode?.content as Uint8Array).byteLength, 16)
     assert.deepEqual(firstTokenNode?.content, secondTokenNode?.content)
 
-    const changedResult = await buildReportingTokenArtifacts({
+    const changedResult = buildReportingTokenArtifacts({
         message: baseMessage,
         stanzaId: 'msg-2',
         senderUserJid: '551100000000@s.whatsapp.net',
@@ -421,7 +421,7 @@ test('reporting token helpers cover secret injection and deterministic token gen
         : null
     assert.notDeepEqual(firstTokenNode?.content, changedTokenNode?.content)
 
-    const incompatible = await buildReportingTokenArtifacts({
+    const incompatible = buildReportingTokenArtifacts({
         message: {
             reactionMessage: {},
             messageContextInfo: {

--- a/src/message/crypto/__tests__/reporting-token.test.ts
+++ b/src/message/crypto/__tests__/reporting-token.test.ts
@@ -25,12 +25,12 @@ const input = {
     remoteJid: '5511999998888@s.whatsapp.net'
 }
 
-test('reporting token from caller-supplied bytes matches the self-encoded path', async () => {
-    const fromMessage = await buildReportingTokenArtifacts(input)
+test('reporting token from caller-supplied bytes matches the self-encoded path', () => {
+    const fromMessage = buildReportingTokenArtifacts(input)
     assert.ok(fromMessage)
 
     const messageBytes = proto.Message.encode(message).finish()
-    const fromBytes = await buildReportingTokenArtifacts({ ...input, messageBytes })
+    const fromBytes = buildReportingTokenArtifacts({ ...input, messageBytes })
     assert.ok(fromBytes)
 
     assert.equal(bytesToHex(fromBytes.reportingToken), bytesToHex(fromMessage.reportingToken))
@@ -43,11 +43,11 @@ test('reporting token from caller-supplied bytes matches the self-encoded path',
 
 test('unpadded envelope plaintext yields the same reporting token as a fresh encode', async () => {
     const padded = await writeRandomPadMax16(proto.Message.encode(message).finish())
-    const fromEnvelope = await buildReportingTokenArtifacts({
+    const fromEnvelope = buildReportingTokenArtifacts({
         ...input,
         messageBytes: unpadPkcs7(padded)
     })
-    const fromMessage = await buildReportingTokenArtifacts(input)
+    const fromMessage = buildReportingTokenArtifacts(input)
     assert.ok(fromEnvelope)
     assert.ok(fromMessage)
     assert.equal(bytesToHex(fromEnvelope.reportingToken), bytesToHex(fromMessage.reportingToken))

--- a/src/message/crypto/reporting-token.ts
+++ b/src/message/crypto/reporting-token.ts
@@ -82,10 +82,9 @@ export interface BuildReportingTokenArtifactsResult {
 let reportingTokenConfigSpec: ReportingTokenConfigSpec | null = null
 const reportingTokenConfigCache = new Map<number, ReportingTokenConfig>()
 
-// eslint-disable-next-line @typescript-eslint/require-await
-export async function buildReportingTokenArtifacts(
+export function buildReportingTokenArtifacts(
     input: BuildReportingTokenNodeInput
-): Promise<BuildReportingTokenArtifactsResult | null> {
+): BuildReportingTokenArtifactsResult | null {
     const stanzaId = input.stanzaId.trim()
     if (!stanzaId || !isMessageReportingTokenCompatible(input.message)) {
         return null

--- a/src/message/encode/__tests__/content.test.ts
+++ b/src/message/encode/__tests__/content.test.ts
@@ -5,13 +5,16 @@ import {
     getContentType,
     isSendMediaMessage,
     resolveButtonAddonKind,
+    resolveDecryptFailAttr,
     resolveEditAttr,
     resolveEncMediaType,
     resolveMessageTypeAttr,
-    resolveMetaAttrs
+    resolveMetaAttrs,
+    resolveOutboundMessageAttrs
 } from '@message/encode/content'
 import { unwrapDeviceSentMessage, wrapDeviceSentMessage } from '@message/encode/device-sent'
 import { unpadPkcs7, writeRandomPadMax16 } from '@message/encode/padding'
+import { proto, type Proto } from '@proto'
 
 test('content helpers detect media payload and resolve message type', () => {
     assert.equal(
@@ -105,4 +108,44 @@ test('padding helpers add random padding and reverse pkcs7', async () => {
     const unpadded = unpadPkcs7(new Uint8Array([10, 11, 2, 2]))
     assert.deepEqual(unpadded, new Uint8Array([10, 11]))
     assert.throws(() => unpadPkcs7(new Uint8Array([])), /empty bytes/)
+})
+
+test('resolveOutboundMessageAttrs matches the individual resolvers', () => {
+    const corpus: Proto.IMessage[] = [
+        { conversation: 'texto simples' },
+        { extendedTextMessage: { text: 'link', matchedText: 'https://x.com' } },
+        { imageMessage: { url: 'x', mimetype: 'image/jpeg' } },
+        { audioMessage: { ptt: true } },
+        { videoMessage: { gifPlayback: true } },
+        { reactionMessage: { text: '' } },
+        { reactionMessage: { text: '👍' } },
+        {
+            protocolMessage: {
+                type: proto.Message.ProtocolMessage.Type.REVOKE,
+                key: { fromMe: true }
+            }
+        },
+        { protocolMessage: { type: proto.Message.ProtocolMessage.Type.MESSAGE_EDIT } },
+        { pollCreationMessageV3: { name: 'enquete' } },
+        { pollUpdateMessage: { vote: { encPayload: new Uint8Array(4) } } },
+        { eventMessage: { name: 'evento' } },
+        { listMessage: { title: 'lista' } },
+        { buttonsMessage: { contentText: 'botoes' } },
+        { interactiveMessage: { nativeFlowMessage: {} } },
+        { pinInChatMessage: { key: { id: '1' } } },
+        { ephemeralMessage: { message: { conversation: 'efemera' } } },
+        { viewOnceMessage: { message: { imageMessage: { url: 'x' } } } },
+        { ephemeralMessage: { message: { viewOnceMessageV2: { message: { videoMessage: {} } } } } },
+        { deviceSentMessage: { message: { extendedTextMessage: { text: 'ds' } } } }
+    ]
+    for (const message of corpus) {
+        const combined = resolveOutboundMessageAttrs(message)
+        const label = JSON.stringify(message).slice(0, 60)
+        assert.equal(combined.buttonAddonKind, resolveButtonAddonKind(message), label)
+        assert.equal(combined.typeAttr, resolveMessageTypeAttr(message), label)
+        assert.equal(combined.edit, resolveEditAttr(message), label)
+        assert.equal(combined.mediatype, resolveEncMediaType(message), label)
+        assert.deepEqual(combined.metaAttrs, resolveMetaAttrs(message), label)
+        assert.equal(combined.decryptFail, resolveDecryptFailAttr(message), label)
+    }
 })

--- a/src/message/encode/content.ts
+++ b/src/message/encode/content.ts
@@ -219,8 +219,10 @@ export function unwrapMessage(message: Proto.IMessage): Proto.IMessage {
 }
 
 export function resolveMessageTypeAttr(message: Proto.IMessage): string {
-    const msg = unwrapMessage(message)
+    return resolveMessageTypeAttrFrom(unwrapMessage(message))
+}
 
+function resolveMessageTypeAttrFrom(msg: Proto.IMessage): string {
     if (msg.reactionMessage || msg.encReactionMessage) {
         return WA_STANZA_MSG_TYPES.REACTION
     }
@@ -281,7 +283,10 @@ export function resolveMessageTypeAttr(message: Proto.IMessage): string {
 const REVOKED_REACTION_TEXT = ''
 
 export function resolveDecryptFailAttr(message: Proto.IMessage): 'hide' | undefined {
-    const msg = unwrapMessage(message)
+    return resolveDecryptFailAttrFrom(unwrapMessage(message))
+}
+
+function resolveDecryptFailAttrFrom(msg: Proto.IMessage): 'hide' | undefined {
     const secretEncType = msg.secretEncryptedMessage?.secretEncType
     if (
         msg.reactionMessage ||
@@ -332,8 +337,10 @@ export function needsSecretPersistence(message: Proto.IMessage): boolean {
 }
 
 export function resolveEditAttr(message: Proto.IMessage): string | null {
-    const msg = unwrapMessage(message)
+    return resolveEditAttrFrom(unwrapMessage(message))
+}
 
+function resolveEditAttrFrom(msg: Proto.IMessage): string | null {
     if (msg.protocolMessage) {
         const protocolType = msg.protocolMessage.type
         if (protocolType === proto.Message.ProtocolMessage.Type.REVOKE) {
@@ -386,8 +393,10 @@ export function resolveEditAttr(message: Proto.IMessage): string | null {
 }
 
 export function resolveEncMediaType(message: Proto.IMessage): string | null {
-    const msg = unwrapMessage(message)
+    return resolveEncMediaTypeFrom(unwrapMessage(message))
+}
 
+function resolveEncMediaTypeFrom(msg: Proto.IMessage): string | null {
     if (msg.imageMessage) return WA_ENC_MEDIA_TYPES.IMAGE
     if (msg.stickerMessage) return WA_ENC_MEDIA_TYPES.STICKER
     if (msg.stickerPackMessage) return WA_ENC_MEDIA_TYPES.STICKER_PACK
@@ -424,7 +433,10 @@ export function resolveEncMediaType(message: Proto.IMessage): string | null {
 export type WaButtonAddonKind = 'list' | 'interactive'
 
 export function resolveButtonAddonKind(message: Proto.IMessage): WaButtonAddonKind | null {
-    const msg = unwrapMessage(message)
+    return resolveButtonAddonKindFrom(unwrapMessage(message))
+}
+
+function resolveButtonAddonKindFrom(msg: Proto.IMessage): WaButtonAddonKind | null {
     if (msg.listMessage) return 'list'
     if (msg.buttonsMessage || msg.interactiveMessage?.nativeFlowMessage) return 'interactive'
     return null
@@ -436,8 +448,41 @@ export interface MessageMetaAttrs {
     readonly view_once?: string
 }
 
-export function resolveMetaAttrs(message: Proto.IMessage): MessageMetaAttrs | null {
+export interface WaOutboundMessageAttrs {
+    readonly buttonAddonKind: WaButtonAddonKind | null
+    readonly typeAttr: string
+    readonly edit: string | null
+    readonly mediatype: string | null
+    readonly metaAttrs: MessageMetaAttrs | null
+    readonly decryptFail: 'hide' | undefined
+}
+
+/**
+ * Resolves every outbound stanza attribute derived from the message body in
+ * one pass, unwrapping the envelope (`ephemeralMessage`, `viewOnceMessage`,
+ * `deviceSentMessage`, ...) a single time instead of once per resolver.
+ * Equivalent to calling the individual `resolve*` helpers on `message`.
+ */
+export function resolveOutboundMessageAttrs(message: Proto.IMessage): WaOutboundMessageAttrs {
     const msg = unwrapMessage(message)
+    return {
+        buttonAddonKind: resolveButtonAddonKindFrom(msg),
+        typeAttr: resolveMessageTypeAttrFrom(msg),
+        edit: resolveEditAttrFrom(msg),
+        mediatype: resolveEncMediaTypeFrom(msg),
+        metaAttrs: resolveMetaAttrsFrom(message, msg),
+        decryptFail: resolveDecryptFailAttrFrom(msg)
+    }
+}
+
+export function resolveMetaAttrs(message: Proto.IMessage): MessageMetaAttrs | null {
+    return resolveMetaAttrsFrom(message, unwrapMessage(message))
+}
+
+function resolveMetaAttrsFrom(
+    message: Proto.IMessage,
+    msg: Proto.IMessage
+): MessageMetaAttrs | null {
     let polltype: string | undefined
     let eventType: string | undefined
     let viewOnce: string | undefined

--- a/src/signal/group/SenderKeyChain.ts
+++ b/src/signal/group/SenderKeyChain.ts
@@ -19,12 +19,11 @@ export interface SenderKeyMessageKeySelection {
     readonly updatedRecord: SenderKeyRecord
 }
 
-// eslint-disable-next-line @typescript-eslint/require-await
-export async function selectMessageKey(
+export function selectMessageKey(
     senderKey: SenderKeyRecord,
     targetIteration: number,
     futureMessagesMax?: number
-): Promise<SenderKeyMessageKeySelection> {
+): SenderKeyMessageKeySelection {
     const delta = targetIteration - senderKey.iteration
     if (delta > (futureMessagesMax ?? SENDER_KEY_FUTURE_MESSAGES_MAX)) {
         throw new Error('sender key message is too far in future')

--- a/src/signal/group/SenderKeyManager.ts
+++ b/src/signal/group/SenderKeyManager.ts
@@ -278,7 +278,7 @@ export class SenderKeyManager {
                 }
             }
 
-            const selected = await selectMessageKey(
+            const selected = selectMessageKey(
                 senderKey,
                 parsed.iteration,
                 this.getFutureMessagesMax?.()

--- a/src/signal/group/__tests__/sender-key.test.ts
+++ b/src/signal/group/__tests__/sender-key.test.ts
@@ -49,12 +49,12 @@ test('sender key chain derives message keys and handles stale/future counters', 
     assert.equal(derived.messageKey.iteration, 0)
     assert.equal(derived.messageKey.seed.length, 50)
 
-    const selectedFuture = await selectMessageKey(senderKey, 3)
+    const selectedFuture = selectMessageKey(senderKey, 3)
     assert.equal(selectedFuture.messageKey.iteration, 3)
     assert.equal(selectedFuture.updatedRecord.iteration, 4)
     assert.ok((selectedFuture.updatedRecord.unusedMessageKeys?.length ?? 0) > 0)
 
-    const selectedStale = await selectMessageKey(selectedFuture.updatedRecord, 1)
+    const selectedStale = selectMessageKey(selectedFuture.updatedRecord, 1)
     assert.equal(selectedStale.messageKey.iteration, 1)
     assert.equal(
         (selectedStale.updatedRecord.unusedMessageKeys?.length ?? 0) <
@@ -62,11 +62,11 @@ test('sender key chain derives message keys and handles stale/future counters', 
         true
     )
 
-    await assert.rejects(
+    assert.throws(
         () => selectMessageKey(selectedStale.updatedRecord, 1),
         /sender key message iteration is stale/
     )
-    await assert.rejects(
+    assert.throws(
         () => selectMessageKey(senderKey, 50_000),
         /sender key message is too far in future/
     )

--- a/src/signal/session/SignalProtocol.ts
+++ b/src/signal/session/SignalProtocol.ts
@@ -339,7 +339,7 @@ export class SignalProtocol {
                     throw new Error('identity mismatch')
                 }
 
-                const [updatedSession, encrypted] = await encryptMsg(session, request.plaintext)
+                const [updatedSession, encrypted] = encryptMsg(session, request.plaintext)
                 latestSessionByAddress.set(addressKey, updatedSession)
                 sessionUpdatesByAddress.set(addressKey, {
                     address,

--- a/src/signal/session/SignalRatchet.ts
+++ b/src/signal/session/SignalRatchet.ts
@@ -70,11 +70,10 @@ export function deriveMsgKey(
     return deriveMsgKeyFromChainKey(index, chainKey)
 }
 
-// eslint-disable-next-line @typescript-eslint/require-await
-export async function selectMessageKey(
+export function selectMessageKey(
     chain: SignalRecvChain,
     targetCounter: number
-): Promise<{ readonly messageKey: SignalMessageKey; readonly updatedChain: SignalRecvChain }> {
+): { readonly messageKey: SignalMessageKey; readonly updatedChain: SignalRecvChain } {
     const delta = targetCounter - chain.nextMsgIndex
     if (delta > FUTURE_MESSAGES_MAX) {
         throw new Error('message too far in future')
@@ -161,11 +160,10 @@ function deriveMsgKeyFromChainKey(
     }
 }
 
-// eslint-disable-next-line @typescript-eslint/require-await
-export async function encryptMsg(
+export function encryptMsg(
     session: SignalSessionRecord,
     plaintext: Uint8Array
-): Promise<readonly [SignalSessionRecord, { type: 'msg' | 'pkmsg'; ciphertext: Uint8Array }]> {
+): readonly [SignalSessionRecord, { type: 'msg' | 'pkmsg'; ciphertext: Uint8Array }] {
     const { nextChainKey, messageKey } = deriveMsgKey(
         session.sendChain.nextMsgIndex,
         session.sendChain.chainKey
@@ -292,10 +290,8 @@ export async function decryptMsgFromSession(
             chainKey: recvRatchet.chainKey,
             unusedMsgKeys: []
         }
-        const [selected, newSendRatchet] = await Promise.all([
-            selectMessageKey(freshRecvChain, message.counter),
-            generateSerializedKeyPair()
-        ])
+        const selected = selectMessageKey(freshRecvChain, message.counter)
+        const newSendRatchet = await generateSerializedKeyPair()
         selectedMessageKey = selected.messageKey
 
         const sendRatchet = await calculateRatchet(
@@ -323,7 +319,7 @@ export async function decryptMsgFromSession(
             session.recvChains[recvChainIndex],
             `recvChains[${recvChainIndex}]`
         )
-        const selected = await selectMessageKey(decoded, message.counter)
+        const selected = selectMessageKey(decoded, message.counter)
         selectedMessageKey = selected.messageKey
         const nextRecvChains: RawSignalRecvChain[] = session.recvChains.slice()
         nextRecvChains[recvChainIndex] = encodeSignalRecvChain(selected.updatedChain)

--- a/src/signal/session/__tests__/session.test.ts
+++ b/src/signal/session/__tests__/session.test.ts
@@ -166,15 +166,15 @@ test('signal ratchet derives keys, selects future message keys and rejects dupli
         chainKey,
         unusedMsgKeys: []
     }
-    const future = await selectMessageKey(chain, 2)
+    const future = selectMessageKey(chain, 2)
     assert.equal(future.messageKey.index, 2)
     assert.equal(future.updatedChain.nextMsgIndex, 3)
     assert.ok(future.updatedChain.unusedMsgKeys.length > 0)
 
-    const stale = await selectMessageKey(future.updatedChain, 1)
+    const stale = selectMessageKey(future.updatedChain, 1)
     assert.equal(stale.messageKey.index, 1)
-    await assert.rejects(() => selectMessageKey(stale.updatedChain, 1), /duplicate message/)
-    await assert.rejects(() => selectMessageKey(chain, 5_000), /message too far in future/)
+    assert.throws(() => selectMessageKey(stale.updatedChain, 1), /duplicate message/)
+    assert.throws(() => selectMessageKey(chain, 5_000), /message too far in future/)
 })
 
 test('signal protocol establishes outgoing session and decrypts prekey message on receiver', async () => {


### PR DESCRIPTION
- resolve every outbound stanza attribute (type, edit, mediatype, meta, button addon, decrypt-fail) through resolveOutboundMessageAttrs, which unwraps the message envelope once per send instead of once per resolver; the individual resolve* helpers keep their signatures and are pinned to the combined path by an equivalence test over a corpus of wrapped and unwrapped messages
- make selectMessageKey (1:1 and sender-key), encryptMsg and buildReportingTokenArtifacts plain sync functions: their bodies are HMAC/HKDF/AES only and none of them is reachable through the public exports map, so the async wrappers were pure ceremony (one Promise plus a microtask per device in the fanout encrypt loop)
- createUseCaseSecret and the addon payload helpers stay async: they are re-exported through zapo-js/message, so narrowing Promise<T> to T there would be a breaking change

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved outbound message processing across text, media, reactions, polls, events, interactive messages, and wrapped messages.
  * Preserved button-specific text and media handling.
  * Improved group message construction and reporting-token handling.
  * Streamlined encryption, decryption, and message-key processing for more predictable delivery behavior.
* **Bug Fixes**
  * Maintained existing handling for duplicate, stale, and future messages while improving processing consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->