### PR TITLE
feat(media): request media reupload when the CDN blob expired

### DIFF
--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -87,6 +87,10 @@ import { createDefaultLinkPreviewFetcher } from '@message/addons/link-preview/fe
 import { processNewsletterLiveUpdates } from '@message/kinds/newsletter'
 import { handleIncomingMessageAck } from '@message/primitives/incoming'
 import {
+    createMediaRetryRequester,
+    type WaMediaRetryRequester
+} from '@message/primitives/media-retry'
+import {
     createPeerDataOperationRequester,
     type PeerDataOperationRequester
 } from '@message/primitives/peer-data-operation'
@@ -309,6 +313,7 @@ function createIncomingNodeRuntime(input: {
     readonly streamControl: WaStreamControlHandler
     readonly mediaMessageBuildOptions: WaMediaMessageOptions
     readonly retryCoordinator: WaRetryCoordinator
+    readonly mediaRetryRequester: WaMediaRetryRequester
     readonly messageDispatch: WaMessageDispatchCoordinator
     readonly sendNode: (node: BinaryNode) => Promise<void>
     readonly syncAppState: () => Promise<void>
@@ -333,6 +338,7 @@ function createIncomingNodeRuntime(input: {
         streamControl,
         mediaMessageBuildOptions,
         retryCoordinator,
+        mediaRetryRequester,
         messageDispatch,
         sendNode,
         syncAppState,
@@ -366,6 +372,7 @@ function createIncomingNodeRuntime(input: {
             handleIncomingMessageAck(node, incomingMessageAckOptions),
         sendNode,
         handleIncomingRetryReceipt: (node) => retryCoordinator.handleIncomingRetryReceipt(node),
+        handleMediaRetryNotification: (node) => mediaRetryRequester.handleNotification(node),
         trackOutboundReceipt: (node) => retryCoordinator.trackOutboundReceipt(node),
         emitIncomingReceipt: (event) => emitEvent('receipt', event),
         emitIncomingPresence: (event) => emitEvent('presence', event),
@@ -816,9 +823,16 @@ export function buildWaClientDependencies(input: {
         subscribeToProtocolMessage: runtime.subscribeProtocolMessage
     })
 
+    const mediaRetryRequester = createMediaRetryRequester({
+        logger,
+        sendNode: (node) => nodeOrchestrator.sendNode(node, false),
+        getCurrentCredentials
+    })
+
     const messageCoordinator = new WaMessageCoordinator({
         messageDispatch,
         mediaTransfer,
+        mediaRetry: mediaRetryRequester,
         mediaUploadOptions: mediaMessageBuildOptions,
         logger,
         messageStore: sessionStore.messages,
@@ -1092,6 +1106,7 @@ export function buildWaClientDependencies(input: {
             streamControl,
             mediaMessageBuildOptions,
             retryCoordinator,
+            mediaRetryRequester,
             messageDispatch,
             sendNode: runtime.sendNode,
             syncAppState: runtime.syncAppState,

--- a/src/client/__tests__/incoming.test.ts
+++ b/src/client/__tests__/incoming.test.ts
@@ -25,6 +25,36 @@ import {
 } from '@protocol/constants'
 import type { BinaryNode } from '@transport/types'
 
+test('mediaretry notifications reach the media retry runtime and are still acked', async () => {
+    const sent: BinaryNode[] = []
+    const handled: BinaryNode[] = []
+    const handler = createIncomingNotificationHandler({
+        logger: createNoopLogger(),
+        sendNode: async (node) => {
+            sent.push(node)
+        },
+        emitIncomingNotification: () => undefined,
+        emitMexNotification: () => undefined,
+        emitUnhandledStanza: () => undefined,
+        handleMediaRetryNotification: (node) => {
+            handled.push(node)
+        }
+    })
+
+    const node: BinaryNode = {
+        tag: 'notification',
+        attrs: { id: 'mediaretry-2', from: 's.whatsapp.net', type: 'mediaretry' },
+        content: [{ tag: 'error', attrs: { code: '2' } }]
+    }
+    await handler(node)
+
+    assert.equal(handled.length, 1)
+    assert.equal(handled[0], node)
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].tag, 'ack')
+    assert.equal(sent[0].attrs.type, 'mediaretry')
+})
+
 test('notification ack includes participant only for mediaretry and psa types', async () => {
     const sent: BinaryNode[] = []
     const handler = createIncomingNotificationHandler({

--- a/src/client/coordinators/WaIncomingNodeCoordinator.ts
+++ b/src/client/coordinators/WaIncomingNodeCoordinator.ts
@@ -79,6 +79,7 @@ interface WaIncomingNodeRuntime {
     readonly handleIncomingMessageNode: (node: BinaryNode) => Promise<boolean>
     readonly sendNode: (node: BinaryNode) => Promise<void>
     readonly handleIncomingRetryReceipt: (node: BinaryNode) => Promise<void>
+    readonly handleMediaRetryNotification: (node: BinaryNode) => void
     readonly trackOutboundReceipt: (node: BinaryNode) => Promise<void>
     readonly emitIncomingReceipt: (event: WaIncomingReceiptEvent) => void
     readonly emitIncomingPresence: (event: WaIncomingPresenceEvent) => void
@@ -371,7 +372,8 @@ export class WaIncomingNodeCoordinator {
                 emitIncomingNotification: runtime.emitIncomingNotification,
                 emitMexNotification: runtime.emitMexNotification,
                 emitUnhandledStanza: runtime.emitUnhandledIncomingNode,
-                syncAppState: runtime.syncAppState
+                syncAppState: runtime.syncAppState,
+                handleMediaRetryNotification: runtime.handleMediaRetryNotification
             })
         })
         this.registerIncomingHandler({

--- a/src/client/coordinators/WaMessageCoordinator.ts
+++ b/src/client/coordinators/WaMessageCoordinator.ts
@@ -37,7 +37,13 @@ import {
     shouldUseAddonAdditionalData
 } from '@message/crypto/addon-crypto'
 import { unwrapMessage } from '@message/encode/content'
+import { resolveMediaPayload } from '@message/encode/media-payload'
 import { encodeGroupHistoryBundle } from '@message/kinds/group-history'
+import type {
+    WaMediaRetryRequest,
+    WaMediaRetryRequester,
+    WaMediaRetryResult
+} from '@message/primitives/media-retry'
 import type { PeerDataOperationRequester } from '@message/primitives/peer-data-operation'
 import type {
     WaMessagePublishResult,
@@ -59,6 +65,8 @@ import { longToNumber, toError } from '@util/primitives'
 export interface WaMessageCoordinatorDeps {
     readonly messageDispatch: WaMessageDispatchCoordinator
     readonly mediaTransfer: WaMediaTransferClient
+    /** Backs {@link WaMessageCoordinator.requestMediaReupload}. */
+    readonly mediaRetry: WaMediaRetryRequester
     /** Media upload wiring shared with the send path; backs {@link WaMessageCoordinator.upload}. */
     readonly mediaUploadOptions: WaMediaMessageOptions
     readonly logger: Logger
@@ -279,6 +287,7 @@ async function normalizeUploadSource(source: WaUploadMediaSource): Promise<Uint8
 export class WaMessageCoordinator {
     private readonly messageDispatch: WaMessageDispatchCoordinator
     private readonly mediaTransfer: WaMediaTransferClient
+    private readonly mediaRetry: WaMediaRetryRequester
     private readonly mediaUploadOptions: WaMediaMessageOptions
     private readonly logger: Logger
     private readonly messageStore: WaMessageStore
@@ -293,6 +302,7 @@ export class WaMessageCoordinator {
     public constructor(deps: WaMessageCoordinatorDeps) {
         this.messageDispatch = deps.messageDispatch
         this.mediaTransfer = deps.mediaTransfer
+        this.mediaRetry = deps.mediaRetry
         this.mediaUploadOptions = deps.mediaUploadOptions
         this.logger = deps.logger
         this.messageStore = deps.messageStore
@@ -796,6 +806,81 @@ export class WaMessageCoordinator {
     ): Promise<Uint8Array> {
         const stream = await this.download(source, options)
         return readAllBytes(stream, { maxBytes: options.maxBytes })
+    }
+
+    /**
+     * Asks the sender's primary device to re-upload a message's media, for when
+     * the CDN answers `404`/`410` because the blob expired - typically old
+     * media surfaced by a history sync. Sends a `server-error` receipt carrying
+     * the sealed request and resolves once the server answers with a
+     * `mediaretry` notification, usually within a couple of seconds.
+     *
+     * On `result: 'success'` only the `directPath` changes - the media key,
+     * hashes, and length of the original message stay valid, so patch the path
+     * into the message and download again. A second call for a message already
+     * in flight joins the first request instead of sending another receipt.
+     *
+     * The other three `result` values are answers too, not thrown errors:
+     * `not_found` means the sender no longer holds the file and nothing can
+     * recover it, `decryption_error` that it could not open its own copy, and
+     * `general_error` anything else including a result code this version does
+     * not recognize.
+     *
+     * Requires the message's media key, so it only works for media you received
+     * or sent, never for a bare message id. Newsletter messages are rejected -
+     * channel media has no per-message key to seal the request with. Pass an
+     * explicit `WaMediaRetryRequest` instead of an event when you hold the
+     * message id, chat jid, and media key but not the decoded message.
+     *
+     * @throws when the message carries no downloadable media, is a newsletter
+     * message, the session is not paired, the stanza cannot be sent, or no
+     * notification arrives before `options.timeoutMs`. It does **not** throw on
+     * a `not_found` / `general_error` answer - check `result`.
+     * @example
+     * ```ts
+     * const image = event.message?.imageMessage
+     * try {
+     *     return await client.message.downloadBytes(event)
+     * } catch {
+     *     const retry = await client.message.requestMediaReupload(event)
+     *     if (retry.result !== 'success') throw new Error(`reupload ${retry.result}`)
+     *     return await client.message.downloadBytes({
+     *         imageMessage: { ...image, directPath: retry.directPath }
+     *     })
+     * }
+     * ```
+     */
+    public requestMediaReupload(
+        event: WaIncomingMessageEvent,
+        options?: { readonly timeoutMs?: number }
+    ): Promise<WaMediaRetryResult>
+    public requestMediaReupload(request: WaMediaRetryRequest): Promise<WaMediaRetryResult>
+    public requestMediaReupload(
+        source: WaIncomingMessageEvent | WaMediaRetryRequest,
+        options?: { readonly timeoutMs?: number }
+    ): Promise<WaMediaRetryResult> {
+        if (!('key' in source)) {
+            return this.mediaRetry.request(source)
+        }
+        const key = source.key
+        if (!key.id || !key.remoteJid) {
+            throw new Error('requestMediaReupload event is missing key.remoteJid or key.id')
+        }
+        if (key.isNewsletter) {
+            throw new Error('requestMediaReupload is not supported on newsletter messages')
+        }
+        const payload = resolveMediaPayload(source.message)
+        if (!payload) {
+            throw new Error('message has no downloadable media')
+        }
+        return this.mediaRetry.request({
+            messageId: key.id,
+            chatJid: key.remoteJid,
+            mediaKey: payload.mediaKey,
+            fromMe: key.fromMe,
+            participant: key.participant,
+            timeoutMs: options?.timeoutMs
+        })
     }
 
     /**

--- a/src/client/coordinators/WaMobileCoordinator.ts
+++ b/src/client/coordinators/WaMobileCoordinator.ts
@@ -27,6 +27,7 @@ import {
     type BinaryNode,
     findNodeChild,
     getFirstNodeChild,
+    getNodeBytesContent,
     getNodeChildren,
     getNodeTextContent
 } from '@transport'
@@ -773,8 +774,7 @@ export class WaMobileCoordinator {
     }
 
     private nodeBytes(parent: BinaryNode, tag: string): Uint8Array | null {
-        const content = findNodeChild(parent, tag)?.content
-        return content instanceof Uint8Array ? content : null
+        return getNodeBytesContent(findNodeChild(parent, tag)) ?? null
     }
 
     private requirePrimaryIdentityKeyPair() {

--- a/src/client/coordinators/__tests__/coordinators.test.ts
+++ b/src/client/coordinators/__tests__/coordinators.test.ts
@@ -76,6 +76,7 @@ function createIncomingRuntime() {
             handleIncomingMessageNode: async () => false,
             sendNode: async () => undefined,
             handleIncomingRetryReceipt: async () => undefined,
+            handleMediaRetryNotification: () => undefined,
             trackOutboundReceipt: async () => undefined,
             emitIncomingReceipt: () => undefined,
             emitIncomingPresence: () => undefined,

--- a/src/client/coordinators/__tests__/message-coordinator-upload.test.ts
+++ b/src/client/coordinators/__tests__/message-coordinator-upload.test.ts
@@ -72,6 +72,7 @@ function createUploadCoordinator(mediaUploadOptions: WaMediaMessageOptions): WaM
     return new WaMessageCoordinator({
         messageDispatch: {} as never,
         mediaTransfer: {} as never,
+        mediaRetry: {} as never,
         mediaUploadOptions,
         logger: createNoopLogger(),
         messageStore: {} as never,

--- a/src/client/coordinators/__tests__/message-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/message-coordinator.test.ts
@@ -31,10 +31,14 @@ function createFakePdo(): {
     return { requester, sendCalls, requestCalls }
 }
 
-function createCoordinator(peerDataOperation: PeerDataOperationRequester): WaMessageCoordinator {
+function createCoordinator(
+    peerDataOperation: PeerDataOperationRequester,
+    mediaRetry: unknown = {}
+): WaMessageCoordinator {
     return new WaMessageCoordinator({
         messageDispatch: {} as never,
         mediaTransfer: {} as never,
+        mediaRetry: mediaRetry as never,
         mediaUploadOptions: {} as never,
         logger: createNoopLogger(),
         messageStore: {} as never,

--- a/src/client/coordinators/__tests__/message-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/message-coordinator.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import { WaMessageCoordinator } from '@client/coordinators/WaMessageCoordinator'
 import { createNoopLogger } from '@infra/log/types'
+import type { WaMediaRetryRequest, WaMediaRetryRequester } from '@message/primitives/media-retry'
 import type { PeerDataOperationRequester } from '@message/primitives/peer-data-operation'
 import { proto, type Proto } from '@proto'
 
@@ -33,12 +34,12 @@ function createFakePdo(): {
 
 function createCoordinator(
     peerDataOperation: PeerDataOperationRequester,
-    mediaRetry: unknown = {}
+    mediaRetry: Partial<WaMediaRetryRequester> = {}
 ): WaMessageCoordinator {
     return new WaMessageCoordinator({
         messageDispatch: {} as never,
         mediaTransfer: {} as never,
-        mediaRetry: mediaRetry as never,
+        mediaRetry: mediaRetry as WaMediaRetryRequester,
         mediaUploadOptions: {} as never,
         logger: createNoopLogger(),
         messageStore: {} as never,
@@ -114,4 +115,80 @@ test('requestHistorySync rejects invalid count and timestamp inputs', async () =
         /invalid oldestMsgTimestampMs/
     )
     assert.equal(pdo.sendCalls.length, 0)
+})
+
+test('requestMediaReupload derives the request from an incoming message event', async () => {
+    const calls: WaMediaRetryRequest[] = []
+    const coordinator = createCoordinator(createFakePdo().requester, {
+        request: async (input) => {
+            calls.push(input)
+            return {
+                messageId: input.messageId,
+                result: 'success',
+                resultCode: 1,
+                directPath: '/v/x'
+            }
+        }
+    })
+    const mediaKey = new Uint8Array(32).fill(3)
+
+    const result = await coordinator.requestMediaReupload({
+        rawNode: { tag: 'message', attrs: {} },
+        key: {
+            remoteJid: '120363@g.us',
+            id: 'MSG1',
+            fromMe: false,
+            isGroup: true,
+            isBroadcast: false,
+            isNewsletter: false,
+            senderDevice: 0,
+            participant: '5511@s.whatsapp.net'
+        },
+        offline: false,
+        message: { imageMessage: { directPath: '/v/old', mediaKey } }
+    } as never)
+
+    assert.equal(result.directPath, '/v/x')
+    assert.equal(calls.length, 1)
+    assert.deepEqual(
+        { ...calls[0], mediaKey: undefined },
+        {
+            messageId: 'MSG1',
+            chatJid: '120363@g.us',
+            fromMe: false,
+            participant: '5511@s.whatsapp.net',
+            mediaKey: undefined,
+            timeoutMs: undefined
+        }
+    )
+    assert.deepEqual(calls[0].mediaKey, mediaKey)
+})
+
+test('requestMediaReupload rejects newsletters and messages without media', () => {
+    const coordinator = createCoordinator(createFakePdo().requester)
+    const base = {
+        rawNode: { tag: 'message', attrs: {} },
+        offline: false,
+        message: { imageMessage: { directPath: '/v/x', mediaKey: new Uint8Array(32) } }
+    }
+    const key = {
+        remoteJid: '123@newsletter',
+        id: 'MSG1',
+        fromMe: false,
+        isGroup: false,
+        isBroadcast: false,
+        isNewsletter: true,
+        senderDevice: 0
+    }
+
+    assert.throws(() => coordinator.requestMediaReupload({ ...base, key } as never), /newsletter/)
+    assert.throws(
+        () =>
+            coordinator.requestMediaReupload({
+                ...base,
+                key: { ...key, isNewsletter: false },
+                message: { conversation: 'hi' }
+            } as never),
+        /no downloadable media/
+    )
 })

--- a/src/client/events/business.ts
+++ b/src/client/events/business.ts
@@ -18,6 +18,7 @@ import { WA_BUSINESS_NOTIFICATION_TAGS, WA_NOTIFICATION_TYPES } from '@protocol/
 import { WA_NODE_TAGS } from '@protocol/nodes'
 import {
     findNodeChild,
+    getNodeBytesContent,
     getNodeChildren,
     getNodeChildrenByTag,
     getNodeTextContent
@@ -60,7 +61,7 @@ export function parseVerifiedNameNode(node: BinaryNode): WaVerifiedNameResult | 
     const level = node.attrs.verified_level as string | undefined
     const attrSerial = node.attrs.serial as string | undefined
 
-    const contentBytes = node.content instanceof Uint8Array ? node.content : undefined
+    const contentBytes = getNodeBytesContent(node)
     const certData = contentBytes !== undefined ? parseCertificateContent(contentBytes) : null
 
     const entry: {

--- a/src/client/events/incoming.ts
+++ b/src/client/events/incoming.ts
@@ -66,6 +66,8 @@ type IncomingNotificationHandlerOptions = IncomingAckRuntime & {
     readonly emitMexNotification: (event: WaMexNotificationEvent) => void
     readonly emitUnhandledStanza: (event: WaIncomingUnhandledStanzaEvent) => void
     readonly syncAppState?: () => Promise<void>
+    /** Resolves a pending media reupload request; never throws. */
+    readonly handleMediaRetryNotification?: (node: BinaryNode) => void
 }
 
 type IncomingGroupNotificationHandlerOptions = IncomingAckRuntime & {
@@ -401,6 +403,10 @@ export function createIncomingNotificationHandler(
                     reason: 'notification.mex.parse_failed'
                 })
             }
+        }
+
+        if (notificationType === WA_NOTIFICATION_TYPES.MEDIA_RETRY) {
+            options.handleMediaRetryNotification?.(node)
         }
 
         if (classification === 'out_of_scope') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,6 +270,11 @@ export { resolveMediaPayload } from '@message/encode/media-payload'
 export { unpadPkcs7, writeRandomPadMax16 } from '@message/encode/padding'
 export type { WaGroupHistoryBundleEncoding } from '@message/kinds/group-history'
 export type { WaResolvedMediaPayload } from '@message/encode/media-payload'
+export type {
+    WaMediaRetryRequest,
+    WaMediaRetryResult,
+    WaMediaRetryResultType
+} from '@message/primitives/media-retry'
 export type { WaSendContextInfo } from '@message/context-info'
 export type {
     WaLinkPreviewFetcher,

--- a/src/media/crypto/__tests__/media-crypto.test.ts
+++ b/src/media/crypto/__tests__/media-crypto.test.ts
@@ -1,7 +1,16 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
+import { hkdf } from '@crypto/core/hkdf'
+import { aesGcmEncrypt } from '@crypto/core/primitives'
+import {
+    decryptMediaRetryNotification,
+    encryptServerErrorReceipt,
+    MEDIA_RETRY_IV_SIZE
+} from '@media/crypto/media-retry'
 import { WaMediaCrypto } from '@media/crypto/WaMediaCrypto'
+import { proto, type Proto } from '@proto'
+import { bytesToHex, TEXT_ENCODER } from '@util/bytes'
 
 test('media crypto encrypt/decrypt bytes round-trip and hash validation', async () => {
     const mediaKey = await WaMediaCrypto.generateMediaKey()
@@ -54,4 +63,102 @@ test('media crypto decryptBytes rejects tampered MAC by default and bypasses it 
         true
     )
     assert.deepEqual(bypassed.plaintext, plaintext)
+})
+
+const STANZA_ID = '3EB0RMRTEST01'
+
+function fixedMediaKey(): Uint8Array {
+    const mediaKey = new Uint8Array(32)
+    for (let index = 0; index < mediaKey.length; index += 1) {
+        mediaKey[index] = index
+    }
+    return mediaKey
+}
+
+function fixedIv(): Uint8Array {
+    const iv = new Uint8Array(MEDIA_RETRY_IV_SIZE)
+    for (let index = 0; index < iv.length; index += 1) {
+        iv[index] = 0xa0 + index
+    }
+    return iv
+}
+
+function sealNotification(
+    mediaKey: Uint8Array,
+    iv: Uint8Array,
+    stanzaId: string,
+    payload: Proto.MediaRetryNotification.$Properties
+): Uint8Array {
+    const key = hkdf(mediaKey, null, TEXT_ENCODER.encode('WhatsApp Media Retry Notification'), 32)
+    return aesGcmEncrypt(
+        key,
+        iv,
+        proto.MediaRetryNotification.encode(payload).finish(),
+        TEXT_ENCODER.encode(stanzaId)
+    )
+}
+
+test('media retry request matches the WhatsApp Web payload for a known key/iv', async () => {
+    const { ciphertext, iv } = await encryptServerErrorReceipt(
+        fixedMediaKey(),
+        STANZA_ID,
+        fixedIv()
+    )
+
+    assert.equal(
+        bytesToHex(ciphertext),
+        '452b8a6b77056e26e155ee876a78fe2ad5fa6b945d78a1da315ce420e00cb4'
+    )
+    assert.deepEqual(iv, fixedIv())
+})
+
+test('media retry request generates a fresh 12-byte iv when none is supplied', async () => {
+    const mediaKey = fixedMediaKey()
+    const first = await encryptServerErrorReceipt(mediaKey, STANZA_ID)
+    const second = await encryptServerErrorReceipt(mediaKey, STANZA_ID)
+
+    assert.equal(first.iv.byteLength, MEDIA_RETRY_IV_SIZE)
+    assert.equal(second.iv.byteLength, MEDIA_RETRY_IV_SIZE)
+    assert.notDeepEqual(first.iv, second.iv)
+    assert.notDeepEqual(first.ciphertext, second.ciphertext)
+})
+
+test('media retry notification decrypts to the reupload result', () => {
+    const mediaKey = fixedMediaKey()
+    const iv = fixedIv()
+    const ciphertext = sealNotification(mediaKey, iv, STANZA_ID, {
+        stanzaId: STANZA_ID,
+        directPath: '/v/t62.7118-24/reuploaded',
+        result: proto.MediaRetryNotification.ResultType.SUCCESS
+    })
+
+    const decoded = decryptMediaRetryNotification({ mediaKey, ciphertext, iv, stanzaId: STANZA_ID })
+
+    assert.equal(decoded.stanzaId, STANZA_ID)
+    assert.equal(decoded.directPath, '/v/t62.7118-24/reuploaded')
+    assert.equal(decoded.result, proto.MediaRetryNotification.ResultType.SUCCESS)
+})
+
+test('media retry notification is bound to its stanza id through the aad', () => {
+    const mediaKey = fixedMediaKey()
+    const iv = fixedIv()
+    const ciphertext = sealNotification(mediaKey, iv, STANZA_ID, { stanzaId: STANZA_ID })
+
+    assert.throws(() =>
+        decryptMediaRetryNotification({ mediaKey, ciphertext, iv, stanzaId: 'ANOTHERID' })
+    )
+})
+
+test('media retry crypto rejects a wrong-sized media key or iv', async () => {
+    const mediaKey = fixedMediaKey()
+    await assert.rejects(() => encryptServerErrorReceipt(new Uint8Array(16), STANZA_ID))
+    await assert.rejects(() => encryptServerErrorReceipt(mediaKey, STANZA_ID, new Uint8Array(16)))
+    assert.throws(() =>
+        decryptMediaRetryNotification({
+            mediaKey,
+            ciphertext: new Uint8Array(32),
+            iv: new Uint8Array(16),
+            stanzaId: STANZA_ID
+        })
+    )
 })

--- a/src/media/crypto/media-retry.ts
+++ b/src/media/crypto/media-retry.ts
@@ -1,0 +1,84 @@
+import { hkdf } from '@crypto/core/hkdf'
+import { aesGcmDecrypt, aesGcmEncrypt } from '@crypto/core/primitives'
+import { randomBytesAsync } from '@crypto/core/random'
+import { proto, type Proto } from '@proto'
+import { assertByteLength, TEXT_ENCODER } from '@util/bytes'
+
+/** AES-GCM nonce size of both media-reupload payloads. */
+export const MEDIA_RETRY_IV_SIZE = 12
+
+/** Media key the RMR key is expanded from, and the AES-256 key it expands to. */
+const MEDIA_KEY_SIZE = 32
+const MEDIA_RETRY_KEY_SIZE = 32
+
+const MEDIA_RETRY_HKDF_INFO_BYTES = TEXT_ENCODER.encode('WhatsApp Media Retry Notification')
+
+/** `<enc_p>` / `<enc_iv>` of a media-reupload payload (auth tag appended to the ciphertext). */
+export interface WaMediaRetryEncryptedPayload {
+    readonly ciphertext: Uint8Array
+    readonly iv: Uint8Array
+}
+
+/** Input for {@link decryptMediaRetryNotification}. */
+export interface WaMediaRetryDecryptInput {
+    readonly mediaKey: Uint8Array
+    readonly ciphertext: Uint8Array
+    readonly iv: Uint8Array
+    /** Stanza id of the original message; doubles as the AES-GCM associated data. */
+    readonly stanzaId: string
+}
+
+/** HKDF-SHA-256 over the media key, empty salt, `WhatsApp Media Retry Notification` context. */
+function deriveMediaRetryKey(mediaKey: Uint8Array): Uint8Array {
+    assertByteLength(
+        mediaKey,
+        MEDIA_KEY_SIZE,
+        `invalid media key length ${mediaKey.byteLength}, expected ${MEDIA_KEY_SIZE}`
+    )
+    return hkdf(mediaKey, null, MEDIA_RETRY_HKDF_INFO_BYTES, MEDIA_RETRY_KEY_SIZE)
+}
+
+/**
+ * Seals the `ServerErrorReceipt` a `server-error` receipt carries. The stanza id
+ * is both the payload and the AES-GCM associated data, so the blob cannot be
+ * replayed against another message. Leave `iv` unset outside tests.
+ */
+export async function encryptServerErrorReceipt(
+    mediaKey: Uint8Array,
+    stanzaId: string,
+    iv?: Uint8Array
+): Promise<WaMediaRetryEncryptedPayload> {
+    const key = deriveMediaRetryKey(mediaKey)
+    const nonce = iv ?? (await randomBytesAsync(MEDIA_RETRY_IV_SIZE))
+    assertByteLength(
+        nonce,
+        MEDIA_RETRY_IV_SIZE,
+        `invalid media retry iv length ${nonce.byteLength}, expected ${MEDIA_RETRY_IV_SIZE}`
+    )
+    const plaintext = proto.ServerErrorReceipt.encode({ stanzaId }).finish()
+    const ciphertext = aesGcmEncrypt(key, nonce, plaintext, TEXT_ENCODER.encode(stanzaId))
+    return { ciphertext, iv: nonce }
+}
+
+/**
+ * Opens the `<encrypt>` payload of a `mediaretry` notification. Callers must
+ * still check the decoded `stanzaId` against the notification's id - a valid
+ * auth tag only proves the payload was sealed under this media key.
+ */
+export function decryptMediaRetryNotification(
+    input: WaMediaRetryDecryptInput
+): Proto.IMediaRetryNotification {
+    const key = deriveMediaRetryKey(input.mediaKey)
+    assertByteLength(
+        input.iv,
+        MEDIA_RETRY_IV_SIZE,
+        `invalid media retry iv length ${input.iv.byteLength}, expected ${MEDIA_RETRY_IV_SIZE}`
+    )
+    const plaintext = aesGcmDecrypt(
+        key,
+        input.iv,
+        input.ciphertext,
+        TEXT_ENCODER.encode(input.stanzaId)
+    )
+    return proto.MediaRetryNotification.decode(plaintext)
+}

--- a/src/media/crypto/media-retry.ts
+++ b/src/media/crypto/media-retry.ts
@@ -21,6 +21,7 @@ export interface WaMediaRetryEncryptedPayload {
 
 /** Input for {@link decryptMediaRetryNotification}. */
 export interface WaMediaRetryDecryptInput {
+    /** Media key of the original message. Sensitive key material - do not log. */
     readonly mediaKey: Uint8Array
     readonly ciphertext: Uint8Array
     readonly iv: Uint8Array

--- a/src/message/primitives/__tests__/media-retry.test.ts
+++ b/src/message/primitives/__tests__/media-retry.test.ts
@@ -1,0 +1,430 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { hkdf } from '@crypto/core/hkdf'
+import { aesGcmEncrypt } from '@crypto/core/primitives'
+import { createNoopLogger } from '@infra/log/types'
+import { MEDIA_RETRY_IV_SIZE } from '@media/crypto/media-retry'
+import {
+    createMediaRetryRequester,
+    parseMediaRetryNotification
+} from '@message/primitives/media-retry'
+import { proto, type Proto } from '@proto'
+import type { BinaryNode } from '@transport/types'
+import { TEXT_ENCODER } from '@util/bytes'
+
+const MESSAGE_ID = '3EB0RMR'
+const CHAT_JID = '5511999999999@s.whatsapp.net'
+const GROUP_JID = '120363000000000000@g.us'
+const ME_LID = '77770000:12@lid'
+
+function mediaKey(): Uint8Array {
+    return new Uint8Array(32).fill(7)
+}
+
+function createRequester(options: {
+    readonly defaultTimeoutMs?: number
+    readonly maxPending?: number
+}) {
+    const sent: BinaryNode[] = []
+    let onSent: (() => void) | null = null
+    const requester = createMediaRetryRequester({
+        logger: createNoopLogger(),
+        sendNode: async (node: BinaryNode) => {
+            sent.push(node)
+            onSent?.()
+        },
+        getCurrentCredentials: () => ({ meLid: ME_LID }) as never,
+        ...options
+    })
+    const waitForSends = async (count: number): Promise<void> => {
+        while (sent.length < count) {
+            await new Promise<void>((resolve) => {
+                onSent = resolve
+            })
+        }
+    }
+    return { requester, sent, waitForSends }
+}
+
+function notificationNode(
+    payload: Proto.MediaRetryNotification.$Properties,
+    overrides: { readonly messageId?: string } = {}
+): BinaryNode {
+    const stanzaId = overrides.messageId ?? MESSAGE_ID
+    const iv = new Uint8Array(MEDIA_RETRY_IV_SIZE).fill(3)
+    const key = hkdf(mediaKey(), null, TEXT_ENCODER.encode('WhatsApp Media Retry Notification'), 32)
+    const ciphertext = aesGcmEncrypt(
+        key,
+        iv,
+        proto.MediaRetryNotification.encode(payload).finish(),
+        TEXT_ENCODER.encode(stanzaId)
+    )
+    return {
+        tag: 'notification',
+        attrs: { id: stanzaId, from: ME_LID, type: 'mediaretry' },
+        content: [
+            {
+                tag: 'encrypt',
+                attrs: {},
+                content: [
+                    { tag: 'enc_p', attrs: {}, content: ciphertext },
+                    { tag: 'enc_iv', attrs: {}, content: iv }
+                ]
+            }
+        ]
+    }
+}
+
+function findChild(node: BinaryNode, tag: string): BinaryNode | undefined {
+    return Array.isArray(node.content) ? node.content.find((child) => child.tag === tag) : undefined
+}
+
+test('media reupload request builds the server-error receipt WhatsApp Web sends', async () => {
+    const { requester, sent, waitForSends } = createRequester({})
+
+    const pending = requester.request({
+        messageId: MESSAGE_ID,
+        chatJid: CHAT_JID,
+        mediaKey: mediaKey(),
+        fromMe: false
+    })
+    await waitForSends(1)
+
+    assert.equal(sent.length, 1)
+    const receipt = sent[0]
+    assert.equal(receipt.tag, 'receipt')
+    assert.equal(receipt.attrs.type, 'server-error')
+    assert.equal(receipt.attrs.id, MESSAGE_ID)
+    assert.equal(receipt.attrs.to, '77770000@lid')
+
+    const encrypt = findChild(receipt, 'encrypt')
+    assert.ok(encrypt)
+    assert.ok(findChild(encrypt, 'enc_p')?.content instanceof Uint8Array)
+    assert.equal(
+        (findChild(encrypt, 'enc_iv')?.content as Uint8Array).byteLength,
+        MEDIA_RETRY_IV_SIZE
+    )
+
+    const rmr = findChild(receipt, 'rmr')
+    assert.ok(rmr)
+    assert.equal(rmr.attrs.jid, CHAT_JID)
+    assert.equal(rmr.attrs.from_me, 'false')
+    assert.equal(rmr.attrs.participant, undefined)
+
+    requester.handleNotification(
+        notificationNode({
+            stanzaId: MESSAGE_ID,
+            result: proto.MediaRetryNotification.ResultType.SUCCESS,
+            directPath: '/v/x'
+        })
+    )
+    await pending
+})
+
+test('media reupload request names the author on group chats', async () => {
+    const { requester, sent, waitForSends } = createRequester({})
+
+    const pending = requester.request({
+        messageId: MESSAGE_ID,
+        chatJid: GROUP_JID,
+        mediaKey: mediaKey(),
+        fromMe: true,
+        participant: '5511888888888:5@s.whatsapp.net'
+    })
+    await waitForSends(1)
+
+    const rmr = findChild(sent[0], 'rmr')
+    assert.ok(rmr)
+    assert.equal(rmr.attrs.jid, GROUP_JID)
+    assert.equal(rmr.attrs.from_me, 'true')
+    assert.equal(rmr.attrs.participant, '5511888888888@s.whatsapp.net')
+
+    requester.handleNotification(
+        notificationNode({
+            stanzaId: MESSAGE_ID,
+            result: proto.MediaRetryNotification.ResultType.SUCCESS,
+            directPath: '/v/x'
+        })
+    )
+    await pending
+})
+
+test('media reupload resolves with the fresh direct path', async () => {
+    const { requester, waitForSends } = createRequester({})
+
+    const pending = requester.request({
+        messageId: MESSAGE_ID,
+        chatJid: CHAT_JID,
+        mediaKey: mediaKey(),
+        fromMe: false
+    })
+    await waitForSends(1)
+
+    requester.handleNotification(
+        notificationNode({
+            stanzaId: MESSAGE_ID,
+            result: proto.MediaRetryNotification.ResultType.SUCCESS,
+            directPath: '/v/t62.7118-24/reuploaded'
+        })
+    )
+
+    const result = await pending
+    assert.equal(result.result, 'success')
+    assert.equal(result.resultCode, proto.MediaRetryNotification.ResultType.SUCCESS)
+    assert.equal(result.directPath, '/v/t62.7118-24/reuploaded')
+})
+
+test('media reupload maps a not-found answer without rejecting', async () => {
+    const { requester, waitForSends } = createRequester({})
+
+    const pending = requester.request({
+        messageId: MESSAGE_ID,
+        chatJid: CHAT_JID,
+        mediaKey: mediaKey(),
+        fromMe: false
+    })
+    await waitForSends(1)
+
+    requester.handleNotification(
+        notificationNode({
+            stanzaId: MESSAGE_ID,
+            result: proto.MediaRetryNotification.ResultType.NOT_FOUND
+        })
+    )
+
+    const result = await pending
+    assert.equal(result.result, 'not_found')
+    assert.equal(result.directPath, undefined)
+})
+
+test('media reupload maps the error form of the notification', async () => {
+    const { requester, waitForSends } = createRequester({})
+
+    const pending = requester.request({
+        messageId: MESSAGE_ID,
+        chatJid: CHAT_JID,
+        mediaKey: mediaKey(),
+        fromMe: false
+    })
+    await waitForSends(1)
+
+    requester.handleNotification({
+        tag: 'notification',
+        attrs: { id: MESSAGE_ID, from: ME_LID, type: 'mediaretry' },
+        content: [
+            {
+                tag: 'error',
+                attrs: { code: String(proto.MediaRetryNotification.ResultType.DECRYPTION_ERROR) }
+            }
+        ]
+    })
+
+    const result = await pending
+    assert.equal(result.result, 'decryption_error')
+})
+
+test('media reupload rejects when the sealed stanza id does not match', async () => {
+    const { requester, waitForSends } = createRequester({})
+
+    const pending = requester.request({
+        messageId: MESSAGE_ID,
+        chatJid: CHAT_JID,
+        mediaKey: mediaKey(),
+        fromMe: false
+    })
+    await waitForSends(1)
+
+    requester.handleNotification(
+        notificationNode({
+            stanzaId: 'SOMEOTHERID',
+            result: proto.MediaRetryNotification.ResultType.SUCCESS,
+            directPath: '/v/x'
+        })
+    )
+
+    await assert.rejects(pending, /stanza id mismatch/)
+})
+
+test('a second request for the same message joins the first', async () => {
+    const { requester, sent, waitForSends } = createRequester({})
+    const input = {
+        messageId: MESSAGE_ID,
+        chatJid: CHAT_JID,
+        mediaKey: mediaKey(),
+        fromMe: false
+    }
+
+    const first = requester.request(input)
+    await waitForSends(1)
+    const second = requester.request(input)
+
+    requester.handleNotification(
+        notificationNode({
+            stanzaId: MESSAGE_ID,
+            result: proto.MediaRetryNotification.ResultType.SUCCESS,
+            directPath: '/v/x'
+        })
+    )
+
+    assert.deepEqual(await first, await second)
+    assert.equal(sent.length, 1)
+})
+
+test('media reupload rejects when no notification arrives in time', async () => {
+    const { requester } = createRequester({ defaultTimeoutMs: 5 })
+
+    const pending = requester.request({
+        messageId: MESSAGE_ID,
+        chatJid: CHAT_JID,
+        mediaKey: mediaKey(),
+        fromMe: false
+    })
+
+    await assert.rejects(pending, /media reupload timeout/)
+})
+
+test('pending media reupload requests are bounded', async () => {
+    const { requester, waitForSends } = createRequester({ maxPending: 1 })
+
+    const first = requester.request({
+        messageId: MESSAGE_ID,
+        chatJid: CHAT_JID,
+        mediaKey: mediaKey(),
+        fromMe: false
+    })
+    const rejection = assert.rejects(first, /evicted/)
+    await waitForSends(1)
+
+    const second = requester.request({
+        messageId: 'OTHERMSG',
+        chatJid: CHAT_JID,
+        mediaKey: mediaKey(),
+        fromMe: false
+    })
+    await waitForSends(2)
+    await rejection
+
+    requester.handleNotification(
+        notificationNode(
+            {
+                stanzaId: 'OTHERMSG',
+                result: proto.MediaRetryNotification.ResultType.SUCCESS,
+                directPath: '/v/x'
+            },
+            { messageId: 'OTHERMSG' }
+        )
+    )
+    assert.equal((await second).result, 'success')
+})
+
+test('an unmatched notification is ignored instead of throwing', () => {
+    const { requester } = createRequester({})
+
+    assert.doesNotThrow(() => {
+        requester.handleNotification(
+            notificationNode({
+                stanzaId: MESSAGE_ID,
+                result: proto.MediaRetryNotification.ResultType.SUCCESS
+            })
+        )
+        requester.handleNotification({ tag: 'notification', attrs: { type: 'mediaretry' } })
+    })
+})
+
+test('a request without a paired session throws before sending anything', async () => {
+    const sent: BinaryNode[] = []
+    const requester = createMediaRetryRequester({
+        logger: createNoopLogger(),
+        sendNode: async (node: BinaryNode) => {
+            sent.push(node)
+        },
+        getCurrentCredentials: () => null
+    })
+
+    await assert.rejects(
+        requester.request({
+            messageId: MESSAGE_ID,
+            chatJid: CHAT_JID,
+            mediaKey: mediaKey(),
+            fromMe: false
+        }),
+        /paired session/
+    )
+    assert.equal(sent.length, 0)
+})
+
+function parserNotification(iv: Uint8Array): BinaryNode {
+    return {
+        tag: 'notification',
+        attrs: {
+            id: '3EB0AAA',
+            from: '5511999999999@s.whatsapp.net',
+            type: 'mediaretry',
+            participant: '5511888888888@s.whatsapp.net'
+        },
+        content: [
+            {
+                tag: 'encrypt',
+                attrs: {},
+                content: [
+                    { tag: 'enc_p', attrs: {}, content: new Uint8Array([9, 9, 9]) },
+                    { tag: 'enc_iv', attrs: {}, content: iv }
+                ]
+            }
+        ]
+    }
+}
+
+test('parses the encrypted mediaretry payload', () => {
+    const parsed = parseMediaRetryNotification(parserNotification(new Uint8Array(12)))
+
+    assert.ok(parsed)
+    assert.equal(parsed.messageId, '3EB0AAA')
+    assert.equal(parsed.from, '5511999999999@s.whatsapp.net')
+    assert.equal(parsed.errorCode, undefined)
+    assert.deepEqual(parsed.ciphertext, new Uint8Array([9, 9, 9]))
+    assert.equal(parsed.iv?.byteLength, 12)
+})
+
+test('parses the error form of a mediaretry notification', () => {
+    const parsed = parseMediaRetryNotification({
+        tag: 'notification',
+        attrs: { id: '3EB0BBB', type: 'mediaretry' },
+        content: [{ tag: 'error', attrs: { code: '2' } }]
+    })
+
+    assert.ok(parsed)
+    assert.equal(parsed.errorCode, 2)
+    assert.equal(parsed.ciphertext, undefined)
+})
+
+test('rejects a mediaretry notification with a wrong-sized iv', () => {
+    assert.equal(parseMediaRetryNotification(parserNotification(new Uint8Array(16))), null)
+})
+
+test('rejects a mediaretry notification with no id, payload, or error code', () => {
+    assert.equal(
+        parseMediaRetryNotification({
+            tag: 'notification',
+            attrs: { type: 'mediaretry' },
+            content: [{ tag: 'error', attrs: { code: '2' } }]
+        }),
+        null
+    )
+    assert.equal(
+        parseMediaRetryNotification({
+            tag: 'notification',
+            attrs: { id: '3EB0CCC', type: 'mediaretry' }
+        }),
+        null
+    )
+    assert.equal(
+        parseMediaRetryNotification({
+            tag: 'notification',
+            attrs: { id: '3EB0DDD', type: 'mediaretry' },
+            content: [{ tag: 'error', attrs: {} }]
+        }),
+        null
+    )
+})

--- a/src/message/primitives/__tests__/media-retry.test.ts
+++ b/src/message/primitives/__tests__/media-retry.test.ts
@@ -428,3 +428,48 @@ test('rejects a mediaretry notification with no id, payload, or error code', () 
         null
     )
 })
+
+test('two concurrent requests for the same message share one receipt', async () => {
+    const { requester, sent } = createRequester({ defaultTimeoutMs: 200 })
+    const input = {
+        messageId: MESSAGE_ID,
+        chatJid: CHAT_JID,
+        mediaKey: mediaKey(),
+        fromMe: false
+    }
+
+    const first = requester.request(input)
+    const second = requester.request(input)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    assert.equal(sent.length, 1)
+    requester.handleNotification(
+        notificationNode({
+            stanzaId: MESSAGE_ID,
+            result: proto.MediaRetryNotification.ResultType.SUCCESS,
+            directPath: '/v/x'
+        })
+    )
+    assert.equal((await first).result, 'success')
+    assert.equal((await second).result, 'success')
+})
+
+test('rejects a mediaretry notification whose sealed payload is empty', () => {
+    assert.equal(
+        parseMediaRetryNotification({
+            tag: 'notification',
+            attrs: { id: MESSAGE_ID, type: 'mediaretry' },
+            content: [
+                {
+                    tag: 'encrypt',
+                    attrs: {},
+                    content: [
+                        { tag: 'enc_p', attrs: {}, content: new Uint8Array() },
+                        { tag: 'enc_iv', attrs: {}, content: new Uint8Array(MEDIA_RETRY_IV_SIZE) }
+                    ]
+                }
+            ]
+        }),
+        null
+    )
+})

--- a/src/message/primitives/media-retry.ts
+++ b/src/message/primitives/media-retry.ts
@@ -77,7 +77,7 @@ export function parseMediaRetryNotification(node: BinaryNode): ParsedMediaRetryN
     }
     const ciphertext = getNodeBytesContent(findNodeChild(encryptNode, 'enc_p'))
     const iv = getNodeBytesContent(findNodeChild(encryptNode, 'enc_iv'))
-    if (!ciphertext || !iv || iv.byteLength !== MEDIA_RETRY_IV_SIZE) {
+    if (!ciphertext?.byteLength || !iv || iv.byteLength !== MEDIA_RETRY_IV_SIZE) {
         return null
     }
     return { messageId, from, ciphertext, iv }
@@ -199,11 +199,12 @@ export function createMediaRetryRequester(
                 return inFlight.promise
             }
 
-            const node = await buildRequestNode(input)
             const entry = trackPending(input)
-            sendNode(node).catch((error: unknown) => {
-                rejectPending(input.messageId, toError(error))
-            })
+            buildRequestNode(input)
+                .then((node) => sendNode(node))
+                .catch((error: unknown) => {
+                    rejectPending(input.messageId, toError(error))
+                })
             return entry.promise
         },
 

--- a/src/message/primitives/media-retry.ts
+++ b/src/message/primitives/media-retry.ts
@@ -1,0 +1,277 @@
+import type { WaAuthCredentials } from '@auth/types'
+import type { Logger } from '@infra/log/types'
+import {
+    decryptMediaRetryNotification,
+    encryptServerErrorReceipt,
+    MEDIA_RETRY_IV_SIZE
+} from '@media/crypto/media-retry'
+import { proto } from '@proto'
+import { WA_DEFAULTS, WA_NODE_TAGS } from '@protocol/constants'
+import { isGroupOrBroadcastJid, isOwnAccountJid, toUserJid } from '@protocol/jid'
+import { buildReceiptNode } from '@transport/node/builders/global'
+import { findNodeChild, getNodeBytesContent } from '@transport/node/helpers'
+import type { BinaryNode } from '@transport/types'
+import { setBoundedMapEntry } from '@util/collections'
+import { parseOptionalInt, toError } from '@util/primitives'
+
+export type WaMediaRetryResultType = 'success' | 'not_found' | 'decryption_error' | 'general_error'
+
+export interface WaMediaRetryResult {
+    readonly messageId: string
+    readonly result: WaMediaRetryResultType
+    readonly resultCode: number
+    readonly directPath?: string
+}
+
+export interface WaMediaRetryRequest {
+    readonly messageId: string
+    readonly chatJid: string
+    readonly mediaKey: Uint8Array
+    readonly fromMe: boolean
+    readonly participant?: string
+    readonly timeoutMs?: number
+}
+
+export interface WaMediaRetryRequesterOptions {
+    readonly logger: Logger
+    readonly sendNode: (node: BinaryNode) => Promise<void>
+    readonly getCurrentCredentials: () => WaAuthCredentials | null
+    readonly defaultTimeoutMs?: number
+    readonly maxPending?: number
+}
+
+export interface WaMediaRetryRequester {
+    readonly request: (input: WaMediaRetryRequest) => Promise<WaMediaRetryResult>
+    readonly handleNotification: (node: BinaryNode) => void
+}
+
+interface PendingMediaRetry {
+    readonly mediaKey: Uint8Array
+    readonly promise: Promise<WaMediaRetryResult>
+    readonly resolve: (result: WaMediaRetryResult) => void
+    readonly reject: (error: Error) => void
+    readonly timeout: ReturnType<typeof setTimeout>
+}
+
+type ParsedMediaRetryNotification = { readonly messageId: string; readonly from?: string } & (
+    | { readonly errorCode: number; readonly ciphertext?: undefined }
+    | { readonly errorCode?: undefined; readonly ciphertext: Uint8Array; readonly iv: Uint8Array }
+)
+
+export function parseMediaRetryNotification(node: BinaryNode): ParsedMediaRetryNotification | null {
+    const messageId = node.attrs.id
+    if (!messageId) {
+        return null
+    }
+    const from = node.attrs.from
+
+    const errorNode = findNodeChild(node, WA_NODE_TAGS.ERROR)
+    if (errorNode) {
+        const errorCode = parseOptionalInt(errorNode.attrs.code)
+        return errorCode === undefined ? null : { messageId, from, errorCode }
+    }
+
+    const encryptNode = findNodeChild(node, 'encrypt')
+    if (!encryptNode) {
+        return null
+    }
+    const ciphertext = getNodeBytesContent(findNodeChild(encryptNode, 'enc_p'))
+    const iv = getNodeBytesContent(findNodeChild(encryptNode, 'enc_iv'))
+    if (!ciphertext || !iv || iv.byteLength !== MEDIA_RETRY_IV_SIZE) {
+        return null
+    }
+    return { messageId, from, ciphertext, iv }
+}
+
+function toResultType(code: number | null | undefined): WaMediaRetryResultType {
+    switch (code) {
+        case proto.MediaRetryNotification.ResultType.SUCCESS:
+            return 'success'
+        case proto.MediaRetryNotification.ResultType.NOT_FOUND:
+            return 'not_found'
+        case proto.MediaRetryNotification.ResultType.DECRYPTION_ERROR:
+            return 'decryption_error'
+        default:
+            return 'general_error'
+    }
+}
+
+export function createMediaRetryRequester(
+    options: WaMediaRetryRequesterOptions
+): WaMediaRetryRequester {
+    const { logger, sendNode, getCurrentCredentials } = options
+    const defaultTimeoutMs = options.defaultTimeoutMs ?? WA_DEFAULTS.MEDIA_RETRY_TIMEOUT_MS
+    const maxPending = options.maxPending ?? WA_DEFAULTS.MAX_PENDING_MEDIA_RETRIES
+    const pending = new Map<string, PendingMediaRetry>()
+
+    const takePending = (messageId: string): PendingMediaRetry | undefined => {
+        const entry = pending.get(messageId)
+        if (!entry) {
+            return undefined
+        }
+        clearTimeout(entry.timeout)
+        pending.delete(messageId)
+        return entry
+    }
+
+    const rejectPending = (messageId: string, error: Error): void => {
+        takePending(messageId)?.reject(error)
+    }
+
+    const settle = (result: WaMediaRetryResult): void => {
+        const entry = takePending(result.messageId)
+        if (!entry) {
+            return
+        }
+        logger.debug('media reupload resolved', {
+            id: result.messageId,
+            result: result.result,
+            hasDirectPath: result.directPath !== undefined
+        })
+        entry.resolve(result)
+    }
+
+    const buildRequestNode = async (input: WaMediaRetryRequest): Promise<BinaryNode> => {
+        const credentials = getCurrentCredentials()
+        const ownJid = credentials?.meLid ?? credentials?.meJid
+        if (!ownJid) {
+            throw new Error('media reupload request requires a paired session')
+        }
+        const { ciphertext, iv } = await encryptServerErrorReceipt(input.mediaKey, input.messageId)
+        return buildReceiptNode({
+            kind: 'server_error',
+            id: input.messageId,
+            to: toUserJid(ownJid),
+            encryptCiphertext: ciphertext,
+            encryptIv: iv,
+            rmrJid: input.chatJid,
+            rmrFromMe: input.fromMe,
+            rmrParticipant:
+                input.participant && isGroupOrBroadcastJid(input.chatJid)
+                    ? toUserJid(input.participant)
+                    : undefined
+        })
+    }
+
+    const trackPending = (input: WaMediaRetryRequest): PendingMediaRetry => {
+        const timeoutMs = input.timeoutMs ?? defaultTimeoutMs
+        let resolve!: (result: WaMediaRetryResult) => void
+        let reject!: (error: Error) => void
+        const promise = new Promise<WaMediaRetryResult>((res, rej) => {
+            resolve = res
+            reject = rej
+        })
+        const timeout = setTimeout(() => {
+            rejectPending(
+                input.messageId,
+                new Error(`media reupload timeout (${input.messageId}) after ${timeoutMs}ms`)
+            )
+        }, timeoutMs)
+
+        const entry: PendingMediaRetry = {
+            mediaKey: input.mediaKey,
+            promise,
+            resolve,
+            reject,
+            timeout
+        }
+        setBoundedMapEntry(pending, input.messageId, entry, maxPending, (evictedKey, evicted) => {
+            clearTimeout(evicted.timeout)
+            logger.warn('media reupload pending entry evicted: capacity reached', {
+                evictedId: evictedKey,
+                maxPending
+            })
+            evicted.reject(new Error(`media reupload evicted from pending map (id=${evictedKey})`))
+        })
+        return entry
+    }
+
+    return {
+        request: async (input) => {
+            if (!input.messageId) {
+                throw new Error('media reupload request requires a message id')
+            }
+            if (!input.chatJid) {
+                throw new Error('media reupload request requires a chat jid')
+            }
+            const inFlight = pending.get(input.messageId)
+            if (inFlight) {
+                return inFlight.promise
+            }
+
+            const node = await buildRequestNode(input)
+            const entry = trackPending(input)
+            sendNode(node).catch((error: unknown) => {
+                rejectPending(input.messageId, toError(error))
+            })
+            return entry.promise
+        },
+
+        handleNotification: (node) => {
+            const notificationLogger = logger.child({ id: node.attrs.id })
+            const parsed = parseMediaRetryNotification(node)
+            if (!parsed) {
+                notificationLogger.warn('failed to parse mediaretry notification', {
+                    from: node.attrs.from
+                })
+                return
+            }
+
+            const entry = pending.get(parsed.messageId)
+            if (!entry) {
+                notificationLogger.debug('mediaretry notification without a pending request')
+                return
+            }
+
+            const credentials = getCurrentCredentials()
+            if (
+                parsed.from &&
+                !isOwnAccountJid(parsed.from, credentials?.meJid, credentials?.meLid)
+            ) {
+                notificationLogger.warn('mediaretry notification did not come from this account', {
+                    from: parsed.from
+                })
+            }
+
+            if (parsed.ciphertext === undefined) {
+                settle({
+                    messageId: parsed.messageId,
+                    result: toResultType(parsed.errorCode),
+                    resultCode: parsed.errorCode
+                })
+                return
+            }
+
+            let result: WaMediaRetryResult
+            try {
+                const decoded = decryptMediaRetryNotification({
+                    mediaKey: entry.mediaKey,
+                    ciphertext: parsed.ciphertext,
+                    iv: parsed.iv,
+                    stanzaId: parsed.messageId
+                })
+                if (decoded.stanzaId !== parsed.messageId) {
+                    throw new Error(
+                        `mediaretry stanza id mismatch: sealed ${String(decoded.stanzaId)}`
+                    )
+                }
+                result = {
+                    messageId: parsed.messageId,
+                    result: toResultType(decoded.result),
+                    resultCode:
+                        decoded.result ?? proto.MediaRetryNotification.ResultType.GENERAL_ERROR,
+                    directPath: decoded.directPath ?? undefined
+                }
+            } catch (error) {
+                const normalized = toError(error)
+                notificationLogger.warn('failed to open mediaretry notification', {
+                    message: normalized.message
+                })
+                rejectPending(parsed.messageId, normalized)
+                return
+            }
+
+            settle(result)
+        }
+    }
+}

--- a/src/protocol/defaults.ts
+++ b/src/protocol/defaults.ts
@@ -31,6 +31,14 @@ export const WA_DEFAULTS = Object.freeze({
     HEALTH_CHECK_INTERVAL_MS: 15_000,
     DEAD_SOCKET_TIMEOUT_MS: 20_000,
     MEDIA_TIMEOUT_MS: 30_000,
+    /**
+     * How long a media-reupload request waits for the `mediaretry`
+     * notification. The sender's primary device has to be reachable and
+     * re-upload the file, so this is deliberately longer than an IQ timeout.
+     */
+    MEDIA_RETRY_TIMEOUT_MS: 60_000,
+    /** In-flight media-reupload requests kept in memory; the oldest is rejected past it. */
+    MAX_PENDING_MEDIA_RETRIES: 64,
     APP_STATE_SYNC_TIMEOUT_MS: 30_000,
     SIGNAL_FETCH_KEY_BUNDLES_TIMEOUT_MS: 20_000,
     MESSAGE_ACK_TIMEOUT_MS: 10_000,

--- a/src/protocol/notification.ts
+++ b/src/protocol/notification.ts
@@ -8,6 +8,7 @@ export const WA_NOTIFICATION_TYPES = Object.freeze({
     NEWSLETTER: 'newsletter',
     BUSINESS: 'business',
     PICTURE: 'picture',
+    MEDIA_RETRY: 'mediaretry',
     PASSKEY_PROLOGUE_REQUEST: 'passkey_prologue_request',
     CRSC_CONTINUATION: 'crsc_continuation'
 } as const)

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -55,6 +55,7 @@ export type { BuildAckNodeInput, BuildReceiptNodeInput } from '@transport/node/b
 export {
     findNodeChild,
     getFirstNodeChild,
+    getNodeBytesContent,
     getNodeChildren,
     getNodeChildrenByTag,
     getNodeTextContent,

--- a/src/transport/node/helpers.ts
+++ b/src/transport/node/helpers.ts
@@ -163,7 +163,9 @@ export function getNodeTextContent(node: BinaryNode | null | undefined): string 
 
 /**
  * Binary counterpart of {@link getNodeTextContent}: the node's raw bytes, or
- * `undefined` when it is missing, empty, or carries children/text instead.
+ * `undefined` when it is missing or carries children/text instead. Empty
+ * content comes back as a zero-length view, mirroring the empty string
+ * {@link getNodeTextContent} returns - check `byteLength` when that matters.
  */
 export function getNodeBytesContent(node: BinaryNode | null | undefined): Uint8Array | undefined {
     return node?.content instanceof Uint8Array ? node.content : undefined

--- a/src/transport/node/helpers.ts
+++ b/src/transport/node/helpers.ts
@@ -161,6 +161,14 @@ export function getNodeTextContent(node: BinaryNode | null | undefined): string 
     return undefined
 }
 
+/**
+ * Binary counterpart of {@link getNodeTextContent}: the node's raw bytes, or
+ * `undefined` when it is missing, empty, or carries children/text instead.
+ */
+export function getNodeBytesContent(node: BinaryNode | null | undefined): Uint8Array | undefined {
+    return node?.content instanceof Uint8Array ? node.content : undefined
+}
+
 export function decodeNodeContentBase64OrBytes(
     value: BinaryNode['content'],
     field: string


### PR DESCRIPTION
Adds `client.message.requestMediaReupload()`, the round-trip WhatsApp Web runs when a media download answers 404/410 - typically old media surfaced by a history sync. A `server-error` receipt carrying an encrypted `ServerErrorReceipt` goes out, and the sender's primary device answers with a `mediaretry` notification holding a fresh `directPath`.

- `@media/crypto/media-retry` seals and opens both payloads: HKDF-SHA-256 over the media key with the `WhatsApp Media Retry Notification` context, AES-256-GCM bound to the stanza id as associated data.
- `@message/primitives/media-retry` owns the round-trip. A plain node query cannot serve here: the ack and the notification carry the same stanza id, so a query would resolve on the ack and drop the answer. Requests are keyed by message id, deduplicated, bounded, and expire.
- The `mediaretry` notification is parsed and settled through the existing incoming pipeline; the ack it already sent is unchanged.
- `getNodeBytesContent` joins the transport helpers, replacing three copies of the same optional-node-bytes expression.

On success only the `directPath` changes: the media key, hashes, and length of the original message stay valid. `not_found` is a normal answer, meaning the sender no longer holds the file.

Validated against the live server end to end, including an image whose CDN blob had expired 77 days earlier: the reupload returned a new `directPath` and the download verified against the original keys.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added media re-upload support for recoverable message media.
  * Added public media retry request and result types.
  * Added handling for incoming media-retry notifications, including encrypted payloads.
  * Added configurable retry timeouts and limits for pending requests.
  * Added request validation, duplicate-request handling, and result tracking.

* **Bug Fixes**
  * Improved extraction of binary node content across message and verification flows.
  * Added safer handling for invalid, malformed, or unmatched media-retry notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->