### PR TITLE
fix(mailbox): persist the live message fromMe flag

### DIFF
--- a/src/client/persistence/__tests__/mailbox.test.ts
+++ b/src/client/persistence/__tests__/mailbox.test.ts
@@ -5,9 +5,10 @@ import { persistIncomingMailboxEntities } from '@client/persistence/mailbox'
 import type { WaIncomingMessageEvent } from '@client/types'
 import { createNoopLogger } from '@infra/log/types'
 import type { WaStoredContactRecord } from '@store/contracts/contact.store'
+import type { WaStoredMessageRecord } from '@store/contracts/message.store'
 
 interface Captured {
-    readonly messages: { readonly id: string; readonly threadJid: string }[]
+    readonly messages: WaStoredMessageRecord[]
     readonly contacts: WaStoredContactRecord[]
 }
 
@@ -17,8 +18,8 @@ function captureWriteBehind(): {
 } {
     const captured: Captured = { messages: [], contacts: [] }
     const writeBehind = {
-        persistMessage: (record: { id: string; threadJid: string }) => {
-            captured.messages.push({ id: record.id, threadJid: record.threadJid })
+        persistMessage: (record: WaStoredMessageRecord) => {
+            captured.messages.push(record)
         },
         persistContact: (record: WaStoredContactRecord) => {
             captured.contacts.push(record)
@@ -147,6 +148,68 @@ test('mailbox persist does NOT treat remoteJid pair as user pair for groups', ()
     const crossRefRows = captured.contacts.filter((c) => c.phoneNumber || c.lid)
     assert.equal(crossRefRows.length, 1)
     assert.equal(crossRefRows[0].jid, '111111111111111@lid')
+})
+
+test('mailbox persist keeps fromMe=true for a message authored by the own account', () => {
+    const { captured, writeBehind } = captureWriteBehind()
+    persistIncomingMailboxEntities({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        messageSecretStore: { set: async () => undefined } as never,
+        event: baseEvent({
+            keyOverrides: {
+                id: 'own-1',
+                remoteJid: '5511999999999@s.whatsapp.net',
+                isGroup: false,
+                fromMe: true
+            }
+        })
+    })
+
+    assert.equal(captured.messages.length, 1)
+    assert.equal(captured.messages[0].id, 'own-1')
+    assert.equal(captured.messages[0].fromMe, true)
+})
+
+test('mailbox persist keeps fromMe=false for a message authored by the peer', () => {
+    const { captured, writeBehind } = captureWriteBehind()
+    persistIncomingMailboxEntities({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        messageSecretStore: { set: async () => undefined } as never,
+        event: baseEvent({
+            keyOverrides: {
+                id: 'peer-1',
+                remoteJid: '5511999999999@s.whatsapp.net',
+                isGroup: false,
+                fromMe: false
+            }
+        })
+    })
+
+    assert.equal(captured.messages.length, 1)
+    assert.equal(captured.messages[0].id, 'peer-1')
+    assert.equal(captured.messages[0].fromMe, false)
+})
+
+test('mailbox persist keeps fromMe=true for an own group message', () => {
+    const { captured, writeBehind } = captureWriteBehind()
+    persistIncomingMailboxEntities({
+        logger: createNoopLogger(),
+        writeBehind: writeBehind as never,
+        messageSecretStore: { set: async () => undefined } as never,
+        event: baseEvent({
+            keyOverrides: {
+                id: 'own-group-1',
+                participant: '111111111111111@lid',
+                fromMe: true
+            }
+        })
+    })
+
+    assert.equal(captured.messages.length, 1)
+    assert.equal(captured.messages[0].fromMe, true)
+    assert.equal(captured.messages[0].senderJid, '111111111111111@lid')
 })
 
 const PLAIN_SECRET = new Uint8Array(32).fill(7)

--- a/src/client/persistence/mailbox.ts
+++ b/src/client/persistence/mailbox.ts
@@ -98,7 +98,7 @@ export function persistIncomingMailboxEntities(options: WaPersistIncomingMailbox
             senderJid:
                 event.key.participant ?? event.rawNode.attrs.participant ?? event.key.remoteJid,
             participantJid: event.rawNode.attrs.participant,
-            fromMe: false,
+            fromMe: event.key.fromMe,
             timestampMs:
                 event.timestampSeconds === undefined ? undefined : event.timestampSeconds * 1_000,
             messageBytes


### PR DESCRIPTION
The live mailbox path hardcoded `fromMe: false`, so every message the account authored from the phone or another linked device was stored as incoming. History sync and group history bundles already carried the value through, which made the two ingestion paths disagree on the same message.

`event.key.fromMe` is resolved by the incoming parser through the same own-account check wa-web applies (`isMeAccount` over the PN and the LID user, device-insensitive), so the flag is available at the callsite and just needed to be passed on. It matters beyond the column: wa-web builds the message identity as `fromMe_remote_id`, so a constant `false` also broke the app-state message-range keys that read the stored record.

Covers 1:1 in both directions plus the own-group case, where the author arrives as `key.participant`.

Fixes #249

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the sender status recorded for incoming messages.
  * Message history now accurately preserves whether messages were sent by you, including direct and group conversations.
  * Improved handling of sender information for group messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->