### PR TITLE
feat(fake-server): allow pinning the Noise root CA

### DIFF
--- a/packages/fake-server/src/api/FakeWaServer.ts
+++ b/packages/fake-server/src/api/FakeWaServer.ts
@@ -134,6 +134,12 @@ export interface FakeWaServerOptions {
      * A client in a separate process cannot read it back: it has to pin the
      * anchor before it dials, while the server is not listening yet. Pass a CA
      * both sides derive from a shared seed to make it knowable ahead of time.
+     *
+     * Carries the signing half, unlike the public-only
+     * {@link FakeWaServerNoiseRootCa} this server exposes. It signs a chain no
+     * real client trusts, so it is test material rather than a secret — but a
+     * seed committed beside the tests is the intended source, not one shared
+     * with anything that matters.
      */
     readonly noiseRootCa?: FakeNoiseRootCa
 }

--- a/packages/fake-server/src/api/FakeWaServer.ts
+++ b/packages/fake-server/src/api/FakeWaServer.ts
@@ -126,6 +126,16 @@ export interface FakeWaServerOptions {
      * client's `mobileTransport.tcpUrl`.
      */
     readonly tcp?: boolean | { readonly host?: string; readonly port?: number }
+    /**
+     * Root of the Noise certificate chain the server presents. Defaults to a
+     * fresh random CA per {@link FakeWaServer.listen}, read back from
+     * {@link FakeWaServer.noiseRootCa}.
+     *
+     * A client in a separate process cannot read it back: it has to pin the
+     * anchor before it dials, while the server is not listening yet. Pass a CA
+     * both sides derive from a shared seed to make it knowable ahead of time.
+     */
+    readonly noiseRootCa?: FakeNoiseRootCa
 }
 
 const HOST_DOMAIN = 's.whatsapp.net'
@@ -743,7 +753,7 @@ export class FakeWaServer {
             return
         }
         ;[this.rootCa, this.serverStaticKeyPair] = await Promise.all([
-            generateFakeNoiseRootCa(),
+            this.options.noiseRootCa ?? generateFakeNoiseRootCa(),
             X25519.generateKeyPair()
         ])
         const mediaHandler = this.buildMediaRequestHandler()

--- a/packages/fake-server/src/api/__tests__/noise-root-ca-option.test.ts
+++ b/packages/fake-server/src/api/__tests__/noise-root-ca-option.test.ts
@@ -30,13 +30,18 @@ test('a pinned root CA survives a stop/start cycle', async () => {
     }
 })
 
