### PR TITLE
feat(username): support username handles on receive, queries and privacy

### DIFF
--- a/.changeset/username-contact-column.md
+++ b/.changeset/username-contact-column.md
@@ -1,0 +1,14 @@
+---
+'@zapo-js/store-postgres': minor
+'@zapo-js/store-sqlite': minor
+'@zapo-js/store-mysql': minor
+'@zapo-js/store-mongo': minor
+'@zapo-js/store-redis': minor
+---
+
+Persist the contact's username handle. `WaStoredContactRecord` gained an
+optional `username` field, and every backend now reads and writes it: SQL
+providers add a `username` column through a new migration (`0020` on sqlite,
+`0021` on postgres and mysql), redis adds a hash field, and mongo adds a
+document field. The handle feeds the username-addressed blocklist and
+privacy-list identifiers.

--- a/packages/store-mongo/src/contact.store.ts
+++ b/packages/store-mongo/src/contact.store.ts
@@ -12,6 +12,7 @@ interface ContactDoc {
     push_name: string | null
     lid: string | null
     phone_number: string | null
+    username: string | null
     last_updated_ms: number
 }
 
@@ -22,6 +23,7 @@ function docToRecord(doc: ContactDoc): WaStoredContactRecord {
         pushName: doc.push_name ?? undefined,
         lid: doc.lid ?? undefined,
         phoneNumber: doc.phone_number ?? undefined,
+        username: doc.username ?? undefined,
         lastUpdatedMs: doc.last_updated_ms
     }
 }
@@ -34,6 +36,7 @@ function buildCoalesceSet(record: WaStoredContactRecord): Partial<ContactDoc> {
     if (record.pushName !== undefined) set.push_name = record.pushName
     if (record.lid !== undefined) set.lid = record.lid
     if (record.phoneNumber !== undefined) set.phone_number = record.phoneNumber
+    if (record.username !== undefined) set.username = record.username
     return set
 }
 

--- a/packages/store-mysql/src/connection.ts
+++ b/packages/store-mysql/src/connection.ts
@@ -394,6 +394,14 @@ const MIGRATIONS: readonly Migration[] = [
                 KEY chat_metadata_cache_by_expiry (session_id, expires_at_ms)
             )
         `
+    },
+    {
+        name: '0021_mailbox_contacts_username',
+        domain: 'mailbox',
+        sql: `
+            ALTER TABLE \`__PREFIX__mailbox_contacts\`
+                ADD COLUMN username VARCHAR(255)
+        `
     }
 ]
 

--- a/packages/store-mysql/src/contact.store.ts
+++ b/packages/store-mysql/src/contact.store.ts
@@ -16,13 +16,14 @@ export class WaContactMysqlStore extends BaseMysqlStore implements WaContactStor
         await this.pool.execute(
             `INSERT INTO ${this.t('mailbox_contacts')} (
                 session_id, jid, display_name, push_name, lid,
-                phone_number, last_updated_ms
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                phone_number, username, last_updated_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ON DUPLICATE KEY UPDATE
                 display_name = COALESCE(VALUES(display_name), display_name),
                 push_name = COALESCE(VALUES(push_name), push_name),
                 lid = COALESCE(VALUES(lid), lid),
                 phone_number = COALESCE(VALUES(phone_number), phone_number),
+                username = COALESCE(VALUES(username), username),
                 last_updated_ms = VALUES(last_updated_ms)`,
             [
                 this.sessionId,
@@ -31,6 +32,7 @@ export class WaContactMysqlStore extends BaseMysqlStore implements WaContactStor
                 record.pushName ?? null,
                 record.lid ?? null,
                 record.phoneNumber ?? null,
+                record.username ?? null,
                 record.lastUpdatedMs
             ]
         )
@@ -42,7 +44,7 @@ export class WaContactMysqlStore extends BaseMysqlStore implements WaContactStor
             executor: { execute: PoolConnection['execute'] },
             chunk: readonly WaStoredContactRecord[]
         ): Promise<void> => {
-            const placeholders = chunk.map(() => '(?, ?, ?, ?, ?, ?, ?)').join(', ')
+            const placeholders = chunk.map(() => '(?, ?, ?, ?, ?, ?, ?, ?)').join(', ')
             const params: MysqlParam[] = []
             for (const record of chunk) {
                 params.push(
@@ -52,19 +54,21 @@ export class WaContactMysqlStore extends BaseMysqlStore implements WaContactStor
                     record.pushName ?? null,
                     record.lid ?? null,
                     record.phoneNumber ?? null,
+                    record.username ?? null,
                     record.lastUpdatedMs
                 )
             }
             await executor.execute(
                 `INSERT INTO ${this.t('mailbox_contacts')} (
                     session_id, jid, display_name, push_name, lid,
-                    phone_number, last_updated_ms
+                    phone_number, username, last_updated_ms
                 ) VALUES ${placeholders}
                 ON DUPLICATE KEY UPDATE
                     display_name = COALESCE(VALUES(display_name), display_name),
                     push_name = COALESCE(VALUES(push_name), push_name),
                     lid = COALESCE(VALUES(lid), lid),
                     phone_number = COALESCE(VALUES(phone_number), phone_number),
+                    username = COALESCE(VALUES(username), username),
                     last_updated_ms = VALUES(last_updated_ms)`,
                 params
             )
@@ -89,7 +93,7 @@ export class WaContactMysqlStore extends BaseMysqlStore implements WaContactStor
         const row = queryFirst(
             await this.pool.execute(
                 `SELECT jid, display_name, push_name, lid,
-                    phone_number, last_updated_ms
+                    phone_number, username, last_updated_ms
              FROM ${this.t('mailbox_contacts')}
              WHERE session_id = ? AND jid = ?`,
                 [this.sessionId, jid]
@@ -107,7 +111,7 @@ export class WaContactMysqlStore extends BaseMysqlStore implements WaContactStor
         const row = queryFirst(
             await this.pool.execute(
                 `SELECT jid, display_name, push_name, lid,
-                    phone_number, last_updated_ms
+                    phone_number, username, last_updated_ms
              FROM ${this.t('mailbox_contacts')}
              WHERE session_id = ? AND phone_number = ?
              LIMIT 1`,
@@ -124,6 +128,7 @@ export class WaContactMysqlStore extends BaseMysqlStore implements WaContactStor
             pushName: (row.push_name as string | null) ?? undefined,
             lid: (row.lid as string | null) ?? undefined,
             phoneNumber: (row.phone_number as string | null) ?? undefined,
+            username: (row.username as string | null) ?? undefined,
             lastUpdatedMs: Number(row.last_updated_ms)
         }
     }

--- a/packages/store-postgres/src/connection.ts
+++ b/packages/store-postgres/src/connection.ts
@@ -400,6 +400,13 @@ const MIGRATIONS: readonly Migration[] = [
             CREATE INDEX IF NOT EXISTS "__PREFIX__idx_chat_metadata_cache_expires"
                 ON "__PREFIX__chat_metadata_cache" (session_id, expires_at_ms);
         `
+    },
+    {
+        name: '0021_mailbox_contacts_username',
+        domain: 'mailbox',
+        sql: `
+            ALTER TABLE "__PREFIX__mailbox_contacts" ADD COLUMN IF NOT EXISTS username TEXT
+        `
     }
 ]
 

--- a/packages/store-postgres/src/contact.store.ts
+++ b/packages/store-postgres/src/contact.store.ts
@@ -14,7 +14,7 @@ export class WaContactPgStore extends BasePgStore implements WaContactStore {
     private upsertQuery(values: unknown[]) {
         return {
             name: this.stmtName('contact_upsert'),
-            text: `INSERT INTO ${this.t('mailbox_contacts')} (session_id, jid, display_name, push_name, lid, phone_number, last_updated_ms) VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (session_id, jid) DO UPDATE SET display_name = COALESCE(EXCLUDED.display_name, ${this.t('mailbox_contacts')}.display_name), push_name = COALESCE(EXCLUDED.push_name, ${this.t('mailbox_contacts')}.push_name), lid = COALESCE(EXCLUDED.lid, ${this.t('mailbox_contacts')}.lid), phone_number = COALESCE(EXCLUDED.phone_number, ${this.t('mailbox_contacts')}.phone_number), last_updated_ms = EXCLUDED.last_updated_ms`,
+            text: `INSERT INTO ${this.t('mailbox_contacts')} (session_id, jid, display_name, push_name, lid, phone_number, username, last_updated_ms) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT (session_id, jid) DO UPDATE SET display_name = COALESCE(EXCLUDED.display_name, ${this.t('mailbox_contacts')}.display_name), push_name = COALESCE(EXCLUDED.push_name, ${this.t('mailbox_contacts')}.push_name), lid = COALESCE(EXCLUDED.lid, ${this.t('mailbox_contacts')}.lid), phone_number = COALESCE(EXCLUDED.phone_number, ${this.t('mailbox_contacts')}.phone_number), username = COALESCE(EXCLUDED.username, ${this.t('mailbox_contacts')}.username), last_updated_ms = EXCLUDED.last_updated_ms`,
             values
         }
     }
@@ -29,6 +29,7 @@ export class WaContactPgStore extends BasePgStore implements WaContactStore {
                 record.pushName ?? null,
                 record.lid ?? null,
                 record.phoneNumber ?? null,
+                record.username ?? null,
                 record.lastUpdatedMs
             ])
         )
@@ -44,8 +45,8 @@ export class WaContactPgStore extends BasePgStore implements WaContactStore {
             let paramIdx = 1
             const placeholders = chunk
                 .map(() => {
-                    const p = `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}, $${paramIdx + 5}, $${paramIdx + 6})`
-                    paramIdx += 7
+                    const p = `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}, $${paramIdx + 5}, $${paramIdx + 6}, $${paramIdx + 7})`
+                    paramIdx += 8
                     return p
                 })
                 .join(', ')
@@ -58,19 +59,22 @@ export class WaContactPgStore extends BasePgStore implements WaContactStore {
                     record.pushName ?? null,
                     record.lid ?? null,
                     record.phoneNumber ?? null,
+                    record.username ?? null,
                     record.lastUpdatedMs
                 )
             }
             await executor.query({
                 name: this.stmtName(`contact_upsert_batch_${chunk.length}`),
                 text: `INSERT INTO ${table} (
-                    session_id, jid, display_name, push_name, lid, phone_number, last_updated_ms
+                    session_id, jid, display_name, push_name, lid, phone_number, username,
+                    last_updated_ms
                 ) VALUES ${placeholders}
                 ON CONFLICT (session_id, jid) DO UPDATE SET
                     display_name = COALESCE(EXCLUDED.display_name, ${table}.display_name),
                     push_name = COALESCE(EXCLUDED.push_name, ${table}.push_name),
                     lid = COALESCE(EXCLUDED.lid, ${table}.lid),
                     phone_number = COALESCE(EXCLUDED.phone_number, ${table}.phone_number),
+                    username = COALESCE(EXCLUDED.username, ${table}.username),
                     last_updated_ms = EXCLUDED.last_updated_ms`,
                 values: params
             })
@@ -96,7 +100,7 @@ export class WaContactPgStore extends BasePgStore implements WaContactStore {
             await this.pool.query({
                 name: this.stmtName('contact_get_by_jid'),
                 text: `SELECT jid, display_name, push_name, lid,
-                    phone_number, last_updated_ms
+                    phone_number, username, last_updated_ms
              FROM ${this.t('mailbox_contacts')}
              WHERE session_id = $1 AND jid = $2`,
                 values: [this.sessionId, jid]
@@ -115,7 +119,7 @@ export class WaContactPgStore extends BasePgStore implements WaContactStore {
             await this.pool.query({
                 name: this.stmtName('contact_get_by_phone_number'),
                 text: `SELECT jid, display_name, push_name, lid,
