### PR TITLE
fix(plugins): keep plugin event maps under exactOptionalPropertyTypes

### DIFF
--- a/src/client/plugins/types.ts
+++ b/src/client/plugins/types.ts
@@ -82,11 +82,19 @@ export type WaClientExposedFromPlugins<P extends readonly unknown[]> = UnionToIn
     ExposedOf<P[number]>
 >
 
-/** Event map a plugin contributes, carried as a phantom marker on its definition. */
+/**
+ * Event map a plugin contributes, carried as a phantom marker on its definition.
+ *
+ * The marker is optional (it never exists at runtime), so under
+ * `exactOptionalPropertyTypes` the inferred `E` keeps the `| undefined` the
+ * declaration emits. `Exclude` drops it before the union reaches
+ * {@link UnionToIntersection}, which would otherwise collapse
+ * `Events | undefined` to `never` and type every client listener as `never`.
+ */
 type EventsOf<P> = P extends { readonly __pluginEvents?: infer E }
     ? unknown extends E
         ? {}
-        : E
+        : Exclude<E, undefined>
     : {}
 
 /**


### PR DESCRIPTION
The `__pluginEvents` marker is a phantom, so it is declared optional and the emitted declaration writes it as `?: E | undefined`. A consumer compiling with `exactOptionalPropertyTypes` keeps that `undefined` when `EventsOf` infers `E`, and `UnionToIntersection` then reduces `Events | undefined` to `never`. The client resolves as `WaClient<never>`, which types every listener parameter as `never`, including core events that have nothing to do with a plugin:

    client.on('auth_qr', ({ qr }) => ...)
    // Argument of type '...' is not assignable to parameter of type 'never'
    // Binding element 'qr' implicitly has an 'any' type

`EventsOf` now drops `undefined` before the union reaches the intersection. Every plugin was affected, not only the one reported: voip fails identically despite declaring a real event map, since the collapse happens after the marker is read, not because of what it holds.

The break only reproduces through the built .d.ts. Compiling against the sources infers `E` from an optional property with no explicit `| undefined`, which the flag has nothing to preserve, so it cannot be covered from `src/`: an assertion there passes with and without this change. A real guard needs a fixture compiled against `dist/` with the flag on.

Verified against the reporter's dependency set (zapo-js 1.7.0, @zapo-js/wam 0.1.1, @zapo-js/voip) with the flag on: core events, plugin getters and plugin events all type, and an unknown event name is still rejected.

Closes #236.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin event type handling when optional event markers are used.
  * Preserved support for unknown event types while providing more accurate event mappings.

* **Documentation**
  * Added guidance on optional event markers and their interaction with TypeScript’s `exactOptionalPropertyTypes` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->