-test('an omitted root CA stays random per listen', async () => {
-    const first = await FakeWaServer.start()
-    const firstKey = first.noiseRootCa.publicKey
-    await first.stop()
-    const second = await FakeWaServer.start()
-    const secondKey = second.noiseRootCa.publicKey
-    await second.stop()
+// One instance across two cycles, so a `stop()` that retained the generated CA
+// would fail here; two instances could not tell that apart.
+test('an omitted root CA is regenerated on each listen', async () => {
+    const server = await FakeWaServer.start()
 
-    assert.notDeepEqual(firstKey, secondKey)
+    try {
+        const first = server.noiseRootCa.publicKey
+        await server.stop()
+        await server.listen()
+
+        assert.notDeepEqual(server.noiseRootCa.publicKey, first)
+    } finally {
+        await server.stop()
+    }
 })

--- a/packages/fake-server/src/api/__tests__/noise-root-ca-option.test.ts
+++ b/packages/fake-server/src/api/__tests__/noise-root-ca-option.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { generateFakeNoiseRootCa } from '../../protocol/auth/cert-chain'
+import { FakeWaServer } from '../FakeWaServer'
+
+test('a pinned Noise root CA is the one the server presents', async () => {
+    const pinned = await generateFakeNoiseRootCa()
+    const server = await FakeWaServer.start({ noiseRootCa: pinned })
+
+    try {
+        assert.deepEqual(server.noiseRootCa.publicKey, pinned.publicKey)
+        assert.equal(server.noiseRootCa.serial, pinned.serial)
+    } finally {
+        await server.stop()
+    }
+})
+
+// A client that pinned the anchor must still trust the server after a restart.
+test('a pinned root CA survives a stop/start cycle', async () => {
+    const pinned = await generateFakeNoiseRootCa()
+    const server = await FakeWaServer.start({ noiseRootCa: pinned })
+    await server.stop()
+    await server.listen()
+
+    try {
+        assert.deepEqual(server.noiseRootCa.publicKey, pinned.publicKey)
+    } finally {
+        await server.stop()
+    }
+})
+
+test('an omitted root CA stays random per listen', async () => {
+    const first = await FakeWaServer.start()
+    const firstKey = first.noiseRootCa.publicKey
+    await first.stop()
+    const second = await FakeWaServer.start()
+    const secondKey = second.noiseRootCa.publicKey
+    await second.stop()
+
+    assert.notDeepEqual(firstKey, secondKey)
+})

--- a/packages/fake-server/src/index.ts
+++ b/packages/fake-server/src/index.ts
@@ -27,7 +27,11 @@ export type {
     WaFakeAuthenticatedInfo,
     WaFakeConnectionPipeline
 } from './api/FakeWaServer'
-// Signing half of the Noise root, needed only to pin `noiseRootCa`.
+/**
+ * Signing half of the Noise root, needed only to pin
+ * {@link FakeWaServerOptions.noiseRootCa}. Readers of `server.noiseRootCa` get
+ * the public-only {@link FakeWaServerNoiseRootCa} instead.
+ */
 export type { FakeNoiseRootCa } from './protocol/auth/cert-chain'
 export { IqExpectation, Scenario } from './api/Scenario'
 export type { AuthenticatedPipelineListener, ScenarioServer } from './api/Scenario'

--- a/packages/fake-server/src/index.ts
+++ b/packages/fake-server/src/index.ts
@@ -27,6 +27,8 @@ export type {
     WaFakeAuthenticatedInfo,
     WaFakeConnectionPipeline
 } from './api/FakeWaServer'
+// Signing half of the Noise root, needed only to pin `noiseRootCa`.
+export type { FakeNoiseRootCa } from './protocol/auth/cert-chain'
 export { IqExpectation, Scenario } from './api/Scenario'
 export type { AuthenticatedPipelineListener, ScenarioServer } from './api/Scenario'
 export { WaFakeConnection } from './infra/WaFakeConnection'


### PR DESCRIPTION
## Why

`listen()` always generates a fresh Noise root CA. That suits an in-process test: it starts the server, reads the public half back from `server.noiseRootCa`, and passes it to the client it just constructed.

A client running in a **separate process** cannot do that. It has to pin the trust anchor before it dials, and at that moment the server is not listening yet — there is nothing to read back. Today the only way out is to co-locate client and server in one process, which defeats the point when you want to measure the client on its own.

## What

`FakeWaServerOptions.noiseRootCa` lets the caller supply the CA, so both sides can derive it independently from a shared seed and agree before either starts. Omitting it keeps the current behaviour exactly: a random CA per `listen()`.

`FakeNoiseRootCa` is exported, since pinning needs the signing half — `server.noiseRootCa` keeps returning the public-only `FakeWaServerNoiseRootCa`.

## Notes

- Three tests: the pinned CA is the one presented, it survives a stop/start cycle, and an omitted one stays random per listen.
- Full `fake-server` suite passes (216 tests), `tsc --noEmit`, ESLint and Prettier clean.
- Verified end to end outside the test suite: a `zapo-js` client in its own process completes the Noise XX handshake (`noise session established { mode: 'full' }`), pairs, and exchanges messages against a server whose CA it pinned from a seed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for supplying a custom Noise root certificate authority when starting the fake server.
  * Custom certificates remain consistent across server stop/start cycles, enabling certificate pinning in test environments.
  * The certificate authority type is now publicly available for integrations and configuration.
* **Bug Fixes**
  * Preserved automatic certificate generation when no custom authority is provided, with fresh certificates generated for separate server sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->