### PR TITLE
fix(newsletter): send fetch_pinned_messages on metadata queries

### DIFF
--- a/src/client/coordinators/__tests__/newsletter-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/newsletter-coordinator.test.ts
@@ -153,6 +153,46 @@ test('parseNewsletterMetadata maps wa-web envelope into metadata', () => {
     assert.equal(meta.preview?.id, 'pv-id')
 })
 
+test('coordinator fetch sends every condition variable the query declares', async () => {
+    const env = createTestCoordinator({
+        resultData: { xwa2_newsletter: { id: '111111111111111111@newsletter' } }
+    })
+
+    await env.coordinator.fetch('111111111111111111@newsletter')
+    const queryNode = env.mexCalls[0].node.content?.[0] as BinaryNode | undefined
+    assert.ok(queryNode)
+    assert.equal(queryNode.attrs.query_id, '27456920720571478')
+    const body = JSON.parse(queryNode.content as string)
+    assert.deepEqual(Object.keys(body.variables).sort(), [
+        'fetch_creation_time',
+        'fetch_full_image',
+        'fetch_pinned_messages',
+        'fetch_status_metadata',
+        'fetch_viewer_metadata',
+        'fetch_wamo_sub',
+        'input'
+    ])
+    assert.equal(body.variables.fetch_pinned_messages, true)
+})
+
+test('coordinator fetchDehydrated sends every condition variable the query declares', async () => {
+    const env = createTestCoordinator({
+        resultData: { xwa2_newsletter: { id: '111111111111111111@newsletter' } }
+    })
+
+    await env.coordinator.fetchDehydrated('111111111111111111@newsletter')
+    const queryNode = env.mexCalls[0].node.content?.[0] as BinaryNode | undefined
+    assert.ok(queryNode)
+    assert.equal(queryNode.attrs.query_id, '26944199458535748')
+    const body = JSON.parse(queryNode.content as string)
+    assert.deepEqual(Object.keys(body.variables).sort(), [
+        'fetch_pinned_messages',
+        'fetch_wamo_sub',
+        'input'
+    ])
+    assert.equal(body.variables.fetch_pinned_messages, true)
+})
+
 test('coordinator follow/unfollow sends mex with newsletter_id', async () => {
     const env = createTestCoordinator({
         resultData: { xwa2_newsletter_join_v2: { id: '1', state: { type: 'ACTIVE' } } }

--- a/src/client/newsletter/discovery.ts
+++ b/src/client/newsletter/discovery.ts
@@ -91,7 +91,8 @@ export function createDiscoveryOps(deps: WaNewsletterMexDeps): WaNewsletterDisco
             fetch_full_image: opts?.fetchFullImage ?? keyType !== 'INVITE',
             fetch_creation_time: opts?.fetchCreationTime ?? true,
             fetch_wamo_sub: opts?.fetchWamoSub ?? false,
-            fetch_status_metadata: false
+            fetch_status_metadata: false,
+            fetch_pinned_messages: true
         })
         if (!data?.xwa2_newsletter) {
             throw new Error('newsletter fetch returned no envelope')
@@ -183,7 +184,8 @@ export function createDiscoveryOps(deps: WaNewsletterMexDeps): WaNewsletterDisco
                     type: isJid ? 'JID' : 'INVITE',
                     view_role: opts?.viewRole ?? WA_NEWSLETTER_VIEW_ROLES.SUBSCRIBER
                 },
-                fetch_wamo_sub: opts?.fetchWamoSub ?? false
+                fetch_wamo_sub: opts?.fetchWamoSub ?? false,
+                fetch_pinned_messages: true
             })
             return parseDehydratedMetadata(data)
         }


### PR DESCRIPTION
FetchNewsletter and FetchNewsletterDehydrated declare every fetch_* flag as a Relay condition variable (Boolean!), so the server rejects the whole query with 400 Bad Request when one is absent or null, before validating any input. Both call sites omitted fetch_pinned_messages, which broke fetch(), fetchByInvite() and fetchDehydrated() for every newsletter, including ones the account owns.

The generated MEX variable types mark all fields optional, so TypeScript never flagged the omission. The new tests assert the exact key set each query declares to keep it from regressing.

Closes #238

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newsletter discovery now includes pinned messages when retrieving newsletter metadata.

* **Bug Fixes**
  * Improved metadata retrieval to consistently apply the setting that enables pinned message fetching.

* **Tests**
  * Added coverage to verify newsletter requests send the expected query parameters and identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->