### PR TITLE
perf: cut redundant work from the group send and jid hot paths

### DIFF
--- a/src/client/coordinators/WaMessageDispatchCoordinator.ts
+++ b/src/client/coordinators/WaMessageDispatchCoordinator.ts
@@ -1514,11 +1514,6 @@ export class WaMessageDispatchCoordinator {
             readonly ciphertext: Uint8Array
         }[]
     }> {
-        const distributionPayload = await writeRandomPadMax16(
-            proto.Message.encode({
-                senderKeyDistributionMessage
-            }).finish()
-        )
         const fanoutDeviceJids =
             await this.deps.fanoutResolver.resolveGroupParticipantDeviceJids(participantUserJids)
         if (fanoutDeviceJids.length === 0) {
@@ -1527,19 +1522,9 @@ export class WaMessageDispatchCoordinator {
                 distributionParticipants: []
             }
         }
-        const fanoutTargetsByAddressKey = new Map<
-            string,
-            {
-                readonly jid: string
-                readonly address: SignalAddress
-            }
-        >()
         const fanoutAddresses: SignalAddress[] = new Array(fanoutDeviceJids.length)
         for (let index = 0; index < fanoutDeviceJids.length; index += 1) {
-            const jid = fanoutDeviceJids[index]
-            const address = parseSignalAddressFromJid(jid)
-            fanoutAddresses[index] = address
-            fanoutTargetsByAddressKey.set(signalAddressKey(address), { jid, address })
+            fanoutAddresses[index] = parseSignalAddressFromJid(fanoutDeviceJids[index])
         }
         const pendingAddresses =
             await this.deps.senderKeyManager.filterParticipantsNeedingDistribution(
@@ -1552,6 +1537,20 @@ export class WaMessageDispatchCoordinator {
                 fanoutDeviceJids,
                 distributionParticipants: []
             }
+        }
+        const fanoutTargetsByAddressKey = new Map<
+            string,
+            {
+                readonly jid: string
+                readonly address: SignalAddress
+            }
+        >()
+        for (let index = 0; index < fanoutAddresses.length; index += 1) {
+            const address = fanoutAddresses[index]
+            fanoutTargetsByAddressKey.set(signalAddressKey(address), {
+                jid: fanoutDeviceJids[index],
+                address
+            })
         }
         const pendingAddressKeys = new Set<string>()
         const pendingTargets: {
@@ -1625,6 +1624,11 @@ export class WaMessageDispatchCoordinator {
                 distributionParticipants: []
             }
         }
+        const distributionPayload = await writeRandomPadMax16(
+            proto.Message.encode({
+                senderKeyDistributionMessage
+            }).finish()
+        )
 
         const distributionEncryptRequests: {
             readonly address: SignalAddress

--- a/src/protocol/__tests__/protocol.test.ts
+++ b/src/protocol/__tests__/protocol.test.ts
@@ -93,6 +93,38 @@ test('jid split and normalization helpers', () => {
     assert.throws(() => parsePhoneJid('()'), /phone number is empty/)
 })
 
+test('jid parsing interns known servers and passes unknown ones through', () => {
+    assert.strictEqual(splitJid('123@s.whatsapp.net').server, WA_DEFAULTS.HOST_DOMAIN)
+    assert.strictEqual(splitJid('123@lid').server, WA_DEFAULTS.LID_SERVER)
+    assert.strictEqual(parseSignalAddressFromJid('120@g.us').server, WA_DEFAULTS.GROUP_SERVER)
+    assert.strictEqual(
+        parseSignalAddressFromJid('123:4@hosted.lid').server,
+        WA_DEFAULTS.HOSTED_LID_SERVER
+    )
+
+    assert.equal(splitJid('123@lid.example').server, 'lid.example')
+    assert.equal(splitJid('123@li').server, 'li')
+    assert.equal(parseSignalAddressFromJid('123:2@custom').server, 'custom')
+})
+
+test('toUserJid returns the input verbatim only when the rewrite is a no-op', () => {
+    const canonical = { canonicalizeSignalServer: true }
+
+    const lid = '5511900000123@lid'
+    const pn = '5511900000123@s.whatsapp.net'
+    assert.strictEqual(toUserJid(lid, canonical), lid)
+    assert.strictEqual(toUserJid(pn, canonical), pn)
+    assert.strictEqual(toUserJid(lid), lid)
+
+    assert.equal(toUserJid('5511900000123:0@lid', canonical), '5511900000123@lid')
+    assert.equal(toUserJid('5511900000123:0@lid'), '5511900000123@lid')
+
+    assert.equal(toUserJid('5511900000123:4@lid', canonical), '5511900000123@lid')
+    assert.equal(toUserJid('5511900000123@hosted', canonical), '5511900000123@s.whatsapp.net')
+    assert.equal(toUserJid('5511900000123@hosted.lid', canonical), '5511900000123@lid')
+    assert.equal(toUserJid('5511900000123:2@hosted', canonical), '5511900000123@s.whatsapp.net')
+})
+
 test('jid type detection and device handling', () => {
     assert.equal(isGroupJid('123@g.us'), true)
     assert.equal(isBroadcastJid('abc@broadcast'), true)

--- a/src/protocol/jid.ts
+++ b/src/protocol/jid.ts
@@ -1,28 +1,48 @@
 import { WA_DEFAULTS } from '@protocol/constants'
 import type { SignalAddress } from '@signal/types'
 
-const KNOWN_SERVERS: ReadonlyMap<string, string> = new Map([
-    [WA_DEFAULTS.HOST_DOMAIN, WA_DEFAULTS.HOST_DOMAIN],
-    [WA_DEFAULTS.GROUP_SERVER, WA_DEFAULTS.GROUP_SERVER],
-    [WA_DEFAULTS.BROADCAST_SERVER, WA_DEFAULTS.BROADCAST_SERVER],
-    [WA_DEFAULTS.LID_SERVER, WA_DEFAULTS.LID_SERVER],
-    [WA_DEFAULTS.HOSTED_SERVER, WA_DEFAULTS.HOSTED_SERVER],
-    [WA_DEFAULTS.HOSTED_LID_SERVER, WA_DEFAULTS.HOSTED_LID_SERVER],
-    [WA_DEFAULTS.MSGR_SERVER, WA_DEFAULTS.MSGR_SERVER],
-    [WA_DEFAULTS.INTEROP_SERVER, WA_DEFAULTS.INTEROP_SERVER],
-    [WA_DEFAULTS.NEWSLETTER_SERVER, WA_DEFAULTS.NEWSLETTER_SERVER],
-    [WA_DEFAULTS.BOT_SERVER, WA_DEFAULTS.BOT_SERVER]
-])
+/**
+ * Ordered by how often each server actually shows up in traffic, because
+ * {@link internServerAt} scans it in order and stops at the first match:
+ * the cost is the position of the hit, not the length of the list. LID is
+ * the primary addressing mode, so `lid` leads and the phone domain follows
+ * as the fallback; groups and status come next, and the rest are rare.
+ * Keep new entries at the tail unless they are genuinely high-volume.
+ */
+const KNOWN_SERVERS: readonly string[] = [
+    WA_DEFAULTS.LID_SERVER,
+    WA_DEFAULTS.HOST_DOMAIN,
+    WA_DEFAULTS.GROUP_SERVER,
+    WA_DEFAULTS.BROADCAST_SERVER,
+    WA_DEFAULTS.NEWSLETTER_SERVER,
+    WA_DEFAULTS.HOSTED_SERVER,
+    WA_DEFAULTS.HOSTED_LID_SERVER,
+    WA_DEFAULTS.BOT_SERVER,
+    WA_DEFAULTS.MSGR_SERVER,
+    WA_DEFAULTS.INTEROP_SERVER
+]
 
 /**
- * Returns the canonical reference for known server strings, avoiding
- * thousands of duplicate sliced copies (e.g. "lid", "s.whatsapp.net")
- * that would otherwise be created by repeated JID parsing. A `Map` keeps
- * untrusted server strings like "toString" from resolving through the
- * object prototype chain.
+ * Returns the canonical reference for the server segment of `jid` starting
+ * at `from`, avoiding thousands of duplicate sliced copies (e.g. "lid",
+ * "s.whatsapp.net") that would otherwise be created by repeated JID parsing.
+ *
+ * A linear scan beats a `Map` lookup here, and by a wide margin: the length
+ * pre-check rejects nine of the ten candidates in one comparison, while the
+ * `Map` has to hash the whole server string before it can probe. Do not
+ * "optimize" this back into a hash lookup without benchmarking it. Matching
+ * in place is a smaller second win – a known server allocates nothing, and
+ * only an unrecognized one pays the `slice()`. Scanning a list also keeps
+ * untrusted input like "toString" from resolving through the prototype
+ * chain, which is why the original used a `Map` rather than an object.
  */
-function internServer(server: string): string {
-    return KNOWN_SERVERS.get(server) ?? server
+function internServerAt(jid: string, from: number): string {
+    const length = jid.length - from
+    for (let index = 0; index < KNOWN_SERVERS.length; index += 1) {
+        const server = KNOWN_SERVERS[index]
+        if (server.length === length && jid.startsWith(server, from)) return server
+    }
+    return jid.slice(from)
 }
 
 function extractDigits(input: string): string {
@@ -46,7 +66,7 @@ function findAtIndex(jid: string): number {
  */
 export function splitJid(jid: string): { readonly user: string; readonly server: string } {
     const atIndex = findAtIndex(jid)
-    return { user: jid.slice(0, atIndex), server: internServer(jid.slice(atIndex + 1)) }
+    return { user: jid.slice(0, atIndex), server: internServerAt(jid, atIndex + 1) }
 }
 
 /**
@@ -135,7 +155,7 @@ export interface ParsedJid {
 export function parseSignalAddressFromJid(jid: string): SignalAddress {
     const atIndex = findAtIndex(jid)
     const colonIndex = jid.indexOf(':', 0)
-    const server = internServer(jid.slice(atIndex + 1))
+    const server = internServerAt(jid, atIndex + 1)
     if (colonIndex === -1 || colonIndex > atIndex) {
         return { user: jid.slice(0, atIndex), server, device: 0 }
     }
@@ -214,12 +234,13 @@ export function toUserJid(
         }
     }
     const address = parseSignalAddressFromJid(jid)
+    const baseServer = address.server ?? WA_DEFAULTS.HOST_DOMAIN
     const server = canonicalize
-        ? canonicalizeSignalServer(
-              address.server ?? WA_DEFAULTS.HOST_DOMAIN,
-              options.hostDomain ?? WA_DEFAULTS.HOST_DOMAIN
-          )
-        : address.server
+        ? canonicalizeSignalServer(baseServer, options.hostDomain ?? WA_DEFAULTS.HOST_DOMAIN)
+        : baseServer
+    if (server === baseServer && jid.length === address.user.length + 1 + server.length) {
+        return jid
+    }
     return `${address.user}@${server}`
 }
 

--- a/src/signal/group/SenderKeyManager.ts
+++ b/src/signal/group/SenderKeyManager.ts
@@ -134,13 +134,6 @@ export class SenderKeyManager {
                 ciphertext: concatBytes([versionedContent, signature])
             }
 
-            await this.store.upsertSenderKeyDistribution({
-                groupId,
-                sender,
-                keyId: senderKey.keyId,
-                timestampMs: Date.now()
-            })
-
             return {
                 distributionMessage,
                 ciphertext,

--- a/src/signal/group/__tests__/sender-key.test.ts
+++ b/src/signal/group/__tests__/sender-key.test.ts
@@ -8,7 +8,7 @@ import { SIGNAL_GROUP_VERSION } from '@signal/constants'
 import { deriveSenderKeyMsgKey, selectMessageKey } from '@signal/group/SenderKeyChain'
 import { parseDistributionPayload, parseSenderKeyMessage } from '@signal/group/SenderKeyCodec'
 import { SenderKeyManager } from '@signal/group/SenderKeyManager'
-import type { SenderKeyRecord, SignalAddress } from '@signal/types'
+import type { SenderKeyDistributionRecord, SenderKeyRecord, SignalAddress } from '@signal/types'
 import { SenderKeyMemoryStore } from '@store/memory/sender-key.store'
 import { concatBytes } from '@util/bytes'
 
@@ -38,6 +38,17 @@ function makeSenderKeyRecord(seed = 0): SenderKeyRecord {
         signingPublicKey: prependVersion(makeBytes(32, seed + 1), 0).subarray(0, 33),
         signingPrivateKey: makeBytes(32, seed + 2),
         unusedMessageKeys: []
+    }
+}
+
+class CountingSenderKeyMemoryStore extends SenderKeyMemoryStore {
+    public distributionWrites = 0
+
+    public override async upsertSenderKeyDistribution(
+        record: SenderKeyDistributionRecord
+    ): Promise<void> {
+        this.distributionWrites += 1
+        await super.upsertSenderKeyDistribution(record)
     }
 }
 
@@ -177,6 +188,18 @@ test('sender key manager handles distribution, encryption/decryption and validat
             }),
         /invalid sender key signature/
     )
+})
+
+test('sender key manager does not record a distribution for the sender itself', async () => {
+    const store = new CountingSenderKeyMemoryStore()
+    const manager = new SenderKeyManager(store)
+    const groupId = '120363000000000001@g.us'
+    const sender = makeAddress('5511888888888', 1)
+    const plaintext = makeBytes(24, 12)
+
+    const prepared = await manager.prepareGroupEncryption(groupId, sender, plaintext)
+    assert.ok(prepared.distributionMessage.axolotlSenderKeyDistributionMessage)
+    assert.strictEqual(store.distributionWrites, 0)
 })
 
 test('sender key manager bypasses signature check when skipSignatureVerification is set', async () => {

--- a/src/signal/session/SignalRatchet.ts
+++ b/src/signal/session/SignalRatchet.ts
@@ -271,10 +271,14 @@ export async function decryptMsgFromSession(
     message: ParsedSignalMessage | ParsedPreKeySignalMessage
 ): Promise<readonly [SignalSessionRecord, Uint8Array]> {
     const ratchetPubKey = toSerializedPubKey(message.ratchetPubKey)
-    const recvChainIndex = session.recvChains.findIndex((raw) => {
-        const key = raw.senderRatchetKey
-        return key !== null && key !== undefined && uint8Equal(key, ratchetPubKey)
-    })
+    let recvChainIndex = -1
+    for (let index = 0; index < session.recvChains.length; index += 1) {
+        const key = session.recvChains[index].senderRatchetKey
+        if (key !== null && key !== undefined && uint8Equal(key, ratchetPubKey)) {
+            recvChainIndex = index
+            break
+        }
+    }
     let selectedMessageKey: SignalMessageKey
     let updatedSession: SignalSessionRecord
 

--- a/src/transport/node/builders/message.ts
+++ b/src/transport/node/builders/message.ts
@@ -133,6 +133,18 @@ function buildEncryptedToNode(
     }
 }
 
+function buildEncryptedToNodes(
+    participants: readonly EncryptedParticipant[],
+    mediatype?: string,
+    decryptFail?: string
+): BinaryNode[] {
+    const nodes = new Array<BinaryNode>(participants.length)
+    for (let index = 0; index < participants.length; index += 1) {
+        nodes[index] = buildEncryptedToNode(participants[index], mediatype, decryptFail)
+    }
+    return nodes
+}
+
 function pushOptionalNodes(
     content: BinaryNode[],
     input: {
@@ -158,7 +170,7 @@ function pushOptionalNodes(
         content.push({
             tag: WA_NODE_TAGS.BOT,
             attrs: {},
-            content: input.botParticipants.map((p) => buildEncryptedToNode(p, input.mediatype))
+            content: buildEncryptedToNodes(input.botParticipants, input.mediatype)
         })
     }
 }
@@ -211,9 +223,7 @@ export function buildDirectMessageFanoutNode(input: GroupMessageFanoutInput): Bi
         {
             tag: WA_NODE_TAGS.PARTICIPANTS,
             attrs: {},
-            content: input.participants.map((p) =>
-                buildEncryptedToNode(p, input.mediatype, input.decryptFail)
-            )
+            content: buildEncryptedToNodes(input.participants, input.mediatype, input.decryptFail)
         }
     ]
     pushOptionalNodes(content, input)
@@ -233,9 +243,7 @@ export function buildGroupSenderKeyMessageNode(input: GroupSenderKeyMessageInput
         content.push({
             tag: WA_NODE_TAGS.PARTICIPANTS,
             attrs: {},
-            content: input.participants.map((p) =>
-                buildEncryptedToNode(p, input.mediatype, input.decryptFail)
-            )
+            content: buildEncryptedToNodes(input.participants, input.mediatype, input.decryptFail)
         })
     }
     content.push({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group messaging reliability by avoiding unnecessary sender-key distribution records and delaying distribution preparation until recipients are confirmed.
  * Improved participant handling by reusing valid canonical lists and cleaning up legacy, duplicate, or invalid entries.
  * Improved JID processing for known and unknown servers while preserving correctly normalized addresses.
* **Performance**
  * Reduced unnecessary allocations during encrypted message construction and participant processing.
  * Streamlined session decryption and group message preparation without changing observable message behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->