### PR TITLE
perf(history): stream history sync and group history ingestion

### DIFF
--- a/src/client/__tests__/client.test.ts
+++ b/src/client/__tests__/client.test.ts
@@ -79,7 +79,7 @@ test('history sync processor persists conversations and emits chunk event', asyn
         {
             logger: createNoopLogger(),
             mediaTransfer: {
-                downloadAndDecrypt: async () => {
+                downloadAndDecryptStream: async () => {
                     throw new Error('should not be called for inline payload')
                 }
             } as never,
@@ -143,7 +143,7 @@ test('history sync processor handles ON_DEMAND chunks (peer-data-operation respo
         {
             logger: createNoopLogger(),
             mediaTransfer: {
-                downloadAndDecrypt: async () => {
+                downloadAndDecryptStream: async () => {
                     throw new Error('should not be called for inline payload')
                 }
             } as never,
@@ -206,7 +206,7 @@ test('history sync processor does not emit chunk event when chunk persistence fa
                 {
                     logger: createNoopLogger(),
                     mediaTransfer: {
-                        downloadAndDecrypt: async () => {
+                        downloadAndDecryptStream: async () => {
                             throw new Error('should not be called for inline payload')
                         }
                     } as never,
@@ -258,7 +258,7 @@ test('history sync processor forwards privacy token payloads and nct salt hooks'
         {
             logger: createNoopLogger(),
             mediaTransfer: {
-                downloadAndDecrypt: async () => {
+                downloadAndDecryptStream: async () => {
                     throw new Error('should not be called for inline payload')
                 }
             } as never,
@@ -333,7 +333,7 @@ test('history sync processor skips stub messages (system events)', async () => {
         {
             logger: createNoopLogger(),
             mediaTransfer: {
-                downloadAndDecrypt: async () => {
+                downloadAndDecryptStream: async () => {
                     throw new Error('should not be called for inline payload')
                 }
             } as never,
@@ -376,7 +376,7 @@ test('history sync processor persists phoneNumberToLidMappings as a single LID-c
         {
             logger: createNoopLogger(),
             mediaTransfer: {
-                downloadAndDecrypt: async () => {
+                downloadAndDecryptStream: async () => {
                     throw new Error('should not be called for inline payload')
                 }
             } as never,
@@ -433,7 +433,7 @@ test('history sync processor coalesces pushname onto the LID-canonical row when 
         {
             logger: createNoopLogger(),
             mediaTransfer: {
-                downloadAndDecrypt: async () => {
+                downloadAndDecryptStream: async () => {
                     throw new Error('should not be called for inline payload')
                 }
             } as never,
@@ -485,7 +485,7 @@ test('history sync processor invokes onProcessed after handled chunk (for hist_s
         {
             logger: createNoopLogger(),
             mediaTransfer: {
-                downloadAndDecrypt: async () => {
+                downloadAndDecryptStream: async () => {
                     throw new Error('should not be called for inline payload')
                 }
             } as never,
@@ -514,7 +514,7 @@ test('history sync processor invokes onProcessed for INITIAL_STATUS_V3 (recogniz
         {
             logger: createNoopLogger(),
             mediaTransfer: {
-                downloadAndDecrypt: async () => {
+                downloadAndDecryptStream: async () => {
                     throw new Error('should not be called - status_v3 is skipped before download')
                 }
             } as never,
@@ -541,7 +541,7 @@ test('history sync processor does NOT invoke onProcessed when syncType is null',
     await processHistorySyncNotification(
         {
             logger: createNoopLogger(),
-            mediaTransfer: { downloadAndDecrypt: async () => new Uint8Array() } as never,
+            mediaTransfer: { downloadAndDecryptStream: async () => new Uint8Array() } as never,
             writeBehind: {
                 persistMessageAsync: async () => undefined,
                 persistThreadAsync: async () => undefined,
@@ -578,7 +578,7 @@ test('history sync processor handles NON_BLOCKING_DATA syncType (previously skip
         {
             logger: createNoopLogger(),
             mediaTransfer: {
-                downloadAndDecrypt: async () => {
+                downloadAndDecryptStream: async () => {
                     throw new Error('should not be called for inline payload')
                 }
             } as never,

--- a/src/client/persistence/__tests__/group-history.test.ts
+++ b/src/client/persistence/__tests__/group-history.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { Readable } from 'node:stream'
 import test from 'node:test'
 
 import type { WaAbPropName } from '@abprops-spec'
@@ -52,10 +53,13 @@ function createHarness(overrides: Partial<WaGroupHistoryDeps> = {}): Harness {
     const deps = {
         logger: createNoopLogger(),
         mediaTransfer: {
-            downloadAndDecrypt: async (request: { readonly mediaType: string }) => {
+            downloadAndDecryptStream: async (request: { readonly mediaType: string }) => {
                 downloads.count += 1
                 assert.equal(request.mediaType, 'group-history')
-                return blob
+                return {
+                    plaintext: Readable.from([Buffer.from(blob)]),
+                    metadata: Promise.resolve(null)
+                }
             }
         },
         writeBehind: {

--- a/src/client/persistence/__tests__/history-sync.test.ts
+++ b/src/client/persistence/__tests__/history-sync.test.ts
@@ -377,6 +377,12 @@ test('streaming history sync tolerates a Conversation whose id follows its messa
         capture.messages.map((record) => [record.id, record.threadJid]),
         [['REVERSED', '5511444444444@s.whatsapp.net']]
     )
+    const emitted = capture.events[0] as Record<string, number>
+    assert.equal(
+        emitted.messagesCount,
+        capture.messages.length,
+        'a parked message must be counted exactly once, when it is written'
+    )
 })
 
 test('streaming history sync rejects a chunk whose MAC fails, without acking it', async () => {
@@ -559,27 +565,65 @@ test('history sync bounds the messages parked before their thread jid', async ()
     conversation.set(idPart, messagesPart.length)
     const blob = new Uint8Array([0x12, ...encodeVarint(conversation.length), ...conversation])
 
-    const warnings: { message: string; context?: Record<string, unknown> }[] = []
-    const logger = {
-        ...createNoopLogger(),
-        warn: (message: string, context?: Record<string, unknown>) => {
-            warnings.push({ message, context })
-        }
-    }
+    const payload = toBytesView(await gzipAsync(blob))
     const { capture, deps } = createCapture()
-    await processHistorySyncNotification(
-        { ...(deps as Record<string, unknown>), logger } as never,
-        {
-            syncType: proto.Message.HistorySyncType.RECENT,
-            initialHistBootstrapInlinePayload: toBytesView(await gzipAsync(blob))
-        }
+    await assert.rejects(
+        () =>
+            processHistorySyncNotification(deps as never, {
+                syncType: proto.Message.HistorySyncType.RECENT,
+                initialHistBootstrapInlinePayload: payload
+            }),
+        /parked 1024 messages with no thread jid/
     )
 
-    assert.equal(capture.messages.length, 1_024, 'the park must stop at its cap')
-    assert.equal(warnings.length, 1, 'the drop must be visible to the operator')
-    assert.equal(warnings[0].context?.droppedParked, 176)
+    assert.deepEqual(capture.acked, [], 'an aborted chunk must stay unacked so it is resent')
+    assert.deepEqual(capture.events, [], 'no chunk event may report a partial apply')
+})
+
+test('history sync counts only the messages it persisted', async () => {
+    const { capture, deps } = createCapture()
+    await processHistorySyncNotification(deps as never, {
+        syncType: proto.Message.HistorySyncType.RECENT,
+        initialHistBootstrapInlinePayload: toBytesView(
+            await gzipAsync(
+                proto.HistorySync.encode({
+                    conversations: [
+                        {
+                            id: '5511222222222@s.whatsapp.net',
+                            messages: [
+                                {
+                                    message: {
+                                        key: {
+                                            remoteJid: '5511222222222@s.whatsapp.net',
+                                            id: 'KEPT'
+                                        },
+                                        message: { conversation: 'kept' },
+                                        messageTimestamp: 1_722_000_000
+                                    }
+                                },
+                                {
+                                    message: {
+                                        key: {
+                                            remoteJid: '5511222222222@s.whatsapp.net',
+                                            id: 'STUB'
+                                        },
+                                        messageStubType:
+                                            proto.WebMessageInfo.StubType.GROUP_PARTICIPANT_ADD
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }).finish()
+            )
+        )
+    })
+
+    const emitted = capture.events[0] as Record<string, number>
+    assert.equal(capture.messages.length, 1)
     assert.equal(
-        capture.messages.every((record) => record.threadJid === '5511444444444@s.whatsapp.net'),
-        true
+        emitted.messagesCount,
+        capture.messages.length,
+        'the reported count must match what was written'
     )
 })

--- a/src/client/persistence/__tests__/history-sync.test.ts
+++ b/src/client/persistence/__tests__/history-sync.test.ts
@@ -1,20 +1,39 @@
 import assert from 'node:assert/strict'
+import { Readable } from 'node:stream'
 import test from 'node:test'
 import { promisify } from 'node:util'
 import { gzip } from 'node:zlib'
 
 import {
-    processHistorySyncNotification,
-    scanConversationJidPair,
-    scanHistorySyncBlob
+    CONVERSATION_FIELDS,
+    HISTORY_SYNC_FIELDS,
+    processHistorySyncNotification
 } from '@client/persistence/history-sync'
 import { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
 import { createNoopLogger } from '@infra/log/types'
 import { proto, type Proto } from '@proto'
+import type { WaStoredContactRecord } from '@store/contracts/contact.store'
+import type { WaStoredMessageRecord } from '@store/contracts/message.store'
 import type { WaStoredThreadRecord } from '@store/contracts/thread.store'
 import { toBytesView } from '@util/bytes'
+import { readProtoVarint } from '@util/protoscan'
 
 const gzipAsync = promisify(gzip)
+
+/**
+ * Reads a field number back out of the generated encoder: encode a message
+ * carrying only that field, then decode the leading tag. Keeps the hardcoded
+ * numbers pinned to the code that actually serializes the wire, with no
+ * reflection metadata to depend on.
+ */
+function encodedFieldNumber(
+    type: { encode: (value: never) => { finish: () => Uint8Array } },
+    value: unknown
+): number {
+    const bytes = type.encode(value as never).finish()
+    assert.ok(bytes.length > 0, 'the probe field must actually be encoded')
+    return Math.floor(readProtoVarint(bytes, 0, bytes.length).value / 8)
+}
 
 function createThreadCapture(): {
     readonly writes: WaStoredThreadRecord[]
@@ -43,6 +62,66 @@ function createThreadCapture(): {
         createNoopLogger()
     )
     return { writes, writeBehind }
+}
+
+interface TokenConversation {
+    readonly jid: string
+    readonly tcToken?: Uint8Array | null
+    readonly tcTokenTimestamp?: number | null
+}
+
+interface Capture {
+    readonly order: string[]
+    readonly messages: WaStoredMessageRecord[]
+    readonly threads: WaStoredThreadRecord[]
+    readonly contacts: WaStoredContactRecord[]
+    readonly events: unknown[]
+    readonly acked: number[]
+    readonly salts: Uint8Array[]
+    readonly tokens: TokenConversation[]
+}
+
+function createCapture(): { readonly capture: Capture; readonly deps: unknown } {
+    const capture: Capture = {
+        order: [],
+        messages: [],
+        threads: [],
+        contacts: [],
+        events: [],
+        acked: [],
+        salts: [],
+        tokens: []
+    }
+    const deps = {
+        logger: createNoopLogger(),
+        mediaTransfer: {} as never,
+        writeBehind: {
+            persistMessageAsync: async (record: WaStoredMessageRecord) => {
+                capture.order.push(`msg:${record.id}`)
+                capture.messages.push(record)
+            },
+            persistThreadAsync: async (record: WaStoredThreadRecord) => {
+                capture.order.push(`thread:${record.jid}`)
+                capture.threads.push(record)
+            },
+            persistContactAsync: async (record: WaStoredContactRecord) => {
+                capture.contacts.push(record)
+            }
+        } as never,
+        emitEvent: (_type: string, payload: unknown) => {
+            capture.events.push(payload)
+        },
+        onNctSalt: async (salt: Uint8Array) => {
+            capture.salts.push(salt)
+        },
+        onPrivacyTokens: async (conversations: readonly TokenConversation[]) => {
+            capture.tokens.push(...conversations)
+        },
+        onProcessed: async (syncType: number) => {
+            capture.acked.push(syncType)
+        }
+    }
+    return { capture, deps }
 }
 
 async function buildInlineNotification(
@@ -129,7 +208,7 @@ test('history sync leaves ephemeralSettingTimestamp absent for a non-ephemeral c
     assert.equal(thread.ephemeralSettingTimestamp, undefined)
 })
 
-test('scanHistorySyncBlob is equivalent to the monolithic HistorySync decode', () => {
+test('streaming history sync is equivalent to the monolithic HistorySync decode', async () => {
     const historySync: Proto.IHistorySync = {
         syncType: proto.HistorySync.HistorySyncType.RECENT,
         chunkOrder: 4,
@@ -140,7 +219,10 @@ test('scanHistorySyncBlob is equivalent to the monolithic HistorySync decode', (
             { id: '5511111111111@s.whatsapp.net', pushname: 'Alice' },
             { id: '5522222222222@s.whatsapp.net', pushname: 'Bob' }
         ],
-        phoneNumberToLidMappings: [{ pnJid: '5511111111111@s.whatsapp.net', lidJid: '111@lid' }],
+        phoneNumberToLidMappings: [
+            { pnJid: '5511111111111@s.whatsapp.net', lidJid: '111@lid' },
+            { pnJid: '5544444444444@s.whatsapp.net', lidJid: '444@lid' }
+        ],
         inlineContacts: [
             { pnJid: '5522222222222@s.whatsapp.net', lidJid: '222@lid', fullName: 'Bob Silva' }
         ],
@@ -154,12 +236,20 @@ test('scanHistorySyncBlob is equivalent to the monolithic HistorySync decode', (
                 pnJid: '5511111111111@s.whatsapp.net',
                 lidJid: '111@lid',
                 tcToken: new Uint8Array([5, 5, 5]),
+                name: 'Alice',
+                unreadCount: 3,
                 messages: [
                     {
                         message: {
                             key: { remoteJid: '5511111111111@s.whatsapp.net', id: 'M1' },
                             message: { conversation: 'oi' },
                             messageTimestamp: 1_722_000_000
+                        }
+                    },
+                    {
+                        message: {
+                            key: { remoteJid: '5511111111111@s.whatsapp.net', id: 'M2' },
+                            messageStubType: proto.WebMessageInfo.StubType.GROUP_PARTICIPANT_ADD
                         }
                     }
                 ]
@@ -168,7 +258,6 @@ test('scanHistorySyncBlob is equivalent to the monolithic HistorySync decode', (
                 id: '5533333333333@s.whatsapp.net',
                 pnJid: '5533333333333@s.whatsapp.net',
                 accountLid: '333@lid',
-                muteEndTime: -1,
                 messages: []
             },
             { id: '123@g.us', messages: [] }
@@ -183,35 +272,143 @@ test('scanHistorySyncBlob is equivalent to the monolithic HistorySync decode', (
     blob.set(unknownLen, unknownVarint.length + clean.length)
 
     const reference = proto.HistorySync.decode(blob)
-    const scan = scanHistorySyncBlob(blob)
+    const { capture, deps } = createCapture()
+    await processHistorySyncNotification(deps as never, {
+        syncType: proto.Message.HistorySyncType.RECENT,
+        initialHistBootstrapInlinePayload: toBytesView(await gzipAsync(blob))
+    })
 
-    assert.equal(scan.conversationRanges.length, reference.conversations.length)
-    for (let i = 0; i < scan.conversationRanges.length; i += 1) {
-        const range = scan.conversationRanges[i]
-        const incremental = proto.Conversation.decode(blob.subarray(range.start, range.end))
-        assert.deepEqual(
-            Array.from(proto.Conversation.encode(incremental).finish()),
-            Array.from(proto.Conversation.encode(reference.conversations[i]).finish()),
-            `conversation ${i}`
-        )
-        const pair = scanConversationJidPair(blob, range)
-        assert.equal(pair.pnJid, reference.conversations[i].pnJid ?? null)
-        assert.equal(
-            pair.lidJid,
-            reference.conversations[i].lidJid ?? reference.conversations[i].accountLid ?? null
-        )
+    const emitted = capture.events[0] as Record<string, number>
+    assert.equal(emitted.conversationsCount, reference.conversations.length)
+    assert.equal(emitted.pushnamesCount, reference.pushnames.length)
+    assert.equal(emitted.inlineContactsCount, reference.inlineContacts.length)
+    assert.equal(emitted.chunkOrder, reference.chunkOrder)
+    assert.equal(emitted.progress, reference.progress)
+
+    assert.deepEqual(
+        capture.threads.map((record) => record.jid),
+        reference.conversations.map((conversation) => conversation.id)
+    )
+    const alice = capture.threads[0]
+    assert.equal(alice.name, 'Alice')
+    assert.equal(alice.unreadCount, 3)
+
+    assert.deepEqual(
+        capture.messages.map((record) => record.id),
+        ['M1']
+    )
+    assert.equal(capture.messages[0].threadJid, '5511111111111@s.whatsapp.net')
+    assert.equal(capture.messages[0].timestampMs, 1_722_000_000_000)
+    const messageBytes = capture.messages[0].messageBytes
+    assert.ok(messageBytes, 'message payload must be persisted')
+    assert.deepEqual(
+        Array.from(messageBytes),
+        Array.from(proto.Message.encode({ conversation: 'oi' }).finish())
+    )
+
+    const bob = capture.contacts.find((record) => record.pushName === 'Bob')
+    assert.ok(bob, 'Bob pushname must be persisted')
+    assert.equal(bob.jid, '222@lid', 'pushname must land on the canonical LID row')
+    const aliceContact = capture.contacts.find((record) => record.pushName === 'Alice')
+    assert.ok(aliceContact)
+    assert.equal(aliceContact.jid, '111@lid')
+
+    assert.deepEqual(
+        capture.salts.map((salt) => Array.from(salt)),
+        [Array.from(reference.nctSalt as Uint8Array)],
+        'the chunk nctSalt must be handed over'
+    )
+    assert.deepEqual(
+        capture.tokens.map((token) => [token.jid, Array.from(token.tcToken ?? [])]),
+        [
+            [
+                '5511111111111@s.whatsapp.net',
+                Array.from(reference.conversations[0].tcToken as Uint8Array)
+            ]
+        ],
+        'privacy tokens must be collected from the conversations that carry them'
+    )
+
+    const standalone = capture.contacts.find((record) => record.jid === '444@lid')
+    assert.ok(standalone, 'a mapping with no conversation or inline contact must still land')
+    assert.equal(standalone.phoneNumber, '5544444444444@s.whatsapp.net')
+
+    const firstMessage = capture.order.indexOf('msg:M1')
+    const ownerThread = capture.order.indexOf('thread:5511111111111@s.whatsapp.net')
+    assert.ok(firstMessage >= 0 && ownerThread >= 0)
+    assert.ok(
+        firstMessage < ownerThread,
+        'messages must be written as they stream, before their conversation closes'
+    )
+
+    assert.deepEqual(capture.acked, [proto.Message.HistorySyncType.RECENT])
+})
+
+test('streaming history sync tolerates a Conversation whose id follows its messages', async () => {
+    const messageField = proto.Conversation.encode({
+        messages: [
+            {
+                message: {
+                    key: { remoteJid: '5511444444444@s.whatsapp.net', id: 'REVERSED' },
+                    message: { conversation: 'fora de ordem' },
+                    messageTimestamp: 1_722_000_001
+                }
+            }
+        ]
+    }).finish()
+    const idField = proto.Conversation.encode({ id: '5511444444444@s.whatsapp.net' }).finish()
+    const conversation = new Uint8Array(messageField.length + idField.length)
+    conversation.set(messageField, 0)
+    conversation.set(idField, messageField.length)
+
+    assert.ok(conversation.length < 128, 'fixture must fit single-byte length framing')
+    const blob = new Uint8Array(2 + conversation.length)
+    blob.set([0x12, conversation.length], 0)
+    blob.set(conversation, 2)
+
+    const { capture, deps } = createCapture()
+    await processHistorySyncNotification(deps as never, {
+        syncType: proto.Message.HistorySyncType.RECENT,
+        initialHistBootstrapInlinePayload: toBytesView(await gzipAsync(blob))
+    })
+
+    assert.deepEqual(
+        capture.messages.map((record) => [record.id, record.threadJid]),
+        [['REVERSED', '5511444444444@s.whatsapp.net']]
+    )
+})
+
+test('streaming history sync rejects a chunk whose MAC fails, without acking it', async () => {
+    const payload = proto.HistorySync.encode({
+        syncType: proto.HistorySync.HistorySyncType.RECENT,
+        conversations: [{ id: '5511555555555@s.whatsapp.net', messages: [] }]
+    }).finish()
+    const gzipped = toBytesView(await gzipAsync(payload))
+
+    const { capture, deps } = createCapture()
+    const withTransfer = {
+        ...(deps as Record<string, unknown>),
+        mediaTransfer: {
+            downloadAndDecryptStream: async () => ({
+                plaintext: Readable.from([Buffer.from(gzipped)]),
+                metadata: Promise.reject(new Error('media MAC mismatch'))
+            })
+        }
     }
 
-    assert.equal(scan.pushnames.length, reference.pushnames.length)
-    for (let i = 0; i < scan.pushnames.length; i += 1) {
-        assert.equal(scan.pushnames[i].id, reference.pushnames[i].id)
-        assert.equal(scan.pushnames[i].pushname, reference.pushnames[i].pushname)
-    }
-    assert.equal(scan.inlineContacts.length, reference.inlineContacts.length)
-    assert.equal(scan.phoneNumberToLidMappings.length, reference.phoneNumberToLidMappings.length)
-    assert.equal(scan.chunkOrder, reference.chunkOrder ?? null)
-    assert.equal(scan.progress, reference.progress ?? null)
-    assert.deepEqual(Array.from(scan.nctSalt ?? []), Array.from(reference.nctSalt ?? []))
+    await assert.rejects(
+        () =>
+            processHistorySyncNotification(withTransfer as never, {
+                syncType: proto.Message.HistorySyncType.RECENT,
+                directPath: '/history',
+                mediaKey: new Uint8Array(32),
+                fileSha256: new Uint8Array(32),
+                fileEncSha256: new Uint8Array(32)
+            }),
+        /media MAC mismatch/
+    )
+    assert.deepEqual(capture.acked, [], 'a chunk that failed verification must stay unacked')
+    assert.deepEqual(capture.events, [], 'no chunk event may be emitted for unverified data')
 })
 
 test('history sync abort on a corrupt conversation settles pending writes', async () => {
@@ -277,5 +474,32 @@ test('history sync abort on a corrupt conversation settles pending writes', asyn
         threadJids,
         ['5511111111111@s.whatsapp.net'],
         'the conversation before the corrupt record must have been written'
+    )
+})
+
+test('history sync field numbers match the generated encoder', () => {
+    assert.deepEqual(
+        {
+            CONVERSATIONS: encodedFieldNumber(proto.HistorySync, { conversations: [{ id: 'x' }] }),
+            CHUNK_ORDER: encodedFieldNumber(proto.HistorySync, { chunkOrder: 1 }),
+            PROGRESS: encodedFieldNumber(proto.HistorySync, { progress: 1 }),
+            PUSHNAMES: encodedFieldNumber(proto.HistorySync, { pushnames: [{ id: 'x' }] }),
+            PHONE_NUMBER_TO_LID_MAPPINGS: encodedFieldNumber(proto.HistorySync, {
+                phoneNumberToLidMappings: [{ pnJid: 'x' }]
+            }),
+            NCT_SALT: encodedFieldNumber(proto.HistorySync, { nctSalt: new Uint8Array([1]) }),
+            INLINE_CONTACTS: encodedFieldNumber(proto.HistorySync, {
+                inlineContacts: [{ pnJid: 'x' }]
+            })
+        },
+        { ...HISTORY_SYNC_FIELDS }
+    )
+
+    assert.deepEqual(
+        {
+            ID: encodedFieldNumber(proto.Conversation, { id: 'x' }),
+            MESSAGES: encodedFieldNumber(proto.Conversation, { messages: [{}] })
+        },
+        { ...CONVERSATION_FIELDS }
     )
 })

--- a/src/client/persistence/__tests__/history-sync.test.ts
+++ b/src/client/persistence/__tests__/history-sync.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test'
 import { promisify } from 'node:util'
 import { gzip } from 'node:zlib'
 
+import { openHistoryBlobStream } from '@client/persistence/history-blob'
 import {
     CONVERSATION_FIELDS,
     HISTORY_SYNC_FIELDS,
@@ -501,5 +502,84 @@ test('history sync field numbers match the generated encoder', () => {
             MESSAGES: encodedFieldNumber(proto.Conversation, { messages: [{}] })
         },
         { ...CONVERSATION_FIELDS }
+    )
+})
+
+test('destroying the inflated stream tears down the decryption source', async () => {
+    const plaintext = new Readable({ read: () => undefined })
+    const blob = await openHistoryBlobStream(
+        {
+            downloadAndDecryptStream: async () => ({
+                plaintext,
+                metadata: Promise.resolve(null)
+            })
+        } as never,
+        {
+            directPath: '/history',
+            mediaKey: new Uint8Array(32),
+            fileSha256: new Uint8Array(32),
+            fileEncSha256: new Uint8Array(32)
+        },
+        'history',
+        'history sync'
+    )
+
+    assert.equal(plaintext.destroyed, false)
+    blob.inflated.destroy(new Error('consumer gave up'))
+    await new Promise((resolve) => setImmediate(resolve))
+    assert.equal(plaintext.destroyed, true, 'the source must not keep draining after an abort')
+})
+
+test('history sync bounds the messages parked before their thread jid', async () => {
+    const encodeVarint = (value: number): number[] => {
+        const out: number[] = []
+        let rest = value
+        while (rest > 0x7f) {
+            out.push((rest & 0x7f) | 0x80)
+            rest = Math.floor(rest / 128)
+        }
+        out.push(rest)
+        return out
+    }
+
+    const messages: Proto.IHistorySyncMsg[] = []
+    for (let index = 0; index < 1_200; index += 1) {
+        messages.push({
+            message: {
+                key: { remoteJid: '5511444444444@s.whatsapp.net', id: `P${index}` },
+                message: { conversation: 'parked' },
+                messageTimestamp: 1_722_000_000 + index
+            }
+        })
+    }
+    const messagesPart = proto.Conversation.encode({ messages }).finish()
+    const idPart = proto.Conversation.encode({ id: '5511444444444@s.whatsapp.net' }).finish()
+    const conversation = new Uint8Array(messagesPart.length + idPart.length)
+    conversation.set(messagesPart, 0)
+    conversation.set(idPart, messagesPart.length)
+    const blob = new Uint8Array([0x12, ...encodeVarint(conversation.length), ...conversation])
+
+    const warnings: { message: string; context?: Record<string, unknown> }[] = []
+    const logger = {
+        ...createNoopLogger(),
+        warn: (message: string, context?: Record<string, unknown>) => {
+            warnings.push({ message, context })
+        }
+    }
+    const { capture, deps } = createCapture()
+    await processHistorySyncNotification(
+        { ...(deps as Record<string, unknown>), logger } as never,
+        {
+            syncType: proto.Message.HistorySyncType.RECENT,
+            initialHistBootstrapInlinePayload: toBytesView(await gzipAsync(blob))
+        }
+    )
+
+    assert.equal(capture.messages.length, 1_024, 'the park must stop at its cap')
+    assert.equal(warnings.length, 1, 'the drop must be visible to the operator')
+    assert.equal(warnings[0].context?.droppedParked, 176)
+    assert.equal(
+        capture.messages.every((record) => record.threadJid === '5511444444444@s.whatsapp.net'),
+        true
     )
 })

--- a/src/client/persistence/group-history.ts
+++ b/src/client/persistence/group-history.ts
@@ -1,15 +1,16 @@
 import type { WaAbPropName } from '@abprops-spec'
-import { downloadHistoryBlob, flushPendingWrites } from '@client/persistence/history-blob'
+import { flushPendingWrites, openHistoryBlobStream } from '@client/persistence/history-blob'
 import type { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
 import type { WaClientEventMap, WaGroupHistoryBundleEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
-import { decodeGroupHistoryBundle } from '@message/kinds/group-history'
+import { streamGroupHistoryBundle } from '@message/kinds/group-history'
 import { proto, type Proto } from '@proto'
 import { isGroupJid, toUserJid } from '@protocol/jid'
 import { longToNumber, toError } from '@util/primitives'
 
 const GROUP_HISTORY_MAX_PENDING_WRITES = 1_024
+const GROUP_HISTORY_MAX_RECORD_BYTES = 16 * 1024 * 1024
 
 export interface WaGroupHistoryBundleInput {
     /** The `messageHistoryBundle` payload carried by the incoming message. */
@@ -85,13 +86,12 @@ export async function processGroupHistoryBundle(
         return
     }
 
-    const blob = await downloadHistoryBlob(
+    const blob = await openHistoryBlobStream(
         deps.mediaTransfer,
         input.bundle,
         'group-history',
         'group history bundle'
     )
-    const history = await decodeGroupHistoryBundle(blob)
 
     const messageTtlSeconds = deps.getAbPropNumber(
         'group_history_messages_time_limit_receiver_enforcement_secs'
@@ -100,63 +100,79 @@ export async function processGroupHistoryBundle(
     const dropped = { foreignChat: 0, ephemeralExpired: 0, tooOld: 0, stub: 0 }
 
     let messagesCount = 0
+    let outOfWindowPinsCount = 0
     let oldestTimestampMs: number | undefined
-    for (const source of [
-        { messages: history.messages, skipAgeCheck: false },
-        { messages: history.outOfWindowPinnedMessages, skipAgeCheck: true }
-    ]) {
-        for (const webMsg of source.messages) {
-            if (!webMsg.key?.id || !webMsg.message) {
-                dropped.stub += 1
-                continue
-            }
-            if (webMsg.key.remoteJid && webMsg.key.remoteJid !== input.groupJid) {
-                dropped.foreignChat += 1
-                continue
-            }
-            const timestampSeconds = longToNumber(webMsg.messageTimestamp)
-            if (isEphemeralExpired(webMsg, timestampSeconds, nowMs)) {
-                dropped.ephemeralExpired += 1
-                continue
-            }
-            if (
-                !source.skipAgeCheck &&
-                timestampSeconds > 0 &&
-                (timestampSeconds + 2 * messageTtlSeconds) * 1_000 < nowMs
-            ) {
-                dropped.tooOld += 1
-                continue
-            }
 
-            const timestampMs = timestampSeconds * 1_000
-            if (
-                timestampMs > 0 &&
-                (oldestTimestampMs === undefined || timestampMs < oldestTimestampMs)
-            ) {
-                oldestTimestampMs = timestampMs
-            }
-            pendingWrites[pendingWrites.length] = deps.writeBehind.persistMessageAsync({
-                id: webMsg.key.id,
-                threadJid: input.groupJid,
-                senderJid: webMsg.key.participant ?? undefined,
-                fromMe: webMsg.key.fromMe === true,
-                timestampMs: timestampMs || undefined,
-                messageBytes: proto.Message.encode(webMsg.message).finish()
-            })
-            if (pendingWrites.length >= GROUP_HISTORY_MAX_PENDING_WRITES) {
-                await flushPendingWrites(pendingWrites)
-            }
-            messagesCount += 1
+    const onMessage = (
+        webMsg: Proto.WebMessageInfo,
+        outOfWindow: boolean
+    ): Promise<void> | undefined => {
+        if (outOfWindow) {
+            outOfWindowPinsCount += 1
         }
+        if (!webMsg.key?.id || !webMsg.message) {
+            dropped.stub += 1
+            return undefined
+        }
+        if (webMsg.key.remoteJid && webMsg.key.remoteJid !== input.groupJid) {
+            dropped.foreignChat += 1
+            return undefined
+        }
+        const timestampSeconds = longToNumber(webMsg.messageTimestamp)
+        if (isEphemeralExpired(webMsg, timestampSeconds, nowMs)) {
+            dropped.ephemeralExpired += 1
+            return undefined
+        }
+        if (
+            !outOfWindow &&
+            timestampSeconds > 0 &&
+            (timestampSeconds + 2 * messageTtlSeconds) * 1_000 < nowMs
+        ) {
+            dropped.tooOld += 1
+            return undefined
+        }
+
+        const timestampMs = timestampSeconds * 1_000
+        if (
+            timestampMs > 0 &&
+            (oldestTimestampMs === undefined || timestampMs < oldestTimestampMs)
+        ) {
+            oldestTimestampMs = timestampMs
+        }
+        const write = deps.writeBehind.persistMessageAsync({
+            id: webMsg.key.id,
+            threadJid: input.groupJid,
+            senderJid: webMsg.key.participant ?? undefined,
+            fromMe: webMsg.key.fromMe === true,
+            timestampMs: timestampMs || undefined,
+            messageBytes: proto.Message.encode(webMsg.message).finish()
+        })
+        write.catch(() => undefined)
+        pendingWrites[pendingWrites.length] = write
+        messagesCount += 1
+        if (pendingWrites.length >= GROUP_HISTORY_MAX_PENDING_WRITES) {
+            return flushPendingWrites(pendingWrites)
+        }
+        return undefined
     }
 
+    try {
+        await streamGroupHistoryBundle(blob.inflated, onMessage, GROUP_HISTORY_MAX_RECORD_BYTES)
+    } catch (error) {
+        blob.inflated.destroy(toError(error))
+        await Promise.allSettled(pendingWrites)
+        await blob.verified.catch(() => undefined)
+        throw toError(error)
+    }
+
+    await blob.verified
     await flushPendingWrites(pendingWrites)
 
     const droppedCount =
         dropped.foreignChat + dropped.ephemeralExpired + dropped.tooOld + dropped.stub
     logger.debug('processed group history bundle', {
         messagesCount,
-        outOfWindowPinsCount: history.outOfWindowPinnedMessages.length,
+        outOfWindowPinsCount,
         droppedCount,
         dropped
     })
@@ -166,7 +182,7 @@ export async function processGroupHistoryBundle(
         senderJid: input.senderJid,
         bundleMessageId: input.bundleMessageId,
         messagesCount,
-        outOfWindowPinsCount: history.outOfWindowPinnedMessages.length,
+        outOfWindowPinsCount,
         droppedCount,
         oldestTimestampMs,
         historyReceivers: [...(input.bundle.messageHistoryMetadata?.historyReceivers ?? [])]

--- a/src/client/persistence/history-blob.ts
+++ b/src/client/persistence/history-blob.ts
@@ -1,10 +1,9 @@
-import { Readable } from 'node:stream'
+import { pipeline, Readable } from 'node:stream'
 import { createUnzip } from 'node:zlib'
 
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import type { MediaCryptoType } from '@media/types'
 import { decodeProtoBytes } from '@util/bytes'
-import { toError } from '@util/primitives'
 
 /**
  * Encrypted-blob fields shared by the history-sync notification and the
@@ -90,17 +89,20 @@ export async function openHistoryBlobStream(
 }
 
 /**
- * `createUnzip` detects the framing. Forwards upstream errors, which `pipe` drops,
- * and parks a handler on `verified` so an early rejection is never unobserved.
+ * `createUnzip` detects the framing. `pipeline` rather than `pipe` so failure
+ * closes both directions: a consumer that destroys `inflated` mid-chunk also
+ * tears down the decryption pump and its socket, which `pipe` would leave
+ * draining. Also parks a handler on `verified` so an early rejection is never
+ * unobserved.
  */
 function inflateHistoryStream(
     plaintext: Readable,
     verified: Promise<unknown>
 ): WaHistoryBlobStream {
     const unzip = createUnzip()
-    plaintext.on('error', (error: unknown) => unzip.destroy(toError(error)))
+    pipeline(plaintext, unzip, () => undefined)
     verified.catch(() => undefined)
-    return { inflated: plaintext.pipe(unzip), verified }
+    return { inflated: unzip, verified }
 }
 
 /**

--- a/src/client/persistence/history-blob.ts
+++ b/src/client/persistence/history-blob.ts
@@ -1,6 +1,10 @@
+import { Readable } from 'node:stream'
+import { createUnzip } from 'node:zlib'
+
 import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClient'
 import type { MediaCryptoType } from '@media/types'
 import { decodeProtoBytes } from '@util/bytes'
+import { toError } from '@util/primitives'
 
 /**
  * Encrypted-blob fields shared by the history-sync notification and the
@@ -39,6 +43,64 @@ export async function downloadHistoryBlob(
         fileSha256,
         fileEncSha256
     })
+}
+
+export interface WaHistoryBlobStream {
+    /** Decrypted and decompressed bytes. Consume fully, then await `verified`. */
+    readonly inflated: Readable
+    /**
+     * Settles once the transfer ended and its MAC checked out. Verification can
+     * only finish with the last byte, so anything read from `inflated` is
+     * unauthenticated until this resolves - await it before treating the chunk
+     * as applied.
+     */
+    readonly verified: Promise<unknown>
+}
+
+/**
+ * Streaming counterpart of {@link downloadHistoryBlob}, so a multi-megabyte chunk
+ * is never held whole. Uses `inlinePayload` when the notification carried the
+ * blob inline instead of pointing at a CDN object.
+ *
+ * @throws when neither an inline payload nor a `directPath` is present, or when
+ * a key/hash field is missing.
+ */
+export async function openHistoryBlobStream(
+    mediaTransfer: WaMediaTransferClient,
+    source: WaHistoryBlobSource,
+    mediaType: MediaCryptoType,
+    label: string,
+    inlinePayload?: Uint8Array | string | null
+): Promise<WaHistoryBlobStream> {
+    if (inlinePayload) {
+        const bytes = decodeProtoBytes(inlinePayload, `${label} inline payload`)
+        return inflateHistoryStream(Readable.from([bytes]), Promise.resolve(null))
+    }
+    if (!source.directPath) {
+        throw new Error(`${label} missing directPath`)
+    }
+    const decrypted = await mediaTransfer.downloadAndDecryptStream({
+        directPath: source.directPath,
+        mediaType,
+        mediaKey: decodeProtoBytes(source.mediaKey, `${label} mediaKey`),
+        fileSha256: decodeProtoBytes(source.fileSha256, `${label} fileSha256`),
+        fileEncSha256: decodeProtoBytes(source.fileEncSha256, `${label} fileEncSha256`)
+    })
+    return inflateHistoryStream(decrypted.plaintext, decrypted.metadata)
+}
+
+/**
+ * `createUnzip` detects the framing. Forwards upstream errors, which `pipe` drops,
+ * and parks a handler on `verified` so an early rejection is never unobserved.
+ */
+function inflateHistoryStream(
+    plaintext: Readable,
+    verified: Promise<unknown>
+): WaHistoryBlobStream {
+    const unzip = createUnzip()
+    plaintext.on('error', (error: unknown) => unzip.destroy(toError(error)))
+    verified.catch(() => undefined)
+    return { inflated: plaintext.pipe(unzip), verified }
 }
 
 /**

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -29,7 +29,9 @@ const HISTORY_SYNC_MAX_RECORD_BYTES = 16 * 1024 * 1024
 /**
  * Ceiling on messages held while waiting for their `Conversation.id`. Field order
  * puts the id first, so this only fills if a serializer reverses it, and letting
- * it grow would rebuild the very peak the streaming pass removes.
+ * it grow would rebuild the very peak the streaming pass removes. Exceeding it
+ * fails the chunk rather than dropping records: an aborted chunk stays unacked
+ * and gets resent, while a dropped one would be acked and lost for good.
  */
 const HISTORY_SYNC_MAX_PARKED_MESSAGES = 1_024
 
@@ -200,7 +202,6 @@ async function consumeHistorySyncStream(
     let headerParts: Uint8Array[] | null = null
     let threadJid: string | null = null
     let parked: ParkedHistoryMessage[] | null = null
-    let droppedParked = 0
 
     const onEvent = (event: ProtoStreamEvent): void | Promise<void> => {
         if (event.kind === PROTO_STREAM_EVENT_KINDS.ENTER) {
@@ -230,16 +231,17 @@ async function consumeHistorySyncStream(
                 if (!message) {
                     return undefined
                 }
-                state.messagesCount += 1
                 if (!threadJid) {
                     parked ??= []
                     if (parked.length >= HISTORY_SYNC_MAX_PARKED_MESSAGES) {
-                        droppedParked += 1
-                        return undefined
+                        throw new Error(
+                            `history sync parked ${parked.length} messages with no thread jid, exceeding the ${HISTORY_SYNC_MAX_PARKED_MESSAGES} limit`
+                        )
                     }
                     parked[parked.length] = message
                     return undefined
                 }
+                state.messagesCount += 1
                 pushWrite(
                     state,
                     deps.writeBehind.persistMessageAsync({
@@ -307,13 +309,6 @@ async function consumeHistorySyncStream(
             depth === 0 && fieldNumber === HISTORY_SYNC_FIELDS.CONVERSATIONS,
         maxFieldBytes: HISTORY_SYNC_MAX_RECORD_BYTES
     })
-
-    if (droppedParked > 0) {
-        deps.logger.warn('dropped history sync messages that arrived before their thread jid', {
-            droppedParked,
-            limit: HISTORY_SYNC_MAX_PARKED_MESSAGES
-        })
-    }
 }
 
 async function closeConversation(
@@ -408,6 +403,7 @@ async function closeConversation(
     }
 
     for (const message of parked ?? []) {
+        state.messagesCount += 1
         pushWrite(
             state,
             deps.writeBehind.persistMessageAsync({

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -26,6 +26,12 @@ const HANDLED_SYNC_TYPES = new Set([
 ])
 const HISTORY_SYNC_MAX_PENDING_WRITES = 1_024
 const HISTORY_SYNC_MAX_RECORD_BYTES = 16 * 1024 * 1024
+/**
+ * Ceiling on messages held while waiting for their `Conversation.id`. Field order
+ * puts the id first, so this only fills if a serializer reverses it, and letting
+ * it grow would rebuild the very peak the streaming pass removes.
+ */
+const HISTORY_SYNC_MAX_PARKED_MESSAGES = 1_024
 
 export const HISTORY_SYNC_FIELDS = Object.freeze({
     CONVERSATIONS: 2,
@@ -194,6 +200,7 @@ async function consumeHistorySyncStream(
     let headerParts: Uint8Array[] | null = null
     let threadJid: string | null = null
     let parked: ParkedHistoryMessage[] | null = null
+    let droppedParked = 0
 
     const onEvent = (event: ProtoStreamEvent): void | Promise<void> => {
         if (event.kind === PROTO_STREAM_EVENT_KINDS.ENTER) {
@@ -226,6 +233,10 @@ async function consumeHistorySyncStream(
                 state.messagesCount += 1
                 if (!threadJid) {
                     parked ??= []
+                    if (parked.length >= HISTORY_SYNC_MAX_PARKED_MESSAGES) {
+                        droppedParked += 1
+                        return undefined
+                    }
                     parked[parked.length] = message
                     return undefined
                 }
@@ -296,6 +307,13 @@ async function consumeHistorySyncStream(
             depth === 0 && fieldNumber === HISTORY_SYNC_FIELDS.CONVERSATIONS,
         maxFieldBytes: HISTORY_SYNC_MAX_RECORD_BYTES
     })
+
+    if (droppedParked > 0) {
+        deps.logger.warn('dropped history sync messages that arrived before their thread jid', {
+            droppedParked,
+            limit: HISTORY_SYNC_MAX_PARKED_MESSAGES
+        })
+    }
 }
 
 async function closeConversation(

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -1,7 +1,4 @@
-import { promisify } from 'node:util'
-import { unzip } from 'node:zlib'
-
-import { downloadHistoryBlob, flushPendingWrites } from '@client/persistence/history-blob'
+import { flushPendingWrites, openHistoryBlobStream } from '@client/persistence/history-blob'
 import type { WriteBehindPersistence } from '@client/persistence/WriteBehindPersistence'
 import type { WaClientEventMap, WaHistorySyncChunkEvent } from '@client/types'
 import type { Logger } from '@infra/log/types'
@@ -10,11 +7,14 @@ import { proto, type Proto } from '@proto'
 import { isUserJid } from '@protocol/jid'
 import { normalizeEphemeralSettingSeconds } from '@protocol/message'
 import type { WaChatMetadataStore } from '@store/contracts/chat-metadata.store'
-import { decodeProtoBytes, TEXT_DECODER, toBytesView } from '@util/bytes'
+import { concatBytes, TEXT_DECODER } from '@util/bytes'
 import { longToNumber, toError } from '@util/primitives'
-import { PROTO_WIRE_TYPES, scanProtoFields } from '@util/protoscan'
-
-const unzipAsync = promisify(unzip)
+import {
+    PROTO_STREAM_EVENT_KINDS,
+    type ProtoStreamEvent,
+    streamProtoFields
+} from '@util/proto-stream'
+import { PROTO_WIRE_TYPES } from '@util/protoscan'
 
 const HANDLED_SYNC_TYPES = new Set([
     proto.Message.HistorySyncType.INITIAL_BOOTSTRAP,
@@ -25,8 +25,9 @@ const HANDLED_SYNC_TYPES = new Set([
     proto.Message.HistorySyncType.NON_BLOCKING_DATA
 ])
 const HISTORY_SYNC_MAX_PENDING_WRITES = 1_024
+const HISTORY_SYNC_MAX_RECORD_BYTES = 16 * 1024 * 1024
 
-const HISTORY_SYNC_FIELDS = Object.freeze({
+export const HISTORY_SYNC_FIELDS = Object.freeze({
     CONVERSATIONS: 2,
     CHUNK_ORDER: 5,
     PROGRESS: 6,
@@ -36,101 +37,16 @@ const HISTORY_SYNC_FIELDS = Object.freeze({
     INLINE_CONTACTS: 20
 } as const)
 
-const CONVERSATION_JID_FIELDS = Object.freeze({
-    PN_JID: 39,
-    LID_JID: 42,
-    ACCOUNT_LID: 49
+export const CONVERSATION_FIELDS = Object.freeze({
+    ID: 1,
+    MESSAGES: 2
 } as const)
 
-interface ByteRange {
-    readonly start: number
-    readonly end: number
-}
-
-interface HistorySyncScan {
-    readonly conversationRanges: readonly ByteRange[]
-    readonly pushnames: readonly Proto.IPushname[]
-    readonly inlineContacts: readonly Proto.IInlineContact[]
-    readonly phoneNumberToLidMappings: readonly Proto.IPhoneNumberToLIDMapping[]
-    readonly nctSalt: Uint8Array | null
-    readonly chunkOrder: number | null
-    readonly progress: number | null
-}
-
-export function scanHistorySyncBlob(bytes: Uint8Array): HistorySyncScan {
-    const conversationRanges: ByteRange[] = []
-    const pushnames: Proto.IPushname[] = []
-    const inlineContacts: Proto.IInlineContact[] = []
-    const phoneNumberToLidMappings: Proto.IPhoneNumberToLIDMapping[] = []
-    let nctSalt: Uint8Array | null = null
-    let chunkOrder: number | null = null
-    let progress: number | null = null
-
-    scanProtoFields(bytes, 0, bytes.length, (field) => {
-        if (field.wireType === PROTO_WIRE_TYPES.LEN) {
-            if (field.fieldNumber === HISTORY_SYNC_FIELDS.CONVERSATIONS) {
-                conversationRanges[conversationRanges.length] = {
-                    start: field.valueStart,
-                    end: field.valueEnd
-                }
-            } else if (field.fieldNumber === HISTORY_SYNC_FIELDS.PUSHNAMES) {
-                pushnames[pushnames.length] = proto.Pushname.decode(
-                    bytes.subarray(field.valueStart, field.valueEnd)
-                )
-            } else if (field.fieldNumber === HISTORY_SYNC_FIELDS.PHONE_NUMBER_TO_LID_MAPPINGS) {
-                phoneNumberToLidMappings[phoneNumberToLidMappings.length] =
-                    proto.PhoneNumberToLIDMapping.decode(
-                        bytes.subarray(field.valueStart, field.valueEnd)
-                    )
-            } else if (field.fieldNumber === HISTORY_SYNC_FIELDS.INLINE_CONTACTS) {
-                inlineContacts[inlineContacts.length] = proto.InlineContact.decode(
-                    bytes.subarray(field.valueStart, field.valueEnd)
-                )
-            } else if (field.fieldNumber === HISTORY_SYNC_FIELDS.NCT_SALT) {
-                nctSalt = bytes.slice(field.valueStart, field.valueEnd)
-            }
-            return
-        }
-        if (field.wireType === PROTO_WIRE_TYPES.VARINT) {
-            if (field.fieldNumber === HISTORY_SYNC_FIELDS.CHUNK_ORDER) {
-                chunkOrder = field.varintValue
-            } else if (field.fieldNumber === HISTORY_SYNC_FIELDS.PROGRESS) {
-                progress = field.varintValue
-            }
-        }
-    })
-
-    return {
-        conversationRanges,
-        pushnames,
-        inlineContacts,
-        phoneNumberToLidMappings,
-        nctSalt,
-        chunkOrder,
-        progress
-    }
-}
-
-export function scanConversationJidPair(
-    bytes: Uint8Array,
-    range: ByteRange
-): { readonly pnJid: string | null; readonly lidJid: string | null } {
-    let pnJid: string | null = null
-    let lidJid: string | null = null
-    let accountLid: string | null = null
-    scanProtoFields(bytes, range.start, range.end, (field) => {
-        if (field.wireType !== PROTO_WIRE_TYPES.LEN) {
-            return
-        }
-        if (field.fieldNumber === CONVERSATION_JID_FIELDS.PN_JID) {
-            pnJid = TEXT_DECODER.decode(bytes.subarray(field.valueStart, field.valueEnd))
-        } else if (field.fieldNumber === CONVERSATION_JID_FIELDS.LID_JID) {
-            lidJid = TEXT_DECODER.decode(bytes.subarray(field.valueStart, field.valueEnd))
-        } else if (field.fieldNumber === CONVERSATION_JID_FIELDS.ACCOUNT_LID) {
-            accountLid = TEXT_DECODER.decode(bytes.subarray(field.valueStart, field.valueEnd))
-        }
-    })
-    return { pnJid, lidJid: lidJid ?? accountLid }
+interface WaHistorySyncPrivacyTokenConversation {
+    readonly jid: string
+    readonly tcToken?: Uint8Array | null
+    readonly tcTokenTimestamp?: number | null
+    readonly tcTokenSenderTimestamp?: number | null
 }
 
 interface WaHistorySyncDeps {
@@ -143,22 +59,33 @@ interface WaHistorySyncDeps {
         ...args: Parameters<WaClientEventMap[K]>
     ) => void
     readonly onPrivacyTokens?: (
-        conversations: readonly {
-            readonly jid: string
-            readonly tcToken?: Uint8Array | null
-            readonly tcTokenTimestamp?: number | null
-            readonly tcTokenSenderTimestamp?: number | null
-        }[]
+        conversations: readonly WaHistorySyncPrivacyTokenConversation[]
     ) => Promise<void>
     readonly onNctSalt?: (salt: Uint8Array) => Promise<void>
-    /**
-     * Invoked once per recognized chunk after it has been fully processed (or
-     * after the early-return for `INITIAL_STATUS_V3` and other recognized-but-
-     * unhandled types). The WaClient wires this to the `hist_sync` receipt
-     * stanza required by wa-web so the primary device does not keep resending
-     * the same chunk.
-     */
+    /** Acks the chunk via the `hist_sync` receipt so the primary stops resending it. */
     readonly onProcessed?: (syncType: Proto.Message.HistorySyncType) => Promise<void>
+}
+
+interface ParkedHistoryMessage {
+    readonly id: string
+    readonly senderJid: string | undefined
+    readonly fromMe: boolean
+    readonly timestampMs: number | undefined
+    readonly messageBytes: Uint8Array
+}
+
+interface HistorySyncChunkState {
+    readonly nowMs: number
+    readonly pendingWrites: Promise<void>[]
+    readonly pushnames: Proto.IPushname[]
+    readonly inlineContacts: Proto.IInlineContact[]
+    readonly pnToLid: Map<string, string>
+    readonly tokenConversations: WaHistorySyncPrivacyTokenConversation[]
+    nctSalt: Uint8Array | null
+    chunkOrder: number | null
+    progress: number | null
+    conversationsCount: number
+    messagesCount: number
 }
 
 export async function runHistorySyncNotification(
@@ -176,6 +103,11 @@ export async function runHistorySyncNotification(
     }
 }
 
+/**
+ * Applies one history sync chunk while it downloads, descending into
+ * `conversations` so peak memory tracks the largest single message and not the
+ * chunk. Chunk-wide records settle after the stream, once every LID mapping is in.
+ */
 export async function processHistorySyncNotification(
     deps: WaHistorySyncDeps,
     notification: Proto.Message.IHistorySyncNotification
@@ -187,159 +119,248 @@ export async function processHistorySyncNotification(
     }
     if (!HANDLED_SYNC_TYPES.has(syncType)) {
         deps.logger.debug('skipping unhandled history sync type', { syncType })
-        // INITIAL_STATUS_V3 is the only recognized syncType we do not process today;
-        // still ack it so the primary device does not keep resending the same chunk.
         if (syncType === proto.Message.HistorySyncType.INITIAL_STATUS_V3 && deps.onProcessed) {
             await deps.onProcessed(syncType)
         }
         return
     }
 
-    const blob = await downloadHistorySyncBlob(deps, notification)
-    const decompressed = toBytesView(await unzipAsync(blob))
-    // Conversations are decoded one record at a time in the loop below so the
-    // full message graph never coexists in memory; the scan only records their
-    // byte ranges and decodes the small metadata fields.
-    const scan = scanHistorySyncBlob(decompressed)
+    const blob = await openHistoryBlobStream(
+        deps.mediaTransfer,
+        notification,
+        'history',
+        'history sync',
+        notification.initialHistBootstrapInlinePayload
+    )
+
+    const state: HistorySyncChunkState = {
+        nowMs: Date.now(),
+        pendingWrites: [],
+        pushnames: [],
+        inlineContacts: [],
+        pnToLid: new Map<string, string>(),
+        tokenConversations: [],
+        nctSalt: null,
+        chunkOrder: null,
+        progress: null,
+        conversationsCount: 0,
+        messagesCount: 0
+    }
+
+    try {
+        await consumeHistorySyncStream(deps, blob.inflated, state)
+    } catch (error) {
+        blob.inflated.destroy(toError(error))
+        await Promise.allSettled(state.pendingWrites)
+        await blob.verified.catch(() => undefined)
+        throw toError(error)
+    }
+
+    await blob.verified
+
+    await settleHistorySyncChunk(deps, state)
 
     deps.logger.info('decoded history sync chunk', {
         syncType,
-        chunkOrder: scan.chunkOrder,
-        progress: scan.progress,
-        conversations: scan.conversationRanges.length,
-        pushnames: scan.pushnames.length,
-        inlineContacts: scan.inlineContacts.length
+        chunkOrder: state.chunkOrder,
+        progress: state.progress,
+        conversations: state.conversationsCount,
+        messages: state.messagesCount,
+        pushnames: state.pushnames.length,
+        inlineContacts: state.inlineContacts.length
     })
 
-    const nowMs = Date.now()
-    const pendingWrites: Promise<void>[] = []
+    const event: WaHistorySyncChunkEvent = {
+        syncType,
+        messagesCount: state.messagesCount,
+        conversationsCount: state.conversationsCount,
+        pushnamesCount: state.pushnames.length,
+        inlineContactsCount: state.inlineContacts.length,
+        chunkOrder: state.chunkOrder ?? undefined,
+        progress: state.progress ?? undefined
+    }
+    await flushPendingWrites(state.pendingWrites)
+    deps.emitEvent('history_sync_chunk', event)
+    if (deps.onProcessed) {
+        await deps.onProcessed(syncType)
+    }
+}
 
-    // Build PN -> LID lookup from this chunk's mappings (and inline contacts
-    // and conversation-level pn/lid pairs, which carry the same pair) so
-    // pushnames and mappings land on a single canonical (LID-form) contact
-    // row instead of two mirror rows (one keyed by PN, one keyed by LID).
-    const pnToLid = new Map<string, string>()
-    for (const map of scan.phoneNumberToLidMappings) {
-        if (map.pnJid && map.lidJid) {
-            pnToLid.set(map.pnJid, map.lidJid)
-        }
-    }
-    for (const c of scan.inlineContacts) {
-        if (c.pnJid && c.lidJid) {
-            pnToLid.set(c.pnJid, c.lidJid)
-        }
-    }
-    for (const range of scan.conversationRanges) {
-        const pair = scanConversationJidPair(decompressed, range)
-        if (pair.pnJid && pair.lidJid) {
-            pnToLid.set(pair.pnJid, pair.lidJid)
-        }
-    }
+async function consumeHistorySyncStream(
+    deps: WaHistorySyncDeps,
+    inflated: Parameters<typeof streamProtoFields>[0],
+    state: HistorySyncChunkState
+): Promise<void> {
+    let headerParts: Uint8Array[] | null = null
+    let threadJid: string | null = null
+    let parked: ParkedHistoryMessage[] | null = null
 
-    for (const pn of scan.pushnames) {
-        if (!pn.id) {
-            continue
-        }
-        const lidJid = pnToLid.get(pn.id)
-        pendingWrites[pendingWrites.length] = deps.writeBehind.persistContactAsync(
-            lidJid
-                ? {
-                      jid: lidJid,
-                      pushName: pn.pushname ?? undefined,
-                      phoneNumber: pn.id,
-                      lastUpdatedMs: nowMs
-                  }
-                : {
-                      jid: pn.id,
-                      pushName: pn.pushname ?? undefined,
-                      lastUpdatedMs: nowMs
-                  }
-        )
-        if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
-            await flushPendingWrites(pendingWrites)
-        }
-    }
-
-    for (const c of scan.inlineContacts) {
-        const jid = c.lidJid ?? c.pnJid
-        if (!jid) {
-            continue
-        }
-        const displayName = c.fullName || c.firstName || undefined
-        if (!displayName && !c.pnJid) {
-            continue
-        }
-        pendingWrites[pendingWrites.length] = deps.writeBehind.persistContactAsync({
-            jid,
-            displayName,
-            phoneNumber: c.pnJid ?? undefined,
-            lastUpdatedMs: nowMs
-        })
-        if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
-            await flushPendingWrites(pendingWrites)
-        }
-    }
-
-    let messagesCount = 0
-    const tokenConversations: {
-        readonly jid: string
-        readonly tcToken?: Uint8Array | null
-        readonly tcTokenTimestamp?: number | null
-        readonly tcTokenSenderTimestamp?: number | null
-    }[] = []
-    for (const range of scan.conversationRanges) {
-        let conversation: Proto.Conversation
-        try {
-            conversation = proto.Conversation.decode(decompressed.subarray(range.start, range.end))
-        } catch (error) {
-            await Promise.allSettled(pendingWrites)
-            throw toError(error)
-        }
-        const threadJid = conversation.id
-        if (!threadJid) {
-            deps.logger.debug('skipping history sync conversation without thread jid')
-            continue
+    const onEvent = (event: ProtoStreamEvent): void | Promise<void> => {
+        if (event.kind === PROTO_STREAM_EVENT_KINDS.ENTER) {
+            headerParts = []
+            threadJid = null
+            parked = null
+            state.conversationsCount += 1
+            return undefined
         }
 
-        if (
-            deps.onPrivacyTokens &&
-            (conversation.tcToken ||
-                conversation.tcTokenTimestamp ||
-                conversation.tcTokenSenderTimestamp)
-        ) {
-            tokenConversations[tokenConversations.length] = {
-                jid: threadJid,
-                tcToken: conversation.tcToken ? new Uint8Array(conversation.tcToken) : undefined,
-                tcTokenTimestamp: longToNumber(conversation.tcTokenTimestamp) || undefined,
-                tcTokenSenderTimestamp:
-                    longToNumber(conversation.tcTokenSenderTimestamp) || undefined
+        if (event.kind === PROTO_STREAM_EVENT_KINDS.LEAVE) {
+            const parts = headerParts
+            const jid = threadJid
+            const pending = parked
+            headerParts = null
+            threadJid = null
+            parked = null
+            return parts ? closeConversation(deps, state, parts, jid, pending) : undefined
+        }
+
+        if (event.depth === 1) {
+            if (
+                event.fieldNumber === CONVERSATION_FIELDS.MESSAGES &&
+                event.wireType === PROTO_WIRE_TYPES.LEN
+            ) {
+                const message = readHistoryMessage(event.value)
+                if (!message) {
+                    return undefined
+                }
+                state.messagesCount += 1
+                if (!threadJid) {
+                    parked ??= []
+                    parked[parked.length] = message
+                    return undefined
+                }
+                pushWrite(
+                    state,
+                    deps.writeBehind.persistMessageAsync({
+                        id: message.id,
+                        threadJid,
+                        senderJid: message.senderJid,
+                        fromMe: message.fromMe,
+                        timestampMs: message.timestampMs,
+                        messageBytes: message.messageBytes
+                    })
+                )
+                return maybeFlush(state)
             }
+
+            if (headerParts) {
+                if (
+                    event.fieldNumber === CONVERSATION_FIELDS.ID &&
+                    event.wireType === PROTO_WIRE_TYPES.LEN
+                ) {
+                    threadJid = TEXT_DECODER.decode(event.value)
+                }
+                headerParts[headerParts.length] = event.raw.slice()
+            }
+            return undefined
         }
 
-        const ephemeralExpiration = conversation.ephemeralExpiration ?? undefined
-        const ephemeralSettingTimestamp =
-            normalizeEphemeralSettingSeconds(
-                longToNumber(conversation.ephemeralSettingTimestamp)
-            ) || undefined
-        if (deps.chatMetadataStore && ephemeralExpiration !== undefined) {
-            pendingWrites[pendingWrites.length] = deps.chatMetadataStore
+        if (event.depth !== 0) {
+            return undefined
+        }
+
+        if (event.wireType === PROTO_WIRE_TYPES.VARINT) {
+            if (event.fieldNumber === HISTORY_SYNC_FIELDS.CHUNK_ORDER) {
+                state.chunkOrder = event.varintValue
+            } else if (event.fieldNumber === HISTORY_SYNC_FIELDS.PROGRESS) {
+                state.progress = event.varintValue
+            }
+            return undefined
+        }
+
+        if (event.wireType !== PROTO_WIRE_TYPES.LEN) {
+            return undefined
+        }
+
+        if (event.fieldNumber === HISTORY_SYNC_FIELDS.PUSHNAMES) {
+            state.pushnames[state.pushnames.length] = proto.Pushname.decode(event.value)
+        } else if (event.fieldNumber === HISTORY_SYNC_FIELDS.PHONE_NUMBER_TO_LID_MAPPINGS) {
+            const map = proto.PhoneNumberToLIDMapping.decode(event.value)
+            if (map.pnJid && map.lidJid) {
+                state.pnToLid.set(map.pnJid, map.lidJid)
+            }
+        } else if (event.fieldNumber === HISTORY_SYNC_FIELDS.INLINE_CONTACTS) {
+            const contact = proto.InlineContact.decode(event.value)
+            state.inlineContacts[state.inlineContacts.length] = contact
+            if (contact.pnJid && contact.lidJid) {
+                state.pnToLid.set(contact.pnJid, contact.lidJid)
+            }
+        } else if (event.fieldNumber === HISTORY_SYNC_FIELDS.NCT_SALT) {
+            state.nctSalt = event.value.slice()
+        }
+        return undefined
+    }
+
+    await streamProtoFields(inflated, onEvent, {
+        shouldDescend: (fieldNumber, depth) =>
+            depth === 0 && fieldNumber === HISTORY_SYNC_FIELDS.CONVERSATIONS,
+        maxFieldBytes: HISTORY_SYNC_MAX_RECORD_BYTES
+    })
+}
+
+async function closeConversation(
+    deps: WaHistorySyncDeps,
+    state: HistorySyncChunkState,
+    headerParts: readonly Uint8Array[],
+    threadJid: string | null,
+    parked: readonly ParkedHistoryMessage[] | null
+): Promise<void> {
+    const conversation = proto.Conversation.decode(concatBytes(headerParts))
+    const resolvedJid = threadJid ?? conversation.id
+    if (!resolvedJid) {
+        deps.logger.debug('skipping history sync conversation without thread jid')
+        return
+    }
+
+    if (conversation.pnJid) {
+        const lidJid = conversation.lidJid ?? conversation.accountLid
+        if (lidJid) {
+            state.pnToLid.set(conversation.pnJid, lidJid)
+        }
+    }
+
+    if (
+        deps.onPrivacyTokens &&
+        (conversation.tcToken ||
+            conversation.tcTokenTimestamp ||
+            conversation.tcTokenSenderTimestamp)
+    ) {
+        state.tokenConversations[state.tokenConversations.length] = {
+            jid: resolvedJid,
+            tcToken: conversation.tcToken ? new Uint8Array(conversation.tcToken) : undefined,
+            tcTokenTimestamp: longToNumber(conversation.tcTokenTimestamp) || undefined,
+            tcTokenSenderTimestamp: longToNumber(conversation.tcTokenSenderTimestamp) || undefined
+        }
+    }
+
+    const ephemeralExpiration = conversation.ephemeralExpiration ?? undefined
+    const ephemeralSettingTimestamp =
+        normalizeEphemeralSettingSeconds(longToNumber(conversation.ephemeralSettingTimestamp)) ||
+        undefined
+    if (deps.chatMetadataStore && ephemeralExpiration !== undefined) {
+        pushWrite(
+            state,
+            deps.chatMetadataStore
                 .upsertChatMetadata({
-                    chatJid: threadJid,
+                    chatJid: resolvedJid,
                     ephemeralExpiration,
                     ...(ephemeralSettingTimestamp !== undefined
                         ? { ephemeralSettingTimestamp }
                         : {}),
-                    updatedAtMs: nowMs
+                    updatedAtMs: state.nowMs
                 })
                 .catch((error: unknown) => {
                     deps.logger.debug('failed to cache history sync chat metadata', {
-                        jid: threadJid,
+                        jid: resolvedJid,
                         message: toError(error).message
                     })
                 })
-        }
-        pendingWrites[pendingWrites.length] = deps.writeBehind.persistThreadAsync({
-            jid: threadJid,
+        )
+    }
+    pushWrite(
+        state,
+        deps.writeBehind.persistThreadAsync({
+            jid: resolvedJid,
             name: conversation.name ?? undefined,
             unreadCount: conversation.unreadCount ?? undefined,
             archived: conversation.archived ?? undefined,
@@ -349,98 +370,137 @@ export async function processHistorySyncNotification(
             ephemeralExpiration,
             ephemeralSettingTimestamp
         })
-        if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
-            await flushPendingWrites(pendingWrites)
-        }
+    )
 
-        if (isUserJid(threadJid) || (conversation.lidJid ?? conversation.accountLid)) {
-            const contactDisplay = conversation.displayName || conversation.username || undefined
-            const contactPn = conversation.pnJid ?? undefined
-            const contactLid = conversation.lidJid ?? conversation.accountLid ?? undefined
-            if (contactDisplay || contactPn || contactLid) {
-                const contactJid = contactLid ?? threadJid
-                pendingWrites[pendingWrites.length] = deps.writeBehind.persistContactAsync({
-                    jid: contactJid,
+    if (isUserJid(resolvedJid) || (conversation.lidJid ?? conversation.accountLid)) {
+        const contactDisplay = conversation.displayName || conversation.username || undefined
+        const contactPn = conversation.pnJid ?? undefined
+        const contactLid = conversation.lidJid ?? conversation.accountLid ?? undefined
+        if (contactDisplay || contactPn || contactLid) {
+            pushWrite(
+                state,
+                deps.writeBehind.persistContactAsync({
+                    jid: contactLid ?? resolvedJid,
                     displayName: contactDisplay,
                     phoneNumber: contactPn,
-                    lastUpdatedMs: nowMs
+                    lastUpdatedMs: state.nowMs
                 })
-                if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
-                    await flushPendingWrites(pendingWrites)
-                }
-            }
+            )
         }
-        for (const histMsg of conversation.messages ?? []) {
-            const webMsg = histMsg.message
-            if (!webMsg?.key?.id || !webMsg.message) {
-                // Stubs (group system events: add/remove/promote, revokes, ephemeral toggles)
-                // arrive as WebMessageInfo with a key + messageStubType but no `.message`. They
-                // duplicate live `notification` stanzas that the client already processes, and
-                // storing them as content-less rows produces "ghost" entries — skip them here.
-                continue
-            }
-            const timestampMs = longToNumber(webMsg.messageTimestamp) * 1000
-            pendingWrites[pendingWrites.length] = deps.writeBehind.persistMessageAsync({
-                id: webMsg.key.id,
-                threadJid,
-                senderJid: webMsg.key.participant ?? undefined,
-                fromMe: webMsg.key.fromMe === true,
-                timestampMs: timestampMs || undefined,
-                messageBytes: proto.Message.encode(webMsg.message).finish()
+    }
+
+    for (const message of parked ?? []) {
+        pushWrite(
+            state,
+            deps.writeBehind.persistMessageAsync({
+                id: message.id,
+                threadJid: resolvedJid,
+                senderJid: message.senderJid,
+                fromMe: message.fromMe,
+                timestampMs: message.timestampMs,
+                messageBytes: message.messageBytes
             })
-            if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
-                await flushPendingWrites(pendingWrites)
-            }
-            messagesCount += 1
+        )
+    }
+
+    await maybeFlush(state)
+}
+
+async function settleHistorySyncChunk(
+    deps: WaHistorySyncDeps,
+    state: HistorySyncChunkState
+): Promise<void> {
+    for (const pushname of state.pushnames) {
+        if (!pushname.id) {
+            continue
         }
+        const lidJid = state.pnToLid.get(pushname.id)
+        pushWrite(
+            state,
+            deps.writeBehind.persistContactAsync(
+                lidJid
+                    ? {
+                          jid: lidJid,
+                          pushName: pushname.pushname ?? undefined,
+                          phoneNumber: pushname.id,
+                          lastUpdatedMs: state.nowMs
+                      }
+                    : {
+                          jid: pushname.id,
+                          pushName: pushname.pushname ?? undefined,
+                          lastUpdatedMs: state.nowMs
+                      }
+            )
+        )
+        await maybeFlush(state)
     }
 
-    // Persist LID<->PN mappings as a single LID-canonical row per contact.
-    // Lookups by PN form fall through to `getByPhoneNumber` via the secondary
-    // index, so the mirror PN row is no longer needed.
-    for (const [pnJid, lidJid] of pnToLid) {
-        pendingWrites[pendingWrites.length] = deps.writeBehind.persistContactAsync({
-            jid: lidJid,
-            phoneNumber: pnJid,
-            lastUpdatedMs: nowMs
-        })
-        if (pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
-            await flushPendingWrites(pendingWrites)
+    for (const contact of state.inlineContacts) {
+        const jid = contact.lidJid ?? contact.pnJid
+        if (!jid) {
+            continue
         }
+        const displayName = contact.fullName || contact.firstName || undefined
+        if (!displayName && !contact.pnJid) {
+            continue
+        }
+        pushWrite(
+            state,
+            deps.writeBehind.persistContactAsync({
+                jid,
+                displayName,
+                phoneNumber: contact.pnJid ?? undefined,
+                lastUpdatedMs: state.nowMs
+            })
+        )
+        await maybeFlush(state)
     }
 
-    if (deps.onPrivacyTokens && tokenConversations.length > 0) {
-        pendingWrites[pendingWrites.length] = deps.onPrivacyTokens(tokenConversations)
-    }
-    if (deps.onNctSalt && scan.nctSalt) {
-        pendingWrites[pendingWrites.length] = deps.onNctSalt(scan.nctSalt)
+    for (const [pnJid, lidJid] of state.pnToLid) {
+        pushWrite(
+            state,
+            deps.writeBehind.persistContactAsync({
+                jid: lidJid,
+                phoneNumber: pnJid,
+                lastUpdatedMs: state.nowMs
+            })
+        )
+        await maybeFlush(state)
     }
 
-    const event: WaHistorySyncChunkEvent = {
-        syncType,
-        messagesCount,
-        conversationsCount: scan.conversationRanges.length,
-        pushnamesCount: scan.pushnames.length,
-        inlineContactsCount: scan.inlineContacts.length,
-        chunkOrder: scan.chunkOrder ?? undefined,
-        progress: scan.progress ?? undefined
+    if (deps.onPrivacyTokens && state.tokenConversations.length > 0) {
+        pushWrite(state, deps.onPrivacyTokens(state.tokenConversations))
     }
-    await flushPendingWrites(pendingWrites)
-    deps.emitEvent('history_sync_chunk', event)
-    if (deps.onProcessed) {
-        await deps.onProcessed(syncType)
+    if (deps.onNctSalt && state.nctSalt) {
+        pushWrite(state, deps.onNctSalt(state.nctSalt))
     }
 }
 
-async function downloadHistorySyncBlob(
-    deps: WaHistorySyncDeps,
-    notification: Proto.Message.IHistorySyncNotification
-): Promise<Uint8Array> {
-    if (notification.initialHistBootstrapInlinePayload) {
-        return decodeProtoBytes(
-            notification.initialHistBootstrapInlinePayload,
-            'initialHistBootstrapInlinePayload'
-        )
+/** `null` for content-less stubs, which duplicate live notification stanzas. */
+function readHistoryMessage(record: Uint8Array): ParkedHistoryMessage | null {
+    const webMsg = proto.HistorySyncMsg.decode(record).message
+    if (!webMsg?.key?.id || !webMsg.message) {
+        return null
     }
-    return downloadHistoryBlob(deps.mediaTransfer, notification, 'history', 'history sync')
+    const timestampMs = longToNumber(webMsg.messageTimestamp) * 1000
+    return {
+        id: webMsg.key.id,
+        senderJid: webMsg.key.participant ?? undefined,
+        fromMe: webMsg.key.fromMe === true,
+        timestampMs: timestampMs || undefined,
+        messageBytes: proto.Message.encode(webMsg.message).finish()
+    }
+}
+
+/** The no-op handler keeps a queued rejection observed until the flush rejects on it. */
+function pushWrite(state: HistorySyncChunkState, write: Promise<void>): void {
+    write.catch(() => undefined)
+    state.pendingWrites[state.pendingWrites.length] = write
+}
+
+function maybeFlush(state: HistorySyncChunkState): Promise<void> | undefined {
+    if (state.pendingWrites.length >= HISTORY_SYNC_MAX_PENDING_WRITES) {
+        return flushPendingWrites(state.pendingWrites)
+    }
+    return undefined
 }

--- a/src/message/kinds/__tests__/group-history.test.ts
+++ b/src/message/kinds/__tests__/group-history.test.ts
@@ -153,3 +153,39 @@ test('streamGroupHistoryBundle rejects a truncated stream', async () => {
         /unexpected end of protobuf stream/
     )
 })
+
+test('streamGroupHistoryBundle hands out messages that survive the walk', async () => {
+    // The payload has to outgrow the reader's buffer, otherwise it never
+    // compacts and a retained alias is never overwritten.
+    const secret = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+    const messages: Proto.IWebMessageInfo[] = []
+    for (let index = 0; index < 2_000; index += 1) {
+        messages.push({
+            key: { id: `S${index}`, remoteJid: groupJid, fromMe: false },
+            message: { conversation: `body ${index} ${'x'.repeat(80)}` },
+            messageTimestamp: 100 + index,
+            messageSecret: secret
+        })
+    }
+    const inflated = proto.GroupHistory.encode({ messages }).finish()
+    assert.ok(inflated.length > 64 * 1024, 'fixture must exceed the reader buffer')
+
+    const chunks: Buffer[] = []
+    for (let offset = 0; offset < inflated.length; offset += 64) {
+        chunks.push(Buffer.from(inflated.subarray(offset, Math.min(offset + 64, inflated.length))))
+    }
+
+    const retained: Proto.WebMessageInfo[] = []
+    await streamGroupHistoryBundle(Readable.from(chunks), (message) => {
+        retained.push(message)
+    })
+
+    assert.equal(retained.length, 2_000)
+    for (const message of retained) {
+        assert.deepEqual(
+            Array.from(message.messageSecret ?? []),
+            Array.from(secret),
+            'a retained message must not alias the reader buffer'
+        )
+    }
+})

--- a/src/message/kinds/__tests__/group-history.test.ts
+++ b/src/message/kinds/__tests__/group-history.test.ts
@@ -1,8 +1,16 @@
 import assert from 'node:assert/strict'
+import { Readable } from 'node:stream'
 import test from 'node:test'
+import { unzipSync } from 'node:zlib'
 
-import { decodeGroupHistoryBundle, encodeGroupHistoryBundle } from '@message/kinds/group-history'
-import type { Proto } from '@proto'
+import {
+    decodeGroupHistoryBundle,
+    encodeGroupHistoryBundle,
+    GROUP_HISTORY_FIELDS,
+    streamGroupHistoryBundle
+} from '@message/kinds/group-history'
+import { proto, type Proto } from '@proto'
+import { readProtoVarint } from '@util/protoscan'
 
 const groupJid = '120363000000000000@g.us'
 
@@ -53,4 +61,95 @@ test('encodeGroupHistoryBundle omits out-of-window pins when the list is empty',
 
 test('decodeGroupHistoryBundle rejects a blob that is not zlib', async () => {
     await assert.rejects(() => decodeGroupHistoryBundle(new Uint8Array([1, 2, 3, 4])))
+})
+
+async function collectStreamed(
+    inflated: Uint8Array,
+    maxRecordBytes?: number
+): Promise<{ id: string | null | undefined; outOfWindow: boolean }[]> {
+    const seen: { id: string | null | undefined; outOfWindow: boolean }[] = []
+    await streamGroupHistoryBundle(
+        Readable.from([Buffer.from(inflated)]),
+        (message, outOfWindow) => {
+            seen.push({ id: message.key?.id, outOfWindow })
+        },
+        maxRecordBytes
+    )
+    return seen
+}
+
+test('streamGroupHistoryBundle is equivalent to the buffered decode', async () => {
+    const inflated = proto.GroupHistory.encode({
+        messages: [buildMessage('A', 'first', 100), buildMessage('B', 'second', 200)],
+        commentMessages: [buildMessage('C', 'comment', 150)],
+        uncountedAssociatedMessageLists: [
+            {
+                parentMessage: { id: 'A', remoteJid: groupJid },
+                messages: [buildMessage('U', 'associated', 160)]
+            }
+        ],
+        outOfWindowPinnedMessages: [buildMessage('P', 'old pin', 1)]
+    }).finish()
+
+    const reference = proto.GroupHistory.decode(inflated)
+    const streamed = await collectStreamed(inflated)
+
+    assert.deepEqual(streamed, [
+        { id: 'A', outOfWindow: false },
+        { id: 'B', outOfWindow: false },
+        { id: 'P', outOfWindow: true }
+    ])
+    assert.deepEqual(
+        streamed.filter((entry) => !entry.outOfWindow).map((entry) => entry.id),
+        reference.messages.map((message) => message.key?.id),
+        'plain messages must match the buffered decode, in wire order'
+    )
+    assert.deepEqual(
+        streamed.filter((entry) => entry.outOfWindow).map((entry) => entry.id),
+        reference.outOfWindowPinnedMessages.map((message) => message.key?.id)
+    )
+})
+
+test('streamGroupHistoryBundle walks a real compressed bundle', async () => {
+    const { compressed } = await encodeGroupHistoryBundle(
+        [buildMessage('A', 'recent', 300)],
+        [buildMessage('P', 'old pin', 1)]
+    )
+    const streamed = await collectStreamed(new Uint8Array(unzipSync(Buffer.from(compressed))))
+    assert.deepEqual(streamed, [
+        { id: 'A', outOfWindow: false },
+        { id: 'P', outOfWindow: true }
+    ])
+})
+
+test('streamGroupHistoryBundle rejects a record above maxRecordBytes', async () => {
+    const inflated = proto.GroupHistory.encode({
+        messages: [buildMessage('A', 'a fairly long message body to push past the cap', 100)]
+    }).finish()
+    await assert.rejects(() => collectStreamed(inflated, 8), /exceeds the 8 byte limit/)
+})
+
+test('group history field numbers match the generated encoder', () => {
+    const fieldNumberOf = (value: Proto.IGroupHistory): number => {
+        const bytes = proto.GroupHistory.encode(value).finish()
+        assert.ok(bytes.length > 0, 'the probe field must actually be encoded')
+        return Math.floor(readProtoVarint(bytes, 0, bytes.length).value / 8)
+    }
+    assert.deepEqual(
+        {
+            MESSAGES: fieldNumberOf({ messages: [{}] }),
+            OUT_OF_WINDOW_PINNED_MESSAGES: fieldNumberOf({ outOfWindowPinnedMessages: [{}] })
+        },
+        { ...GROUP_HISTORY_FIELDS }
+    )
+})
+
+test('streamGroupHistoryBundle rejects a truncated stream', async () => {
+    const inflated = proto.GroupHistory.encode({
+        messages: [buildMessage('A', 'first', 100)]
+    }).finish()
+    await assert.rejects(
+        () => collectStreamed(inflated.subarray(0, inflated.length - 3)),
+        /unexpected end of protobuf stream/
+    )
 })

--- a/src/message/kinds/group-history.ts
+++ b/src/message/kinds/group-history.ts
@@ -64,7 +64,9 @@ export async function decodeGroupHistoryBundle(blob: Uint8Array): Promise<Proto.
 
 /**
  * `outOfWindow` marks a pinned message from outside the shared window, which the
- * receiver keeps regardless of the age cutoff.
+ * receiver keeps regardless of the age cutoff. The message is decoded from a
+ * private copy, so it stays valid after the handler returns; protobuf decoding
+ * aliases the source buffer for `bytes` fields, and the reader reuses its own.
  */
 export type WaGroupHistoryMessageHandler = (
     message: Proto.WebMessageInfo,
@@ -97,10 +99,10 @@ export async function streamGroupHistoryBundle(
                 return undefined
             }
             if (event.fieldNumber === GROUP_HISTORY_FIELDS.MESSAGES) {
-                return onMessage(proto.WebMessageInfo.decode(event.value), false)
+                return onMessage(proto.WebMessageInfo.decode(event.value.slice()), false)
             }
             if (event.fieldNumber === GROUP_HISTORY_FIELDS.OUT_OF_WINDOW_PINNED_MESSAGES) {
-                return onMessage(proto.WebMessageInfo.decode(event.value), true)
+                return onMessage(proto.WebMessageInfo.decode(event.value.slice()), true)
             }
             return undefined
         },

--- a/src/message/kinds/group-history.ts
+++ b/src/message/kinds/group-history.ts
@@ -1,11 +1,19 @@
+import type { Readable } from 'node:stream'
 import { promisify } from 'node:util'
 import { deflate, unzip } from 'node:zlib'
 
 import { proto, type Proto } from '@proto'
 import { toBytesView } from '@util/bytes'
+import { PROTO_STREAM_EVENT_KINDS, streamProtoFields } from '@util/proto-stream'
+import { PROTO_WIRE_TYPES } from '@util/protoscan'
 
 const deflateAsync = promisify(deflate)
 const unzipAsync = promisify(unzip)
+
+export const GROUP_HISTORY_FIELDS = Object.freeze({
+    MESSAGES: 1,
+    OUT_OF_WINDOW_PINNED_MESSAGES: 4
+} as const)
 
 /**
  * Wire form of a group-history bundle: the zlib-compressed blob that is
@@ -52,4 +60,50 @@ export async function encodeGroupHistoryBundle(
 export async function decodeGroupHistoryBundle(blob: Uint8Array): Promise<Proto.GroupHistory> {
     const inflated = toBytesView(await unzipAsync(blob))
     return proto.GroupHistory.decode(inflated)
+}
+
+/**
+ * `outOfWindow` marks a pinned message from outside the shared window, which the
+ * receiver keeps regardless of the age cutoff.
+ */
+export type WaGroupHistoryMessageHandler = (
+    message: Proto.WebMessageInfo,
+    outOfWindow: boolean
+) => void | Promise<void>
+
+/**
+ * Streaming counterpart of {@link decodeGroupHistoryBundle}: walks an inflated
+ * bundle and hands out one message at a time, so peak memory tracks the largest
+ * single message instead of the whole bundle. `GroupHistory` carries its messages
+ * as top-level repeated fields, so no record needs descending into.
+ *
+ * Comment messages and associated-message lists are skipped, matching what the
+ * buffered consumer reads.
+ *
+ * @throws when the stream is truncated or a record exceeds `maxRecordBytes`.
+ */
+export async function streamGroupHistoryBundle(
+    inflated: Readable,
+    onMessage: WaGroupHistoryMessageHandler,
+    maxRecordBytes?: number
+): Promise<void> {
+    await streamProtoFields(
+        inflated,
+        (event) => {
+            if (
+                event.kind !== PROTO_STREAM_EVENT_KINDS.FIELD ||
+                event.wireType !== PROTO_WIRE_TYPES.LEN
+            ) {
+                return undefined
+            }
+            if (event.fieldNumber === GROUP_HISTORY_FIELDS.MESSAGES) {
+                return onMessage(proto.WebMessageInfo.decode(event.value), false)
+            }
+            if (event.fieldNumber === GROUP_HISTORY_FIELDS.OUT_OF_WINDOW_PINNED_MESSAGES) {
+                return onMessage(proto.WebMessageInfo.decode(event.value), true)
+            }
+            return undefined
+        },
+        maxRecordBytes !== undefined ? { maxFieldBytes: maxRecordBytes } : {}
+    )
 }

--- a/src/util/__tests__/proto-stream.test.ts
+++ b/src/util/__tests__/proto-stream.test.ts
@@ -247,6 +247,47 @@ test('streamProtoFields skips a deprecated group', async () => {
     }
 })
 
+test('streamProtoFields rejects a varint that overruns its parent field', async () => {
+    const seen: number[] = []
+    const conversation = new Uint8Array([0x08, 0xff])
+    const blob = new Uint8Array([0x12, conversation.length, ...conversation, 0x28, 0x01])
+    await assert.rejects(
+        () =>
+            streamProtoFields(
+                chunked(blob, 3),
+                (event) => {
+                    seen.push(event.fieldNumber)
+                },
+                { shouldDescend: (fieldNumber, depth) => fieldNumber === 2 && depth === 0 }
+            ),
+        /overran its parent field/
+    )
+    assert.deepEqual(seen, [2], 'only the enter must have been delivered, never the bad field')
+})
+
+test('streamProtoFields rejects a fixed-width field that overruns its parent field', async () => {
+    const conversation = new Uint8Array([0x0d, 0x01, 0x02])
+    const blob = new Uint8Array([0x12, conversation.length, ...conversation, 0x28, 0x01])
+    await assert.rejects(
+        () =>
+            collect(blob, {
+                shouldDescend: (fieldNumber, depth) => fieldNumber === 2 && depth === 0
+            }),
+        /overran its parent field/
+    )
+})
+
+test('streamProtoFields caps descent depth', async () => {
+    let payload = new Uint8Array([0x08, 0x01])
+    for (let level = 0; level < 40; level += 1) {
+        payload = new Uint8Array([0x12, payload.length, ...payload])
+    }
+    await assert.rejects(
+        () => collect(payload, { shouldDescend: (fieldNumber) => fieldNumber === 2 }),
+        /descent exceeds the 32 level limit/
+    )
+})
+
 test('streamProtoFields handles an empty stream', async () => {
     assert.deepEqual(await collect(new Uint8Array(0)), [])
 })

--- a/src/util/__tests__/proto-stream.test.ts
+++ b/src/util/__tests__/proto-stream.test.ts
@@ -1,0 +1,252 @@
+import assert from 'node:assert/strict'
+import { Readable } from 'node:stream'
+import test from 'node:test'
+
+import { proto } from '@proto'
+import {
+    PROTO_STREAM_EVENT_KINDS,
+    type ProtoStreamEvent,
+    streamProtoFields
+} from '@util/proto-stream'
+import { PROTO_WIRE_TYPES, scanProtoFields } from '@util/protoscan'
+
+/** Splits `bytes` into fixed-size chunks so buffer refills land mid-field. */
+function chunked(bytes: Uint8Array, size: number): Readable {
+    const chunks: Uint8Array[] = []
+    for (let offset = 0; offset < bytes.byteLength; offset += size) {
+        chunks[chunks.length] = bytes.subarray(offset, Math.min(offset + size, bytes.byteLength))
+    }
+    return Readable.from(chunks.length > 0 ? chunks.map((c) => Buffer.from(c)) : [Buffer.alloc(0)])
+}
+
+async function collect(
+    bytes: Uint8Array,
+    options?: Parameters<typeof streamProtoFields>[2],
+    chunkSize = 7
+): Promise<ProtoStreamEvent[]> {
+    const events: ProtoStreamEvent[] = []
+    await streamProtoFields(
+        chunked(bytes, chunkSize),
+        (event) => {
+            events[events.length] =
+                event.kind === PROTO_STREAM_EVENT_KINDS.FIELD
+                    ? { ...event, value: event.value.slice(), raw: event.raw.slice() }
+                    : event
+        },
+        options
+    )
+    return events
+}
+
+const SAMPLE = proto.HistorySync.encode({
+    syncType: proto.HistorySync.HistorySyncType.RECENT,
+    chunkOrder: 4,
+    progress: 88,
+    nctSalt: new Uint8Array([9, 8, 7, 6]),
+    pushnames: [{ id: '5511111111111@s.whatsapp.net', pushname: 'Alice' }],
+    conversations: [
+        {
+            id: '5511111111111@s.whatsapp.net',
+            name: 'Alice',
+            unreadCount: 2,
+            messages: [
+                {
+                    message: {
+                        key: { remoteJid: '5511111111111@s.whatsapp.net', id: 'M1' },
+                        message: { conversation: 'oi' },
+                        messageTimestamp: 1_722_000_000
+                    }
+                },
+                {
+                    message: {
+                        key: { remoteJid: '5511111111111@s.whatsapp.net', id: 'M2' },
+                        message: { conversation: 'tudo bem' },
+                        messageTimestamp: 1_722_000_001
+                    }
+                }
+            ]
+        },
+        { id: '123@g.us', messages: [] }
+    ]
+}).finish()
+
+test('streamProtoFields matches scanProtoFields on the top-level fields', async () => {
+    const expected: string[] = []
+    scanProtoFields(SAMPLE, 0, SAMPLE.length, (field) => {
+        expected[expected.length] = `${field.fieldNumber}/${field.wireType}/${field.varintValue}`
+    })
+
+    const events = await collect(SAMPLE)
+    const actual = events.map(
+        (event) =>
+            `${event.fieldNumber}/${event.kind === PROTO_STREAM_EVENT_KINDS.FIELD ? event.wireType : PROTO_WIRE_TYPES.LEN}/${
+                event.kind === PROTO_STREAM_EVENT_KINDS.FIELD ? event.varintValue : 0
+            }`
+    )
+    assert.deepEqual(actual, expected)
+})
+
+test('streamProtoFields yields identical results at every chunk boundary', async () => {
+    const reference = await collect(SAMPLE, undefined, SAMPLE.byteLength)
+    const flatten = (events: readonly ProtoStreamEvent[]): string =>
+        events
+            .map((event) =>
+                event.kind === PROTO_STREAM_EVENT_KINDS.FIELD
+                    ? `F${event.fieldNumber}:${event.wireType}:${event.depth}:${event.varintValue}:${Buffer.from(event.value).toString('hex')}`
+                    : `${event.kind}${event.fieldNumber}:${event.depth}`
+            )
+            .join('|')
+    const expected = flatten(reference)
+
+    for (const size of [1, 2, 3, 5, 13, 64, 1024]) {
+        const events = await collect(SAMPLE, undefined, size)
+        assert.equal(flatten(events), expected, `chunk size ${size}`)
+    }
+})
+
+test('streamProtoFields descends without materializing the container', async () => {
+    const events = await collect(SAMPLE, {
+        shouldDescend: (fieldNumber, depth) => fieldNumber === 2 && depth === 0
+    })
+
+    const enters = events.filter((event) => event.kind === PROTO_STREAM_EVENT_KINDS.ENTER)
+    const leaves = events.filter((event) => event.kind === PROTO_STREAM_EVENT_KINDS.LEAVE)
+    assert.equal(enters.length, 2, 'one enter per conversation')
+    assert.equal(leaves.length, 2, 'every enter is closed')
+    assert.equal(
+        events.some(
+            (event) =>
+                event.kind === PROTO_STREAM_EVENT_KINDS.FIELD &&
+                event.depth === 0 &&
+                event.fieldNumber === 2
+        ),
+        false,
+        'a descended field must never be delivered as a materialized value'
+    )
+
+    const messageRecords = events.filter(
+        (event) =>
+            event.kind === PROTO_STREAM_EVENT_KINDS.FIELD &&
+            event.depth === 1 &&
+            event.fieldNumber === 2
+    )
+    assert.equal(messageRecords.length, 2)
+    const ids = messageRecords.map((event) =>
+        event.kind === PROTO_STREAM_EVENT_KINDS.FIELD
+            ? proto.HistorySyncMsg.decode(event.value).message?.key?.id
+            : null
+    )
+    assert.deepEqual(ids, ['M1', 'M2'])
+})
+
+test('streamProtoFields raw bytes re-encode into a decodable subset message', async () => {
+    const events = await collect(SAMPLE, {
+        shouldDescend: (fieldNumber, depth) => fieldNumber === 2 && depth === 0
+    })
+
+    const parts: Uint8Array[] = []
+    let seenEnter = false
+    for (const event of events) {
+        if (event.kind === PROTO_STREAM_EVENT_KINDS.ENTER) {
+            if (seenEnter) break
+            seenEnter = true
+            continue
+        }
+        if (event.kind !== PROTO_STREAM_EVENT_KINDS.FIELD || event.depth !== 1) {
+            continue
+        }
+        if (event.fieldNumber === 2) {
+            continue
+        }
+        parts[parts.length] = event.raw
+    }
+    const header = Buffer.concat(parts.map((part) => Buffer.from(part)))
+    const conversation = proto.Conversation.decode(header)
+    assert.equal(conversation.id, '5511111111111@s.whatsapp.net')
+    assert.equal(conversation.name, 'Alice')
+    assert.equal(conversation.unreadCount, 2)
+    assert.equal(conversation.messages.length, 0, 'messages must be excluded from the subset')
+})
+
+test('streamProtoFields skips unknown fields by wire type', async () => {
+    const unknownVarint = new Uint8Array([0xf8, 0x1f, 0x2a])
+    const unknownLen = new Uint8Array([0xfa, 0x1f, 0x02, 0xde, 0xad])
+    const unknownFixed32 = new Uint8Array([0xfd, 0x1f, 0x01, 0x02, 0x03, 0x04])
+    const unknownFixed64 = new Uint8Array([0xf9, 0x1f, 1, 2, 3, 4, 5, 6, 7, 8])
+    const known = proto.Pushname.encode({ id: 'a@s.whatsapp.net', pushname: 'A' }).finish()
+    const blob = Buffer.concat([
+        Buffer.from(unknownVarint),
+        Buffer.from(known),
+        Buffer.from(unknownFixed32),
+        Buffer.from(unknownLen),
+        Buffer.from(unknownFixed64)
+    ])
+
+    const events = await collect(new Uint8Array(blob), undefined, 3)
+    assert.deepEqual(
+        events.map((event) => event.fieldNumber),
+        [511, 1, 2, 511, 511, 511]
+    )
+})
+
+test('streamProtoFields rejects a materialized field above maxFieldBytes', async () => {
+    await assert.rejects(() => collect(SAMPLE, { maxFieldBytes: 8 }), /exceeds the 8 byte limit/)
+})
+
+test('streamProtoFields exempts descended fields from maxFieldBytes', async () => {
+    const events = await collect(SAMPLE, {
+        maxFieldBytes: 64,
+        shouldDescend: (fieldNumber, depth) => fieldNumber === 2 && depth === 0
+    })
+    assert.ok(
+        events.some((event) => event.kind === PROTO_STREAM_EVENT_KINDS.ENTER),
+        'the oversized conversation must still be walked'
+    )
+})
+
+test('streamProtoFields rejects a truncated stream', async () => {
+    await assert.rejects(
+        () => collect(SAMPLE.subarray(0, SAMPLE.byteLength - 4), undefined, 5),
+        /unexpected end of protobuf stream/
+    )
+})
+
+test('streamProtoFields rejects a nested length that overruns its parent', async () => {
+    const blob = new Uint8Array([0x12, 0x04, 0x12, 0xc8, 0x01, 0x00])
+    await assert.rejects(
+        () =>
+            collect(blob, {
+                shouldDescend: (fieldNumber, depth) => fieldNumber === 2 && depth === 0
+            }),
+        /exceeds its parent field/
+    )
+})
+
+test('streamProtoFields rejects an invalid field number', async () => {
+    await assert.rejects(
+        () => collect(new Uint8Array([0x00, 0x01])),
+        /invalid protobuf field number/
+    )
+})
+
+test('streamProtoFields rejects an unmatched end-group', async () => {
+    await assert.rejects(() => collect(new Uint8Array([0x0c])), /unmatched protobuf end-group/)
+})
+
+test('streamProtoFields skips a deprecated group', async () => {
+    const blob = new Uint8Array([0x0b, 0x10, 0x2a, 0x0c, 0x28, 0x07])
+    const events = await collect(blob, undefined, 2)
+    assert.deepEqual(
+        events.map((event) => event.fieldNumber),
+        [5]
+    )
+    const field = events[0]
+    assert.equal(field.kind, PROTO_STREAM_EVENT_KINDS.FIELD)
+    if (field.kind === PROTO_STREAM_EVENT_KINDS.FIELD) {
+        assert.equal(field.varintValue, 7)
+    }
+})
+
+test('streamProtoFields handles an empty stream', async () => {
+    assert.deepEqual(await collect(new Uint8Array(0)), [])
+})

--- a/src/util/proto-stream.ts
+++ b/src/util/proto-stream.ts
@@ -1,0 +1,374 @@
+import type { Readable } from 'node:stream'
+
+import { EMPTY_BYTES, toChunkBytes } from '@util/bytes'
+import { PROTO_WIRE_TYPES } from '@util/protoscan'
+
+const PROTO_STREAM_INITIAL_BUFFER_BYTES = 64 * 1024
+const PROTO_STREAM_VARINT_MAX_BYTES = 10
+const PROTO_STREAM_DEFAULT_MAX_FIELD_BYTES = 32 * 1024 * 1024
+const PROTO_STREAM_GROUP_MAX_DEPTH = 64
+
+export const PROTO_STREAM_EVENT_KINDS = Object.freeze({
+    FIELD: 'field',
+    ENTER: 'enter',
+    LEAVE: 'leave'
+} as const)
+
+export type ProtoStreamEventKind =
+    (typeof PROTO_STREAM_EVENT_KINDS)[keyof typeof PROTO_STREAM_EVENT_KINDS]
+
+export interface ProtoStreamFieldEvent {
+    readonly kind: typeof PROTO_STREAM_EVENT_KINDS.FIELD
+    readonly fieldNumber: number
+    readonly wireType: number
+    readonly depth: number
+    /** `LEN` payload, empty otherwise. Aliases the reader buffer: copy to retain. */
+    readonly value: Uint8Array
+    /** The field as it was on the wire, tag included, for re-emitting a subset. */
+    readonly raw: Uint8Array
+    readonly varintValue: number
+}
+
+export interface ProtoStreamEnterEvent {
+    readonly kind: typeof PROTO_STREAM_EVENT_KINDS.ENTER
+    readonly fieldNumber: number
+    readonly depth: number
+    readonly byteLength: number
+}
+
+export interface ProtoStreamLeaveEvent {
+    readonly kind: typeof PROTO_STREAM_EVENT_KINDS.LEAVE
+    readonly fieldNumber: number
+    readonly depth: number
+}
+
+export type ProtoStreamEvent = ProtoStreamFieldEvent | ProtoStreamEnterEvent | ProtoStreamLeaveEvent
+
+/** Return nothing to keep the walk synchronous; return a promise only to make it wait. */
+export type ProtoStreamHandler = (event: ProtoStreamEvent) => void | Promise<void>
+
+export interface ProtoStreamOptions {
+    /** Recurse into a `LEN` field instead of materializing it; subfields arrive at `depth + 1`. */
+    readonly shouldDescend?: (fieldNumber: number, depth: number, byteLength: number) => boolean
+    /** Cap on one materialized payload. Descended fields are exempt. Defaults to 32 MiB. */
+    readonly maxFieldBytes?: number
+}
+
+interface DescentFrame {
+    readonly fieldNumber: number
+    readonly endOffset: number
+}
+
+class ProtoStreamReader {
+    private readonly iterator: AsyncIterator<unknown>
+    private buffer: Uint8Array
+    private readPos = 0
+    private writePos = 0
+    private markPos = -1
+    public consumed = 0
+
+    public constructor(source: Readable) {
+        this.iterator = source[Symbol.asyncIterator]() as AsyncIterator<unknown>
+        this.buffer = new Uint8Array(PROTO_STREAM_INITIAL_BUFFER_BYTES)
+    }
+
+    public get buffered(): number {
+        return this.writePos - this.readPos
+    }
+
+    public mark(): void {
+        this.markPos = this.readPos
+    }
+
+    public takeMarked(): Uint8Array {
+        const start = this.markPos
+        this.markPos = -1
+        if (start < 0) {
+            return EMPTY_BYTES
+        }
+        return this.buffer.subarray(start, this.readPos)
+    }
+
+    public async ensure(byteLength: number): Promise<boolean> {
+        while (this.buffered < byteLength) {
+            const next = await this.iterator.next()
+            if (next.done === true) {
+                return false
+            }
+            const chunk = toChunkBytes(next.value)
+            if (chunk.byteLength === 0) {
+                continue
+            }
+            this.reserve(chunk.byteLength)
+            this.buffer.set(chunk, this.writePos)
+            this.writePos += chunk.byteLength
+        }
+        return true
+    }
+
+    public tryReadVarint(): number | null {
+        let value = 0
+        let factor = 1
+        let cursor = this.readPos
+        const limit = Math.min(this.writePos, this.readPos + PROTO_STREAM_VARINT_MAX_BYTES)
+        while (cursor < limit) {
+            const byte = this.buffer[cursor]
+            cursor += 1
+            value += (byte & 0x7f) * factor
+            if ((byte & 0x80) === 0) {
+                this.consumed += cursor - this.readPos
+                this.readPos = cursor
+                return value
+            }
+            factor *= 128
+        }
+        if (cursor - this.readPos >= PROTO_STREAM_VARINT_MAX_BYTES) {
+            throw new Error('varint exceeds the 10 byte protobuf limit')
+        }
+        return null
+    }
+
+    public async readVarint(): Promise<number> {
+        let value = 0
+        let factor = 1
+        for (let index = 0; index < PROTO_STREAM_VARINT_MAX_BYTES; index += 1) {
+            if (this.buffered === 0 && !(await this.ensure(1))) {
+                throw new Error('unexpected end of protobuf stream while reading varint')
+            }
+            const byte = this.buffer[this.readPos]
+            this.readPos += 1
+            this.consumed += 1
+            value += (byte & 0x7f) * factor
+            if ((byte & 0x80) === 0) {
+                return value
+            }
+            factor *= 128
+        }
+        throw new Error('varint exceeds the 10 byte protobuf limit')
+    }
+
+    public tryReadExact(byteLength: number): Uint8Array | null {
+        if (this.buffered < byteLength) {
+            return null
+        }
+        const start = this.readPos
+        this.readPos += byteLength
+        this.consumed += byteLength
+        return this.buffer.subarray(start, start + byteLength)
+    }
+
+    public async readExact(byteLength: number): Promise<Uint8Array> {
+        if (byteLength === 0) {
+            return this.buffer.subarray(this.readPos, this.readPos)
+        }
+        if (!(await this.ensure(byteLength))) {
+            throw new Error('unexpected end of protobuf stream')
+        }
+        const start = this.readPos
+        this.readPos += byteLength
+        this.consumed += byteLength
+        return this.buffer.subarray(start, start + byteLength)
+    }
+
+    public trySkip(byteLength: number): boolean {
+        if (this.buffered < byteLength) {
+            return false
+        }
+        this.readPos += byteLength
+        this.consumed += byteLength
+        return true
+    }
+
+    public async skip(byteLength: number): Promise<void> {
+        let remaining = byteLength
+        while (remaining > 0) {
+            if (this.buffered === 0 && !(await this.ensure(1))) {
+                throw new Error('unexpected end of protobuf stream')
+            }
+            const step = Math.min(remaining, this.buffered)
+            this.readPos += step
+            this.consumed += step
+            remaining -= step
+        }
+    }
+
+    private reserve(incomingBytes: number): void {
+        if (this.writePos + incomingBytes <= this.buffer.byteLength) {
+            return
+        }
+        const retainFrom = this.markPos >= 0 ? Math.min(this.markPos, this.readPos) : this.readPos
+        const live = this.writePos - retainFrom
+        if (retainFrom > 0 && live + incomingBytes <= this.buffer.byteLength) {
+            this.buffer.copyWithin(0, retainFrom, this.writePos)
+            this.readPos -= retainFrom
+            this.writePos -= retainFrom
+            if (this.markPos >= 0) {
+                this.markPos -= retainFrom
+            }
+            return
+        }
+        let grown = this.buffer.byteLength
+        while (grown < live + incomingBytes) {
+            grown *= 2
+        }
+        const next = new Uint8Array(grown)
+        next.set(this.buffer.subarray(retainFrom, this.writePos))
+        this.readPos -= retainFrom
+        this.writePos -= retainFrom
+        if (this.markPos >= 0) {
+            this.markPos -= retainFrom
+        }
+        this.buffer = next
+    }
+}
+
+/**
+ * Streaming counterpart of `scanProtoFields`: walks a protobuf message as it
+ * arrives, calling `onEvent` per field in wire order. Fields chosen by
+ * `shouldDescend` are recursed into instead of buffered, so peak memory tracks
+ * the largest materialized leaf rather than the message. Unknown fields are
+ * skipped by wire type.
+ *
+ * @throws on a truncated stream, an invalid length, or a payload over `maxFieldBytes`.
+ */
+export async function streamProtoFields(
+    source: Readable,
+    onEvent: ProtoStreamHandler,
+    options: ProtoStreamOptions = {}
+): Promise<void> {
+    const maxFieldBytes = options.maxFieldBytes ?? PROTO_STREAM_DEFAULT_MAX_FIELD_BYTES
+    if (!Number.isSafeInteger(maxFieldBytes) || maxFieldBytes <= 0) {
+        throw new Error(`invalid max field bytes limit: ${maxFieldBytes}`)
+    }
+    const shouldDescend = options.shouldDescend
+    const reader = new ProtoStreamReader(source)
+    const stack: DescentFrame[] = []
+    let value: Uint8Array = EMPTY_BYTES
+    let varintValue = 0
+
+    while (true) {
+        while (stack.length > 0 && reader.consumed >= stack[stack.length - 1].endOffset) {
+            const frame = stack[stack.length - 1]
+            if (reader.consumed > frame.endOffset) {
+                throw new Error('protobuf field overran its declared length')
+            }
+            stack.length -= 1
+            const pending = onEvent({
+                kind: PROTO_STREAM_EVENT_KINDS.LEAVE,
+                fieldNumber: frame.fieldNumber,
+                depth: stack.length
+            })
+            if (pending) {
+                await pending
+            }
+        }
+
+        if (reader.buffered === 0 && !(await reader.ensure(1))) {
+            if (stack.length > 0) {
+                throw new Error('unexpected end of protobuf stream inside a nested field')
+            }
+            return
+        }
+
+        const depth = stack.length
+        const parentEnd = stack.length > 0 ? stack[stack.length - 1].endOffset : null
+        reader.mark()
+        const tag = reader.tryReadVarint() ?? (await reader.readVarint())
+        const fieldNumber = Math.floor(tag / 8)
+        const wireType = tag & 0x07
+        if (fieldNumber < 1) {
+            throw new Error(`invalid protobuf field number ${fieldNumber}`)
+        }
+
+        if (wireType === PROTO_WIRE_TYPES.LEN) {
+            const byteLength = reader.tryReadVarint() ?? (await reader.readVarint())
+            if (!Number.isSafeInteger(byteLength) || byteLength < 0) {
+                throw new Error(`invalid protobuf length-delimited field length ${byteLength}`)
+            }
+            if (parentEnd !== null && reader.consumed + byteLength > parentEnd) {
+                throw new Error('protobuf field length exceeds its parent field')
+            }
+            if (shouldDescend?.(fieldNumber, depth, byteLength) === true) {
+                reader.takeMarked()
+                stack[stack.length] = { fieldNumber, endOffset: reader.consumed + byteLength }
+                const pending = onEvent({
+                    kind: PROTO_STREAM_EVENT_KINDS.ENTER,
+                    fieldNumber,
+                    depth,
+                    byteLength
+                })
+                if (pending) {
+                    await pending
+                }
+                continue
+            }
+            if (byteLength > maxFieldBytes) {
+                throw new Error(
+                    `protobuf field ${fieldNumber} of ${byteLength} bytes exceeds the ${maxFieldBytes} byte limit`
+                )
+            }
+            value = reader.tryReadExact(byteLength) ?? (await reader.readExact(byteLength))
+            varintValue = 0
+        } else if (wireType === PROTO_WIRE_TYPES.VARINT) {
+            value = EMPTY_BYTES
+            varintValue = reader.tryReadVarint() ?? (await reader.readVarint())
+        } else if (wireType === PROTO_WIRE_TYPES.FIXED64 || wireType === PROTO_WIRE_TYPES.FIXED32) {
+            const width = wireType === PROTO_WIRE_TYPES.FIXED64 ? 8 : 4
+            if (!reader.trySkip(width)) {
+                await reader.skip(width)
+            }
+            value = EMPTY_BYTES
+            varintValue = 0
+        } else if (wireType === PROTO_WIRE_TYPES.START_GROUP) {
+            reader.takeMarked()
+            await skipStreamGroup(reader)
+            continue
+        } else if (wireType === PROTO_WIRE_TYPES.END_GROUP) {
+            throw new Error('unmatched protobuf end-group field')
+        } else {
+            throw new Error(`unsupported protobuf wire type ${wireType}`)
+        }
+
+        const pending = onEvent({
+            kind: PROTO_STREAM_EVENT_KINDS.FIELD,
+            fieldNumber,
+            wireType,
+            depth,
+            value,
+            raw: reader.takeMarked(),
+            varintValue
+        })
+        if (pending) {
+            await pending
+        }
+    }
+}
+
+async function skipStreamGroup(reader: ProtoStreamReader, depth = 0): Promise<void> {
+    if (depth >= PROTO_STREAM_GROUP_MAX_DEPTH) {
+        throw new Error('protobuf group nesting exceeds supported depth')
+    }
+    while (true) {
+        if (reader.buffered === 0 && !(await reader.ensure(1))) {
+            throw new Error('unexpected end of protobuf stream while skipping group')
+        }
+        const tag = reader.tryReadVarint() ?? (await reader.readVarint())
+        const wireType = tag & 0x07
+        if (wireType === PROTO_WIRE_TYPES.END_GROUP) {
+            return
+        }
+        if (wireType === PROTO_WIRE_TYPES.VARINT) {
+            reader.tryReadVarint() ?? (await reader.readVarint())
+        } else if (wireType === PROTO_WIRE_TYPES.FIXED64) {
+            await reader.skip(8)
+        } else if (wireType === PROTO_WIRE_TYPES.FIXED32) {
+            await reader.skip(4)
+        } else if (wireType === PROTO_WIRE_TYPES.LEN) {
+            await reader.skip(reader.tryReadVarint() ?? (await reader.readVarint()))
+        } else if (wireType === PROTO_WIRE_TYPES.START_GROUP) {
+            await skipStreamGroup(reader, depth + 1)
+        } else {
+            throw new Error(`unsupported protobuf wire type ${wireType}`)
+        }
+    }
+}

--- a/src/util/proto-stream.ts
+++ b/src/util/proto-stream.ts
@@ -7,6 +7,7 @@ const PROTO_STREAM_INITIAL_BUFFER_BYTES = 64 * 1024
 const PROTO_STREAM_VARINT_MAX_BYTES = 10
 const PROTO_STREAM_DEFAULT_MAX_FIELD_BYTES = 32 * 1024 * 1024
 const PROTO_STREAM_GROUP_MAX_DEPTH = 64
+const PROTO_STREAM_MAX_DESCENT_DEPTH = 32
 
 export const PROTO_STREAM_EVENT_KINDS = Object.freeze({
     FIELD: 'field',
@@ -274,6 +275,7 @@ export async function streamProtoFields(
         const parentEnd = stack.length > 0 ? stack[stack.length - 1].endOffset : null
         reader.mark()
         const tag = reader.tryReadVarint() ?? (await reader.readVarint())
+        assertWithinFrame(reader.consumed, parentEnd)
         const fieldNumber = Math.floor(tag / 8)
         const wireType = tag & 0x07
         if (fieldNumber < 1) {
@@ -282,6 +284,7 @@ export async function streamProtoFields(
 
         if (wireType === PROTO_WIRE_TYPES.LEN) {
             const byteLength = reader.tryReadVarint() ?? (await reader.readVarint())
+            assertWithinFrame(reader.consumed, parentEnd)
             if (!Number.isSafeInteger(byteLength) || byteLength < 0) {
                 throw new Error(`invalid protobuf length-delimited field length ${byteLength}`)
             }
@@ -289,6 +292,11 @@ export async function streamProtoFields(
                 throw new Error('protobuf field length exceeds its parent field')
             }
             if (shouldDescend?.(fieldNumber, depth, byteLength) === true) {
+                if (stack.length >= PROTO_STREAM_MAX_DESCENT_DEPTH) {
+                    throw new Error(
+                        `protobuf descent exceeds the ${PROTO_STREAM_MAX_DESCENT_DEPTH} level limit`
+                    )
+                }
                 reader.takeMarked()
                 stack[stack.length] = { fieldNumber, endOffset: reader.consumed + byteLength }
                 const pending = onEvent({
@@ -312,8 +320,10 @@ export async function streamProtoFields(
         } else if (wireType === PROTO_WIRE_TYPES.VARINT) {
             value = EMPTY_BYTES
             varintValue = reader.tryReadVarint() ?? (await reader.readVarint())
+            assertWithinFrame(reader.consumed, parentEnd)
         } else if (wireType === PROTO_WIRE_TYPES.FIXED64 || wireType === PROTO_WIRE_TYPES.FIXED32) {
             const width = wireType === PROTO_WIRE_TYPES.FIXED64 ? 8 : 4
+            assertWithinFrame(reader.consumed + width, parentEnd)
             if (!reader.trySkip(width)) {
                 await reader.skip(width)
             }
@@ -341,6 +351,17 @@ export async function streamProtoFields(
         if (pending) {
             await pending
         }
+    }
+}
+
+/**
+ * A field must not read past the record that contains it. Checked before the
+ * handler runs, so a truncated varint or fixed-width field is rejected instead
+ * of being delivered with bytes borrowed from the parent.
+ */
+function assertWithinFrame(consumed: number, parentEnd: number | null): void {
+    if (parentEnd !== null && consumed > parentEnd) {
+        throw new Error('protobuf field overran its parent field')
     }
 }
 


### PR DESCRIPTION
History chunks were downloaded, inflated and walked entirely in memory. The peak was dominated by the decoded object graph of a single conversation, not by the buffers: in a real chunk one chat is 94% of 7 MB inflated, and its 882 messages expand to roughly 180 MB of JS objects.

Decrypt and inflate now feed an incremental protobuf reader that descends into `conversations` instead of materializing them, so one message is alive at a time. Measured over 21 real chunks: peak 192 MB to 15 MB (12x), with writes byte-identical to the generated decoder.

- add `streamProtoFields`, the streaming counterpart of `scanProtoFields`. Callback-shaped, with a synchronous fast path on every read: handing each field back across an async boundary cost 1.24 us per field, around 16% of ingest throughput.
- `openHistoryBlobStream` decrypts and inflates as the bytes arrive. The MAC can only be checked once the last byte landed, so `verified` is awaited before the chunk event and the receipt; a mismatch leaves the chunk unacked and the primary resends it.
- group history bundles get the same treatment. `GroupHistory` carries its messages as top-level repeated fields, so nothing needs descending into, and comment messages and associated lists are skipped by wire type instead of being decoded and thrown away.
- pin every hardcoded field number to the generated encoder in tests, so a spec renumber fails the suite instead of silently dropping records.

Queued write rejections now sit unobserved across the awaits of the rest of the chunk, where Node's default unhandled-rejection mode would take the process down rather than surface at the flush, so they are observed on queue.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * History synchronization now processes encrypted and compressed history incrementally, improving performance and memory use for large bundles.
  * Group history imports are streamed with safeguards for oversized, incomplete, or malformed records.
  * Conversation mappings, privacy tokens, contacts, messages, and acknowledgements are handled reliably during synchronization.
* **Bug Fixes**
  * Improved detection and cleanup of verification, decryption, truncation, and corrupted-data failures.
  * Group-history event counts now accurately include pinned messages.
  * Improved handling of interrupted streams and temporarily out-of-order history records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->