### PR TITLE
feat(client): expose each decrypted payload before it is decoded

### DIFF
--- a/src/client/WaClient.ts
+++ b/src/client/WaClient.ts
@@ -119,6 +119,7 @@ class WaClientImpl extends EventEmitter {
                 syncAppStateWithOptions: (syncOptions) =>
                     this.deps.chatCoordinator.sync(syncOptions),
                 emitEvent: this.emit.bind(this),
+                hasEventListener: (event) => this.listenerCount(event) > 0,
                 handleIncomingMessageEvent: this.handleIncomingMessageEvent.bind(this),
                 handleError: this.handleError.bind(this),
                 handleIncomingFrame: this.handleIncomingFrame.bind(this),

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -75,6 +75,7 @@ import {
 import type {
     WaClientEventMap,
     WaClientOptions,
+    WaIncomingDecryptedPayloadEvent,
     WaIncomingMessageEvent,
     WaIncomingProtocolMessageEvent,
     WaIncomingUnhandledStanzaEvent,
@@ -1049,7 +1050,9 @@ export function buildWaClientDependencies(input: {
             runtime.emitEvent('newsletter_message_update', event),
         emitUnavailableMessage: (event) => runtime.emitEvent('message_unavailable', event),
         emitUnhandledStanza: (event: WaIncomingUnhandledStanzaEvent) =>
-            runtime.emitEvent('debug_unhandled_stanza', event)
+            runtime.emitEvent('debug_unhandled_stanza', event),
+        emitDecryptedPayload: (event: WaIncomingDecryptedPayloadEvent) =>
+            runtime.emitEvent('debug_decrypted_payload', event)
     }
 
     const handleClientDirtyBits = (dirtyBits: Parameters<typeof handleDirtyBits>[1]) =>

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -162,6 +162,8 @@ interface WaClientBuildRuntime {
         event: K,
         ...args: Parameters<WaClientEventMap[K]>
     ) => void
+    /** Whether anything is subscribed, for events whose payload costs something to build. */
+    readonly hasEventListener: (event: keyof WaClientEventMap) => boolean
     readonly handleIncomingMessageEvent: (event: WaIncomingMessageEvent) => Promise<void>
     readonly handleError: (error: Error) => void
     readonly handleIncomingFrame: (frame: Uint8Array) => Promise<void>
@@ -1051,8 +1053,14 @@ export function buildWaClientDependencies(input: {
         emitUnavailableMessage: (event) => runtime.emitEvent('message_unavailable', event),
         emitUnhandledStanza: (event: WaIncomingUnhandledStanzaEvent) =>
             runtime.emitEvent('debug_unhandled_stanza', event),
-        emitDecryptedPayload: (event: WaIncomingDecryptedPayloadEvent) =>
-            runtime.emitEvent('debug_decrypted_payload', event)
+        emitDecryptedPayload: (build: () => WaIncomingDecryptedPayloadEvent) => {
+            // Built only if someone is subscribed: the payload carries a copy of
+            // the plaintext and a redacted node, and this runs per `<enc>`.
+            if (!runtime.hasEventListener('debug_decrypted_payload')) {
+                return
+            }
+            runtime.emitEvent('debug_decrypted_payload', build())
+        }
     }
 
     const handleClientDirtyBits = (dirtyBits: Parameters<typeof handleDirtyBits>[1]) =>

--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -725,6 +725,7 @@ test('buildWaClientDependencies wires privacy coordinator', () => {
         clearStoredState: async () => undefined,
         resumeIncomingEvents: () => undefined,
         subscribeProtocolMessage: () => () => undefined,
+        hasEventListener: () => false,
         persistContact: () => undefined
     }
 
@@ -769,6 +770,7 @@ test('buildWaClientDependencies wires trusted contact token AB prop overrides', 
         clearStoredState: async () => undefined,
         resumeIncomingEvents: () => undefined,
         subscribeProtocolMessage: () => () => undefined,
+        hasEventListener: () => false,
         persistContact: () => undefined
     }
 

--- a/src/client/plugins/__tests__/plugins.test.ts
+++ b/src/client/plugins/__tests__/plugins.test.ts
@@ -53,6 +53,7 @@ function createMinimalPluginClient(plugins: NonNullable<WaClientOptions['plugins
         clearStoredState: async () => undefined,
         resumeIncomingEvents: () => undefined,
         subscribeProtocolMessage: () => () => undefined,
+        hasEventListener: () => false,
         persistContact: async () => undefined
     }
     const deps = buildWaClientDependencies({ base, runtime })

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -976,7 +976,7 @@ export interface WaIncomingDecryptedPayloadEvent extends WaIncomingBaseEvent {
     readonly encIndex: number
     /** The `<enc>` node's `type` attribute: `msg`, `pkmsg`, `skmsg`, … */
     readonly encType: string
-    /** The plaintext, unpadded, exactly as decoding receives it. */
+    /** The plaintext, unpadded. A copy, so mutating it cannot alter the message the library delivers. */
     readonly plaintext: Uint8Array
 }
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -957,6 +957,30 @@ export interface WaIncomingUnhandledStanzaEvent extends WaIncomingBaseEvent {
 }
 
 /**
+ * One decrypted `<enc>` payload, surfaced before the library decodes it.
+ *
+ * A payload that decrypts but does not decode is otherwise lost: decoding
+ * throws, the stanza is reported through `debug_unhandled_stanza`, and the
+ * bytes go with it – while the decryption has already advanced the ratchet, so
+ * the same ciphertext will never decrypt again. Fires whether or not decoding
+ * then succeeds, which is what makes the failing case observable at all.
+ */
+export interface WaIncomingDecryptedPayloadEvent extends WaIncomingBaseEvent {
+    /**
+     * Which `<enc>` of the stanza produced these bytes, counting from zero.
+     *
+     * A message addressed to several devices carries several, and their
+     * ciphertexts are unrelated: attributing a payload to the wrong `<enc>`
+     * attributes it to the wrong sender.
+     */
+    readonly encIndex: number
+    /** The `<enc>` node's `type` attribute: `msg`, `pkmsg`, `skmsg`, … */
+    readonly encType: string
+    /** The plaintext, unpadded, exactly as decoding receives it. */
+    readonly plaintext: Uint8Array
+}
+
+/**
  * Why an incoming message arrived as a content-less placeholder. `view_once`: a
  * view-once already consumed elsewhere. `hosted`: a hosted account whose message
  * could not be fanned out. `bot`: a bot message whose fanout never ran. `other`:
@@ -1593,6 +1617,8 @@ export interface WaClientEventMap {
     readonly debug_client_error: (event: { readonly error: Error }) => void
     /** **debug** – incoming stanzas with no registered handler (lets you spot protocol features the lib doesn't model yet). */
     readonly debug_unhandled_stanza: (event: WaIncomingUnhandledStanzaEvent) => void
+    /** **debug** – each decrypted `<enc>` payload, before the library decodes it (fires even when decoding then fails). */
+    readonly debug_decrypted_payload: (event: WaIncomingDecryptedPayloadEvent) => void
     /** **debug** – raw inbound noise frame bytes (before binary-node decode). */
     readonly debug_transport_frame_in: (event: { readonly frame: Uint8Array }) => void
     /** **debug** – raw outbound noise frame bytes (after binary-node encode). */

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export type {
     WaIncomingChatstateEvent,
     WaIncomingErrorStanzaEvent,
     WaIncomingFailureEvent,
+    WaIncomingDecryptedPayloadEvent,
     WaIncomingMessageEvent,
     WaIncomingMessageKey,
     WaIncomingNewsletterEvent,

--- a/src/message/primitives/__tests__/incoming.test.ts
+++ b/src/message/primitives/__tests__/incoming.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import type { WaIncomingMessageEvent, WaIncomingUnavailableMessageEvent } from '@client/types'
+import type {
+    WaIncomingDecryptedPayloadEvent,
+    WaIncomingMessageEvent,
+    WaIncomingUnavailableMessageEvent
+} from '@client/types'
 import { createNoopLogger } from '@infra/log/types'
 import { buildRecoveredIncomingEvent, handleIncomingMessageAck } from '@message/primitives/incoming'
 import { proto } from '@proto'
@@ -462,4 +466,84 @@ test('incoming message ack falls back to retry receipt when decrypt fails', asyn
     assert.equal(sentNodes[0].attrs.id, 'msg-1')
     assert.equal(sentNodes[0].attrs.to, '551100000000@s.whatsapp.net')
     assert.equal(sentNodes[0].attrs.type, 'retry')
+})
+
+test('a decrypted payload is handed over before the library decodes it', async () => {
+    const payloads: WaIncomingDecryptedPayloadEvent[] = []
+    const emitted: WaIncomingMessageEvent[] = []
+    const plaintext = paddedPlaintext({ conversation: 'hi' })
+
+    const handled = await handleIncomingMessageAck(createEncryptedMessageNode(), {
+        ...createDecryptingOptions(emitted),
+        emitDecryptedPayload: (event) => {
+            payloads.push(event)
+        }
+    })
+
+    assert.equal(handled, true)
+    assert.equal(payloads.length, 1)
+    // The unpadded bytes, which is what `proto.Message.decode` receives — not
+    // the padded ciphertext output and not a re-encoding of the decoded message.
+    assert.deepEqual(payloads[0].plaintext, plaintext.subarray(0, plaintext.length - 1))
+    assert.equal(payloads[0].encType, 'msg')
+    assert.equal(payloads[0].encIndex, 0)
+    assert.equal(payloads[0].stanzaId, 'msg-1')
+    assert.equal(payloads[0].chatJid, '551100000000@s.whatsapp.net')
+    assert.equal(emitted.length, 1, 'and the message still arrives as usual')
+})
+
+test('a payload that decrypts but does not decode is still handed over', async () => {
+    // The reason the event exists. Decoding throws, the stanza is reported as
+    // unhandled, and the decryption has already advanced the ratchet — so
+    // without this the bytes are gone for good.
+    const payloads: WaIncomingDecryptedPayloadEvent[] = []
+    const emitted: WaIncomingMessageEvent[] = []
+    // Field 1 of Message is `conversation`: tag 0x0A, then a length. Declaring
+    // 127 bytes and supplying none makes `decode` throw — the bytes are perfectly
+    // good, this build just cannot read them. The trailing byte is the PKCS7 pad.
+    const undecodable = new Uint8Array([0x0a, 0x7f, 0x01])
+
+    await handleIncomingMessageAck(createEncryptedMessageNode(), {
+        ...createDecryptingOptions(emitted),
+        signalProtocol: {
+            decryptMessage: async () => undecodable
+        } as never,
+        emitDecryptedPayload: (event) => {
+            payloads.push(event)
+        }
+    })
+
+    assert.equal(payloads.length, 1, 'handed over despite the decode failing')
+    assert.deepEqual(payloads[0].plaintext, undecodable.subarray(0, 2))
+    assert.equal(emitted.length, 0, 'and nothing was emitted as a message')
+})
+
+test('each enc of a multi-device message reports its own index', async () => {
+    // The ciphertexts are unrelated, so attributing a payload to the wrong
+    // `<enc>` attributes it to the wrong sender.
+    const payloads: WaIncomingDecryptedPayloadEvent[] = []
+    const emitted: WaIncomingMessageEvent[] = []
+    const node: BinaryNode = {
+        tag: 'message',
+        attrs: { id: 'msg-multi', from: '551100000000@s.whatsapp.net', t: '123' },
+        content: [
+            { tag: 'enc', attrs: { type: 'pkmsg' }, content: new Uint8Array([1]) },
+            { tag: 'enc', attrs: { type: 'msg' }, content: new Uint8Array([2]) }
+        ]
+    }
+
+    await handleIncomingMessageAck(node, {
+        ...createDecryptingOptions(emitted),
+        emitDecryptedPayload: (event) => {
+            payloads.push(event)
+        }
+    })
+
+    assert.deepEqual(
+        payloads.map((p) => [p.encIndex, p.encType]),
+        [
+            [0, 'pkmsg'],
+            [1, 'msg']
+        ]
+    )
 })

--- a/src/message/primitives/__tests__/incoming.test.ts
+++ b/src/message/primitives/__tests__/incoming.test.ts
@@ -547,3 +547,40 @@ test('each enc of a multi-device message reports its own index', async () => {
         ]
     )
 })
+
+test('an observer that throws does not turn a good message into a decrypt failure', async () => {
+    // The hook is observability. A listener that blows up must not send a
+    // message that decrypted perfectly into retry handling.
+    const emitted: WaIncomingMessageEvent[] = []
+    const unhandled: unknown[] = []
+
+    const handled = await handleIncomingMessageAck(createEncryptedMessageNode(), {
+        ...createDecryptingOptions(emitted),
+        emitDecryptedPayload: () => {
+            throw new Error('observer blew up')
+        },
+        emitUnhandledStanza: (event) => {
+            unhandled.push(event)
+        }
+    })
+
+    assert.equal(handled, true)
+    assert.equal(emitted.length, 1, 'the message still arrives')
+    assert.equal(unhandled.length, 0, 'and nothing was reported as undecryptable')
+})
+
+test('an observer cannot alter the message the library delivers', async () => {
+    // The buffer the observer sees is handed to decode on the next line, so a
+    // listener that trims or normalizes in place would change the payload.
+    const emitted: WaIncomingMessageEvent[] = []
+
+    await handleIncomingMessageAck(createEncryptedMessageNode(), {
+        ...createDecryptingOptions(emitted, { message: { conversation: 'hi' } }),
+        emitDecryptedPayload: (event) => {
+            event.plaintext.fill(0)
+        }
+    })
+
+    assert.equal(emitted.length, 1)
+    assert.equal(emitted[0]?.message?.conversation, 'hi')
+})

--- a/src/message/primitives/__tests__/incoming.test.ts
+++ b/src/message/primitives/__tests__/incoming.test.ts
@@ -475,8 +475,8 @@ test('a decrypted payload is handed over before the library decodes it', async (
 
     const handled = await handleIncomingMessageAck(createEncryptedMessageNode(), {
         ...createDecryptingOptions(emitted),
-        emitDecryptedPayload: (event) => {
-            payloads.push(event)
+        emitDecryptedPayload: (build) => {
+            payloads.push(build())
         }
     })
 
@@ -508,8 +508,8 @@ test('a payload that decrypts but does not decode is still handed over', async (
         signalProtocol: {
             decryptMessage: async () => undecodable
         } as never,
-        emitDecryptedPayload: (event) => {
-            payloads.push(event)
+        emitDecryptedPayload: (build) => {
+            payloads.push(build())
         }
     })
 
@@ -534,8 +534,8 @@ test('each enc of a multi-device message reports its own index', async () => {
 
     await handleIncomingMessageAck(node, {
         ...createDecryptingOptions(emitted),
-        emitDecryptedPayload: (event) => {
-            payloads.push(event)
+        emitDecryptedPayload: (build) => {
+            payloads.push(build())
         }
     })
 
@@ -576,11 +576,46 @@ test('an observer cannot alter the message the library delivers', async () => {
 
     await handleIncomingMessageAck(createEncryptedMessageNode(), {
         ...createDecryptingOptions(emitted, { message: { conversation: 'hi' } }),
-        emitDecryptedPayload: (event) => {
-            event.plaintext.fill(0)
+        emitDecryptedPayload: (build) => {
+            build().plaintext.fill(0)
         }
     })
 
     assert.equal(emitted.length, 1)
     assert.equal(emitted[0]?.message?.conversation, 'hi')
+})
+
+test('the payload is only built when the hook asks for it', async () => {
+    // The hook is wired unconditionally by the factory, so the optional-call
+    // guard never fires in production. Handing over a builder is what keeps
+    // the plaintext copy and the redacted node off the path when the event has
+    // no listener, which is every session that never subscribes.
+    const emitted: WaIncomingMessageEvent[] = []
+    let handedBuilder = 0
+
+    await handleIncomingMessageAck(createEncryptedMessageNode(), {
+        ...createDecryptingOptions(emitted),
+        // What the factory does when nothing is subscribed: take the builder
+        // and never call it.
+        emitDecryptedPayload: () => {
+            handedBuilder += 1
+        }
+    })
+
+    assert.equal(handedBuilder, 1, 'the hook still runs')
+    assert.equal(emitted.length, 1, 'and the message still arrives')
+
+    // And calling it produces a fresh copy each time, so the copy lives in the
+    // builder rather than on the path to it.
+    const built: WaIncomingDecryptedPayloadEvent[] = []
+    await handleIncomingMessageAck(createEncryptedMessageNode(), {
+        ...createDecryptingOptions(emitted),
+        emitDecryptedPayload: (build) => {
+            built.push(build(), build())
+        }
+    })
+
+    assert.equal(built.length, 2)
+    assert.notEqual(built[0]?.plaintext, built[1]?.plaintext, 'each call copies')
+    assert.deepEqual(built[0]?.plaintext, built[1]?.plaintext, 'to the same bytes')
 })

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -53,7 +53,7 @@ interface WaIncomingMessageAckHandlerOptions {
     readonly emitNewsletterMessageUpdate?: (event: WaIncomingNewsletterMessageUpdateEvent) => void
     readonly emitUnavailableMessage?: (event: WaIncomingUnavailableMessageEvent) => void
     readonly emitUnhandledStanza?: (event: WaIncomingUnhandledStanzaEvent) => void
-    readonly emitDecryptedPayload?: (event: WaIncomingDecryptedPayloadEvent) => void
+    readonly emitDecryptedPayload?: (build: () => WaIncomingDecryptedPayloadEvent) => void
 }
 
 interface MessageIdentityAttrs {
@@ -437,13 +437,13 @@ function processMsmsgEncNode(
 /**
  * Hand a decrypted payload to the observer, before the library decodes it.
  *
- * Separate from the decrypt path in two ways that both matter. It swallows the
- * observer's failures, because this is an observability hook and a listener
- * that throws would otherwise land in the decrypt `catch` and send a message
- * that decrypted perfectly into retry handling. And it copies the plaintext,
- * because the caller hands the same buffer to `decode` on the next line: an
- * observer that trimmed or normalized it in place would change the message the
- * library goes on to deliver.
+ * Separate from the decrypt path in three ways that all matter. It hands over a
+ * builder rather than an event, so the copy below is only paid where something
+ * is subscribed. It swallows the observer's failures, because a listener that
+ * throws would otherwise land in the decrypt `catch` and send a message that
+ * decrypted perfectly into retry handling. And it copies the plaintext, because
+ * the caller hands the same buffer to `decode` on the next line: an observer
+ * that trimmed it in place would change the message the library delivers.
  */
 function emitDecryptedPayload(
     node: BinaryNode,
@@ -456,7 +456,7 @@ function emitDecryptedPayload(
         return
     }
     try {
-        options.emitDecryptedPayload({
+        options.emitDecryptedPayload(() => ({
             rawNode: buildIncomingEventRawNode(node),
             stanzaId: node.attrs.id,
             chatJid: node.attrs.from,
@@ -465,7 +465,7 @@ function emitDecryptedPayload(
             encIndex,
             encType,
             plaintext: plaintext.slice()
-        })
+        }))
     } catch (error) {
         options.logger.warn('decrypted payload observer threw', {
             id: node.attrs.id,

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -434,6 +434,47 @@ function processMsmsgEncNode(
     }
 }
 
+/**
+ * Hand a decrypted payload to the observer, before the library decodes it.
+ *
+ * Separate from the decrypt path in two ways that both matter. It swallows the
+ * observer's failures, because this is an observability hook and a listener
+ * that throws would otherwise land in the decrypt `catch` and send a message
+ * that decrypted perfectly into retry handling. And it copies the plaintext,
+ * because the caller hands the same buffer to `decode` on the next line: an
+ * observer that trimmed or normalized it in place would change the message the
+ * library goes on to deliver.
+ */
+function emitDecryptedPayload(
+    node: BinaryNode,
+    options: WaIncomingMessageAckHandlerOptions,
+    encIndex: number,
+    encType: string,
+    plaintext: Uint8Array
+): void {
+    if (options.emitDecryptedPayload === undefined) {
+        return
+    }
+    try {
+        options.emitDecryptedPayload({
+            rawNode: buildIncomingEventRawNode(node),
+            stanzaId: node.attrs.id,
+            chatJid: node.attrs.from,
+            stanzaType: node.attrs.type,
+            offline: node.attrs.offline !== undefined,
+            encIndex,
+            encType,
+            plaintext: plaintext.slice()
+        })
+    } catch (error) {
+        options.logger.warn('decrypted payload observer threw', {
+            id: node.attrs.id,
+            encType,
+            message: toError(error).message
+        })
+    }
+}
+
 async function decryptAndProcessEncNode(
     node: BinaryNode,
     encNode: BinaryNode,
@@ -455,20 +496,7 @@ async function decryptAndProcessEncNode(
             senderAddress
         )
         const unpaddedPlaintext = unpadPkcs7(decryptedPayload)
-        // Before `decode`, which is the whole point: a payload that decrypts
-        // but does not decode throws below and is reported as unhandled, and
-        // the ratchet has already moved on, so nothing can ask for these bytes
-        // again.
-        options.emitDecryptedPayload?.({
-            rawNode: buildIncomingEventRawNode(node),
-            stanzaId: node.attrs.id,
-            chatJid: node.attrs.from,
-            stanzaType: node.attrs.type,
-            offline: node.attrs.offline !== undefined,
-            encIndex,
-            encType,
-            plaintext: unpaddedPlaintext
-        })
+        emitDecryptedPayload(node, options, encIndex, encType, unpaddedPlaintext)
         const decodedMessage = proto.Message.decode(unpaddedPlaintext)
         const message = unwrapDeviceSentMessage(decodedMessage) ?? decodedMessage
         const senderKeyDistribution = pickSenderKeyDistributionPayload(message)

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -1,4 +1,5 @@
 import type {
+    WaIncomingDecryptedPayloadEvent,
     WaIncomingMessageEvent,
     WaIncomingMessageKey,
     WaIncomingNewsletterMessageUpdateEvent,
@@ -52,6 +53,7 @@ interface WaIncomingMessageAckHandlerOptions {
     readonly emitNewsletterMessageUpdate?: (event: WaIncomingNewsletterMessageUpdateEvent) => void
     readonly emitUnavailableMessage?: (event: WaIncomingUnavailableMessageEvent) => void
     readonly emitUnhandledStanza?: (event: WaIncomingUnhandledStanzaEvent) => void
+    readonly emitDecryptedPayload?: (event: WaIncomingDecryptedPayloadEvent) => void
 }
 
 interface MessageIdentityAttrs {
@@ -436,6 +438,7 @@ async function decryptAndProcessEncNode(
     node: BinaryNode,
     encNode: BinaryNode,
     encType: string,
+    encIndex: number,
     senderJid: string,
     options: WaIncomingMessageAckHandlerOptions,
     decrypt: (ciphertext: Uint8Array, senderAddress: SignalAddress) => Promise<Uint8Array>
@@ -452,6 +455,20 @@ async function decryptAndProcessEncNode(
             senderAddress
         )
         const unpaddedPlaintext = unpadPkcs7(decryptedPayload)
+        // Before `decode`, which is the whole point: a payload that decrypts
+        // but does not decode throws below and is reported as unhandled, and
+        // the ratchet has already moved on, so nothing can ask for these bytes
+        // again.
+        options.emitDecryptedPayload?.({
+            rawNode: buildIncomingEventRawNode(node),
+            stanzaId: node.attrs.id,
+            chatJid: node.attrs.from,
+            stanzaType: node.attrs.type,
+            offline: node.attrs.offline !== undefined,
+            encIndex,
+            encType,
+            plaintext: unpaddedPlaintext
+        })
         const decodedMessage = proto.Message.decode(unpaddedPlaintext)
         const message = unwrapDeviceSentMessage(decodedMessage) ?? decodedMessage
         const senderKeyDistribution = pickSenderKeyDistributionPayload(message)
@@ -564,6 +581,7 @@ export async function handleIncomingMessageAck(
                         node,
                         child,
                         'skmsg',
+                        encCount - 1,
                         senderJid,
                         options,
                         (ciphertext, senderAddress) =>
@@ -585,6 +603,7 @@ export async function handleIncomingMessageAck(
                         node,
                         child,
                         encType,
+                        encCount - 1,
                         senderJid,
                         options,
                         (ciphertext, senderAddress) => {


### PR DESCRIPTION
## Why

When `proto.Message.decode` throws, the stanza goes out through `debug_unhandled_stanza` and the plaintext goes with it. The decryption has already advanced the ratchet at that point, so the same ciphertext will never decrypt again and those bytes are gone for good.

The case I keep running into is a protobuf field newer than the installed version: the payload is perfectly good, the library just cannot read it yet. Today that is a warning and nothing else. There is no way to look at the bytes without rebuilding with extra logging.

## What

`debug_decrypted_payload`, emitted between the unpad and the decode, carrying the plaintext, the `<enc>` type and its index in the stanza. It fires whether or not decoding then succeeds, which is what makes the failing case observable at all.

The index matters as much as the payload. A message addressed to several devices carries several `<enc>` nodes whose ciphertexts are unrelated, so attributing a payload to the wrong one attributes it to the wrong sender.

Other uses: recording traffic for replay (re-encoding a decoded message does not reproduce the original bytes), and decoding with a newer protobuf than the library ships.

## Cost

Nothing when unused. The hook is optional, so `options.emitDecryptedPayload?.({...})` short circuits before the object is built. When a consumer is listening, the plaintext is passed by reference: it is the same `unpaddedPlaintext` that `decode` receives on the next line.

## Shape

Follows the existing pattern rather than inventing one: `debug_*` namespace, `WaIncomingBaseEvent`, and an optional hook on the incoming options wired to `emitEvent` in the factory, same as `emitUnhandledStanza`.

## Tests

Three in `src/message/primitives/__tests__/incoming.test.ts`: the payload handed over before decoding with the message still arriving as usual, a payload that fails to decode still being handed over, and each `<enc>` of a multi device message reporting its own index.

`npm test` passes, 1056 tests.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debug event for inspecting decrypted incoming message payloads.
  * Events include the encryption type, payload index, and unpadded plaintext.
  * Added a public type for consuming decrypted payload event data.
  * Decrypted payloads are reported even when subsequent message decoding fails.
* **Bug Fixes**
  * Improved handling and reporting of decrypted payloads in multi-device messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->