### PR TITLE
perf: decode history sync chunks incrementally instead of materializing the graph

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,8 @@ dist
 node_modules
 spec
 .auth
+target
+coverage
+wa-web
+wa-mob
+packages/native/wasm/pkg

--- a/src/client/persistence/__tests__/history-sync.test.ts
+++ b/src/client/persistence/__tests__/history-sync.test.ts
@@ -3,10 +3,14 @@ import test from 'node:test'
 import { promisify } from 'node:util'
 import { gzip } from 'node:zlib'
 
-import { processHistorySyncNotification } from '@client/persistence/history-sync'
+import {
+    processHistorySyncNotification,
+    scanConversationJidPair,
+    scanHistorySyncBlob
+} from '@client/persistence/history-sync'
 import { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
 import { createNoopLogger } from '@infra/log/types'
-import { proto } from '@proto'
+import { proto, type Proto } from '@proto'
 import type { WaStoredThreadRecord } from '@store/contracts/thread.store'
 import { toBytesView } from '@util/bytes'
 
@@ -123,4 +127,88 @@ test('history sync leaves ephemeralSettingTimestamp absent for a non-ephemeral c
     const thread = writes.find((record) => record.jid === '5511888888888@s.whatsapp.net')
     assert.ok(thread)
     assert.equal(thread.ephemeralSettingTimestamp, undefined)
+})
+
+test('scanHistorySyncBlob is equivalent to the monolithic HistorySync decode', () => {
+    const historySync: Proto.IHistorySync = {
+        syncType: proto.HistorySync.HistorySyncType.RECENT,
+        chunkOrder: 4,
+        progress: 88,
+        threadIdUserSecret: new Uint8Array([1, 2, 3]),
+        nctSalt: new Uint8Array([9, 8, 7, 6]),
+        pushnames: [
+            { id: '5511111111111@s.whatsapp.net', pushname: 'Alice' },
+            { id: '5522222222222@s.whatsapp.net', pushname: 'Bob' }
+        ],
+        phoneNumberToLidMappings: [{ pnJid: '5511111111111@s.whatsapp.net', lidJid: '111@lid' }],
+        inlineContacts: [
+            { pnJid: '5522222222222@s.whatsapp.net', lidJid: '222@lid', fullName: 'Bob Silva' }
+        ],
+        statusV3Messages: [
+            { key: { remoteJid: 'status@broadcast', id: 'S1' }, message: { conversation: 'st' } }
+        ],
+        pastParticipants: [{ groupJid: '123@g.us' }],
+        conversations: [
+            {
+                id: '5511111111111@s.whatsapp.net',
+                pnJid: '5511111111111@s.whatsapp.net',
+                lidJid: '111@lid',
+                tcToken: new Uint8Array([5, 5, 5]),
+                messages: [
+                    {
+                        message: {
+                            key: { remoteJid: '5511111111111@s.whatsapp.net', id: 'M1' },
+                            message: { conversation: 'oi' },
+                            messageTimestamp: 1_722_000_000
+                        }
+                    }
+                ]
+            },
+            {
+                id: '5533333333333@s.whatsapp.net',
+                pnJid: '5533333333333@s.whatsapp.net',
+                accountLid: '333@lid',
+                messages: []
+            },
+            { id: '123@g.us', messages: [] }
+        ]
+    }
+    const clean = proto.HistorySync.encode(historySync).finish()
+    const unknownVarint = new Uint8Array([0xf8, 0x1f, 0x2a])
+    const unknownLen = new Uint8Array([0xfa, 0x1f, 0x02, 0xde, 0xad])
+    const blob = new Uint8Array(clean.length + unknownVarint.length + unknownLen.length)
+    blob.set(unknownVarint, 0)
+    blob.set(clean, unknownVarint.length)
+    blob.set(unknownLen, unknownVarint.length + clean.length)
+
+    const reference = proto.HistorySync.decode(blob)
+    const scan = scanHistorySyncBlob(blob)
+
+    assert.equal(scan.conversationRanges.length, reference.conversations.length)
+    for (let i = 0; i < scan.conversationRanges.length; i += 1) {
+        const range = scan.conversationRanges[i]
+        const incremental = proto.Conversation.decode(blob.subarray(range.start, range.end))
+        assert.deepEqual(
+            Array.from(proto.Conversation.encode(incremental).finish()),
+            Array.from(proto.Conversation.encode(reference.conversations[i]).finish()),
+            `conversation ${i}`
+        )
+        const pair = scanConversationJidPair(blob, range)
+        assert.equal(pair.pnJid, reference.conversations[i].pnJid ?? null)
+        assert.equal(
+            pair.lidJid,
+            reference.conversations[i].lidJid ?? reference.conversations[i].accountLid ?? null
+        )
+    }
+
+    assert.equal(scan.pushnames.length, reference.pushnames.length)
+    for (let i = 0; i < scan.pushnames.length; i += 1) {
+        assert.equal(scan.pushnames[i].id, reference.pushnames[i].id)
+        assert.equal(scan.pushnames[i].pushname, reference.pushnames[i].pushname)
+    }
+    assert.equal(scan.inlineContacts.length, reference.inlineContacts.length)
+    assert.equal(scan.phoneNumberToLidMappings.length, reference.phoneNumberToLidMappings.length)
+    assert.equal(scan.chunkOrder, reference.chunkOrder ?? null)
+    assert.equal(scan.progress, reference.progress ?? null)
+    assert.deepEqual(Array.from(scan.nctSalt ?? []), Array.from(reference.nctSalt ?? []))
 })

--- a/src/client/persistence/__tests__/history-sync.test.ts
+++ b/src/client/persistence/__tests__/history-sync.test.ts
@@ -227,6 +227,10 @@ test('history sync abort on a corrupt conversation settles pending writes', asyn
             }
         ]
     }).finish()
+    assert.ok(
+        validConversation.length < 128,
+        'fixture must stay below 128 bytes for the single-byte length framing below'
+    )
     const corruptRecord = new Uint8Array([0x12, 0x01, 0x0d])
     const blob = new Uint8Array(2 + 2 + validConversation.length + 2 + corruptRecord.length)
     blob.set([0x08, 0x02], 0)
