### PR TITLE
fix: set native_flow biz name for PIX and review-and-pay sends

### DIFF
--- a/src/message/__tests__/message.test.ts
+++ b/src/message/__tests__/message.test.ts
@@ -231,6 +231,36 @@ test('resolveButtonAddonKind classifies list/interactive incl. documentWithCapti
         resolveButtonAddonKind({ interactiveMessage: { nativeFlowMessage: {} } }),
         'interactive'
     )
+    assert.equal(
+        resolveButtonAddonKind({
+            interactiveMessage: {
+                nativeFlowMessage: {
+                    buttons: [{ name: 'payment_info', buttonParamsJson: '{}' }]
+                }
+            }
+        }),
+        'payment_info'
+    )
+    assert.equal(
+        resolveButtonAddonKind({
+            interactiveMessage: {
+                nativeFlowMessage: {
+                    buttons: [{ name: 'review_and_pay', buttonParamsJson: '{}' }]
+                }
+            }
+        }),
+        'order_details'
+    )
+    assert.equal(
+        resolveButtonAddonKind({
+            interactiveMessage: {
+                nativeFlowMessage: {
+                    buttons: [{ name: 'cta_url', buttonParamsJson: '{}' }]
+                }
+            }
+        }),
+        'interactive'
+    )
     assert.equal(resolveButtonAddonKind({ interactiveMessage: {} }), null)
     assert.equal(resolveButtonAddonKind({ conversation: 'hi' }), null)
     assert.equal(
@@ -250,6 +280,20 @@ test('resolveButtonAddonKind classifies list/interactive incl. documentWithCapti
             ephemeralMessage: { message: { listMessage: {} } }
         }),
         'list'
+    )
+    assert.equal(
+        resolveButtonAddonKind({
+            documentWithCaptionMessage: {
+                message: {
+                    interactiveMessage: {
+                        nativeFlowMessage: {
+                            buttons: [{ name: 'payment_info', buttonParamsJson: '{}' }]
+                        }
+                    }
+                }
+            }
+        }),
+        'payment_info'
     )
 })
 

--- a/src/message/encode/__tests__/content.test.ts
+++ b/src/message/encode/__tests__/content.test.ts
@@ -59,8 +59,40 @@ test('resolveButtonAddonKind classifies list/interactive incl. documentWithCapti
         resolveButtonAddonKind({ interactiveMessage: { nativeFlowMessage: {} } }),
         'interactive'
     )
+    assert.equal(
+        resolveButtonAddonKind({
+            interactiveMessage: {
+                nativeFlowMessage: {
+                    buttons: [{ name: 'payment_info', buttonParamsJson: '{}' }]
+                }
+            }
+        }),
+        'payment_info'
+    )
+    assert.equal(
+        resolveButtonAddonKind({
+            interactiveMessage: {
+                nativeFlowMessage: {
+                    buttons: [{ name: 'review_and_pay', buttonParamsJson: '{}' }]
+                }
+            }
+        }),
+        'order_details'
+    )
     assert.equal(resolveButtonAddonKind({ interactiveMessage: {} }), null)
     assert.equal(resolveButtonAddonKind({ conversation: 'hi' }), null)
