### PR TITLE
feat: support WhatsApp Business accounts over the mobile transport

### DIFF
--- a/src/transport/noise/WaMobileClientPayload.ts
+++ b/src/transport/noise/WaMobileClientPayload.ts
@@ -15,6 +15,7 @@ export interface WaMobileTransportDeviceInfo {
     readonly phoneId?: string
     readonly deviceBoard?: string
     readonly deviceModelType?: string
+    readonly business?: boolean
 }
 
 export interface WaMobileLoginPayloadConfig {
@@ -65,7 +66,9 @@ export function buildMobileLoginPayload(config: WaMobileLoginPayloadConfig): Uin
     const version = parseAppVersion(info.appVersion)
 
     const userAgent = {
-        platform: proto.ClientPayload.UserAgent.Platform.ANDROID,
+        platform: info.business
+            ? proto.ClientPayload.UserAgent.Platform.SMB_ANDROID
+            : proto.ClientPayload.UserAgent.Platform.ANDROID,
         releaseChannel: proto.ClientPayload.UserAgent.ReleaseChannel.RELEASE,
         appVersion: version,
         mcc: info.mcc ?? '000',

--- a/src/transport/noise/__tests__/WaMobileClientPayload.test.ts
+++ b/src/transport/noise/__tests__/WaMobileClientPayload.test.ts
@@ -49,6 +49,42 @@ test('buildMobileLoginPayload emits an ANDROID userAgent with primary flags', ()
     assert.equal(ua.appVersion.tertiary, 15)
 })
 
+test('buildMobileLoginPayload emits SMB_ANDROID platform for business accounts', () => {
+    const bytes = buildMobileLoginPayload({
+        username: 5511987654321,
+        deviceInfo: { ...BASE_DEVICE, business: true }
+    })
+    const payload = proto.ClientPayload.decode(bytes)
+    assert.equal(payload.userAgent?.platform, proto.ClientPayload.UserAgent.Platform.SMB_ANDROID)
+})
+
+test('buildMobileLoginPayload keeps ANDROID platform when business is false', () => {
+    const bytes = buildMobileLoginPayload({
+        username: 5511987654321,
+        deviceInfo: { ...BASE_DEVICE, business: false }
+    })
+    const payload = proto.ClientPayload.decode(bytes)
+    assert.equal(payload.userAgent?.platform, proto.ClientPayload.UserAgent.Platform.ANDROID)
+})
+
+test('buildMobileLoginPayload is unchanged when business is omitted', () => {
+    const omitted = buildMobileLoginPayload({
+        username: 5511987654321,
+        deviceInfo: BASE_DEVICE
+    })
+    const explicitUndefined = buildMobileLoginPayload({
+        username: 5511987654321,
+        deviceInfo: { ...BASE_DEVICE, business: undefined }
+    })
+    // Omitting the flag must produce the exact same bytes as an explicit
+    // undefined, and the platform stays consumer ANDROID.
+    assert.deepEqual(omitted, explicitUndefined)
+    assert.equal(
+        proto.ClientPayload.decode(omitted).userAgent?.platform,
+        proto.ClientPayload.UserAgent.Platform.ANDROID
+    )
+})
+
 test('buildMobileLoginPayload sets passive=true when requested', () => {
     const bytes = buildMobileLoginPayload({
         username: 5511987654321,


### PR DESCRIPTION
## Summary

Connecting through the mobile transport with credentials for a **WhatsApp Business** account fails: the noise handshake completes but the server rejects the session with `<failure reason='401'>` right after `wa client connected`, and the stored credentials are then cleared. Root cause: `buildMobileLoginPayload` always sets `userAgent.platform` to consumer `ANDROID`, with no way to advertise the business platform.

## Change

- `WaMobileTransportDeviceInfo` gains an optional `business` flag.
- When set, `buildMobileLoginPayload` advertises `Platform.SMB_ANDROID` in the login `userAgent` instead of `ANDROID`; it defaults to `ANDROID` when unset, so nothing changes for consumer accounts.
- The flag lives on `deviceInfo`, so it rides `credentials.deviceInfo` (synthesized automatically on reconnect) and can also be passed via `mobileTransport.deviceInfo`. No changes needed in `credentials-flow`.

## Confirmation

Overriding only the platform to `SMB_ANDROID` (everything else identical) makes the exact same business credentials log in successfully — the server returns `<success .../>` and the session stays open with normal traffic. Reverting to `ANDROID` reproduces the `401` every time, so the platform value is the sole differentiator.

## Tests

- `src/transport/noise/__tests__/WaMobileClientPayload.test.ts`: `business: true` → `SMB_ANDROID`, `business: false` → `ANDROID`, and `business` omitted → byte-identical output (unchanged, `ANDROID`).
- `typecheck`, `eslint`, `prettier`, and the fake-server `mobile-connect` cross-check all pass locally.

Closes #246


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for WhatsApp Business mobile devices during login.
  * Business devices now use the appropriate SMB Android platform identifier, helping prevent immediate login rejection.
  * Standard Android login behavior remains unchanged when the business option is omitted or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->