### PR TITLE
perf(media): encrypt into a buffer that already reserves room for the mac

### DIFF
--- a/src/crypto/__tests__/crypto.test.ts
+++ b/src/crypto/__tests__/crypto.test.ts
@@ -2,6 +2,52 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import { Ed25519, hkdf, randomBytesAsync, X25519 } from '@crypto'
+import { aesCbcDecrypt, aesCbcEncrypt, aesCbcEncryptWithTrailer } from '@crypto/core'
+
+test('aesCbcEncryptWithTrailer matches aesCbcEncrypt and reserves a zeroed tail', () => {
+    const key = new Uint8Array(32)
+    const iv = new Uint8Array(16)
+    for (let i = 0; i < key.length; i += 1) key[i] = (i * 7 + 3) & 0xff
+    for (let i = 0; i < iv.length; i += 1) iv[i] = (i * 11 + 5) & 0xff
+
+    for (const length of [0, 1, 15, 16, 17, 1_000]) {
+        const plaintext = new Uint8Array(length)
+        for (let i = 0; i < length; i += 1) plaintext[i] = (i * 31) & 0xff
+
+        const expected = aesCbcEncrypt(key, iv, plaintext)
+        for (const trailer of [0, 1, 10]) {
+            const out = aesCbcEncryptWithTrailer(key, iv, plaintext, trailer)
+            assert.equal(out.length, expected.length + trailer, `length at ${length}/${trailer}`)
+            assert.deepEqual(
+                out.subarray(0, expected.length),
+                expected,
+                `ciphertext at ${length}/${trailer}`
+            )
+            assert.deepEqual(
+                out.subarray(expected.length),
+                new Uint8Array(trailer),
+                `trailer must be zeroed at ${length}/${trailer}`
+            )
+            assert.deepEqual(aesCbcDecrypt(key, iv, out.subarray(0, expected.length)), plaintext)
+        }
+    }
+
+    // Payloads past the internal chunk size go through several update() calls.
+    const multiChunk = new Uint8Array(262_144 * 2 + 5)
+    for (let i = 0; i < multiChunk.length; i += 1) multiChunk[i] = (i * 17) & 0xff
+    const chunked = aesCbcEncryptWithTrailer(key, iv, multiChunk, 10)
+    const chunkedExpected = aesCbcEncrypt(key, iv, multiChunk)
+    assert.equal(chunked.length, chunkedExpected.length + 10)
+    assert.deepEqual(chunked.subarray(0, chunkedExpected.length), chunkedExpected)
+
+    for (const bad of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+        assert.throws(
+            () => aesCbcEncryptWithTrailer(key, iv, new Uint8Array(32), bad),
+            /invalid trailer length/,
+            `trailer ${bad} must be rejected`
+        )
+    }
+})
 
 test('crypto barrel exports primary APIs', async () => {
     const bytes = await randomBytesAsync(16)

--- a/src/crypto/core/index.ts
+++ b/src/crypto/core/index.ts
@@ -21,6 +21,7 @@ export {
     aesGcmEncrypt,
     aesGcmDecrypt,
     aesCbcEncrypt,
+    aesCbcEncryptWithTrailer,
     aesCbcDecrypt,
     aesCtrEncrypt,
     aesCtrDecrypt,

--- a/src/crypto/core/primitives.ts
+++ b/src/crypto/core/primitives.ts
@@ -11,6 +11,10 @@ import { promisify } from 'node:util'
 import { concatBytes, EMPTY_BYTES, toBytesView } from '@util/bytes'
 
 const AES_GCM_TAG_LENGTH = 16
+const AES_CBC_BLOCK_SIZE = 16
+
+/** Bounds the transient buffer `cipher.update` returns per call. */
+const AES_CBC_CHUNK_SIZE = 262_144
 
 const pbkdf2Async = promisify(pbkdf2)
 
@@ -112,6 +116,57 @@ export function aesCbcEncrypt(key: Uint8Array, iv: Uint8Array, plaintext: Uint8A
         return toBytesView(head)
     }
     return concatBytes([head, tail])
+}
+
+/**
+ * AES-256-CBC encrypt into a buffer that reserves `trailerBytes` of spare room
+ * after the ciphertext, for a caller that has to append a MAC to it.
+ *
+ * Appending to the result of {@link aesCbcEncrypt} means copying the whole
+ * ciphertext a second time, which on a media payload is a copy of the entire
+ * file to make room for ten bytes. Sizing the destination from the PKCS#7
+ * output length up front removes that copy, and feeding the cipher in bounded
+ * chunks keeps the transient buffer Node hands back to a chunk rather than a
+ * second full-size ciphertext, so peak memory stays near one copy of the
+ * payload instead of two.
+ *
+ * The ciphertext occupies `result.length - trailerBytes`; the reserved tail is
+ * left zeroed for the caller to fill.
+ *
+ * @throws when `trailerBytes` is not a non-negative safe integer, or when the
+ * cipher yields a length other than the PKCS#7 size the destination was cut to.
+ */
+export function aesCbcEncryptWithTrailer(
+    key: Uint8Array,
+    iv: Uint8Array,
+    plaintext: Uint8Array,
+    trailerBytes: number
+): Uint8Array {
+    if (!Number.isSafeInteger(trailerBytes) || trailerBytes < 0) {
+        throw new Error(`invalid trailer length ${trailerBytes}`)
+    }
+    const cipherLength =
+        (Math.floor(plaintext.length / AES_CBC_BLOCK_SIZE) + 1) * AES_CBC_BLOCK_SIZE
+    const out = new Uint8Array(cipherLength + trailerBytes)
+    const cipher = createCipheriv('aes-256-cbc', key, iv)
+    let offset = 0
+    for (let start = 0; start < plaintext.length; start += AES_CBC_CHUNK_SIZE) {
+        const end = Math.min(start + AES_CBC_CHUNK_SIZE, plaintext.length)
+        const block = cipher.update(plaintext.subarray(start, end))
+        if (block.length > 0) {
+            out.set(block, offset)
+            offset += block.length
+        }
+    }
+    const tail = cipher.final()
+    if (tail.length > 0) {
+        out.set(tail, offset)
+        offset += tail.length
+    }
+    if (offset !== cipherLength) {
+        throw new Error(`aes-cbc produced ${offset} bytes, expected ${cipherLength}`)
+    }
+    return out
 }
 
 /** AES-256-CBC decrypt with PKCS#7 padding. */

--- a/src/media/crypto/WaMediaCrypto.ts
+++ b/src/media/crypto/WaMediaCrypto.ts
@@ -6,7 +6,12 @@ import { join } from 'node:path'
 import { PassThrough, type Readable, type Writable } from 'node:stream'
 
 import { hkdf } from '@crypto/core/hkdf'
-import { aesCbcDecrypt, aesCbcEncrypt, hmacSha256Sign, sha256 } from '@crypto/core/primitives'
+import {
+    aesCbcDecrypt,
+    aesCbcEncryptWithTrailer,
+    hmacSha256Sign,
+    sha256
+} from '@crypto/core/primitives'
 import { randomBytesAsync } from '@crypto/core/random'
 import {
     ENC_KEY_END,
@@ -30,13 +35,7 @@ import type {
     WaMediaReadableEncryptionResult
 } from '@media/types'
 import { getWaMediaHkdfInfo, WA_APP_STATE_KEY_TYPES } from '@protocol/constants'
-import {
-    assertByteLength,
-    concatBytes,
-    toBytesView,
-    toChunkBytes,
-    uint8TimingSafeEqual
-} from '@util/bytes'
+import { assertByteLength, toBytesView, toChunkBytes, uint8TimingSafeEqual } from '@util/bytes'
 import { toError } from '@util/primitives'
 
 const AES_BLOCK_SIZE = 16
@@ -153,11 +152,18 @@ export class WaMediaCrypto {
         options?: { readonly sidecar?: boolean; readonly firstFrameLength?: number }
     ): Promise<WaMediaEncryptionResult> {
         const keys = WaMediaCrypto.deriveKeys(mediaType, mediaKey)
-        const ciphertext = aesCbcEncrypt(keys.encKey, keys.iv, plaintext)
+        const ciphertextHmac = aesCbcEncryptWithTrailer(
+            keys.encKey,
+            keys.iv,
+            plaintext,
+            HMAC_TRUNCATED_SIZE
+        )
+        const cipherLength = ciphertextHmac.length - HMAC_TRUNCATED_SIZE
+        const ciphertext = ciphertextHmac.subarray(0, cipherLength)
 
         const mac = hmacSha256Sign(keys.macKey, [keys.iv, ciphertext])
         const signature = mac.subarray(0, HMAC_TRUNCATED_SIZE)
-        const ciphertextHmac = concatBytes([ciphertext, signature])
+        ciphertextHmac.set(signature, cipherLength)
 
         let streamingSidecar: Uint8Array | undefined
         if (options?.sidecar !== false) {


### PR DESCRIPTION
Encrypting a media payload copied the whole file twice. aesCbcEncrypt joins Node's update() and final() output into one buffer, and encryptBytes then joined that with the ten-byte truncated mac, so an N byte upload paid two N-sized allocations and two full memcpys to append ten bytes.

aesCbcEncryptWithTrailer sizes the destination for ciphertext plus trailer up front and writes the cipher blocks into it, leaving the tail for the caller to fill. Peak memory during an upload drops from 2N to N, and the returned bytes are byte identical, verified across empty, sub-block, exact-block and large payloads.

  100 KB   0.935 -> 0.796 ms  -14.9%
    2 MB  11.297 -> 8.249 ms  -27.0%
   16 MB  48.643 -> 41.304 ms -15.1%

Measured with the variants in separate processes, seven runs of nine trials. Profiling the fake-server media upload confirms it end to end: concatBytes was the single largest core frame at 4.19% of busy time and is gone, with the remaining unavoidable copy showing at 2.58%.

AES-CBC had no direct test coverage, so the new one pins the contract the media path depends on: identical ciphertext to aesCbcEncrypt, a zeroed trailer, and a clean decrypt round trip across six payload sizes and three trailer widths.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AES-CBC encryption support with reserved trailer space for authentication data.
  * Media encryption now reserves and writes the truncated integrity signature directly into the encrypted output.

* **Bug Fixes**
  * Improved encrypted media output sizing and compatibility with subsequent integrity verification.

* **Tests**
  * Added coverage for encryption with varying plaintext and trailer lengths, including successful decryption and trailer validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->