@@ -237,16 +241,19 @@ test('history sync abort on a corrupt conversation settles pending writes', asyn
     const gzipped = toBytesView(await promisify(gzip)(blob))
 
     let rejectedWriteSettled = false
+    const threadJids: string[] = []
     const deps = {
         logger: createNoopLogger(),
         mediaTransfer: null as never,
         writeBehind: {
             persistContactAsync: async () => undefined,
-            persistThreadAsync: () =>
-                Promise.reject(new Error('write failed')).catch((error: unknown) => {
+            persistThreadAsync: (input: { readonly jid: string }) => {
+                threadJids.push(input.jid)
+                return Promise.reject(new Error('write failed')).catch((error: unknown) => {
                     rejectedWriteSettled = true
                     throw error
-                }),
+                })
+            },
             persistMessageAsync: async () => undefined
         } as never,
         emitEvent: () => {
@@ -266,4 +273,9 @@ test('history sync abort on a corrupt conversation settles pending writes', asyn
         /invalid|index out of range|protobuf/i
     )
     assert.equal(rejectedWriteSettled, true, 'pending write rejection must be consumed')
+    assert.deepEqual(
+        threadJids,
+        ['5511111111111@s.whatsapp.net'],
+        'the conversation before the corrupt record must have been written'
+    )
 })

--- a/src/client/persistence/__tests__/history-sync.test.ts
+++ b/src/client/persistence/__tests__/history-sync.test.ts
@@ -168,6 +168,7 @@ test('scanHistorySyncBlob is equivalent to the monolithic HistorySync decode', (
                 id: '5533333333333@s.whatsapp.net',
                 pnJid: '5533333333333@s.whatsapp.net',
                 accountLid: '333@lid',
+                muteEndTime: -1,
                 messages: []
             },
             { id: '123@g.us', messages: [] }
@@ -211,4 +212,58 @@ test('scanHistorySyncBlob is equivalent to the monolithic HistorySync decode', (
     assert.equal(scan.chunkOrder, reference.chunkOrder ?? null)
     assert.equal(scan.progress, reference.progress ?? null)
     assert.deepEqual(Array.from(scan.nctSalt ?? []), Array.from(reference.nctSalt ?? []))
+})
+
+test('history sync abort on a corrupt conversation settles pending writes', async () => {
+    const validConversation = proto.Conversation.encode({
+        id: '5511111111111@s.whatsapp.net',
+        messages: [
+            {
+                message: {
+                    key: { remoteJid: '5511111111111@s.whatsapp.net', id: 'M1' },
+                    message: { conversation: 'oi' },
+                    messageTimestamp: 1_722_000_000
+                }
+            }
+        ]
+    }).finish()
+    const corruptRecord = new Uint8Array([0x12, 0x01, 0x0d])
+    const blob = new Uint8Array(2 + 2 + validConversation.length + 2 + corruptRecord.length)
+    blob.set([0x08, 0x02], 0)
+    blob.set([0x12, validConversation.length], 2)
+    blob.set(validConversation, 4)
+    blob.set([0x12, corruptRecord.length], 4 + validConversation.length)
+    blob.set(corruptRecord, 6 + validConversation.length)
+    const gzipped = toBytesView(await promisify(gzip)(blob))
+
+    let rejectedWriteSettled = false
+    const deps = {
+        logger: createNoopLogger(),
+        mediaTransfer: null as never,
+        writeBehind: {
+            persistContactAsync: async () => undefined,
+            persistThreadAsync: () =>
+                Promise.reject(new Error('write failed')).catch((error: unknown) => {
+                    rejectedWriteSettled = true
+                    throw error
+                }),
+            persistMessageAsync: async () => undefined
+        } as never,
+        emitEvent: () => {
+            throw new Error('event must not be emitted on abort')
+        },
+        onProcessed: async () => {
+            throw new Error('chunk must not be acked on abort')
+        }
+    }
+
+    await assert.rejects(
+        () =>
+            processHistorySyncNotification(deps as never, {
+                syncType: proto.Message.HistorySyncType.RECENT,
+                initialHistBootstrapInlinePayload: gzipped
+            }),
+        /invalid|index out of range|protobuf/i
+    )
+    assert.equal(rejectedWriteSettled, true, 'pending write rejection must be consumed')
 })

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -10,8 +10,9 @@ import { proto, type Proto } from '@proto'
 import { isUserJid } from '@protocol/jid'
 import { normalizeEphemeralSettingSeconds } from '@protocol/message'
 import type { WaChatMetadataStore } from '@store/contracts/chat-metadata.store'
-import { decodeProtoBytes, toBytesView } from '@util/bytes'
+import { decodeProtoBytes, TEXT_DECODER, toBytesView } from '@util/bytes'
 import { longToNumber, toError } from '@util/primitives'
+import { PROTO_WIRE_TYPES, scanProtoFields } from '@util/protoscan'
 
 const unzipAsync = promisify(unzip)
 
@@ -24,6 +25,113 @@ const HANDLED_SYNC_TYPES = new Set([
     proto.Message.HistorySyncType.NON_BLOCKING_DATA
 ])
 const HISTORY_SYNC_MAX_PENDING_WRITES = 1_024
+
+const HISTORY_SYNC_FIELDS = Object.freeze({
+    CONVERSATIONS: 2,
+    CHUNK_ORDER: 5,
+    PROGRESS: 6,
+    PUSHNAMES: 7,
+    PHONE_NUMBER_TO_LID_MAPPINGS: 15,
+    NCT_SALT: 19,
+    INLINE_CONTACTS: 20
+} as const)
+
+const CONVERSATION_JID_FIELDS = Object.freeze({
+    PN_JID: 39,
+    LID_JID: 42,
+    ACCOUNT_LID: 49
+} as const)
+
+interface ByteRange {
+    readonly start: number
+    readonly end: number
+}
+
+interface HistorySyncScan {
+    readonly conversationRanges: readonly ByteRange[]
+    readonly pushnames: readonly Proto.IPushname[]
+    readonly inlineContacts: readonly Proto.IInlineContact[]
+    readonly phoneNumberToLidMappings: readonly Proto.IPhoneNumberToLIDMapping[]
+    readonly nctSalt: Uint8Array | null
+    readonly chunkOrder: number | null
+    readonly progress: number | null
+}
+
+export function scanHistorySyncBlob(bytes: Uint8Array): HistorySyncScan {
+    const conversationRanges: ByteRange[] = []
+    const pushnames: Proto.IPushname[] = []
+    const inlineContacts: Proto.IInlineContact[] = []
+    const phoneNumberToLidMappings: Proto.IPhoneNumberToLIDMapping[] = []
+    let nctSalt: Uint8Array | null = null
+    let chunkOrder: number | null = null
+    let progress: number | null = null
+
+    scanProtoFields(bytes, 0, bytes.length, (field) => {
+        if (field.wireType === PROTO_WIRE_TYPES.LEN) {
+            if (field.fieldNumber === HISTORY_SYNC_FIELDS.CONVERSATIONS) {
+                conversationRanges[conversationRanges.length] = {
+                    start: field.valueStart,
+                    end: field.valueEnd
+                }
+            } else if (field.fieldNumber === HISTORY_SYNC_FIELDS.PUSHNAMES) {
+                pushnames[pushnames.length] = proto.Pushname.decode(
+                    bytes.subarray(field.valueStart, field.valueEnd)
+                )
+            } else if (field.fieldNumber === HISTORY_SYNC_FIELDS.PHONE_NUMBER_TO_LID_MAPPINGS) {
+                phoneNumberToLidMappings[phoneNumberToLidMappings.length] =
+                    proto.PhoneNumberToLIDMapping.decode(
+                        bytes.subarray(field.valueStart, field.valueEnd)
+                    )
+            } else if (field.fieldNumber === HISTORY_SYNC_FIELDS.INLINE_CONTACTS) {
+                inlineContacts[inlineContacts.length] = proto.InlineContact.decode(
+                    bytes.subarray(field.valueStart, field.valueEnd)
+                )
+            } else if (field.fieldNumber === HISTORY_SYNC_FIELDS.NCT_SALT) {
+                nctSalt = bytes.slice(field.valueStart, field.valueEnd)
+            }
+            return
+        }
+        if (field.wireType === PROTO_WIRE_TYPES.VARINT) {
+            if (field.fieldNumber === HISTORY_SYNC_FIELDS.CHUNK_ORDER) {
+                chunkOrder = field.varintValue
+            } else if (field.fieldNumber === HISTORY_SYNC_FIELDS.PROGRESS) {
+                progress = field.varintValue
+            }
+        }
+    })
+
+    return {
+        conversationRanges,
+        pushnames,
+        inlineContacts,
+        phoneNumberToLidMappings,
+        nctSalt,
+        chunkOrder,
+        progress
+    }
+}
+
+export function scanConversationJidPair(
+    bytes: Uint8Array,
+    range: ByteRange
+): { readonly pnJid: string | null; readonly lidJid: string | null } {
+    let pnJid: string | null = null
+    let lidJid: string | null = null
+    let accountLid: string | null = null
+    scanProtoFields(bytes, range.start, range.end, (field) => {
+        if (field.wireType !== PROTO_WIRE_TYPES.LEN) {
+            return
+        }
+        if (field.fieldNumber === CONVERSATION_JID_FIELDS.PN_JID) {
+            pnJid = TEXT_DECODER.decode(bytes.subarray(field.valueStart, field.valueEnd))
+        } else if (field.fieldNumber === CONVERSATION_JID_FIELDS.LID_JID) {
+            lidJid = TEXT_DECODER.decode(bytes.subarray(field.valueStart, field.valueEnd))
+        } else if (field.fieldNumber === CONVERSATION_JID_FIELDS.ACCOUNT_LID) {
+            accountLid = TEXT_DECODER.decode(bytes.subarray(field.valueStart, field.valueEnd))
+        }
+    })
+    return { pnJid, lidJid: lidJid ?? accountLid }
+}
 
 interface WaHistorySyncDeps {
     readonly logger: Logger
@@ -89,15 +197,18 @@ export async function processHistorySyncNotification(
 
     const blob = await downloadHistorySyncBlob(deps, notification)
     const decompressed = toBytesView(await unzipAsync(blob))
-    const historySync = proto.HistorySync.decode(decompressed)
+    // Conversations are decoded one record at a time in the loop below so the
+    // full message graph never coexists in memory; the scan only records their
+    // byte ranges and decodes the small metadata fields.
+    const scan = scanHistorySyncBlob(decompressed)
 
     deps.logger.info('decoded history sync chunk', {
         syncType,
-        chunkOrder: historySync.chunkOrder,
-        progress: historySync.progress,
-        conversations: historySync.conversations.length,
-        pushnames: historySync.pushnames.length,
-        inlineContacts: historySync.inlineContacts?.length ?? 0
+        chunkOrder: scan.chunkOrder,
+        progress: scan.progress,
+        conversations: scan.conversationRanges.length,
+        pushnames: scan.pushnames.length,
+        inlineContacts: scan.inlineContacts.length
     })
 
     const nowMs = Date.now()
@@ -108,25 +219,24 @@ export async function processHistorySyncNotification(
     // pushnames and mappings land on a single canonical (LID-form) contact
     // row instead of two mirror rows (one keyed by PN, one keyed by LID).
     const pnToLid = new Map<string, string>()
-    for (const map of historySync.phoneNumberToLidMappings ?? []) {
+    for (const map of scan.phoneNumberToLidMappings) {
         if (map.pnJid && map.lidJid) {
             pnToLid.set(map.pnJid, map.lidJid)
         }
     }
-    for (const c of historySync.inlineContacts ?? []) {
+    for (const c of scan.inlineContacts) {
         if (c.pnJid && c.lidJid) {
             pnToLid.set(c.pnJid, c.lidJid)
         }
     }
-    for (const conversation of historySync.conversations) {
-        const pnJid = conversation.pnJid
-        const lidJid = conversation.lidJid ?? conversation.accountLid
-        if (pnJid && lidJid) {
-            pnToLid.set(pnJid, lidJid)
+    for (const range of scan.conversationRanges) {
+        const pair = scanConversationJidPair(decompressed, range)
+        if (pair.pnJid && pair.lidJid) {
+            pnToLid.set(pair.pnJid, pair.lidJid)
         }
     }
 
-    for (const pn of historySync.pushnames) {
+    for (const pn of scan.pushnames) {
         if (!pn.id) {
             continue
         }
@@ -150,7 +260,7 @@ export async function processHistorySyncNotification(
         }
     }
 
-    for (const c of historySync.inlineContacts ?? []) {
+    for (const c of scan.inlineContacts) {
         const jid = c.lidJid ?? c.pnJid
         if (!jid) {
             continue
@@ -171,11 +281,35 @@ export async function processHistorySyncNotification(
     }
 
     let messagesCount = 0
-    for (const conversation of historySync.conversations) {
+    const tokenConversations: {
+        readonly jid: string
+        readonly tcToken?: Uint8Array | null
+        readonly tcTokenTimestamp?: number | null
+        readonly tcTokenSenderTimestamp?: number | null
+    }[] = []
+    for (const range of scan.conversationRanges) {
+        const conversation = proto.Conversation.decode(
+            decompressed.subarray(range.start, range.end)
+        )
         const threadJid = conversation.id
         if (!threadJid) {
             deps.logger.debug('skipping history sync conversation without thread jid')
             continue
+        }
+
+        if (
+            deps.onPrivacyTokens &&
+            (conversation.tcToken ||
+                conversation.tcTokenTimestamp ||
+                conversation.tcTokenSenderTimestamp)
+        ) {
+            tokenConversations[tokenConversations.length] = {
+                jid: threadJid,
+                tcToken: conversation.tcToken ? new Uint8Array(conversation.tcToken) : undefined,
+                tcTokenTimestamp: longToNumber(conversation.tcTokenTimestamp) || undefined,
+                tcTokenSenderTimestamp:
+                    longToNumber(conversation.tcTokenSenderTimestamp) || undefined
+            }
         }
 
         const ephemeralExpiration = conversation.ephemeralExpiration ?? undefined
@@ -271,45 +405,21 @@ export async function processHistorySyncNotification(
         }
     }
 
-    if (deps.onPrivacyTokens) {
-        const tokenConversations: {
-            readonly jid: string
-            readonly tcToken?: Uint8Array | null
-            readonly tcTokenTimestamp?: number | null
-            readonly tcTokenSenderTimestamp?: number | null
-        }[] = []
-        for (const conversation of historySync.conversations) {
-            if (!conversation.id) continue
-            if (
-                conversation.tcToken ||
-                conversation.tcTokenTimestamp ||
-                conversation.tcTokenSenderTimestamp
-            ) {
-                tokenConversations[tokenConversations.length] = {
-                    jid: conversation.id,
-                    tcToken: conversation.tcToken,
-                    tcTokenTimestamp: longToNumber(conversation.tcTokenTimestamp) || undefined,
-                    tcTokenSenderTimestamp:
-                        longToNumber(conversation.tcTokenSenderTimestamp) || undefined
-                }
-            }
-        }
-        if (tokenConversations.length > 0) {
-            pendingWrites[pendingWrites.length] = deps.onPrivacyTokens(tokenConversations)
-        }
+    if (deps.onPrivacyTokens && tokenConversations.length > 0) {
+        pendingWrites[pendingWrites.length] = deps.onPrivacyTokens(tokenConversations)
     }
-    if (deps.onNctSalt && historySync.nctSalt) {
-        pendingWrites[pendingWrites.length] = deps.onNctSalt(historySync.nctSalt)
+    if (deps.onNctSalt && scan.nctSalt) {
+        pendingWrites[pendingWrites.length] = deps.onNctSalt(scan.nctSalt)
     }
 
     const event: WaHistorySyncChunkEvent = {
         syncType,
         messagesCount,
-        conversationsCount: historySync.conversations.length,
-        pushnamesCount: historySync.pushnames.length,
-        inlineContactsCount: historySync.inlineContacts?.length ?? 0,
-        chunkOrder: historySync.chunkOrder ?? undefined,
-        progress: historySync.progress ?? undefined
+        conversationsCount: scan.conversationRanges.length,
+        pushnamesCount: scan.pushnames.length,
+        inlineContactsCount: scan.inlineContacts.length,
+        chunkOrder: scan.chunkOrder ?? undefined,
+        progress: scan.progress ?? undefined
     }
     await flushPendingWrites(pendingWrites)
     deps.emitEvent('history_sync_chunk', event)

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -288,9 +288,13 @@ export async function processHistorySyncNotification(
         readonly tcTokenSenderTimestamp?: number | null
     }[] = []
     for (const range of scan.conversationRanges) {
-        const conversation = proto.Conversation.decode(
-            decompressed.subarray(range.start, range.end)
-        )
+        let conversation: Proto.Conversation
+        try {
+            conversation = proto.Conversation.decode(decompressed.subarray(range.start, range.end))
+        } catch (error) {
+            await Promise.allSettled(pendingWrites)
+            throw toError(error)
+        }
         const threadJid = conversation.id
         if (!threadJid) {
             deps.logger.debug('skipping history sync conversation without thread jid')

--- a/src/message/crypto/reporting-token.ts
+++ b/src/message/crypto/reporting-token.ts
@@ -2,6 +2,7 @@ import { hkdf, hmacSha256Sign } from '@crypto'
 import { proto, type Proto } from '@proto'
 import type { BinaryNode } from '@transport/types'
 import { base64ToBytesChecked, concatBytes, EMPTY_BYTES, TEXT_ENCODER } from '@util/bytes'
+import { PROTO_WIRE_TYPES, scanProtoFields } from '@util/protoscan'
 
 const WA_REPORTING_TOKEN_BYTES = 16
 const WA_REPORTING_TOKEN_KEY_BYTES = 32
@@ -34,21 +35,6 @@ interface ReportingTokenField {
 
 interface ReportingTokenConfig {
     readonly fields: ReadonlyMap<number, ReportingTokenField>
-}
-
-interface ParsedProtobufField {
-    readonly tag: number
-    readonly fieldNumber: number
-    readonly wireType: number
-    readonly start: number
-    readonly next: number
-    readonly valueStart: number
-    readonly valueEnd: number
-}
-
-interface VarintReadResult {
-    readonly value: number
-    readonly next: number
 }
 
 interface ExtractedFieldPart {
@@ -193,34 +179,20 @@ function getReportingTokenConfigSpec(): ReportingTokenConfigSpec {
 }
 
 function parseReportingTokenConfigSpec(bytes: Uint8Array): ReportingTokenConfigSpec {
-    let cursor = 0
     const fields = new Map<number, ReportingTokenFieldSpec>()
 
-    while (cursor < bytes.length) {
-        const tag = readVarint(bytes, cursor, bytes.length)
-        cursor = tag.next
-        const fieldNumber = Math.floor(tag.value / 8)
-        const wireType = tag.value & 0x07
-
-        if (fieldNumber === 1 && wireType === 2) {
-            const lengthInfo = readVarint(bytes, cursor, bytes.length)
-            const entryStart = lengthInfo.next
-            const entryEnd = entryStart + lengthInfo.value
-            if (entryEnd > bytes.length) {
-                throw new Error('invalid reporting token config map entry length')
-            }
-
-            const parsedEntry = parseReportingTokenConfigMapEntry(bytes, entryStart, entryEnd)
+    scanProtoFields(bytes, 0, bytes.length, (field) => {
+        if (field.fieldNumber === 1 && field.wireType === PROTO_WIRE_TYPES.LEN) {
+            const parsedEntry = parseReportingTokenConfigMapEntry(
+                bytes,
+                field.valueStart,
+                field.valueEnd
+            )
             if (parsedEntry) {
                 fields.set(parsedEntry.key, parsedEntry.value)
             }
-
-            cursor = entryEnd
-            continue
         }
-
-        cursor = skipField(bytes, cursor, bytes.length, wireType)
-    }
+    })
 
     return { fields }
 }
@@ -230,37 +202,16 @@ function parseReportingTokenConfigMapEntry(
     start: number,
     end: number
 ): { readonly key: number; readonly value: ReportingTokenFieldSpec } | null {
-    let cursor = start
     let key: number | null = null
     let value: ReportingTokenFieldSpec | null = null
 
-    while (cursor < end) {
-        const tag = readVarint(bytes, cursor, end)
-        cursor = tag.next
-        const fieldNumber = Math.floor(tag.value / 8)
-        const wireType = tag.value & 0x07
-
-        if (fieldNumber === 1 && wireType === 0) {
-            const keyVarint = readVarint(bytes, cursor, end)
-            key = keyVarint.value
-            cursor = keyVarint.next
-            continue
+    scanProtoFields(bytes, start, end, (field) => {
+        if (field.fieldNumber === 1 && field.wireType === PROTO_WIRE_TYPES.VARINT) {
+            key = field.varintValue
+        } else if (field.fieldNumber === 2 && field.wireType === PROTO_WIRE_TYPES.LEN) {
+            value = parseReportingTokenFieldSpec(bytes, field.valueStart, field.valueEnd)
         }
-
-        if (fieldNumber === 2 && wireType === 2) {
-            const valueLength = readVarint(bytes, cursor, end)
-            const valueStart = valueLength.next
-            const valueEnd = valueStart + valueLength.value
-            if (valueEnd > end) {
-                throw new Error('invalid reporting token config field value length')
-            }
-            value = parseReportingTokenFieldSpec(bytes, valueStart, valueEnd)
-            cursor = valueEnd
-            continue
-        }
-
-        cursor = skipField(bytes, cursor, end, wireType)
-    }
+    })
 
     if (key === null || value === null) {
         return null
@@ -273,58 +224,33 @@ function parseReportingTokenFieldSpec(
     start: number,
     end: number
 ): ReportingTokenFieldSpec {
-    let cursor = start
     let minVersion = 1
     let maxVersion: number | null = null
     let isMessage = false
     const subfields = new Map<number, ReportingTokenFieldSpec>()
 
-    while (cursor < end) {
-        const tag = readVarint(bytes, cursor, end)
-        cursor = tag.next
-        const fieldNumber = Math.floor(tag.value / 8)
-        const wireType = tag.value & 0x07
-
-        if (fieldNumber === 1 && wireType === 0) {
-            const value = readVarint(bytes, cursor, end)
-            minVersion = value.value
-            cursor = value.next
-            continue
-        }
-
-        if (fieldNumber === 2 && wireType === 0) {
-            const value = readVarint(bytes, cursor, end)
-            maxVersion = value.value
-            cursor = value.next
-            continue
-        }
-
-        if (fieldNumber === 4 && wireType === 0) {
-            const value = readVarint(bytes, cursor, end)
-            isMessage = value.value !== 0
-            cursor = value.next
-            continue
-        }
-
-        if (fieldNumber === 5 && wireType === 2) {
-            const lengthInfo = readVarint(bytes, cursor, end)
-            const entryStart = lengthInfo.next
-            const entryEnd = entryStart + lengthInfo.value
-            if (entryEnd > end) {
-                throw new Error('invalid reporting token subfield map entry length')
+    scanProtoFields(bytes, start, end, (field) => {
+        if (field.wireType === PROTO_WIRE_TYPES.VARINT) {
+            if (field.fieldNumber === 1) {
+                minVersion = field.varintValue
+            } else if (field.fieldNumber === 2) {
+                maxVersion = field.varintValue
+            } else if (field.fieldNumber === 4) {
+                isMessage = field.varintValue !== 0
             }
-
-            const parsedEntry = parseReportingTokenConfigMapEntry(bytes, entryStart, entryEnd)
+            return
+        }
+        if (field.fieldNumber === 5 && field.wireType === PROTO_WIRE_TYPES.LEN) {
+            const parsedEntry = parseReportingTokenConfigMapEntry(
+                bytes,
+                field.valueStart,
+                field.valueEnd
+            )
             if (parsedEntry) {
                 subfields.set(parsedEntry.key, parsedEntry.value)
             }
-
-            cursor = entryEnd
-            continue
         }
-
-        cursor = skipField(bytes, cursor, end, wireType)
-    }
+    })
 
     return {
         minVersion,
@@ -380,37 +306,33 @@ function extractProtobufFieldParts(
 ): ExtractedFieldSet {
     const parts: ExtractedFieldPart[] = []
     let totalSize = 0
-    let cursor = start
 
-    while (cursor < end) {
-        const parsedField = parseProtobufField(bytes, cursor, end)
-        cursor = parsedField.next
-
+    scanProtoFields(bytes, start, end, (parsedField) => {
         const configuredField = config.fields.get(parsedField.fieldNumber)
         if (!configuredField) {
-            continue
+            return
         }
 
         if (
             !configuredField.isMessage &&
             (!configuredField.subfields || configuredField.subfields.fields.size === 0)
         ) {
-            const fieldBytes = bytes.subarray(parsedField.start, parsedField.next)
+            const fieldBytes = bytes.subarray(parsedField.headerStart, parsedField.valueEnd)
             parts.push({
                 fieldNumber: parsedField.fieldNumber,
                 bytes: fieldBytes
             })
             totalSize += fieldBytes.length
-            continue
+            return
         }
 
-        if (parsedField.wireType !== 2) {
-            continue
+        if (parsedField.wireType !== PROTO_WIRE_TYPES.LEN) {
+            return
         }
 
         const nestedConfig = configuredField.isMessage ? rootConfig : configuredField.subfields
         if (!nestedConfig) {
-            continue
+            return
         }
 
         const nestedFields = extractProtobufFieldParts(
@@ -421,10 +343,10 @@ function extractProtobufFieldParts(
             rootConfig
         )
         if (nestedFields.parts.length === 0 || nestedFields.totalSize === 0) {
-            continue
+            return
         }
 
-        const tagBytes = encodeVarint(parsedField.tag)
+        const tagBytes = encodeVarint(parsedField.fieldNumber * 8 + parsedField.wireType)
         const nestedLengthBytes = encodeVarint(nestedFields.totalSize)
         const fieldBytes = new Uint8Array(
             tagBytes.length + nestedLengthBytes.length + nestedFields.totalSize
@@ -442,146 +364,13 @@ function extractProtobufFieldParts(
             bytes: fieldBytes
         })
         totalSize += fieldBytes.length
-    }
+    })
 
     parts.sort((left, right) => left.fieldNumber - right.fieldNumber)
     return {
         parts,
         totalSize
     }
-}
-
-function parseProtobufField(bytes: Uint8Array, start: number, end: number): ParsedProtobufField {
-    const tag = readVarint(bytes, start, end)
-    const tagValue = tag.value
-    if (tagValue <= 0 || tagValue > 4_294_967_295) {
-        throw new Error(`protobuf field tag out of bounds: ${tagValue}`)
-    }
-
-    const fieldNumber = Math.floor(tagValue / 8)
-    if (fieldNumber < 1) {
-        throw new Error(`invalid protobuf field number: ${fieldNumber}`)
-    }
-
-    const wireType = tagValue & 0x07
-    if (wireType === 0) {
-        const value = readVarint(bytes, tag.next, end)
-        return {
-            tag: tagValue,
-            fieldNumber,
-            wireType,
-            start,
-            next: value.next,
-            valueStart: value.next,
-            valueEnd: value.next
-        }
-    }
-    if (wireType === 1) {
-        const next = tag.next + 8
-        if (next > end) {
-            throw new Error('invalid protobuf fixed64 field length')
-        }
-        return {
-            tag: tagValue,
-            fieldNumber,
-            wireType,
-            start,
-            next,
-            valueStart: next,
-            valueEnd: next
-        }
-    }
-    if (wireType === 2) {
-        const valueLength = readVarint(bytes, tag.next, end)
-        const valueStart = valueLength.next
-        const valueEnd = valueStart + valueLength.value
-        if (valueEnd > end) {
-            throw new Error('invalid protobuf length-delimited field length')
-        }
-        return {
-            tag: tagValue,
-            fieldNumber,
-            wireType,
-            start,
-            next: valueEnd,
-            valueStart,
-            valueEnd
-        }
-    }
-    if (wireType === 5) {
-        const next = tag.next + 4
-        if (next > end) {
-            throw new Error('invalid protobuf fixed32 field length')
-        }
-        return {
-            tag: tagValue,
-            fieldNumber,
-            wireType,
-            start,
-            next,
-            valueStart: next,
-            valueEnd: next
-        }
-    }
-    throw new Error(`unsupported protobuf wire type: ${wireType}`)
-}
-
-function readVarint(bytes: Uint8Array, start: number, end: number): VarintReadResult {
-    let cursor = start
-    let value = 0
-    let factor = 1
-
-    while (cursor < end) {
-        const byte = bytes[cursor]
-        value += (byte & 0x7f) * factor
-        if (!Number.isSafeInteger(value)) {
-            throw new Error('varint exceeds safe integer range')
-        }
-
-        cursor += 1
-        if ((byte & 0x80) === 0) {
-            return {
-                value,
-                next: cursor
-            }
-        }
-
-        factor *= 128
-        if (factor > 2 ** 56) {
-            throw new Error('varint exceeds supported range')
-        }
-    }
-
-    throw new Error('unexpected end of buffer while reading varint')
-}
-
-function skipField(bytes: Uint8Array, start: number, end: number, wireType: number): number {
-    if (wireType === 0) {
-        return readVarint(bytes, start, end).next
-    }
-    if (wireType === 1) {
-        const next = start + 8
-        if (next > end) {
-            throw new Error('invalid fixed64 field size while skipping')
-        }
-        return next
-    }
-    if (wireType === 2) {
-        const lengthInfo = readVarint(bytes, start, end)
-        const next = lengthInfo.next + lengthInfo.value
-        if (next > end) {
-            throw new Error('invalid length-delimited field size while skipping')
-        }
-        return next
-    }
-    if (wireType === 5) {
-        const next = start + 4
-        if (next > end) {
-            throw new Error('invalid fixed32 field size while skipping')
-        }
-        return next
-    }
-    throw new Error(`unsupported wire type while skipping field: ${wireType}`)
 }
 
 function encodeVarint(value: number): Uint8Array {

--- a/src/util/__tests__/protoscan.test.ts
+++ b/src/util/__tests__/protoscan.test.ts
@@ -81,7 +81,8 @@ test('scanProtoFields rejects truncated and malformed input', () => {
     assert.throws(() => collect(new Uint8Array([0x08])), /unexpected end/)
     assert.throws(() => collect(new Uint8Array([0x12, 0x05, 0x61])), /length-delimited/)
     assert.throws(() => collect(new Uint8Array([0x19, 1, 2])), /fixed64/)
-    assert.throws(() => collect(new Uint8Array([0x0c])), /wire type/)
+    assert.throws(() => collect(new Uint8Array([0x0c])), /end-group/)
+    assert.throws(() => collect(new Uint8Array([0x0e])), /wire type/)
     assert.throws(() => collect(new Uint8Array([0x00])), /field number/)
 })
 
@@ -91,4 +92,51 @@ test('readProtoVarint decodes multi-byte values and enforces bounds', () => {
     assert.throws(() => readProtoVarint(new Uint8Array([0x80]), 0, 1), /unexpected end/)
     const tooBig = concatBytes([new Uint8Array(9).fill(0xff), new Uint8Array([0x01])])
     assert.throws(() => readProtoVarint(tooBig, 0, tooBig.length), /safe integer|supported range/)
+})
+
+test('scanProtoFields walks 10-byte varints from negative int64 fields', () => {
+    const encoded = proto.Conversation.encode({
+        id: '5511999998888@s.whatsapp.net',
+        muteEndTime: -1,
+        pnJid: '5511999998888@s.whatsapp.net'
+    }).finish()
+    const fields = collect(encoded)
+    const byNumber = new Map(fields.map((f) => [f.fieldNumber, f]))
+    assert.ok(byNumber.has(1))
+    assert.ok(byNumber.has(39), 'field after the 10-byte varint must still be reachable')
+    const synthetic = new Uint8Array([
+        0x08, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01, 0x10, 0x07
+    ])
+    const parsed = collect(synthetic)
+    assert.equal(parsed.length, 2)
+    assert.equal(parsed[1].fieldNumber, 2)
+    assert.equal(parsed[1].varintValue, 7)
+})
+
+test('scanProtoFields skips group fields like the generated decoder', () => {
+    const bytes = new Uint8Array([
+        0x2b, // field 5 start-group
+        0x08,
+        0x01, // varint inside the group
+        0x1b,
+        0x1c, // nested empty group
+        0x12,
+        0x02,
+        0x61,
+        0x62, // LEN inside the group
+        0x2c, // field 5 end-group
+        0x30,
+        0x2a // field 6 varint 42
+    ])
+    const fields = collect(bytes)
+    assert.equal(fields.length, 1)
+    assert.equal(fields[0].fieldNumber, 6)
+    assert.equal(fields[0].varintValue, 42)
+    assert.throws(() => collect(new Uint8Array([0x2c])), /unmatched protobuf end-group/)
+    assert.throws(() => collect(new Uint8Array([0x2b, 0x08, 0x01])), /skipping group/)
+})
+
+test('scanProtoFields rejects varints beyond the 10 byte protobuf limit', () => {
+    const overlong = new Uint8Array([0x08, ...new Array(10).fill(0x80), 0x01])
+    assert.throws(() => collect(overlong), /10 byte protobuf limit/)
 })

--- a/src/util/__tests__/protoscan.test.ts
+++ b/src/util/__tests__/protoscan.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { proto } from '@proto'
+import { concatBytes } from '@util/bytes'
+import {
+    PROTO_WIRE_TYPES,
+    type ProtoScanField,
+    readProtoVarint,
+    scanProtoFields
+} from '@util/protoscan'
+
+function collect(bytes: Uint8Array): ProtoScanField[] {
+    const fields: ProtoScanField[] = []
+    scanProtoFields(bytes, 0, bytes.length, (field) => fields.push({ ...field }))
+    return fields
+}
+
+test('scanProtoFields walks every wire type in order', () => {
+    const bytes = new Uint8Array([
+        0x08,
+        0x96,
+        0x01, // field 1 varint 150
+        0x12,
+        0x03,
+        0x61,
+        0x62,
+        0x63, // field 2 LEN "abc"
+        0x19,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8, // field 3 fixed64
+        0x25,
+        9,
+        9,
+        9,
+        9 // field 4 fixed32
+    ])
+    const fields = collect(bytes)
+    assert.equal(fields.length, 4)
+    assert.deepEqual(
+        fields.map((f) => [f.fieldNumber, f.wireType]),
+        [
+            [1, PROTO_WIRE_TYPES.VARINT],
+            [2, PROTO_WIRE_TYPES.LEN],
+            [3, PROTO_WIRE_TYPES.FIXED64],
+            [4, PROTO_WIRE_TYPES.FIXED32]
+        ]
+    )
+    assert.equal(fields[0].varintValue, 150)
+    assert.deepEqual(
+        Array.from(bytes.subarray(fields[1].valueStart, fields[1].valueEnd)),
+        [0x61, 0x62, 0x63]
+    )
+})
+
+test('scanProtoFields matches protobufjs framing on a real message', () => {
+    const encoded = proto.HistorySync.encode({
+        syncType: proto.HistorySync.HistorySyncType.RECENT,
+        chunkOrder: 3,
+        progress: 77,
+        pushnames: [{ id: '5511@s.whatsapp.net', pushname: 'Vini' }]
+    }).finish()
+    const fields = collect(encoded)
+    const byNumber = new Map(fields.map((f) => [f.fieldNumber, f]))
+    assert.equal(byNumber.get(1)?.varintValue, proto.HistorySync.HistorySyncType.RECENT)
+    assert.equal(byNumber.get(5)?.varintValue, 3)
+    assert.equal(byNumber.get(6)?.varintValue, 77)
+    const pushname = byNumber.get(7)
+    assert.ok(pushname)
+    const decoded = proto.Pushname.decode(encoded.subarray(pushname.valueStart, pushname.valueEnd))
+    assert.equal(decoded.pushname, 'Vini')
+})
+
+test('scanProtoFields rejects truncated and malformed input', () => {
+    assert.throws(() => collect(new Uint8Array([0x08])), /unexpected end/)
+    assert.throws(() => collect(new Uint8Array([0x12, 0x05, 0x61])), /length-delimited/)
+    assert.throws(() => collect(new Uint8Array([0x19, 1, 2])), /fixed64/)
+    assert.throws(() => collect(new Uint8Array([0x0c])), /wire type/)
+    assert.throws(() => collect(new Uint8Array([0x00])), /field number/)
+})
+
+test('readProtoVarint decodes multi-byte values and enforces bounds', () => {
+    const bytes = new Uint8Array([0xac, 0x02])
+    assert.deepEqual(readProtoVarint(bytes, 0, bytes.length), { value: 300, next: 2 })
+    assert.throws(() => readProtoVarint(new Uint8Array([0x80]), 0, 1), /unexpected end/)
+    const tooBig = concatBytes([new Uint8Array(9).fill(0xff), new Uint8Array([0x01])])
+    assert.throws(() => readProtoVarint(tooBig, 0, tooBig.length), /safe integer|supported range/)
+})

--- a/src/util/__tests__/protoscan.test.ts
+++ b/src/util/__tests__/protoscan.test.ts
@@ -140,3 +140,22 @@ test('scanProtoFields rejects varints beyond the 10 byte protobuf limit', () => 
     const overlong = new Uint8Array([0x08, ...new Array(10).fill(0x80), 0x01])
     assert.throws(() => collect(overlong), /10 byte protobuf limit/)
 })
+
+test('scanProtoFields bounds group nesting depth', () => {
+    const shallow = new Uint8Array(24)
+    for (let i = 0; i < 10; i += 1) shallow[i] = 0x2b
+    shallow[10] = 0x08
+    shallow[11] = 0x01
+    for (let i = 12; i < 22; i += 1) shallow[i] = 0x2c
+    shallow[22] = 0x30
+    shallow[23] = 0x2a
+    const fields: number[] = []
+    scanProtoFields(shallow, 0, shallow.length, (f) => fields.push(f.fieldNumber))
+    assert.deepEqual(fields, [6])
+
+    const deep = new Uint8Array(200).fill(0x2b)
+    assert.throws(
+        () => scanProtoFields(deep, 0, deep.length, () => undefined),
+        /group nesting exceeds supported depth/
+    )
+})

--- a/src/util/protoscan.ts
+++ b/src/util/protoscan.ts
@@ -8,6 +8,7 @@ export const PROTO_WIRE_TYPES = Object.freeze({
 } as const)
 
 const PROTO_VARINT_MAX_BYTES = 10
+const PROTO_GROUP_MAX_DEPTH = 64
 
 export interface ProtoScanField {
     readonly fieldNumber: number
@@ -79,7 +80,10 @@ function walkVarint(bytes: Uint8Array, start: number, end: number): VarintReadRe
     throw new Error('unexpected end of buffer while reading varint')
 }
 
-function skipGroup(bytes: Uint8Array, start: number, end: number): number {
+function skipGroup(bytes: Uint8Array, start: number, end: number, depth = 0): number {
+    if (depth >= PROTO_GROUP_MAX_DEPTH) {
+        throw new Error('protobuf group nesting exceeds supported depth')
+    }
     let cursor = start
     while (cursor < end) {
         const tag = readProtoVarint(bytes, cursor, end)
@@ -96,7 +100,7 @@ function skipGroup(bytes: Uint8Array, start: number, end: number): number {
             const length = readProtoVarint(bytes, cursor, end)
             cursor = length.next + length.value
         } else if (wireType === PROTO_WIRE_TYPES.START_GROUP) {
-            cursor = skipGroup(bytes, cursor, end)
+            cursor = skipGroup(bytes, cursor, end, depth + 1)
         } else if (wireType === PROTO_WIRE_TYPES.FIXED32) {
             cursor += 4
         } else {

--- a/src/util/protoscan.ts
+++ b/src/util/protoscan.ts
@@ -1,0 +1,137 @@
+export const PROTO_WIRE_TYPES = Object.freeze({
+    VARINT: 0,
+    FIXED64: 1,
+    LEN: 2,
+    FIXED32: 5
+} as const)
+
+export interface ProtoScanField {
+    readonly fieldNumber: number
+    readonly wireType: number
+    /** Offset of the field's tag byte, so callers can slice the whole field. */
+    readonly headerStart: number
+    /** Decoded value for VARINT fields; `0` for every other wire type. */
+    readonly varintValue: number
+    /** Payload bounds for LEN fields; `valueEnd` is the field end for all types. */
+    readonly valueStart: number
+    readonly valueEnd: number
+}
+
+interface VarintReadResult {
+    readonly value: number
+    readonly next: number
+}
+
+export function readProtoVarint(bytes: Uint8Array, start: number, end: number): VarintReadResult {
+    let cursor = start
+    let value = 0
+    let factor = 1
+
+    while (cursor < end) {
+        const byte = bytes[cursor]
+        value += (byte & 0x7f) * factor
+        if (!Number.isSafeInteger(value)) {
+            throw new Error('varint exceeds safe integer range')
+        }
+
+        cursor += 1
+        if ((byte & 0x80) === 0) {
+            return { value, next: cursor }
+        }
+
+        factor *= 128
+        if (factor > 2 ** 56) {
+            throw new Error('varint exceeds supported range')
+        }
+    }
+
+    throw new Error('unexpected end of buffer while reading varint')
+}
+
+/**
+ * Walks the top-level fields of a protobuf-encoded region without decoding
+ * any payload, calling `onField` once per field in wire order. LEN fields
+ * report their payload bounds so callers can decode individual records
+ * lazily; unknown fields are skipped by wire type, matching generated
+ * decoder behavior.
+ */
+export function scanProtoFields(
+    bytes: Uint8Array,
+    start: number,
+    end: number,
+    onField: (field: ProtoScanField) => void
+): void {
+    let cursor = start
+    while (cursor < end) {
+        const tag = readProtoVarint(bytes, cursor, end)
+        const fieldNumber = Math.floor(tag.value / 8)
+        const wireType = tag.value & 0x07
+        if (fieldNumber < 1) {
+            throw new Error(`invalid protobuf field number ${fieldNumber}`)
+        }
+
+        if (wireType === PROTO_WIRE_TYPES.VARINT) {
+            const value = readProtoVarint(bytes, tag.next, end)
+            onField({
+                fieldNumber,
+                wireType,
+                headerStart: cursor,
+                varintValue: value.value,
+                valueStart: tag.next,
+                valueEnd: value.next
+            })
+            cursor = value.next
+            continue
+        }
+        if (wireType === PROTO_WIRE_TYPES.FIXED64) {
+            const valueEnd = tag.next + 8
+            if (valueEnd > end) {
+                throw new Error('invalid protobuf fixed64 field length')
+            }
+            onField({
+                fieldNumber,
+                wireType,
+                headerStart: cursor,
+                varintValue: 0,
+                valueStart: tag.next,
+                valueEnd
+            })
+            cursor = valueEnd
+            continue
+        }
+        if (wireType === PROTO_WIRE_TYPES.LEN) {
+            const length = readProtoVarint(bytes, tag.next, end)
+            const valueEnd = length.next + length.value
+            if (valueEnd > end) {
+                throw new Error('invalid protobuf length-delimited field length')
+            }
+            onField({
+                fieldNumber,
+                wireType,
+                headerStart: cursor,
+                varintValue: 0,
+                valueStart: length.next,
+                valueEnd
+            })
+            cursor = valueEnd
+            continue
+        }
+        if (wireType === PROTO_WIRE_TYPES.FIXED32) {
+            const valueEnd = tag.next + 4
+            if (valueEnd > end) {
+                throw new Error('invalid protobuf fixed32 field length')
+            }
+            onField({
+                fieldNumber,
+                wireType,
+                headerStart: cursor,
+                varintValue: 0,
+                valueStart: tag.next,
+                valueEnd
+            })
+            cursor = valueEnd
+            continue
+        }
+        throw new Error(`unsupported protobuf wire type ${wireType}`)
+    }
+}

--- a/src/util/protoscan.ts
+++ b/src/util/protoscan.ts
@@ -2,8 +2,12 @@ export const PROTO_WIRE_TYPES = Object.freeze({
     VARINT: 0,
     FIXED64: 1,
     LEN: 2,
+    START_GROUP: 3,
+    END_GROUP: 4,
     FIXED32: 5
 } as const)
+
+const PROTO_VARINT_MAX_BYTES = 10
 
 export interface ProtoScanField {
     readonly fieldNumber: number
@@ -49,11 +53,68 @@ export function readProtoVarint(bytes: Uint8Array, start: number, end: number): 
 }
 
 /**
+ * Walks a varint of up to the 10-byte protobuf limit without rejecting
+ * values above `Number.MAX_SAFE_INTEGER` (64-bit fields such as negative
+ * `int64` sign-extend to 10 bytes on the wire). The returned value loses
+ * precision beyond 2^53; callers that need an exact number must use
+ * {@link readProtoVarint}.
+ */
+function walkVarint(bytes: Uint8Array, start: number, end: number): VarintReadResult {
+    let cursor = start
+    let value = 0
+    let factor = 1
+
+    while (cursor < end && cursor - start < PROTO_VARINT_MAX_BYTES) {
+        const byte = bytes[cursor]
+        value += (byte & 0x7f) * factor
+        cursor += 1
+        if ((byte & 0x80) === 0) {
+            return { value, next: cursor }
+        }
+        factor *= 128
+    }
+    if (cursor - start >= PROTO_VARINT_MAX_BYTES) {
+        throw new Error('varint exceeds the 10 byte protobuf limit')
+    }
+    throw new Error('unexpected end of buffer while reading varint')
+}
+
+function skipGroup(bytes: Uint8Array, start: number, end: number): number {
+    let cursor = start
+    while (cursor < end) {
+        const tag = readProtoVarint(bytes, cursor, end)
+        const wireType = tag.value & 0x07
+        cursor = tag.next
+        if (wireType === PROTO_WIRE_TYPES.END_GROUP) {
+            return cursor
+        }
+        if (wireType === PROTO_WIRE_TYPES.VARINT) {
+            cursor = walkVarint(bytes, cursor, end).next
+        } else if (wireType === PROTO_WIRE_TYPES.FIXED64) {
+            cursor += 8
+        } else if (wireType === PROTO_WIRE_TYPES.LEN) {
+            const length = readProtoVarint(bytes, cursor, end)
+            cursor = length.next + length.value
+        } else if (wireType === PROTO_WIRE_TYPES.START_GROUP) {
+            cursor = skipGroup(bytes, cursor, end)
+        } else if (wireType === PROTO_WIRE_TYPES.FIXED32) {
+            cursor += 4
+        } else {
+            throw new Error(`unsupported protobuf wire type ${wireType}`)
+        }
+        if (cursor > end) {
+            throw new Error('invalid protobuf group field length')
+        }
+    }
+    throw new Error('unexpected end of buffer while skipping group')
+}
+
+/**
  * Walks the top-level fields of a protobuf-encoded region without decoding
  * any payload, calling `onField` once per field in wire order. LEN fields
  * report their payload bounds so callers can decode individual records
- * lazily; unknown fields are skipped by wire type, matching generated
- * decoder behavior.
+ * lazily; unknown fields (including deprecated groups) are skipped by wire
+ * type, matching generated decoder behavior.
  */
 export function scanProtoFields(
     bytes: Uint8Array,
@@ -71,7 +132,7 @@ export function scanProtoFields(
         }
 
         if (wireType === PROTO_WIRE_TYPES.VARINT) {
-            const value = readProtoVarint(bytes, tag.next, end)
+            const value = walkVarint(bytes, tag.next, end)
             onField({
                 fieldNumber,
                 wireType,
@@ -131,6 +192,13 @@ export function scanProtoFields(
             })
             cursor = valueEnd
             continue
+        }
+        if (wireType === PROTO_WIRE_TYPES.START_GROUP) {
+            cursor = skipGroup(bytes, tag.next, end)
+            continue
+        }
+        if (wireType === PROTO_WIRE_TYPES.END_GROUP) {
+            throw new Error('unmatched protobuf end-group field')
         }
         throw new Error(`unsupported protobuf wire type ${wireType}`)
     }


### PR DESCRIPTION
The history sync path used to run proto.HistorySync.decode over the whole decompressed blob, materializing every conversation and message at once; that transient graph set the process RSS high-water mark and scaled with whatever chunk size the primary decided to send. The chunk is now walked field by field: a scan pass records conversation byte ranges and decodes the small metadata fields (pushnames, lid mappings, inline contacts, nctSalt, chunkOrder, progress), a shallow pass extracts the pn/lid pairs while skipping the messages payload by offset arithmetic, and the main loop decodes one Conversation at a time, persisting and releasing it before the next. Fields the processor never used (statusV3Messages, pastParticipants, recentStickers, globalSettings) are no longer decoded at all.

Measured on 3 chunks of 200 conversations x 400 messages: peak heap 288 -> 18 MiB and peak RSS 316 -> 67 MiB, with processing time down ~40%; peak heap is now flat in chunk size instead of linear. End-to-end via the fake-server bench: medium chunks +48% msgs/s, large +14% with the scenario RSS delta cut roughly in half.

The field walker lives in @util/protoscan (internal, not exported by the util barrel) and replaces the hand-rolled varint/skip/parse helpers in reporting-token.ts as well, keyed by the new headerStart offset so the extractor can slice whole fields; token output is pinned byte-for-byte by the existing equivalence tests and A/B benches flat.

tcToken and nctSalt are copied out of the decompressed buffer instead of being retained as protobufjs subarray views, so the blob is releasable as soon as the chunk is processed. One failure-path change: a corrupt conversation record now aborts the chunk after earlier conversations were already persisted (idempotent upserts, chunk stays un-acked and is resent) where the monolithic decode failed before any write.

Also ignores cargo/wasm build artifacts in .prettierignore.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved processing efficiency for history synchronization and conversation data.
  * Enhanced extraction of conversation metadata, identifiers, contacts, and privacy-token information.

* **Reliability**
  * Added stronger validation and safer handling of malformed, truncated, or unsupported encoded data.
  * Improved behavior when corrupted conversation data interrupts synchronization.

* **Tests**
  * Expanded coverage for synchronization, encoded data scanning, field types, ordering, and edge cases.

* **Chores**
  * Excluded generated build and coverage directories from formatting checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->