-                    phone_number, last_updated_ms
+                    phone_number, username, last_updated_ms
              FROM ${this.t('mailbox_contacts')}
              WHERE session_id = $1 AND phone_number = $2
              LIMIT 1`,
@@ -132,6 +136,7 @@ export class WaContactPgStore extends BasePgStore implements WaContactStore {
             pushName: (row.push_name as string | null) ?? undefined,
             lid: (row.lid as string | null) ?? undefined,
             phoneNumber: (row.phone_number as string | null) ?? undefined,
+            username: (row.username as string | null) ?? undefined,
             lastUpdatedMs: Number(row.last_updated_ms)
         }
     }

--- a/packages/store-redis/src/contact.store.ts
+++ b/packages/store-redis/src/contact.store.ts
@@ -12,6 +12,7 @@ function hashToRecord(data: Record<string, string>): WaStoredContactRecord {
         pushName: toStringOrNull(data.push_name) ?? undefined,
         lid: toStringOrNull(data.lid) ?? undefined,
         phoneNumber: toStringOrNull(data.phone_number) ?? undefined,
+        username: toStringOrNull(data.username) ?? undefined,
         lastUpdatedMs: Number(data.last_updated_ms)
     }
 }
@@ -33,6 +34,9 @@ function recordToHash(record: WaStoredContactRecord): Record<string, string> {
     }
     if (record.phoneNumber !== undefined) {
         fields.phone_number = record.phoneNumber
+    }
+    if (record.username !== undefined) {
+        fields.username = record.username
     }
 
     return fields

--- a/packages/store-sqlite/src/contact.store.ts
+++ b/packages/store-sqlite/src/contact.store.ts
@@ -12,6 +12,7 @@ interface ContactRow extends Record<string, unknown> {
     readonly push_name: unknown
     readonly lid: unknown
     readonly phone_number: unknown
+    readonly username: unknown
     readonly last_updated_ms: unknown
 }
 
@@ -22,6 +23,7 @@ function decodeContactRow(row: ContactRow): WaStoredContactRecord {
         pushName: asOptionalString(row.push_name, 'mailbox_contacts.push_name'),
         lid: asOptionalString(row.lid, 'mailbox_contacts.lid'),
         phoneNumber: asOptionalString(row.phone_number, 'mailbox_contacts.phone_number'),
+        username: asOptionalString(row.username, 'mailbox_contacts.username'),
         lastUpdatedMs: asNumber(row.last_updated_ms, 'mailbox_contacts.last_updated_ms')
     }
 }
@@ -50,7 +52,7 @@ export class WaContactSqliteStore extends BaseSqliteStore implements Contract {
     public async getByJid(jid: string): Promise<WaStoredContactRecord | null> {
         const db = await this.getConnection()
         const row = db.get<ContactRow>(
-            `SELECT jid, display_name, push_name, lid, phone_number, last_updated_ms
+            `SELECT jid, display_name, push_name, lid, phone_number, username, last_updated_ms
              FROM mailbox_contacts
              WHERE session_id = ? AND jid = ?`,
             [this.options.sessionId, jid]
