### PR TITLE
fix: split poll creation between V1 and V3 by selectableCount

### DIFF
--- a/src/client/messaging/__tests__/messaging.test.ts
+++ b/src/client/messaging/__tests__/messaging.test.ts
@@ -562,8 +562,28 @@ test('buildMediaMessageContent builds keep/unkeep with KeepType enum', async () 
     assert.equal(unkeep.message.keepInChatMessage?.keepType, proto.KeepType.UNDO_KEEP_FOR_ALL)
 })
 
-test('buildMediaMessageContent builds poll creation V3 with hashed-ready options', async () => {
-    const built = await buildMediaMessageContent(
+test('buildMediaMessageContent builds poll creation V3 for single-select and V1 for multi', async () => {
+    const single = await buildMediaMessageContent(
+        BUILD_OPTIONS,
+        {
+            type: 'poll',
+            name: 'Sim ou nao?',
+            options: ['sim', 'nao'],
+            selectableCount: 1,
+            allowAddOption: true
+        },
+        { to: '551122222222@s.whatsapp.net' }
+    )
+    assert.equal(single.message.pollCreationMessageV3?.name, 'Sim ou nao?')
+    assert.equal(single.message.pollCreationMessageV3?.selectableOptionsCount, 1)
+    assert.equal(single.message.pollCreationMessageV3?.allowAddOption, true)
+    assert.equal(single.message.pollCreationMessage, undefined)
+    assert.deepEqual(single.message.pollCreationMessageV3?.options, [
+        { optionName: 'sim' },
+        { optionName: 'nao' }
+    ])
+
+    const multi = await buildMediaMessageContent(
         BUILD_OPTIONS,
         {
             type: 'poll',
@@ -574,14 +594,27 @@ test('buildMediaMessageContent builds poll creation V3 with hashed-ready options
         },
         { to: '551122222222@s.whatsapp.net' }
     )
-    assert.equal(built.message.pollCreationMessageV3?.name, 'Qual cor?')
-    assert.equal(built.message.pollCreationMessageV3?.selectableOptionsCount, 2)
-    assert.equal(built.message.pollCreationMessageV3?.allowAddOption, true)
-    assert.deepEqual(built.message.pollCreationMessageV3?.options, [
+    assert.equal(multi.message.pollCreationMessage?.name, 'Qual cor?')
+    assert.equal(multi.message.pollCreationMessage?.selectableOptionsCount, 2)
+    assert.equal(multi.message.pollCreationMessage?.allowAddOption, true)
+    assert.equal(multi.message.pollCreationMessageV3, undefined)
+    assert.deepEqual(multi.message.pollCreationMessage?.options, [
         { optionName: 'azul' },
         { optionName: 'verde' },
         { optionName: 'vermelho' }
     ])
+
+    const defaultSelectable = await buildMediaMessageContent(
+        BUILD_OPTIONS,
+        {
+            type: 'poll',
+            name: 'default',
+            options: ['a', 'b']
+        },
+        { to: '551122222222@s.whatsapp.net' }
+    )
+    assert.equal(defaultSelectable.message.pollCreationMessageV3?.selectableOptionsCount, 1)
+    assert.equal(defaultSelectable.message.pollCreationMessage, undefined)
 
     await assert.rejects(
         () =>

--- a/src/client/messaging/__tests__/messaging.test.ts
+++ b/src/client/messaging/__tests__/messaging.test.ts
@@ -569,15 +569,14 @@ test('buildMediaMessageContent builds poll creation V3 for single-select and V1 
             type: 'poll',
             name: 'Sim ou nao?',
             options: ['sim', 'nao'],
-            selectableCount: 1,
-            allowAddOption: true
+            selectableCount: 1
         },
         { to: '551122222222@s.whatsapp.net' }
     )
     assert.equal(single.message.pollCreationMessageV3?.name, 'Sim ou nao?')
     assert.equal(single.message.pollCreationMessageV3?.selectableOptionsCount, 1)
-    assert.equal(single.message.pollCreationMessageV3?.allowAddOption, true)
     assert.equal(single.message.pollCreationMessage, undefined)
+    assert.equal(single.message.pollCreationMessageV6, undefined)
     assert.deepEqual(single.message.pollCreationMessageV3?.options, [
         { optionName: 'sim' },
         { optionName: 'nao' }
@@ -589,15 +588,14 @@ test('buildMediaMessageContent builds poll creation V3 for single-select and V1 
             type: 'poll',
             name: 'Qual cor?',
             options: ['azul', { name: 'verde' }, 'vermelho'],
-            selectableCount: 2,
-            allowAddOption: true
+            selectableCount: 2
         },
         { to: '551122222222@s.whatsapp.net' }
     )
     assert.equal(multi.message.pollCreationMessage?.name, 'Qual cor?')
     assert.equal(multi.message.pollCreationMessage?.selectableOptionsCount, 2)
-    assert.equal(multi.message.pollCreationMessage?.allowAddOption, true)
     assert.equal(multi.message.pollCreationMessageV3, undefined)
+    assert.equal(multi.message.pollCreationMessageV6, undefined)
     assert.deepEqual(multi.message.pollCreationMessage?.options, [
         { optionName: 'azul' },
         { optionName: 'verde' },
@@ -625,6 +623,54 @@ test('buildMediaMessageContent builds poll creation V3 for single-select and V1 
             ),
         /at least one option/
     )
+})
+
+test('buildMediaMessageContent routes poll flags to V6 and drops false flags', async () => {
+    const addOption = await buildMediaMessageContent(
+        BUILD_OPTIONS,
+        {
+            type: 'poll',
+            name: 'Sugestoes?',
+            options: ['a', 'b'],
+            allowAddOption: true
+        },
+        { to: '551122222222@s.whatsapp.net' }
+    )
+    assert.equal(addOption.message.pollCreationMessageV6?.name, 'Sugestoes?')
+    assert.equal(addOption.message.pollCreationMessageV6?.selectableOptionsCount, 1)
+    assert.equal(addOption.message.pollCreationMessageV6?.allowAddOption, true)
+    assert.equal(addOption.message.pollCreationMessageV6?.hideParticipantName, undefined)
+    assert.equal(addOption.message.pollCreationMessageV3, undefined)
+
+    const hidden = await buildMediaMessageContent(
+        BUILD_OPTIONS,
+        {
+            type: 'poll',
+            name: 'Anonima',
+            options: ['a', 'b', 'c'],
+            selectableCount: 2,
+            hideParticipantName: true
+        },
+        { to: '551122222222@s.whatsapp.net' }
+    )
+    assert.equal(hidden.message.pollCreationMessageV6?.selectableOptionsCount, 2)
+    assert.equal(hidden.message.pollCreationMessageV6?.hideParticipantName, true)
+    assert.equal(hidden.message.pollCreationMessage, undefined)
+
+    const explicitFalse = await buildMediaMessageContent(
+        BUILD_OPTIONS,
+        {
+            type: 'poll',
+            name: 'Simples',
+            options: ['a', 'b'],
+            allowAddOption: false,
+            hideParticipantName: false
+        },
+        { to: '551122222222@s.whatsapp.net' }
+    )
+    assert.equal(explicitFalse.message.pollCreationMessageV6, undefined)
+    assert.equal(explicitFalse.message.pollCreationMessageV3?.allowAddOption, undefined)
+    assert.equal(explicitFalse.message.pollCreationMessageV3?.hideParticipantName, undefined)
 })
 
 test('buildMediaMessageContent builds event with optional location and fields', async () => {

--- a/src/client/messaging/messages.ts
+++ b/src/client/messaging/messages.ts
@@ -226,16 +226,18 @@ function buildPollCreationMessage(content: WaSendPollMessage): Proto.IMessage {
         optionName: typeof opt === 'string' ? opt : opt.name
     }))
     const selectableOptionsCount = content.selectableCount ?? 1
+    const allowAddOption = content.allowAddOption === true
+    const hideParticipantName = content.hideParticipantName === true
     const pollBody: Proto.Message.IPollCreationMessage = {
         name: content.name,
         options,
         selectableOptionsCount,
-        ...(content.allowAddOption !== undefined ? { allowAddOption: content.allowAddOption } : {}),
-        ...(content.hideParticipantName !== undefined
-            ? { hideParticipantName: content.hideParticipantName }
-            : {})
+        ...(allowAddOption ? { allowAddOption: true } : {}),
+        ...(hideParticipantName ? { hideParticipantName: true } : {})
     }
-    // V3 for single-select (WA mobile), V1 for multi-select (WA Web).
+    if (allowAddOption || hideParticipantName) {
+        return { pollCreationMessageV6: pollBody }
+    }
     if (selectableOptionsCount === 1) {
         return { pollCreationMessageV3: pollBody }
     }

--- a/src/client/messaging/messages.ts
+++ b/src/client/messaging/messages.ts
@@ -225,19 +225,21 @@ function buildPollCreationMessage(content: WaSendPollMessage): Proto.IMessage {
     const options: Proto.Message.PollCreationMessage.IOption[] = content.options.map((opt) => ({
         optionName: typeof opt === 'string' ? opt : opt.name
     }))
-    return {
-        pollCreationMessageV3: {
-            name: content.name,
-            options,
-            selectableOptionsCount: content.selectableCount ?? 1,
-            ...(content.allowAddOption !== undefined
-                ? { allowAddOption: content.allowAddOption }
-                : {}),
-            ...(content.hideParticipantName !== undefined
-                ? { hideParticipantName: content.hideParticipantName }
-                : {})
-        }
+    const selectableOptionsCount = content.selectableCount ?? 1
+    const pollBody: Proto.Message.IPollCreationMessage = {
+        name: content.name,
+        options,
+        selectableOptionsCount,
+        ...(content.allowAddOption !== undefined ? { allowAddOption: content.allowAddOption } : {}),
+        ...(content.hideParticipantName !== undefined
+            ? { hideParticipantName: content.hideParticipantName }
+            : {})
     }
+    // V3 for single-select (WA mobile), V1 for multi-select (WA Web).
+    if (selectableOptionsCount === 1) {
+        return { pollCreationMessageV3: pollBody }
+    }
+    return { pollCreationMessage: pollBody }
 }
 
 function buildEventMessage(content: WaSendEventMessage): Proto.IMessage {

--- a/src/message/encode/content.ts
+++ b/src/message/encode/content.ts
@@ -241,6 +241,7 @@ function resolveMessageTypeAttrFrom(msg: Proto.IMessage): string {
         msg.pollCreationMessageV2 ||
         msg.pollCreationMessageV3 ||
         msg.pollCreationMessageV5 ||
+        msg.pollCreationMessageV6 ||
         msg.pollUpdateMessage ||
         msg.secretEncryptedMessage?.secretEncType ===
             proto.Message.SecretEncryptedMessage.SecretEncType.POLL_EDIT ||
@@ -499,7 +500,13 @@ function resolveMetaAttrsFrom(
     let eventType: string | undefined
     let viewOnce: string | undefined
 
-    if (msg.pollCreationMessage || msg.pollCreationMessageV2 || msg.pollCreationMessageV3) {
+    if (
+        msg.pollCreationMessage ||
+        msg.pollCreationMessageV2 ||
+        msg.pollCreationMessageV3 ||
+        msg.pollCreationMessageV5 ||
+        msg.pollCreationMessageV6
+    ) {
         polltype = WA_POLL_META_TYPES.CREATION
     } else if (msg.pollUpdateMessage) {
         polltype = WA_POLL_META_TYPES.VOTE

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -168,6 +168,14 @@ export interface WaSendPollOptionInput {
     readonly name: string
 }
 
+/**
+ * The proto field the poll lands on is derived from these options, matching
+ * what WhatsApp itself puts on the wire: `allowAddOption` or
+ * `hideParticipantName` send a `pollCreationMessageV6`, a single-select poll
+ * sends a `pollCreationMessageV3`, and a multi-select poll sends a
+ * `pollCreationMessage`. Both flags are only serialized when `true`; sending
+ * them as `false` makes receivers render the poll as an unsupported message.
+ */
 export interface WaSendPollMessage {
     readonly type: 'poll'
     readonly name: string
@@ -175,7 +183,9 @@ export interface WaSendPollMessage {
     readonly options: readonly (string | WaSendPollOptionInput)[]
     /** How many options a voter may pick. Defaults to 1. */
     readonly selectableCount?: number
+    /** Lets voters append their own options. Only honored by recent clients. */
     readonly allowAddOption?: boolean
+    /** Hides who voted for what. Only honored by recent clients. */
     readonly hideParticipantName?: boolean
     readonly contextInfo?: WaSendContextInfo
 }


### PR DESCRIPTION
Outbound polls always used pollCreationMessageV3, which mobile renders but WhatsApp Web often drops. Hineken/Baileys send pollCreationMessageV3 only for single-select (selectableCount === 1) and pollCreationMessage (V1) for multi-select; whatsmeow always uses V1. Matching the Hineken split keeps single-select visible on mobile and multi-select visible on Web. Default selectableCount remains 1 (V3).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected poll creation to use the appropriate protocol for single-select and multi-select polls.
  * Preserved optional poll settings when creating polls.
  * Applied the correct default behavior when the selectable option count is omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->