+    assert.equal(
+        resolveButtonAddonKind({ documentWithCaptionMessage: { message: { listMessage: {} } } }),
+        'list'
+    )
+    assert.equal(
+        resolveButtonAddonKind({
+            documentWithCaptionMessage: {
+                message: { interactiveMessage: { nativeFlowMessage: {} } }
+            }
+        }),
+        'interactive'
+    )
 })
 
 test('resolveEditAttr maps protobuf to correct edit attribute values', () => {

--- a/src/message/encode/content.ts
+++ b/src/message/encode/content.ts
@@ -430,15 +430,34 @@ function resolveEncMediaTypeFrom(msg: Proto.IMessage): string | null {
     return null
 }
 
-export type WaButtonAddonKind = 'list' | 'interactive'
+/**
+ * Companion `<biz>` kind attached to interactive/list outbound stanzas.
+ * `interactive` → `native_flow(name=mixed)` (CTA / generic native flow).
+ * `payment_info` / `order_details` → PIX / Review & Pay (golink/whatsmeow parity).
+ * Note: Review & Pay uses proto button name `review_and_pay` but biz node name
+ * `order_details`.
+ */
+export type WaButtonAddonKind = 'list' | 'interactive' | 'payment_info' | 'order_details'
 
 export function resolveButtonAddonKind(message: Proto.IMessage): WaButtonAddonKind | null {
     return resolveButtonAddonKindFrom(unwrapMessage(message))
 }
 
+function resolveNativeFlowAddonKind(
+    nativeFlow: Proto.Message.InteractiveMessage.INativeFlowMessage
+): WaButtonAddonKind {
+    const firstButtonName = nativeFlow.buttons?.[0]?.name
+    if (firstButtonName === 'payment_info') return 'payment_info'
+    // Proto button is `review_and_pay`; companion biz node must be `order_details`.
+    if (firstButtonName === 'review_and_pay') return 'order_details'
+    return 'interactive'
+}
+
 function resolveButtonAddonKindFrom(msg: Proto.IMessage): WaButtonAddonKind | null {
     if (msg.listMessage) return 'list'
-    if (msg.buttonsMessage || msg.interactiveMessage?.nativeFlowMessage) return 'interactive'
+    if (msg.buttonsMessage) return 'interactive'
+    const nativeFlow = msg.interactiveMessage?.nativeFlowMessage
+    if (nativeFlow) return resolveNativeFlowAddonKind(nativeFlow)
     return null
 }
 

--- a/src/message/encode/content.ts
+++ b/src/message/encode/content.ts
@@ -430,13 +430,7 @@ function resolveEncMediaTypeFrom(msg: Proto.IMessage): string | null {
     return null
 }
 
-/**
- * Companion `<biz>` kind attached to interactive/list outbound stanzas.
- * `interactive` → `native_flow(name=mixed)` (CTA / generic native flow).
- * `payment_info` / `order_details` → PIX / Review & Pay (golink/whatsmeow parity).
- * Note: Review & Pay uses proto button name `review_and_pay` but biz node name
- * `order_details`.
- */
+/** Companion business node kind for list and native-flow messages. */
 export type WaButtonAddonKind = 'list' | 'interactive' | 'payment_info' | 'order_details'
 
 export function resolveButtonAddonKind(message: Proto.IMessage): WaButtonAddonKind | null {
@@ -448,7 +442,6 @@ function resolveNativeFlowAddonKind(
 ): WaButtonAddonKind {
     const firstButtonName = nativeFlow.buttons?.[0]?.name
     if (firstButtonName === 'payment_info') return 'payment_info'
-    // Proto button is `review_and_pay`; companion biz node must be `order_details`.
     if (firstButtonName === 'review_and_pay') return 'order_details'
     return 'interactive'
 }

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -781,6 +781,29 @@ test('message builders create fanout nodes and validate participant requirements
     }
     assert.equal(interactiveChild.content[0].tag, 'native_flow')
     assert.equal(interactiveChild.content[0].attrs.name, 'mixed')
+    assert.equal(interactiveChild.content[0].attrs.v, '9')
+
+    const pixAddon = buildButtonAddonNode('payment_info')
+    assert.equal(pixAddon.tag, 'biz')
+    if (!Array.isArray(pixAddon.content)) throw new Error('expected biz children')
+    const pixInteractive = pixAddon.content[0]
+    assert.equal(pixInteractive.tag, 'interactive')
+    assert.equal(pixInteractive.attrs.type, 'native_flow')
+    if (!Array.isArray(pixInteractive.content)) {
+        throw new Error('expected native_flow child')
+    }
+    assert.equal(pixInteractive.content[0].tag, 'native_flow')
+    assert.equal(pixInteractive.content[0].attrs.name, 'payment_info')
+    assert.equal(pixInteractive.content[0].attrs.v, undefined)
+
+    const reviewAddon = buildButtonAddonNode('order_details')
+    if (!Array.isArray(reviewAddon.content)) throw new Error('expected biz children')
+    const reviewInteractive = reviewAddon.content[0]
+    if (!Array.isArray(reviewInteractive.content)) {
+        throw new Error('expected native_flow child')
+    }
+    assert.equal(reviewInteractive.content[0].attrs.name, 'order_details')
+    assert.equal(reviewInteractive.content[0].attrs.v, undefined)
 
     const fanoutWithAddon = buildDirectMessageFanoutNode({
         to: '5511@s.whatsapp.net',

--- a/src/transport/node/builders/message.ts
+++ b/src/transport/node/builders/message.ts
@@ -164,28 +164,45 @@ function pushOptionalNodes(
 }
 
 export function buildButtonAddonNode(kind: WaButtonAddonKind): BinaryNode {
-    const inner: BinaryNode =
-        kind === 'list'
-            ? {
-                  tag: WA_NODE_TAGS.LIST,
-                  attrs: { type: 'product_list', v: '2' },
-                  content: undefined
-              }
-            : {
-                  tag: WA_NODE_TAGS.INTERACTIVE,
-                  attrs: { type: WA_NODE_TAGS.NATIVE_FLOW, v: '1' },
-                  content: [
-                      {
-                          tag: WA_NODE_TAGS.NATIVE_FLOW,
-                          attrs: { v: '9', name: 'mixed' },
-                          content: undefined
-                      }
-                  ]
-              }
+    if (kind === 'list') {
+        return {
+            tag: WA_NODE_TAGS.BIZ,
+            attrs: {},
+            content: [
+                {
+                    tag: WA_NODE_TAGS.LIST,
+                    attrs: { type: 'product_list', v: '2' },
+                    content: undefined
+                }
+            ]
+        }
+    }
+
+    // PIX / Review & Pay: nested biz > interactive > native_flow(name=...),
+    // matching golinkapi/whatsmeow. CTA / generic native flow keeps name=mixed.
+    const nativeFlowName =
+        kind === 'payment_info' || kind === 'order_details' ? kind : 'mixed'
+    const nativeFlowAttrs: Record<string, string> =
+        nativeFlowName === 'mixed'
+            ? { v: '9', name: 'mixed' }
+            : { name: nativeFlowName }
+
     return {
         tag: WA_NODE_TAGS.BIZ,
         attrs: {},
-        content: [inner]
+        content: [
+            {
+                tag: WA_NODE_TAGS.INTERACTIVE,
+                attrs: { type: WA_NODE_TAGS.NATIVE_FLOW, v: '1' },
+                content: [
+                    {
+                        tag: WA_NODE_TAGS.NATIVE_FLOW,
+                        attrs: nativeFlowAttrs,
+                        content: undefined
+                    }
+                ]
+            }
+        ]
     }
 }
 

--- a/src/transport/node/builders/message.ts
+++ b/src/transport/node/builders/message.ts
@@ -178,14 +178,9 @@ export function buildButtonAddonNode(kind: WaButtonAddonKind): BinaryNode {
         }
     }
 
-    // PIX / Review & Pay: nested biz > interactive > native_flow(name=...),
-    // matching golinkapi/whatsmeow. CTA / generic native flow keeps name=mixed.
-    const nativeFlowName =
-        kind === 'payment_info' || kind === 'order_details' ? kind : 'mixed'
+    const nativeFlowName = kind === 'payment_info' || kind === 'order_details' ? kind : 'mixed'
     const nativeFlowAttrs: Record<string, string> =
-        nativeFlowName === 'mixed'
-            ? { v: '9', name: 'mixed' }
-            : { name: nativeFlowName }
+        nativeFlowName === 'mixed' ? { v: '9', name: 'mixed' } : { name: nativeFlowName }
 
     return {
         tag: WA_NODE_TAGS.BIZ,


### PR DESCRIPTION
Outbound interactive native flows always attached a <biz> companion with native_flow name=mixed, which is correct for CTA buttons but wrong for payment messages. WhatsApp accepts the send and then silently drops the stanza on the recipient when the companion name does not match the button: payment_info for PIX and order_details for review_and_pay (the proto button stays review_and_pay; only the biz node name differs).

resolveButtonAddonKind now inspects the first NativeFlowButton name and returns payment_info / order_details / interactive accordingly; buildButtonAddonNode builds the nested biz > interactive > native_flow tree to match golinkapi/whatsmeow. CTA and generic native flows keep the previous mixed companion with v=9.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for payment information and order details button types in messages.
  * Native-flow buttons now identify payment and order review actions correctly.
  * Preserved interactive and list-based button experiences, including buttons in captioned document messages.

* **Bug Fixes**
  * Improved button classification and message encoding across payment, order, list, and interactive actions.
  * Ensured interactive buttons use the correct versioning in encoded messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->