@@ -65,7 +67,7 @@ export class WaContactSqliteStore extends BaseSqliteStore implements Contract {
     public async getByPhoneNumber(pn: string): Promise<WaStoredContactRecord | null> {
         const db = await this.getConnection()
         const row = db.get<ContactRow>(
-            `SELECT jid, display_name, push_name, lid, phone_number, last_updated_ms
+            `SELECT jid, display_name, push_name, lid, phone_number, username, last_updated_ms
              FROM mailbox_contacts
              WHERE session_id = ? AND phone_number = ?
              LIMIT 1`,
@@ -99,13 +101,15 @@ export class WaContactSqliteStore extends BaseSqliteStore implements Contract {
                 push_name,
                 lid,
                 phone_number,
+                username,
                 last_updated_ms
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(session_id, jid) DO UPDATE SET
                 display_name=COALESCE(excluded.display_name, mailbox_contacts.display_name),
                 push_name=COALESCE(excluded.push_name, mailbox_contacts.push_name),
                 lid=COALESCE(excluded.lid, mailbox_contacts.lid),
                 phone_number=COALESCE(excluded.phone_number, mailbox_contacts.phone_number),
+                username=COALESCE(excluded.username, mailbox_contacts.username),
                 last_updated_ms=excluded.last_updated_ms`,
             [
                 this.options.sessionId,
@@ -114,6 +118,7 @@ export class WaContactSqliteStore extends BaseSqliteStore implements Contract {
                 record.pushName ?? null,
                 record.lid ?? null,
                 record.phoneNumber ?? null,
+                record.username ?? null,
                 record.lastUpdatedMs
             ]
         )

--- a/packages/store-sqlite/src/migrations.ts
+++ b/packages/store-sqlite/src/migrations.ts
@@ -463,6 +463,15 @@ const SQLITE_MIGRATIONS: readonly WaSqliteMigration[] = [
                     ON chat_metadata_cache (session_id, expires_at_ms);
             `)
         }
+    },
+    {
+        id: '0020_mailbox_contacts_username',
+        domain: 'mailbox',
+        up: (db) => {
+            db.exec(`
+                ALTER TABLE mailbox_contacts ADD COLUMN username TEXT;
+            `)
+        }
     }
 ]
 

--- a/src/client/WaClientFactory.ts
+++ b/src/client/WaClientFactory.ts
@@ -63,6 +63,7 @@ import { DEVICE_NOTIFICATION_ACTIONS, parseDeviceNotification } from '@client/ev
 import { handleDirtyBits, parseDirtyBits } from '@client/events/dirty'
 import { parseIdentityChangeNotification } from '@client/events/identity'
 import { parsePrivacyTokenNotification } from '@client/events/privacy-token'
+import { parseOwnUsernameNotification } from '@client/events/username'
 import { createDeviceFanoutResolver } from '@client/messaging/fanout'
 import { createGroupMetadataCache } from '@client/messaging/group-metadata'
 import { createAppStateSyncKeyProtocol } from '@client/messaging/key-protocol'
@@ -674,6 +675,11 @@ export function buildWaClientDependencies(input: {
 
     const privacyCoordinator = createPrivacyCoordinator({
         logger,
+        contactStore: sessionStore.contacts,
+        isUsernamePrivacyListIdentifierEnabled: () =>
+            abPropsCoordinator.getConfigValue<boolean>(
+                'username_contact_privacy_setting_allow_uncontact_set_enable'
+            ),
         queryWithContext: runtime.queryWithContext,
         resolveUserJidPair: (userJid) => signalDeviceSync.resolveUserJidPair(userJid),
         getSelfLid: () => getCurrentCredentials()?.meLid ?? null,
@@ -1318,6 +1324,10 @@ export function buildWaClientDependencies(input: {
         handler: async (node) => {
             if (findNodeChild(node, WA_NODE_TAGS.PRIVACY)) {
                 privacyCoordinator.scheduleAccountSyncRefresh()
+            }
+            const usernameEvent = parseOwnUsernameNotification(node)
+            if (usernameEvent) {
+                runtime.emitEvent('own_username', usernameEvent)
             }
             return false
         }

--- a/src/client/__tests__/incoming.test.ts
+++ b/src/client/__tests__/incoming.test.ts
@@ -13,6 +13,7 @@ import type {
     WaAccountTakeoverNoticeEvent,
     WaBusinessEvent,
     WaIncomingCallEvent,
+    WaIncomingReceiptEvent,
     WaIncomingUnhandledStanzaEvent,
     WaRegistrationCodeEvent
 } from '@client/types'
@@ -654,4 +655,34 @@ test('call handler emits event but sends nothing when call stanza lacks id or fr
     })
     assert.equal(emitted.length, 1)
     assert.equal(sent.length, 0)
+})
+
+test('receipt exposes the participant username handle without the @ prefix', async () => {
+    const events: WaIncomingReceiptEvent[] = []
+    const handler = createIncomingReceiptHandler({
+        logger: createNoopLogger(),
+        sendNode: async () => undefined,
+        emitIncomingReceipt: (event) => {
+            events.push(event)
+        }
+    })
+
+    await handler({
+        tag: 'receipt',
+        attrs: {
+            id: 'r1',
+            from: '123@g.us',
+            type: 'read',
+            participant: '88880000:2@lid',
+            participant_username: '@joao'
+        }
+    })
+    await handler({
+        tag: 'receipt',
+        attrs: { id: 'r2', from: '88880000@lid', type: 'read' }
+    })
+
+    assert.equal(events.length, 2)
+    assert.equal(events[0].participantUsername, 'joao')
+    assert.equal(events[1].participantUsername, undefined)
 })

--- a/src/client/coordinators/WaPrivacyCoordinator.ts
+++ b/src/client/coordinators/WaPrivacyCoordinator.ts
@@ -23,6 +23,7 @@ import {
     type WaPrivacySettingValueMap
 } from '@protocol/privacy'
 import type { SignalUserJidPair } from '@signal/api/SignalDeviceSyncApi'
+import type { WaContactStore } from '@store/contracts/contact.store'
 import {
     buildBlocklistBlockIq,
     buildBlocklistUnblockIq,
@@ -88,7 +89,9 @@ export interface WaPrivacyCoordinator {
     /**
      * Fetches the per-category disallowed list (the JIDs explicitly excluded
      * while the category sits on `'contact_blacklist'`). Returns an empty
-     * list when the category is on any other value.
+     * list when the category is on any other value. `entries` carries the same
+     * membership as `jids` plus each entry's handle, when the server
+     * identified it that way.
      */
     readonly getDisallowedList: (
         category: WaPrivacyDisallowedListSettingName
@@ -129,7 +132,9 @@ export interface WaPrivacyCoordinator {
     /**
      * Returns the current account-wide blocklist. Blocks/unblocks performed
      * on another device are refetched through the same dirty-bit path as
-     * {@link getPrivacySettings} and re-emitted as `blocklist`.
+     * {@link getPrivacySettings} and re-emitted as `blocklist`. `entries`
+     * carries the same membership as `jids` plus each entry's handle, when the
+     * server identified it that way.
      */
     readonly getBlocklist: () => Promise<WaBlocklistResult>
     /**
@@ -144,6 +149,10 @@ export interface WaPrivacyCoordinator {
      * phone-number input is resolved to its LID first (device-list cache,
      * then a usync query). Non-migrated accounts fall back to the plain
      * phone-jid form.
+     *
+     * A migrated entry also carries one identifier attribute, read from the
+     * stored contact: the phone jid, the username handle, or the display name.
+     * Entries with none of them are sent as `unknown_identifier`.
      */
     readonly blockUser: (jid: string) => Promise<void>
     /**
@@ -191,6 +200,39 @@ interface WaPrivacyCoordinatorOptions {
      */
     readonly getSelfLid: () => string | null
     readonly emitPrivacy: (event: WaPrivacyAccountSyncResult) => void
+    /** Source of the username / display-name identifiers a migrated write carries. */
+    readonly contactStore: WaContactStore
+    /**
+     * Server-synced `username_contact_privacy_setting_allow_uncontact_set_enable`
+     * AB-prop, off by default - entries then fall back to `pn_jid`.
+     */
+    readonly isUsernamePrivacyListIdentifierEnabled: () => boolean
+}
+
+/**
+ * Adds the identifier fields a migrated write may carry. Only the writes that
+ * consume them call it - an unblock addresses by jid alone, and a
+ * disallowed-list write with the AB gate closed falls back to `pn_jid`.
+ */
+async function withContactIdentifiers(
+    options: WaPrivacyCoordinatorOptions,
+    target: WaBlocklistTarget
+): Promise<WaBlocklistTarget> {
+    if (target.lidJid === null) return target
+    try {
+        const contact = await options.contactStore.getByJid(target.lidJid)
+        return {
+            ...target,
+            username: contact?.username ?? null,
+            displayName: contact?.displayName ?? null
+        }
+    } catch (error) {
+        options.logger.debug('contact identifier lookup failed', {
+            jid: target.lidJid,
+            message: toError(error).message
+        })
+        return target
+    }
 }
 
 /**
@@ -242,10 +284,19 @@ async function resolveDisallowedListEntries(
         { action: WA_PRIVACY_LIST_ACTIONS.ADD, jids: input.add ?? [] },
         { action: WA_PRIVACY_LIST_ACTIONS.REMOVE, jids: input.remove ?? [] }
     ] as const
+    const usernameIdentifierAllowed = options.isUsernamePrivacyListIdentifierEnabled()
     for (const { action, jids } of actions) {
         for (const jid of jids) {
-            const target = await resolveBlocklistTarget(options, jid)
-            entries.push({ action, lidJid: target.lidJid, pnJid: target.pnJid })
+            const resolved = await resolveBlocklistTarget(options, jid)
+            const target = usernameIdentifierAllowed
+                ? await withContactIdentifiers(options, resolved)
+                : resolved
+            entries.push({
+                action,
+                lidJid: target.lidJid,
+                pnJid: target.pnJid,
+                username: target.username ?? null
+            })
         }
     }
     if (entries.length === 0) {
@@ -417,7 +468,10 @@ export function createPrivacyCoordinator(
         },
 
         blockUser: async (jid) => {
-            const target = await resolveBlocklistTarget(options, jid)
+            const target = await withContactIdentifiers(
+                options,
+                await resolveBlocklistTarget(options, jid)
+            )
             const node = buildBlocklistBlockIq(target)
             const result = await queryWithContext('privacy.blockUser', node, undefined, {
                 jid: target.lidJid ?? target.pnJid

--- a/src/client/coordinators/WaProfileCoordinator.ts
+++ b/src/client/coordinators/WaProfileCoordinator.ts
@@ -433,8 +433,8 @@ function assertValidUsernameKey(key: string | undefined): void {
 }
 
 /**
- * `type="out"` means the handle is not reachable from this account, a missing
- * `jid` means the lookup key is required, anything else resolves.
+ * An `<error>` child or `type="out"` means the handle did not resolve, a
+ * missing `jid` means the lookup key is required, anything else resolves.
  */
 function parseUsernameLookup(result: BinaryNode): WaUsernameLookupResult {
     const userNodes = iterateUsyncUsers(result) ?? []
@@ -442,6 +442,9 @@ function parseUsernameLookup(result: BinaryNode): WaUsernameLookupResult {
 
     const userNode = userNodes[0]
     const contactNode = findNodeChild(userNode, WA_NODE_TAGS.CONTACT)
+    if (contactNode && findNodeChild(contactNode, WA_NODE_TAGS.ERROR)) {
+        return { status: 'not-found' }
+    }
     const rawUsername = contactNode?.attrs.username
     const username = rawUsername !== undefined ? normalizeUsername(rawUsername) : null
     if (contactNode?.attrs.type === 'out') return { status: 'not-found' }

--- a/src/client/coordinators/WaProfileCoordinator.ts
+++ b/src/client/coordinators/WaProfileCoordinator.ts
@@ -3,6 +3,13 @@ import type { Logger } from '@infra/log/types'
 import type { WaMexOperationResponses } from '@mex'
 import { parseJidFull, parsePhoneJid } from '@protocol/jid'
 import { WA_NODE_TAGS } from '@protocol/nodes'
+import {
+    isUsernameKey,
+    normalizeUsername,
+    splitUsernameHandle,
+    validateUsernameLocally,
+    WA_USERNAME_LIMITS
+} from '@protocol/username'
 import type { SignalLidSyncResult } from '@signal/api/SignalDeviceSyncApi'
 import {
     buildDeleteProfilePictureIq,
@@ -14,6 +21,8 @@ import {
     buildSetDisappearingModeIq,
     buildSetProfilePictureIq,
     buildSetStatusIq,
+    buildUsernameLookupContactNode,
+    buildUsernameLookupUsyncQueryNodes,
     type WaProfilePictureType
 } from '@transport/node/builders/profile'
 import {
@@ -89,6 +98,24 @@ export interface WaUsernameAvailabilityResult {
     readonly suggestions: readonly string[]
 }
 
+export type WaUsernameLookupResult =
+    | {
+          readonly status: 'found'
+          readonly jid: string
+          readonly username: string | null
+          readonly isBusiness: boolean
+          readonly pnJid: string | null
+      }
+    | { readonly status: 'key-required'; readonly username: string | null }
+    | { readonly status: 'not-found' }
+
+export interface WaResolveUsernameInput {
+    /** A leading `@` and a `:1234` key suffix are accepted. */
+    readonly username: string
+    /** Overrides a key parsed out of {@link username}. */
+    readonly usernameKey?: string
+}
+
 /**
  * Coordinates own/peer profile queries and mutations: picture, status, text
  * status, username, disappearing mode, and LID lookup. Accessed via
@@ -153,13 +180,23 @@ export interface WaProfileCoordinator {
     readonly setTextStatus: (input: WaSetTextStatusInput) => Promise<void>
     /** Batched fetch of username per JID. */
     readonly getUsernames: (jids: readonly string[]) => Promise<readonly WaUsernameResult[]>
+    /**
+     * Resolves a username handle to the account's LID, so a message can be
+     * addressed to `@handle`. `'key-required'` means the server withheld the
+     * JID - repeat the call with `usernameKey`.
+     *
+     * @throws when the handle fails local validation, before any round-trip.
+     */
+    readonly resolveUsername: (input: WaResolveUsernameInput) => Promise<WaUsernameLookupResult>
     /** Fetches the current account's username record (value, state, recovery pin). */
     readonly getOwnUsername: () => Promise<WaOwnUsernameResult>
     /**
      * Reserves/sets a username on the current account. Returns `true` only
-     * when the server reports `'SUCCESS'`; on any other outcome (taken,
-     * invalid, rate-limited) it returns `false` without throwing - check the
-     * value and consult {@link checkUsernameAvailability} for suggestions.
+     * when the server reports `'SUCCESS'`; on any other server outcome (taken,
+     * rate-limited) it returns `false` without throwing - check the value and
+     * consult {@link checkUsernameAvailability} for suggestions.
+     *
+     * @throws when the handle fails local validation, before any round-trip.
      */
     readonly setUsername: (input: WaSetUsernameInput) => Promise<boolean>
     /** Deletes the current account's username. Returns `true` on success. */
@@ -168,7 +205,11 @@ export interface WaProfileCoordinator {
     readonly getAboutStatus: (jid: string) => Promise<string | null>
     /** Checks whether a username is available and returns server suggestions. */
     readonly checkUsernameAvailability: (username: string) => Promise<WaUsernameAvailabilityResult>
-    /** Sets the username recovery PIN. Returns `true` on success. */
+    /**
+     * Sets the username recovery PIN. Returns `true` on success.
+     *
+     * @throws when `pin` is not exactly 4 digits, before any round-trip.
+     */
     readonly setUsernameKey: (pin: string) => Promise<boolean>
     /** Resolves LIDs for a list of phone numbers (handles normalization). */
     readonly getLidsByPhoneNumbers: (
@@ -362,14 +403,60 @@ function parseUsyncUsernames(result: BinaryNode): readonly WaUsernameResult[] {
         const usernameNode = findNodeChild(userNode, WA_NODE_TAGS.USERNAME)
         const hasUsernameError =
             usernameNode && findNodeChild(usernameNode, WA_NODE_TAGS.ERROR) !== undefined
-        const username =
+        const rawUsername =
             usernameNode && !hasUsernameError ? getNodeTextContent(usernameNode) || null : null
+        const username = rawUsername !== null ? normalizeUsername(rawUsername) : null
 
         results[count] = { jid, username }
         count += 1
     }
     results.length = count
     return results
+}
+
+/** Reports the failing rule, never the rejected handle. */
+function assertValidUsername(username: string): void {
+    const validation = validateUsernameLocally(username)
+    if (!validation.isValid) {
+        throw new Error(`invalid username: ${validation.errorType}`)
+    }
+}
+
+/**
+ * The key is a recovery secret, so a rejection describes the expected shape and
+ * never echoes the value - callers routinely log the errors they catch.
+ */
+function assertValidUsernameKey(key: string | undefined): void {
+    if (key !== undefined && !isUsernameKey(key)) {
+        throw new Error(`invalid username key: expected ${WA_USERNAME_LIMITS.KEY_LENGTH} digits`)
+    }
+}
+
+/**
+ * `type="out"` means the handle is not reachable from this account, a missing
+ * `jid` means the lookup key is required, anything else resolves.
+ */
+function parseUsernameLookup(result: BinaryNode): WaUsernameLookupResult {
+    const userNodes = iterateUsyncUsers(result) ?? []
+    if (userNodes.length !== 1) return { status: 'not-found' }
+
+    const userNode = userNodes[0]
+    const contactNode = findNodeChild(userNode, WA_NODE_TAGS.CONTACT)
+    const rawUsername = contactNode?.attrs.username
+    const username = rawUsername !== undefined ? normalizeUsername(rawUsername) : null
+    if (contactNode?.attrs.type === 'out') return { status: 'not-found' }
+
+    const jid = userNode.attrs.jid as string | undefined
+    if (!jid) return { status: 'key-required', username }
+
+    const businessNode = findNodeChild(userNode, WA_NODE_TAGS.BUSINESS)
+    return {
+        status: 'found',
+        jid,
+        username,
+        isBusiness: businessNode !== undefined && !findNodeChild(businessNode, WA_NODE_TAGS.ERROR),
+        pnJid: businessNode?.attrs.pn_jid ?? null
+    }
 }
 
 function parseOwnUsernameMexResponse(
@@ -621,6 +708,39 @@ export function createProfileCoordinator(
             return parseUsyncUsernames(result)
         },
 
+        resolveUsername: async (input) => {
+            const parsed = splitUsernameHandle(input.username)
+            assertValidUsername(parsed.username)
+            const usernameKey = input.usernameKey ?? parsed.usernameKey ?? undefined
+            assertValidUsernameKey(usernameKey)
+            const sid = await generateSid()
+            const usyncNode = buildUsyncIq({
+                sid,
+                queryProtocolNodes: buildUsernameLookupUsyncQueryNodes(),
+                users: [
+                    {
+                        content: [
+                            buildUsernameLookupContactNode({
+                                username: parsed.username,
+                                ...(usernameKey !== undefined ? { usernameKey } : {})
+                            })
+                        ]
+                    }
+                ]
+            })
+            const result = await queryWithContext('profile.resolveUsername', usyncNode, undefined, {
+                username: parsed.username,
+                withKey: usernameKey !== undefined
+            })
+            assertIqResult(result, 'profile.resolveUsername')
+            logUsyncProtocolErrors(
+                parseUsyncResultEnvelope(result),
+                logger,
+                'profile.resolveUsername'
+            )
+            return parseUsernameLookup(result)
+        },
+
         getOwnUsername: async () => {
             try {
                 const data = await runMexQuery(mexSocket, 'GetUsername', {})
@@ -634,8 +754,10 @@ export function createProfileCoordinator(
         },
 
         setUsername: async (input) => {
+            const username = normalizeUsername(input.username.trim())
+            assertValidUsername(username)
             const data = await runMexQuery(mexSocket, 'SetUsername', {
-                input: input.username,
+                input: username,
                 reserved: input.reserved ?? false,
                 session_id: input.sessionId ?? '',
                 source: input.source ?? 'USER_INPUT'
@@ -663,6 +785,7 @@ export function createProfileCoordinator(
         },
 
         setUsernameKey: async (pin) => {
+            assertValidUsernameKey(pin)
             const data = await runMexQuery(mexSocket, 'SetUsernameKey', { pin })
             return isMexUsernameKeySetSuccess(data)
         },

--- a/src/client/coordinators/__tests__/privacy-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/privacy-coordinator.test.ts
@@ -5,6 +5,8 @@ import { createPrivacyCoordinator } from '@client/coordinators/WaPrivacyCoordina
 import { createNoopLogger } from '@infra/log/types'
 import { WA_DEFAULTS, WA_PRIVACY_CATEGORIES, WA_PRIVACY_TAGS } from '@protocol/constants'
 import type { SignalUserJidPair } from '@signal/api/SignalDeviceSyncApi'
+import type { WaContactStore } from '@store/contracts/contact.store'
+import { WaContactMemoryStore } from '@store/memory/contact.store'
 import type { BinaryNode } from '@transport/types'
 
 function createIqResult(content?: readonly BinaryNode[]): BinaryNode {
@@ -17,10 +19,13 @@ function createIqResult(content?: readonly BinaryNode[]): BinaryNode {
 
 function createBlocklistDeps(
     resolveUserJidPair?: (userJid: string) => Promise<SignalUserJidPair>,
-    selfLid: string | null = null
+    selfLid: string | null = null,
+    contactStore: WaContactStore = new WaContactMemoryStore()
 ) {
     return {
         logger: createNoopLogger(),
+        contactStore,
+        isUsernamePrivacyListIdentifierEnabled: () => true,
         resolveUserJidPair:
             resolveUserJidPair ??
             (async (userJid: string): Promise<SignalUserJidPair> =>
@@ -144,6 +149,7 @@ test('privacy coordinator maps setting/category for set and disallowed list quer
 
     assert.deepEqual(disallowed, {
         jids: ['a@s.whatsapp.net', 'b@s.whatsapp.net'],
+        entries: [{ jid: 'a@s.whatsapp.net' }, { jid: 'b@s.whatsapp.net' }],
         dhash: 'dhash-1'
     })
 
@@ -218,6 +224,7 @@ test('privacy coordinator parses blocklist and sends block/unblock actions', asy
 
     assert.deepEqual(blocklist, {
         jids: ['x@s.whatsapp.net', 'y@s.whatsapp.net'],
+        entries: [{ jid: 'x@s.whatsapp.net' }, { jid: 'y@s.whatsapp.net' }],
         dhash: 'block-hash'
     })
     assert.equal(calls.length, 3)
@@ -318,7 +325,12 @@ test('privacy coordinator refresh returns the settings plus only the reported li
 
     assert.deepEqual(result.settings, { pix: 'contacts' })
     assert.deepEqual(result.disallowedLists, [
-        { setting: 'lastSeen', jids: ['a@s.whatsapp.net'], dhash: 'list-hash' }
+        {
+            setting: 'lastSeen',
+            jids: ['a@s.whatsapp.net'],
+            entries: [{ jid: 'a@s.whatsapp.net' }],
+            dhash: 'list-hash'
+        }
     ])
     assert.deepEqual(
         categories.sort(),
@@ -623,4 +635,38 @@ test('privacy coordinator resolves lid addressing for block/unblock', async () =
     await assert.rejects(() => rejecting.blockUser('123-456@g.us'), {
         message: /blocklist target must be a user jid/
     })
+})
+
+test('disallowed-list username identifier is gated by its ab prop', async () => {
+    const contactStore = new WaContactMemoryStore()
+    await contactStore.upsert({
+        jid: '88880000@lid',
+        username: 'joao',
+        lastUpdatedMs: Date.now()
+    })
+    const resolveUserJidPair = async (): Promise<SignalUserJidPair> => ({
+        lidJid: '88880000@lid',
+        pnJid: null
+    })
+
+    const runWithGate = async (enabled: boolean): Promise<BinaryNode> => {
+        const nodes: BinaryNode[] = []
+        const coordinator = createPrivacyCoordinator({
+            ...createBlocklistDeps(resolveUserJidPair, '99990000@lid', contactStore),
+            isUsernamePrivacyListIdentifierEnabled: () => enabled,
+            queryWithContext: async (_context, node) => {
+                nodes.push(node)
+                return createIqResult()
+            }
+        })
+        await coordinator.setDisallowedList('lastSeen', { add: ['88880000@lid'] })
+        const privacyNode = nodes[1].content as readonly BinaryNode[]
+        const categoryNode = privacyNode[0].content as readonly BinaryNode[]
+        return (categoryNode[0].content as readonly BinaryNode[])[0]
+    }
+
+    assert.equal((await runWithGate(true)).attrs.username, 'joao')
+    const gated = await runWithGate(false)
+    assert.equal(gated.attrs.username, undefined)
+    assert.equal(gated.attrs.jid, '88880000@lid')
 })

--- a/src/client/coordinators/__tests__/profile-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/profile-coordinator.test.ts
@@ -1129,7 +1129,7 @@ test('profile coordinator setUsername returns false on non-SUCCESS result', asyn
             })
         }
     })
-    assert.equal(await coordinator.setUsername({ username: 'x' }), false)
+    assert.equal(await coordinator.setUsername({ username: 'taken.handle' }), false)
 })
 
 test('profile coordinator deleteUsername sends empty variables', async () => {
@@ -1257,4 +1257,126 @@ test('profile coordinator returns empty lid result without calling port', async 
     const result = await coordinator.getLidsByPhoneNumbers([])
     assert.equal(result.length, 0)
     assert.equal(called, false)
+})
+
+function createUsyncListResult(users: readonly BinaryNode[]): BinaryNode {
+    return createIqResult([
+        {
+            tag: 'usync',
+            attrs: {},
+            content: [{ tag: 'list', attrs: {}, content: users }]
+        }
+    ])
+}
+
+function createResolveUsernameCoordinator(
+    result: BinaryNode,
+    calls: Array<{ readonly node: BinaryNode; readonly contextData?: unknown }> = []
+) {
+    return createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
+        logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
+        queryLidsByPhoneJids: async () => [],
+        mexSocket: { query: async () => ({ tag: 'iq', attrs: { type: 'result' } }) },
+        queryWithContext: async (_context, node, _timeoutMs, contextData) => {
+            calls.push({ node, contextData })
+            return result
+        }
+    })
+}
+
+test('profile coordinator resolves a username handle to its lid', async () => {
+    const calls: Array<{ readonly node: BinaryNode; readonly contextData?: unknown }> = []
+    const coordinator = createResolveUsernameCoordinator(
+        createUsyncListResult([
+            {
+                tag: 'user',
+                attrs: { jid: '88880000@lid' },
+                content: [
+                    { tag: 'contact', attrs: { type: 'in', username: '@joao' } },
+                    { tag: 'business', attrs: { pn_jid: '5511999999999@s.whatsapp.net' } }
+                ]
+            }
+        ]),
+        calls
+    )
+
+    const result = await coordinator.resolveUsername({ username: '@joao:1234' })
+
+    assert.deepEqual(result, {
+        status: 'found',
+        jid: '88880000@lid',
+        username: 'joao',
+        isBusiness: true,
+        pnJid: '5511999999999@s.whatsapp.net'
+    })
+    assert.deepEqual(calls[0].contextData, { username: 'joao', withKey: true })
+})
+
+test('profile coordinator reports key-required and unreachable username lookups', async () => {
+    const keyRequired = await createResolveUsernameCoordinator(
+        createUsyncListResult([
+            {
+                tag: 'user',
+                attrs: {},
+                content: [{ tag: 'contact', attrs: { type: 'in', username: 'joao' } }]
+            }
+        ])
+    ).resolveUsername({ username: 'joao' })
+    assert.deepEqual(keyRequired, { status: 'key-required', username: 'joao' })
+
+    const unreachable = await createResolveUsernameCoordinator(
+        createUsyncListResult([
+            {
+                tag: 'user',
+                attrs: { jid: '88880000@lid' },
+                content: [{ tag: 'contact', attrs: { type: 'out' } }]
+            }
+        ])
+    ).resolveUsername({ username: 'joao' })
+    assert.deepEqual(unreachable, { status: 'not-found' })
+
+    const empty = await createResolveUsernameCoordinator(createUsyncListResult([])).resolveUsername(
+        {
+            username: 'joao'
+        }
+    )
+    assert.deepEqual(empty, { status: 'not-found' })
+})
+
+test('profile coordinator rejects invalid usernames and keys before querying', async () => {
+    let queried = false
+    const coordinator = createProfileCoordinator({
+        generateSid: async () => 'test-sid',
+        applyOwnPushName: async () => undefined,
+        resolvePrivacyTokenNode: async () => null,
+        logger: createNoopLogger(),
+        mutations: { set: async () => undefined } as never,
+        queryLidsByPhoneJids: async () => [],
+        mexSocket: {
+            query: async () => {
+                queried = true
+                return { tag: 'iq', attrs: { type: 'result' } }
+            }
+        },
+        queryWithContext: async () => {
+            queried = true
+            return createIqResult()
+        }
+    })
+
+    await assert.rejects(() => coordinator.resolveUsername({ username: 'ab' }), /invalid username/)
+    await assert.rejects(
+        () => coordinator.resolveUsername({ username: 'joao', usernameKey: '12' }),
+        /invalid username key/
+    )
+    await assert.rejects(
+        () => coordinator.setUsername({ username: 'www.joao' }),
+        /invalid username/
+    )
+    await assert.rejects(() => coordinator.setUsernameKey('12'), /invalid username key/)
+    assert.equal(queried, false)
 })

--- a/src/client/coordinators/__tests__/profile-coordinator.test.ts
+++ b/src/client/coordinators/__tests__/profile-coordinator.test.ts
@@ -1380,3 +1380,23 @@ test('profile coordinator rejects invalid usernames and keys before querying', a
     await assert.rejects(() => coordinator.setUsernameKey('12'), /invalid username key/)
     assert.equal(queried, false)
 })
+
+test('profile coordinator does not read a contact error as key-required', async () => {
+    const result = await createResolveUsernameCoordinator(
+        createUsyncListResult([
+            {
+                tag: 'user',
+                attrs: {},
+                content: [
+                    {
+                        tag: 'contact',
+                        attrs: {},
+                        content: [{ tag: 'error', attrs: { code: '429', text: 'rate-limited' } }]
+                    }
+                ]
+            }
+        ])
+    ).resolveUsername({ username: 'joao' })
+
+    assert.deepEqual(result, { status: 'not-found' })
+})

--- a/src/client/events/__tests__/events.test.ts
+++ b/src/client/events/__tests__/events.test.ts
@@ -14,6 +14,7 @@ import type { WaBlocklistResult } from '@client/events/privacy'
 import { parsePrivacyTokenNotification } from '@client/events/privacy-token'
 import { aggregateReceiptTargets, extractReceiptIds } from '@client/events/receipt'
 import { parseRegistrationNotification } from '@client/events/registration'
+import { parseOwnUsernameNotification } from '@client/events/username'
 import { createNoopLogger } from '@infra/log/types'
 import { proto } from '@proto'
 import {
@@ -1287,7 +1288,13 @@ test('account_sync dirty bit runs the privacy refresh and re-emits the blocklist
     )
 
     assert.equal(privacyRefreshes, 1)
-    assert.deepEqual(blocklists, [{ jids: ['x@s.whatsapp.net'], dhash: 'block-hash' }])
+    assert.deepEqual(blocklists, [
+        {
+            jids: ['x@s.whatsapp.net'],
+            entries: [{ jid: 'x@s.whatsapp.net' }],
+            dhash: 'block-hash'
+        }
+    ])
     assert.ok(contexts.includes('account_sync.blocklist'))
     assert.ok(contexts.includes('dirty.clear'))
 })
@@ -1358,4 +1365,38 @@ test('parseOfflineThreadMetadata tolerates a bare node', () => {
 
     assert.deepEqual(metadata.threads, [])
     assert.equal(metadata.readWatermarks, undefined)
+})
+
+test('account_sync username notification maps modify, set, and delete shapes', () => {
+    const build = (child: BinaryNode): BinaryNode => ({
+        tag: 'notification',
+        attrs: { id: 'n1', from: '5511999999999@s.whatsapp.net', type: 'account_sync' },
+        content: [child]
+    })
+
+    const set = parseOwnUsernameNotification(
+        build({ tag: 'username', attrs: { username: '@joao' } })
+    )
+    assert.equal(set?.kind, 'set')
+    assert.equal(set?.username, 'joao')
+
+    const modify = parseOwnUsernameNotification(
+        build({ tag: 'username', attrs: { action: 'modify' } })
+    )
+    assert.equal(modify?.kind, 'modify')
+    assert.equal(modify?.username, null)
+
+    const both = parseOwnUsernameNotification(
+        build({ tag: 'username', attrs: { action: 'modify', username: 'joao' } })
+    )
+    assert.equal(both?.kind, 'modify')
+
+    const deleted = parseOwnUsernameNotification(build({ tag: 'username', attrs: {} }))
+    assert.equal(deleted?.kind, 'delete')
+
+    assert.equal(
+        parseOwnUsernameNotification(build({ tag: 'privacy', attrs: {} })),
+        null,
+        'a notification without a username child is not a username change'
+    )
 })

--- a/src/client/events/incoming.ts
+++ b/src/client/events/incoming.ts
@@ -33,6 +33,7 @@ import {
 } from '@protocol/constants'
 import { isLidJid, normalizeDeviceJid, toUserJid } from '@protocol/jid'
 import type { WaConnectionCode, WaDisconnectReason } from '@protocol/stream'
+import { normalizeUsername } from '@protocol/username'
 import { buildAckNode, buildReceiptNode } from '@transport/node/builders/global'
 import { getFirstNodeChild, getNodeChildrenNonEmptyAttrValuesByTag } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
@@ -289,6 +290,9 @@ export function createIncomingReceiptHandler(
                 status: mapped.status,
                 fromSelfDevice: mapped.fromSelfDevice,
                 participantJid: node.attrs.participant,
+                ...(node.attrs.participant_username !== undefined
+                    ? { participantUsername: normalizeUsername(node.attrs.participant_username) }
+                    : {}),
                 recipientJid: node.attrs.recipient,
                 messageIds: extractReceiptIds(node)
             })

--- a/src/client/events/privacy.ts
+++ b/src/client/events/privacy.ts
@@ -8,6 +8,7 @@ import {
     type WaPrivacySettingValueMap,
     type WaPrivacyValue
 } from '@protocol/privacy'
+import { normalizeUsername } from '@protocol/username'
 import { findNodeChild, getNodeChildren, getNodeChildrenByTag } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
 
@@ -20,16 +21,50 @@ export type WaPrivacySettings = {
     readonly [K in WaPrivacySettingName]?: WaPrivacySettingValueMap[K]
 }
 
+/** `username` is set only when the server identified the entry that way. */
+export interface WaPrivacyListEntry {
+    readonly jid: string
+    readonly username?: string
+}
+
 /** Per-category deny-list (the JIDs excluded from a `contact_blacklist` setting). */
 export interface WaPrivacyDisallowedListResult {
     readonly jids: readonly string[]
+    /** Same membership as {@link jids}, with the per-entry handles. */
+    readonly entries: readonly WaPrivacyListEntry[]
     readonly dhash?: string
 }
 
 /** Account-wide blocklist. The server always sends the full list, never a delta. */
 export interface WaBlocklistResult {
     readonly jids: readonly string[]
+    /** Same membership as {@link jids}, with the per-entry handles. */
+    readonly entries: readonly WaPrivacyListEntry[]
     readonly dhash?: string
+}
+
+function parsePrivacyListEntries(nodes: readonly BinaryNode[]): readonly WaPrivacyListEntry[] {
+    const entries = new Array<WaPrivacyListEntry>(nodes.length)
+    let count = 0
+    for (let i = 0; i < nodes.length; i += 1) {
+        const attrs = nodes[i].attrs
+        const jid = attrs.jid as string | undefined
+        if (!jid) continue
+        const username = attrs.username as string | undefined
+        entries[count] =
+            username !== undefined ? { jid, username: normalizeUsername(username) } : { jid }
+        count += 1
+    }
+    entries.length = count
+    return entries
+}
+
+function toJids(entries: readonly WaPrivacyListEntry[]): readonly string[] {
+    const jids = new Array<string>(entries.length)
+    for (let i = 0; i < entries.length; i += 1) {
+        jids[i] = entries[i].jid
+    }
+    return jids
 }
 
 /**
@@ -131,20 +166,8 @@ export function parseDisallowedListUpdate(
     }
 
     const dhash = listNode.attrs.dhash as string | undefined
-    const userNodes = getNodeChildrenByTag(listNode, WA_PRIVACY_TAGS.USER)
-    const jids = new Array<string>(userNodes.length)
-    let jidsCount = 0
-
-    for (let i = 0; i < userNodes.length; i += 1) {
-        const jid = userNodes[i].attrs.jid as string | undefined
-        if (jid) {
-            jids[jidsCount] = jid
-            jidsCount += 1
-        }
-    }
-    jids.length = jidsCount
-
-    return { jids, dhash }
+    const entries = parsePrivacyListEntries(getNodeChildrenByTag(listNode, WA_PRIVACY_TAGS.USER))
+    return { jids: toJids(entries), entries, dhash }
 }
 
 /**
@@ -153,29 +176,17 @@ export function parseDisallowedListUpdate(
  * membership.
  */
 export function parseDisallowedList(result: BinaryNode): WaPrivacyDisallowedListResult {
-    return parseDisallowedListUpdate(result) ?? { jids: [] }
+    return parseDisallowedListUpdate(result) ?? { jids: [], entries: [] }
 }
 
 /** Parses the `<list>` payload of a blocklist `get` IQ result. */
 export function parseBlocklist(result: BinaryNode): WaBlocklistResult {
     const listNode = findNodeChild(result, WA_NODE_TAGS.LIST)
     if (!listNode) {
-        return { jids: [] }
+        return { jids: [], entries: [] }
     }
 
     const dhash = listNode.attrs.dhash as string | undefined
-    const itemNodes = getNodeChildren(listNode)
-    const jids = new Array<string>(itemNodes.length)
-    let jidsCount = 0
-
-    for (let i = 0; i < itemNodes.length; i += 1) {
-        const jid = itemNodes[i].attrs.jid as string | undefined
-        if (jid) {
-            jids[jidsCount] = jid
-            jidsCount += 1
-        }
-    }
-    jids.length = jidsCount
-
-    return { jids, dhash }
+    const entries = parsePrivacyListEntries(getNodeChildren(listNode))
+    return { jids: toJids(entries), entries, dhash }
 }

--- a/src/client/events/username.ts
+++ b/src/client/events/username.ts
@@ -1,0 +1,28 @@
+import { createIncomingBaseEvent } from '@client/events/incoming'
+import type { WaOwnUsernameNotificationEvent } from '@client/types'
+import { WA_NODE_TAGS } from '@protocol/nodes'
+import { normalizeUsername } from '@protocol/username'
+import { findNodeChild } from '@transport/node/helpers'
+import type { BinaryNode } from '@transport/types'
+
+/**
+ * Reads the `<username>` child of an `account_sync` notification, `null` when
+ * there is none. The shapes are tried in WhatsApp Web's order, so
+ * `action="modify"` wins over a handle when a stanza carries both.
+ */
+export function parseOwnUsernameNotification(
+    node: BinaryNode
+): WaOwnUsernameNotificationEvent | null {
+    const usernameNode = findNodeChild(node, WA_NODE_TAGS.USERNAME)
+    if (!usernameNode) return null
+
+    const base = createIncomingBaseEvent(node)
+    if (usernameNode.attrs.action === 'modify') {
+        return { ...base, kind: 'modify', username: null }
+    }
+    const rawUsername = usernameNode.attrs.username
+    if (rawUsername !== undefined) {
+        return { ...base, kind: 'set', username: normalizeUsername(rawUsername) }
+    }
+    return { ...base, kind: 'delete', username: null }
+}

--- a/src/client/persistence/WriteBehindPersistence.ts
+++ b/src/client/persistence/WriteBehindPersistence.ts
@@ -48,6 +48,7 @@ function mergeContact(
         pushName: incoming.pushName ?? previous.pushName,
         lid: incoming.lid ?? previous.lid,
         phoneNumber: incoming.phoneNumber ?? previous.phoneNumber,
+        username: incoming.username ?? previous.username,
         lastUpdatedMs: Math.max(previous.lastUpdatedMs, incoming.lastUpdatedMs)
     }
 }

--- a/src/client/persistence/history-sync.ts
+++ b/src/client/persistence/history-sync.ts
@@ -6,6 +6,7 @@ import type { WaMediaTransferClient } from '@media/transfer/WaMediaTransferClien
 import { proto, type Proto } from '@proto'
 import { isUserJid } from '@protocol/jid'
 import { normalizeEphemeralSettingSeconds } from '@protocol/message'
+import { normalizeUsername } from '@protocol/username'
 import type { WaChatMetadataStore } from '@store/contracts/chat-metadata.store'
 import { concatBytes, TEXT_DECODER } from '@util/bytes'
 import { longToNumber, toError } from '@util/primitives'
@@ -386,15 +387,19 @@ async function closeConversation(
     )
 
     if (isUserJid(resolvedJid) || (conversation.lidJid ?? conversation.accountLid)) {
-        const contactDisplay = conversation.displayName || conversation.username || undefined
+        const contactDisplay = conversation.displayName || undefined
+        const contactUsername = conversation.username
+            ? normalizeUsername(conversation.username)
+            : undefined
         const contactPn = conversation.pnJid ?? undefined
         const contactLid = conversation.lidJid ?? conversation.accountLid ?? undefined
-        if (contactDisplay || contactPn || contactLid) {
+        if (contactDisplay || contactUsername || contactPn || contactLid) {
             pushWrite(
                 state,
                 deps.writeBehind.persistContactAsync({
                     jid: contactLid ?? resolvedJid,
                     displayName: contactDisplay,
+                    username: contactUsername,
                     phoneNumber: contactPn,
                     lastUpdatedMs: state.nowMs
                 })

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -604,9 +604,15 @@ export interface WaIncomingMessageKey extends WaMessageKey {
     readonly participantAlt?: string
     /** Sender's device id — `0` when the source JID has no `:device` segment. */
     readonly senderDevice: number
+    /**
+     * Author's handle, without the `@`. Absent on self-authored 1:1 stanzas,
+     * where the counterpart's is {@link recipientUsername} instead.
+     */
     readonly senderUsername?: string
     readonly recipientJid?: string
     readonly recipientAlt?: string
+    /** Recipient's handle, without the `@`. */
+    readonly recipientUsername?: string
     /** Server-assigned message id (newsletters / channel messages). */
     readonly serverId?: number
 }
@@ -662,6 +668,8 @@ export interface WaIncomingReceiptEvent extends WaIncomingBaseEvent {
     /** True when the receipt came from another device of the current user (multi-device sync). */
     readonly fromSelfDevice: boolean
     readonly participantJid?: string
+    /** The participant's handle, without the `@`. */
+    readonly participantUsername?: string
     readonly recipientJid?: string
     /**
      * All message ids this receipt acknowledges. For batch read/delivery
@@ -670,6 +678,12 @@ export interface WaIncomingReceiptEvent extends WaIncomingBaseEvent {
      * `externalIds`.
      */
     readonly messageIds: readonly string[]
+}
+
+/** `username` is populated only for `kind: 'set'`. */
+export interface WaOwnUsernameNotificationEvent extends WaIncomingBaseEvent {
+    readonly kind: 'set' | 'delete' | 'modify'
+    readonly username: string | null
 }
 
 export interface WaIncomingPresenceEvent extends WaIncomingBaseEvent {
@@ -1531,6 +1545,13 @@ export interface WaClientEventMap {
      * shape), never a delta.
      */
     readonly blocklist: (event: WaBlocklistResult) => void
+    /**
+     * The account's own username changed on another device. `'modify'` is a
+     * payload-less hint - refetch with
+     * {@link WaProfileCoordinator.getOwnUsername}. Accounts on the MEX
+     * account-sync path get a `mex_notification` instead, not both.
+     */
+    readonly own_username: (event: WaOwnUsernameNotificationEvent) => void
     /**
      * A parsed app-state mutation arriving from a sync – chat mute/star/read/
      * pin/archive/contact/label/etc. changed on another device. Inbound only;

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ export type {
     WaOfflineThreadPreview,
     WaOfflineThreadReadWatermark,
     WaOutgoingMessageEvent,
+    WaOwnUsernameNotificationEvent,
     WaPictureEvent,
     WaPictureEventAction,
     WaPrivacyTokenUpdateEvent,
@@ -206,6 +207,7 @@ export type {
 export type {
     WaBlocklistResult,
     WaPrivacyDisallowedListResult,
+    WaPrivacyListEntry,
     WaPrivacySettings
 } from '@client/events/privacy'
 export type {
@@ -215,9 +217,11 @@ export type {
     WaProfileInfo,
     WaProfilePictureResult,
     WaProfileStatusResult,
+    WaResolveUsernameInput,
     WaSetTextStatusInput,
     WaSetUsernameInput,
     WaTextStatusResult,
+    WaUsernameLookupResult,
     WaUsernameResult
 } from '@client/coordinators/WaProfileCoordinator'
 export type { WaProfilePictureType } from '@transport/node/builders/profile'

--- a/src/message/primitives/__tests__/incoming.test.ts
+++ b/src/message/primitives/__tests__/incoming.test.ts
@@ -671,3 +671,98 @@ test('the payload is only built when the hook asks for it', async () => {
     assert.notEqual(built[0]?.plaintext, built[1]?.plaintext, 'each call copies')
     assert.deepEqual(built[0]?.plaintext, built[1]?.plaintext, 'to the same bytes')
 })
+
+test('incoming 1:1 message exposes the sender username handle', async () => {
+    const emitted: WaIncomingMessageEvent[] = []
+    await handleIncomingMessageAck(
+        {
+            tag: 'message',
+            attrs: {
+                id: 'msg-un',
+                from: '5511999999999:12@s.whatsapp.net',
+                username: '@joao',
+                t: '123'
+            },
+            content: [{ tag: 'enc', attrs: { type: 'msg' }, content: new Uint8Array([1]) }]
+        },
+        createDecryptingOptions(emitted)
+    )
+
+    assert.equal(emitted.length, 1)
+    assert.equal(emitted[0].key.senderUsername, 'joao')
+    assert.equal(emitted[0].key.recipientUsername, undefined)
+})
+
+test('group message prefers participant_username as the sender handle', async () => {
+    const emitted: WaIncomingMessageEvent[] = []
+    await handleIncomingMessageAck(
+        {
+            tag: 'message',
+            attrs: {
+                id: 'msg-grp-un',
+                from: '123456@g.us',
+                participant: '5511999999999:3@s.whatsapp.net',
+                username: 'ignored',
+                participant_username: 'joao',
+                t: '123'
+            },
+            content: [{ tag: 'enc', attrs: { type: 'msg' }, content: new Uint8Array([1]) }]
+        },
+        createDecryptingOptions(emitted)
+    )
+
+    assert.equal(emitted.length, 1)
+    assert.equal(emitted[0].key.senderUsername, 'joao')
+})
+
+test('self-sent 1:1 message carries the peer handle, not the own one', async () => {
+    const emitted: WaIncomingMessageEvent[] = []
+    await handleIncomingMessageAck(
+        {
+            tag: 'message',
+            attrs: {
+                id: 'msg-self-un',
+                from: '5511999999999:12@s.whatsapp.net',
+                recipient: '5511888888888@s.whatsapp.net',
+                username: 'me.handle',
+                peer_recipient_username: 'joao',
+                t: '123'
+            },
+            content: [{ tag: 'enc', attrs: { type: 'msg' }, content: new Uint8Array([1]) }]
+        },
+        createDecryptingOptions(emitted, {
+            getMeJid: () => '5511999999999:2@s.whatsapp.net'
+        })
+    )
+
+    assert.equal(emitted.length, 1)
+    const { key } = emitted[0]
+    assert.equal(key.fromMe, true)
+    assert.equal(key.remoteJid, '5511888888888@s.whatsapp.net')
+    assert.equal(key.recipientUsername, 'joao')
+    assert.equal(
+        key.senderUsername,
+        undefined,
+        'the own handle must not be promoted onto the peer-addressed key'
+    )
+})
+
+test('recipient_username wins over peer_recipient_username when both are present', async () => {
+    const emitted: WaIncomingMessageEvent[] = []
+    await handleIncomingMessageAck(
+        {
+            tag: 'message',
+            attrs: {
+                id: 'msg-rec-un',
+                from: '5511999999999:12@s.whatsapp.net',
+                recipient_username: 'primary',
+                peer_recipient_username: 'fallback',
+                t: '123'
+            },
+            content: [{ tag: 'enc', attrs: { type: 'msg' }, content: new Uint8Array([1]) }]
+        },
+        createDecryptingOptions(emitted)
+    )
+
+    assert.equal(emitted[0].key.recipientUsername, 'primary')
+})

--- a/src/message/primitives/incoming.ts
+++ b/src/message/primitives/incoming.ts
@@ -24,6 +24,7 @@ import {
     parseSignalAddressFromJid,
     toUserJid
 } from '@protocol/jid'
+import { normalizeUsername } from '@protocol/username'
 import type { WaRetryDecryptFailureContext } from '@retry/types'
 import type { SenderKeyManager } from '@signal/group/SenderKeyManager'
 import type { SignalProtocol } from '@signal/session/SignalProtocol'
@@ -62,6 +63,7 @@ interface MessageIdentityAttrs {
     readonly senderUsername?: string
     readonly recipientJid?: string
     readonly recipientAlt?: string
+    readonly recipientUsername?: string
     readonly pushName: string | undefined
 }
 
@@ -74,13 +76,19 @@ function extractMessageIdentityAttrs(attrs: BinaryNode['attrs']): MessageIdentit
     const rawParticipantAlt = attrs.participant_pn ?? attrs.participant_lid
     const rawRecipientAlt = attrs.peer_recipient_pn ?? attrs.peer_recipient_lid
     const rawRecipient = attrs.recipient
-    const senderUsername = attrs.participant_username ?? attrs.username
+    const rawSenderUsername = attrs.participant_username ?? attrs.username
+    const rawRecipientUsername = attrs.recipient_username ?? attrs.peer_recipient_username
+    const senderUsername =
+        rawSenderUsername !== undefined ? normalizeUsername(rawSenderUsername) : undefined
+    const recipientUsername =
+        rawRecipientUsername !== undefined ? normalizeUsername(rawRecipientUsername) : undefined
     return {
         ...(rawRemoteJidAlt ? { remoteJidAlt: toUserJid(rawRemoteJidAlt) } : {}),
         ...(rawParticipantAlt ? { participantAlt: toUserJid(rawParticipantAlt) } : {}),
         ...(senderUsername !== undefined ? { senderUsername } : {}),
         ...(rawRecipient ? { recipientJid: toUserJid(rawRecipient) } : {}),
         ...(rawRecipientAlt ? { recipientAlt: toUserJid(rawRecipientAlt) } : {}),
+        ...(recipientUsername !== undefined ? { recipientUsername } : {}),
         pushName: attrs.notify
     }
 }
@@ -94,12 +102,13 @@ type MessageKeyIdentity = Omit<MessageIdentityAttrs, 'pushName'>
  * whenever the stanza is self-authored 1:1, even when the chat itself did not
  * resolve: the sender attrs always describe the own account there, so letting
  * them through would address the message to the connection's own number.
+ * `senderUsername` goes with them; the peer's is in `recipientUsername`.
  */
 function promoteRecipientAddressing(identity: MessageKeyIdentity): MessageKeyIdentity {
     return {
         ...(identity.recipientAlt ? { remoteJidAlt: identity.recipientAlt } : {}),
-        ...(identity.senderUsername !== undefined
-            ? { senderUsername: identity.senderUsername }
+        ...(identity.recipientUsername !== undefined
+            ? { recipientUsername: identity.recipientUsername }
             : {})
     }
 }

--- a/src/protocol/__tests__/protocol.test.ts
+++ b/src/protocol/__tests__/protocol.test.ts
@@ -46,6 +46,16 @@ import type {
     WaPrivacyDisallowedListSettingName,
     WaPrivacySettingValueMap
 } from '@protocol/privacy'
+import {
+    displayUsername,
+    isUsernameKey,
+    normalizeUsername,
+    parseUsernameHandle,
+    splitUsernameHandle,
+    validateUsernameLocally,
+    WA_USERNAME_LIMITS,
+    WA_USERNAME_VALIDATION_ERRORS
+} from '@protocol/username'
 import { TEXT_DECODER } from '@util/bytes'
 
 test('canonicalizeOwnAccountJid maps own PN device JIDs to LID', () => {
@@ -320,4 +330,70 @@ test('deprecated AB_PROP_CONFIGS view still exposes configCode over the spec tab
         Object.keys(WA_ABPROPS).sort(),
         'the compatibility view must cover the whole catalogue'
     )
+})
+
+test('username validation applies the wa-web rule order', () => {
+    assert.deepEqual(validateUsernameLocally('joao.silva_1'), { isValid: true })
+    assert.deepEqual(validateUsernameLocally('jo ao'), {
+        isValid: false,
+        errorType: WA_USERNAME_VALIDATION_ERRORS.INVALID_CHARACTER
+    })
+    assert.deepEqual(validateUsernameLocally('ab'), {
+        isValid: false,
+        errorType: WA_USERNAME_VALIDATION_ERRORS.INVALID_LENGTH
+    })
+    assert.deepEqual(validateUsernameLocally('a'.repeat(WA_USERNAME_LIMITS.MAX_LENGTH + 1)), {
+        isValid: false,
+        errorType: WA_USERNAME_VALIDATION_ERRORS.INVALID_LENGTH
+    })
+    assert.deepEqual(validateUsernameLocally('1234'), {
+        isValid: false,
+        errorType: WA_USERNAME_VALIDATION_ERRORS.INVALID_NO_LETTERS
+    })
+    assert.deepEqual(validateUsernameLocally('.joao'), {
+        isValid: false,
+        errorType: WA_USERNAME_VALIDATION_ERRORS.INVALID_PERIODS
+    })
+    assert.deepEqual(validateUsernameLocally('joao.'), {
+        isValid: false,
+        errorType: WA_USERNAME_VALIDATION_ERRORS.INVALID_PERIODS
+    })
+    assert.deepEqual(validateUsernameLocally('jo..ao'), {
+        isValid: false,
+        errorType: WA_USERNAME_VALIDATION_ERRORS.INVALID_PERIODS
+    })
+    assert.deepEqual(validateUsernameLocally('www.joao'), {
+        isValid: false,
+        errorType: WA_USERNAME_VALIDATION_ERRORS.INVALID_WWW_PREFIX
+    })
+    assert.deepEqual(validateUsernameLocally('joao.com'), {
+        isValid: false,
+        errorType: WA_USERNAME_VALIDATION_ERRORS.INVALID_DOMAIN_SUFFIX
+    })
+    assert.deepEqual(validateUsernameLocally('myWhatsAppName'), {
+        isValid: false,
+        errorType: WA_USERNAME_VALIDATION_ERRORS.INVALID_WORD
+    })
+})
+
+test('username key and handle parsing', () => {
+    assert.equal(isUsernameKey('1234'), true)
+    assert.equal(isUsernameKey('123'), false)
+    assert.equal(isUsernameKey('12a4'), false)
+    assert.equal(normalizeUsername('@joao'), 'joao')
+    assert.equal(normalizeUsername('joao'), 'joao')
+    assert.equal(displayUsername('joao'), '@joao')
+
+    assert.deepEqual(parseUsernameHandle('@joao'), { username: 'joao', usernameKey: null })
+    assert.deepEqual(parseUsernameHandle('  joao  '), { username: 'joao', usernameKey: null })
+    assert.deepEqual(parseUsernameHandle('@joao:1234'), { username: 'joao', usernameKey: '1234' })
+    assert.equal(parseUsernameHandle('@joao:12'), null)
+    assert.equal(parseUsernameHandle('@ab'), null)
+    assert.equal(parseUsernameHandle('   '), null)
+})
+
+test('splitUsernameHandle separates the parts without validating them', () => {
+    assert.deepEqual(splitUsernameHandle('@joao:1234'), { username: 'joao', usernameKey: '1234' })
+    assert.deepEqual(splitUsernameHandle('  @ab:x  '), { username: 'ab', usernameKey: 'x' })
+    assert.deepEqual(splitUsernameHandle('joao'), { username: 'joao', usernameKey: null })
 })

--- a/src/protocol/constants.ts
+++ b/src/protocol/constants.ts
@@ -136,6 +136,22 @@ export {
 } from '@protocol/group'
 export { WA_USYNC_CONTEXTS, WA_USYNC_DEFAULTS, WA_USYNC_MODES } from '@protocol/usync'
 export {
+    displayUsername,
+    isUsernameKey,
+    isValidUsername,
+    normalizeUsername,
+    parseUsernameHandle,
+    splitUsernameHandle,
+    validateUsernameLocally,
+    WA_USERNAME_LIMITS,
+    WA_USERNAME_VALIDATION_ERRORS
+} from '@protocol/username'
+export type {
+    ParsedUsernameHandle,
+    WaUsernameValidation,
+    WaUsernameValidationError
+} from '@protocol/username'
+export {
     WA_NEWSLETTER_FETCH_KEY_TYPES,
     WA_NEWSLETTER_MUTE_TYPES,
     WA_NEWSLETTER_MUTE_VALUES,

--- a/src/protocol/username.ts
+++ b/src/protocol/username.ts
@@ -1,0 +1,149 @@
+export const WA_USERNAME_LIMITS = Object.freeze({
+    MIN_LENGTH: 3,
+    MAX_LENGTH: 35,
+    KEY_LENGTH: 4
+} as const)
+
+export const WA_USERNAME_VALIDATION_ERRORS = Object.freeze({
+    INVALID_CHARACTER: 'INVALID_CHARACTER',
+    INVALID_LENGTH: 'INVALID_LENGTH',
+    INVALID_NO_LETTERS: 'INVALID_NO_LETTERS',
+    INVALID_PERIODS: 'INVALID_PERIODS',
+    INVALID_DOMAIN_SUFFIX: 'INVALID_DOMAIN_SUFFIX',
+    INVALID_WWW_PREFIX: 'INVALID_WWW_PREFIX',
+    INVALID_WORD: 'INVALID_WORD'
+} as const)
+
+export type WaUsernameValidationError =
+    (typeof WA_USERNAME_VALIDATION_ERRORS)[keyof typeof WA_USERNAME_VALIDATION_ERRORS]
+
+export type WaUsernameValidation =
+    | { readonly isValid: true }
+    | { readonly isValid: false; readonly errorType: WaUsernameValidationError }
+
+const VALID_VALIDATION: WaUsernameValidation = Object.freeze({ isValid: true } as const)
+
+const DOMAIN_SUFFIXES: readonly string[] = [
+    '.com',
+    '.org',
+    '.net',
+    '.int',
+    '.edu',
+    '.gov',
+    '.mil',
+    '.arpa',
+    '.html',
+    '.htm',
+    '.txt',
+    '.xml'
+]
+
+const RESERVED_WORDS: readonly string[] = ['whatsapp', 'instagram', 'facebook', 'oculus']
+
+function isLetterCode(code: number): boolean {
+    return (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
+}
+
+function isAllowedCode(code: number): boolean {
+    return isLetterCode(code) || (code >= 48 && code <= 57) || code === 95 || code === 46
+}
+
+function invalid(errorType: WaUsernameValidationError): WaUsernameValidation {
+    return { isValid: false, errorType }
+}
+
+/** Returns the first rule a username fails, in WhatsApp Web's own order. */
+export function validateUsernameLocally(username: string): WaUsernameValidation {
+    for (let index = 0; index < username.length; index += 1) {
+        if (!isAllowedCode(username.charCodeAt(index))) {
+            return invalid(WA_USERNAME_VALIDATION_ERRORS.INVALID_CHARACTER)
+        }
+    }
+    if (
+        username.length < WA_USERNAME_LIMITS.MIN_LENGTH ||
+        username.length > WA_USERNAME_LIMITS.MAX_LENGTH
+    ) {
+        return invalid(WA_USERNAME_VALIDATION_ERRORS.INVALID_LENGTH)
+    }
+    let hasLetter = false
+    for (let index = 0; index < username.length; index += 1) {
+        if (isLetterCode(username.charCodeAt(index))) {
+            hasLetter = true
+            break
+        }
+    }
+    if (!hasLetter) return invalid(WA_USERNAME_VALIDATION_ERRORS.INVALID_NO_LETTERS)
+    if (username.startsWith('.') || username.endsWith('.') || username.includes('..')) {
+        return invalid(WA_USERNAME_VALIDATION_ERRORS.INVALID_PERIODS)
+    }
+    const lowered = username.toLowerCase()
+    if (lowered.startsWith('www.')) {
+        return invalid(WA_USERNAME_VALIDATION_ERRORS.INVALID_WWW_PREFIX)
+    }
+    for (let index = 0; index < DOMAIN_SUFFIXES.length; index += 1) {
+        if (lowered.endsWith(DOMAIN_SUFFIXES[index])) {
+            return invalid(WA_USERNAME_VALIDATION_ERRORS.INVALID_DOMAIN_SUFFIX)
+        }
+    }
+    for (let index = 0; index < RESERVED_WORDS.length; index += 1) {
+        if (lowered.includes(RESERVED_WORDS[index])) {
+            return invalid(WA_USERNAME_VALIDATION_ERRORS.INVALID_WORD)
+        }
+    }
+    return VALID_VALIDATION
+}
+
+export function isValidUsername(username: string): boolean {
+    return validateUsernameLocally(username).isValid
+}
+
+/** True for the 4-digit numeric username key (recovery PIN). */
+export function isUsernameKey(key: string): boolean {
+    if (key.length !== WA_USERNAME_LIMITS.KEY_LENGTH) return false
+    for (let index = 0; index < key.length; index += 1) {
+        const digit = key.charCodeAt(index) - 48
+        if (digit < 0 || digit > 9) return false
+    }
+    return true
+}
+
+/**
+ * Strips the display-only `@` prefix. The server is not supposed to send it,
+ * but WhatsApp Web tolerates and drops it, so stanza and user input alike go
+ * through here first.
+ */
+export function normalizeUsername(username: string): string {
+    return username.charCodeAt(0) === 64 ? username.slice(1) : username
+}
+
+export function displayUsername(username: string): string {
+    return `@${username}`
+}
+
+export interface ParsedUsernameHandle {
+    readonly username: string
+    readonly usernameKey: string | null
+}
+
+/**
+ * Splits `@user`, `user` or `@user:1234` into its parts without validating
+ * either. Callers that need to tell apart a bad handle from a bad key start
+ * here; {@link parseUsernameHandle} is the validating shorthand.
+ */
+export function splitUsernameHandle(input: string): ParsedUsernameHandle {
+    const withoutPrefix = normalizeUsername(input.trim())
+    const colonIndex = withoutPrefix.indexOf(':')
+    if (colonIndex === -1) return { username: withoutPrefix, usernameKey: null }
+    return {
+        username: withoutPrefix.slice(0, colonIndex),
+        usernameKey: withoutPrefix.slice(colonIndex + 1)
+    }
+}
+
+/** Parses `@user`, `user` or `@user:1234`. `null` when either part is invalid. */
+export function parseUsernameHandle(input: string): ParsedUsernameHandle | null {
+    const { username, usernameKey } = splitUsernameHandle(input)
+    if (!isValidUsername(username)) return null
+    if (usernameKey !== null && !isUsernameKey(usernameKey)) return null
+    return { username, usernameKey }
+}

--- a/src/store/contracts/contact.store.ts
+++ b/src/store/contracts/contact.store.ts
@@ -4,6 +4,8 @@ export interface WaStoredContactRecord {
     readonly pushName?: string
     readonly lid?: string
     readonly phoneNumber?: string
+    /** Username handle, without the display-only `@`. */
+    readonly username?: string
     readonly lastUpdatedMs: number
 }
 

--- a/src/store/memory/contact.store.ts
+++ b/src/store/memory/contact.store.ts
@@ -25,6 +25,7 @@ function mergeContactRecords(
         pushName: incoming.pushName ?? previous.pushName,
         lid: incoming.lid ?? previous.lid,
         phoneNumber: incoming.phoneNumber ?? previous.phoneNumber,
+        username: incoming.username ?? previous.username,
         lastUpdatedMs: Math.max(previous.lastUpdatedMs, incoming.lastUpdatedMs)
     }
 }

--- a/src/transport/node/builders/__tests__/builders.test.ts
+++ b/src/transport/node/builders/__tests__/builders.test.ts
@@ -89,13 +89,18 @@ import {
     buildPrivacyTokenIqNode,
     buildTcTokenMessageNode
 } from '@transport/node/builders/privacy-token'
-import { buildSetDisappearingModeIq } from '@transport/node/builders/profile'
+import {
+    buildSetDisappearingModeIq,
+    buildUsernameLookupContactNode,
+    buildUsernameLookupUsyncQueryNodes
+} from '@transport/node/builders/profile'
 import { buildRetryReceiptNode } from '@transport/node/builders/retry'
 import {
     buildUsyncIq,
     buildUsyncUserNode,
     parseUsyncResultEnvelope
 } from '@transport/node/builders/usync'
+import { findNodeChild } from '@transport/node/helpers'
 import type { BinaryNode } from '@transport/types'
 
 test('presence and offline builders generate expected lightweight nodes', () => {
@@ -2034,4 +2039,130 @@ test('buildEditBusinessProfileIq encodes business hours and rejects unknown mode
             }),
         /invalid business hours mode/
     )
+})
+
+test('username lookup usync builds a jid-less user with the contact identifier', () => {
+    const queryNodes = buildUsernameLookupUsyncQueryNodes()
+    assert.deepEqual(
+        queryNodes.map((node) => node.tag),
+        ['contact', 'business']
+    )
+    assert.equal(queryNodes[0].attrs.addressing_mode, 'lid')
+
+    const iq = buildUsyncIq({
+        sid: 'sid-1',
+        queryProtocolNodes: queryNodes,
+        users: [
+            {
+                content: [
+                    buildUsernameLookupContactNode({
+                        username: 'joao',
+                        usernameKey: '1234'
+                    })
+                ]
+            }
+        ]
+    })
+    const usyncNode = findNodeChild(iq, 'usync')
+    const listNode = usyncNode ? findNodeChild(usyncNode, 'list') : undefined
+    assert.ok(listNode && Array.isArray(listNode.content))
+    if (!listNode || !Array.isArray(listNode.content)) {
+        throw new Error('expected usync list content array')
+    }
+    const userNode = listNode.content[0]
+    assert.equal(userNode.attrs.jid, undefined)
+    if (!Array.isArray(userNode.content)) {
+        throw new Error('expected user content array')
+    }
+    assert.deepEqual(userNode.content[0], {
+        tag: 'contact',
+        attrs: { username: 'joao', pin: '1234' }
+    })
+
+    const withoutKey = buildUsernameLookupContactNode({ username: 'joao' })
+    assert.deepEqual(withoutKey.attrs, { username: 'joao' })
+})
+
+test('blocklist block picks one identifier per wa-web precedence', () => {
+    const readItemAttrs = (node: { content?: unknown }): Record<string, string> => {
+        if (!Array.isArray(node.content)) {
+            throw new Error('expected blocklist item content array')
+        }
+        return node.content[0].attrs
+    }
+
+    assert.deepEqual(
+        readItemAttrs(
+            buildBlocklistBlockIq({
+                lidJid: '88880000@lid',
+                pnJid: '5511999999999@s.whatsapp.net',
+                username: 'joao',
+                displayName: null
+            })
+        ),
+        { action: 'block', jid: '88880000@lid', username: 'joao' }
+    )
+    assert.deepEqual(
+        readItemAttrs(
+            buildBlocklistBlockIq({
+                lidJid: '88880000@lid',
+                pnJid: '5511999999999@s.whatsapp.net',
+                username: 'joao',
+                displayName: 'Joao'
+            })
+        ),
+        { action: 'block', jid: '88880000@lid', pn_jid: '5511999999999@s.whatsapp.net' }
+    )
+    assert.deepEqual(
+        readItemAttrs(
+            buildBlocklistBlockIq({ lidJid: '88880000@lid', pnJid: null, username: 'joao' })
+        ),
+        { action: 'block', jid: '88880000@lid', username: 'joao' }
+    )
+    assert.deepEqual(
+        readItemAttrs(
+            buildBlocklistBlockIq({
+                lidJid: '88880000@lid',
+                pnJid: null,
+                username: null,
+                displayName: 'Joao'
+            })
+        ),
+        { action: 'block', jid: '88880000@lid', display_name: 'Joao' }
+    )
+    assert.deepEqual(
+        readItemAttrs(buildBlocklistBlockIq({ lidJid: '88880000@lid', pnJid: null })),
+        { action: 'block', jid: '88880000@lid', unknown_identifier: 'true' }
+    )
+})
+
+test('disallowed-list entries prefer the username identifier under lid addressing', () => {
+    const iq = buildSetPrivacyDisallowedListIq(
+        WA_PRIVACY_CATEGORIES.LAST_SEEN,
+        [
+            {
+                action: 'add',
+                lidJid: '88880000@lid',
+                pnJid: '5511999999999@s.whatsapp.net',
+                username: 'joao'
+            },
+            { action: 'remove', lidJid: '88881111@lid', pnJid: null, username: null }
+        ],
+        'dhash-1',
+        true
+    )
+    const privacyNode = findNodeChild(iq, 'privacy')
+    const categoryNode = privacyNode ? findNodeChild(privacyNode, 'category') : undefined
+    if (!categoryNode || !Array.isArray(categoryNode.content)) {
+        throw new Error('expected category content array')
+    }
+    assert.deepEqual(categoryNode.content[0].attrs, {
+        action: 'add',
+        jid: '88880000@lid',
+        username: 'joao'
+    })
+    assert.deepEqual(categoryNode.content[1].attrs, {
+        action: 'remove',
+        jid: '88881111@lid'
+    })
 })

--- a/src/transport/node/builders/privacy.ts
+++ b/src/transport/node/builders/privacy.ts
@@ -77,6 +77,8 @@ export interface WaPrivacyDisallowedListEntry {
     readonly action: WaPrivacyListAction
     readonly lidJid: string | null
     readonly pnJid: string | null
+    /** Accepted in place of `pn_jid` for a migrated contact. */
+    readonly username?: string | null
 }
 
 /**
@@ -124,6 +126,9 @@ function buildDisallowedListUserAttrs(
     lidAddressing: boolean
 ): Record<string, string> {
     if (lidAddressing && entry.lidJid !== null) {
+        if (entry.username) {
+            return { action: entry.action, jid: entry.lidJid, username: entry.username }
+        }
         return entry.pnJid !== null
             ? { action: entry.action, jid: entry.lidJid, pn_jid: entry.pnJid }
             : { action: entry.action, jid: entry.lidJid }
@@ -142,27 +147,50 @@ export function buildGetBlocklistIq(): BinaryNode {
 /**
  * Blocklist target in both addressing forms. At least one side is always
  * present: LID-migrated accounts carry `lidJid` (plus `pnJid` when known),
- * non-migrated accounts carry only `pnJid`.
+ * non-migrated accounts carry only `pnJid`. `username` / `displayName` come
+ * from the stored contact record.
  */
-export type WaBlocklistTarget =
+export type WaBlocklistTarget = (
     | { readonly lidJid: string; readonly pnJid: string | null }
     | { readonly lidJid: null; readonly pnJid: string }
+) & {
+    readonly username?: string | null
+    readonly displayName?: string | null
+}
+
+/**
+ * The one identifier attribute a migrated block carries next to `jid`, in
+ * wa-web's precedence. It splits the display name in two - a saved-contact
+ * name decides the username/pn flip, a separate LID display name is the
+ * fallback identifier - while the record here has a single `displayName`
+ * filling both roles.
+ */
+function resolveBlocklistIdentifierAttrs(target: WaBlocklistTarget): Record<string, string> {
+    const { pnJid, username, displayName } = target
+    if (pnJid && username) {
+        return displayName ? { pn_jid: pnJid } : { username }
+    }
+    if (username) return { username }
+    if (pnJid) return { pn_jid: pnJid }
+    if (displayName) return { display_name: displayName }
+    return { unknown_identifier: 'true' }
+}
 
 /**
  * Builds the blocklist `set` IQ for a block action. LID-migrated targets are
- * addressed by the LID jid plus an identifier attribute: `pn_jid` when the
- * phone jid is known, else `unknown_identifier="true"`. Non-migrated targets
- * are addressed by the phone jid alone. The server rejects a block that
- * addresses a migrated account by phone jid or omits the identifier
- * (`400: bad-request`).
+ * addressed by the LID jid plus one identifier attribute (see
+ * {@link resolveBlocklistIdentifierAttrs}). Non-migrated targets are addressed
+ * by the phone jid alone. The server rejects a block that addresses a migrated
+ * account by phone jid or omits the identifier (`400: bad-request`).
  */
 export function buildBlocklistBlockIq(target: WaBlocklistTarget): BinaryNode {
     let attrs: Record<string, string>
     if (target.lidJid !== null) {
-        attrs =
-            target.pnJid !== null
-                ? { action: 'block', jid: target.lidJid, pn_jid: target.pnJid }
-                : { action: 'block', jid: target.lidJid, unknown_identifier: 'true' }
+        attrs = {
+            action: 'block',
+            jid: target.lidJid,
+            ...resolveBlocklistIdentifierAttrs(target)
+        }
     } else {
         attrs = { action: 'block', jid: target.pnJid }
     }

--- a/src/transport/node/builders/profile.ts
+++ b/src/transport/node/builders/profile.ts
@@ -1,4 +1,10 @@
-import { WA_DEFAULTS, WA_IQ_TYPES, WA_NODE_TAGS, WA_XMLNS } from '@protocol/constants'
+import {
+    WA_ADDRESSING_MODES,
+    WA_DEFAULTS,
+    WA_IQ_TYPES,
+    WA_NODE_TAGS,
+    WA_XMLNS
+} from '@protocol/constants'
 import { buildIqNode } from '@transport/node/query'
 import type { BinaryNode } from '@transport/types'
 
@@ -105,6 +111,48 @@ export function buildGetUsernameUsyncQueryNode(): BinaryNode {
     return {
         tag: WA_NODE_TAGS.USERNAME,
         attrs: {}
+    }
+}
+
+/**
+ * `contact` answers with the resolved user plus its reachability `type`,
+ * `business` with the verified name. WhatsApp Web pins `contact` to LID
+ * addressing here, so the lookup resolves to a LID.
+ */
+export function buildUsernameLookupUsyncQueryNodes(): readonly BinaryNode[] {
+    return [
+        {
+            tag: WA_NODE_TAGS.CONTACT,
+            attrs: { addressing_mode: WA_ADDRESSING_MODES.LID }
+        },
+        {
+            tag: WA_NODE_TAGS.BUSINESS,
+            attrs: {},
+            content: [{ tag: 'verified_name', attrs: {} }]
+        }
+    ]
+}
+
+export interface BuildUsernameLookupContactNodeInput {
+    readonly username: string
+    readonly usernameKey?: string
+}
+
+/**
+ * The `<contact>` child identifying the account in a username lookup. It goes
+ * inside a `<user>` carrying no `jid` - the handle is the identifier - with
+ * the optional lookup key in `pin`.
+ */
+export function buildUsernameLookupContactNode(
+    input: BuildUsernameLookupContactNodeInput
+): BinaryNode {
+    const attrs: Record<string, string> = { username: input.username }
+    if (input.usernameKey) {
+        attrs.pin = input.usernameKey
+    }
+    return {
+        tag: WA_NODE_TAGS.CONTACT,
+        attrs
     }
 }
 

--- a/src/transport/node/builders/usync.ts
+++ b/src/transport/node/builders/usync.ts
@@ -16,7 +16,8 @@ export type WaUsyncMode = (typeof WA_USYNC_MODES)[keyof typeof WA_USYNC_MODES]
 export type WaUsyncContext = (typeof WA_USYNC_CONTEXTS)[keyof typeof WA_USYNC_CONTEXTS]
 
 export interface BuildUsyncUserNodeInput {
-    readonly jid: string
+    /** Omitted only by username lookups, which identify by handle instead. */
+    readonly jid?: string
     readonly attrs?: Readonly<Record<string, string>>
     readonly content?: BinaryNode['content']
 }
@@ -37,7 +38,7 @@ export function buildUsyncUserNode(input: BuildUsyncUserNodeInput): BinaryNode {
         tag: WA_NODE_TAGS.USER,
         attrs: {
             ...input.attrs,
-            jid: input.jid
+            ...(input.jid !== undefined ? { jid: input.jid } : {})
         },
         ...(input.content !== undefined ? { content: input.content } : {})
     }


### PR DESCRIPTION
Brings the username (handle) surface in line with WhatsApp Web:

- protocol: local validation rules and limits, `@` normalization, and handle parsing in a new `@protocol/username` module.
- receive: `recipient_username` / `peer_recipient_username` on messages, `participant_username` on receipts, and the `account_sync` `<username>` notification as a new `own_username` event. Handles arriving with the display-only `@` are normalized.
- queries: `profile.resolveUsername()` resolves a handle to its LID over the usync contact protocol, reporting `key-required` when the server withholds the JID until the 4-digit lookup key is supplied.
- privacy: blocklist and disallowed-list writes can address a migrated contact by `username` or `display_name` instead of falling back to `unknown_identifier`. The disallowed-list identifier follows the AB prop WhatsApp gates it behind.
- store: contacts persist the handle, with a migration on every backend.

Behavior changes:

- Self-authored 1:1 stanzas no longer report the own account's handle as `senderUsername`; the peer's is exposed as `recipientUsername`.
- `setUsername`, `setUsernameKey` and `resolveUsername` reject input that fails local validation instead of round-tripping it.
- `WaBlocklistResult` and `WaPrivacyDisallowedListResult` carry `entries` alongside `jids`, adding the per-entry handle.
- History sync stores `Conversation.username` as the contact handle rather than folding it into the display name.

Outgoing sends do not stamp `peer_recipient_username`: resolving it costs a contact-store read per message, which a remote backend cannot absorb. Callers holding the handle can pass it through `additionalAttributes`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added username validation, normalization, formatting, and handle-parsing utilities.
  * Added username lookup with optional verification keys and clear lookup outcomes.
  * Added account username change notifications and username metadata for messages and receipts.
  * Privacy and blocklist entries now expose structured username and display-name details.
  * Contact usernames are now persisted across all storage backends.

* **Bug Fixes**
  * Improved username handling for incoming, self-sent, and history-synchronized messages.
  * Preserved existing usernames when contact updates omit them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->