### PR TITLE
fix(voip): dial relays on the web client port

### DIFF
--- a/.changeset/voip-relay-advertised-port.md
+++ b/.changeset/voip-relay-advertised-port.md
@@ -1,0 +1,15 @@
+---
+'@zapo-js/voip': minor
+---
+
+Dial relays on the web client port. `connectRelays` pinned every relay
+connection to 3478, which WhatsApp Web names `FAUX_WEB_CLIENT_RELAY_PORT` and
+never dials: a relay reached there completes the handshake and accepts the
+uplink, but never forwards the peer's stream back, so the call is silently one
+way. The port is now `TRUE_WEB_CLIENT_RELAY_PORT` (3480), the value the package
+already carried as the fallback in `configureRelays`.
+
+New `useOriginalRelayPort` plugin option, default `false`, dials the port each
+endpoint advertises instead. WhatsApp Web gates the same choice behind
+`shouldUseOriginalRelayPort`; without it a relay is only ever reachable on one
+fixed port, however the `<te2>` block addresses it.

--- a/packages/voip/README.md
+++ b/packages/voip/README.md
@@ -159,7 +159,17 @@ You can also use `client.voip.on('call_state', ...)` etc. for the manager-level 
 | `getCalls()`                                                 | All tracked calls                                         |
 | `on` / `off` / `once`                                        | Manager-level events                                      |
 
-Plugin options: `maxConcurrentCalls?: number` (default `1`), `logLevel?: LogLevel` (caps VOIP diagnostics; defaults to the host client's level).
+Plugin options: `maxConcurrentCalls?: number` (default `1`), `logLevel?: LogLevel` (caps VOIP diagnostics; defaults to the host client's level), `useOriginalRelayPort?: boolean` (default `false`, see below).
+
+## Relay port
+
+Relay endpoints advertise a port each, and the connection is made on the web client port (3480) rather than on the advertised one, which is what WhatsApp Web does. A relay reached on 3478 completes the handshake and carries the uplink but never forwards the peer's stream back, so the call is silently one way.
+
+`useOriginalRelayPort: true` dials the advertised port instead. Against WhatsApp's own relays that is the wrong choice, for the reason above; it exists for a relay deployment that answers on the port it advertises.
+
+```ts
+plugins: [voipPlugin({ useOriginalRelayPort: true })]
+```
 
 ## Codec
 

--- a/packages/voip/src/WaVoipCoordinator.ts
+++ b/packages/voip/src/WaVoipCoordinator.ts
@@ -18,6 +18,18 @@ export interface WaVoipCoordinatorOptions {
      * host, e.g. `'warn'` to keep them out of a `trace` host logger.
      */
     readonly logLevel?: LogLevel
+    /**
+     * Dial each relay on the port its `<te2>` endpoint advertises instead of on
+     * {@link TRUE_WEB_CLIENT_RELAY_PORT}. Defaults to `false`, which is what
+     * WhatsApp Web does unless its own `shouldUseOriginalRelayPort` gate is set.
+     *
+     * Against WhatsApp's own relays this is the wrong choice and the call goes
+     * silently one way: the endpoints advertise a mix of ports, and one reached
+     * on 3478 completes the handshake and carries the uplink without ever
+     * forwarding the peer's stream back. It exists for a relay deployment that
+     * answers on the port it advertises.
+     */
+    readonly useOriginalRelayPort?: boolean
 }
 
 /**
@@ -39,7 +51,8 @@ export class WaVoipCoordinator {
             deps: ctx.deps,
             stores: ctx.stores,
             logger: this.logger,
-            maxConcurrentCalls: options.maxConcurrentCalls
+            maxConcurrentCalls: options.maxConcurrentCalls,
+            useOriginalRelayPort: options.useOriginalRelayPort
         })
         this.registerIncomingHandlers(ctx)
         this.wireClientEvents(ctx)

--- a/packages/voip/src/call/WaCallManager.ts
+++ b/packages/voip/src/call/WaCallManager.ts
@@ -34,6 +34,7 @@ export interface WaCallManagerConfig {
     stores: WaVoipStores
     logger?: Logger
     maxConcurrentCalls?: number
+    useOriginalRelayPort?: boolean
 }
 
 export class WaCallManager extends EventEmitter {
@@ -41,6 +42,7 @@ export class WaCallManager extends EventEmitter {
     private readonly stores: WaVoipStores
     private readonly logger: Logger
     private readonly maxConcurrentCalls: number
+    private readonly useOriginalRelayPort: boolean
 
     private readonly calls = new Map<string, WaCallMediaSession>()
 
@@ -54,6 +56,7 @@ export class WaCallManager extends EventEmitter {
             DEFAULT_MAX_CONCURRENT_CALLS,
             'maxConcurrentCalls'
         )
+        this.useOriginalRelayPort = config.useOriginalRelayPort ?? false
     }
 
     async startCall(options: CallOfferOptions): Promise<string> {
@@ -364,6 +367,7 @@ export class WaCallManager extends EventEmitter {
             deps: this.deps,
             logger: sessionLogger,
             info,
+            useOriginalRelayPort: this.useOriginalRelayPort,
             delegate: {
                 emitState: (call) => this.emitState(call),
                 emitIncoming: (call) => this.emit('call_incoming', call),

--- a/packages/voip/src/call/WaCallMediaSession.ts
+++ b/packages/voip/src/call/WaCallMediaSession.ts
@@ -12,7 +12,7 @@ import { RtpSession } from '../media/rtp.js'
 import { WaAudioEngine } from '../media/WaAudioEngine.js'
 import { parseRelayFromAck } from '../relay/relay-ack.js'
 import { isRtpPacket, isStunPacket } from '../relay/stun.js'
-import { WaSctpRelay } from '../relay/WaSctpRelay.js'
+import { TRUE_WEB_CLIENT_RELAY_PORT, WaSctpRelay } from '../relay/WaSctpRelay.js'
 import {
     buildAcceptReceiptStanza,
     buildAcceptStanza,
@@ -56,6 +56,8 @@ export interface WaCallMediaSessionOptions {
     readonly logger: Logger
     readonly info: CallInfo
     readonly delegate: WaCallMediaSessionDelegate
+    /** See `WaVoipCoordinatorOptions.useOriginalRelayPort`. */
+    readonly useOriginalRelayPort?: boolean
 }
 
 export class WaCallMediaSession implements AudioSender {
@@ -64,6 +66,7 @@ export class WaCallMediaSession implements AudioSender {
     private readonly deps: WaVoipDeps
     private readonly logger: Logger
     private readonly delegate: WaCallMediaSessionDelegate
+    private readonly useOriginalRelayPort: boolean
 
     private rtpSession: RtpSession | null = null
     private srtpSession: SrtpSession | null = null
@@ -109,6 +112,7 @@ export class WaCallMediaSession implements AudioSender {
         this.logger = options.logger
         this.info = options.info
         this.delegate = options.delegate
+        this.useOriginalRelayPort = options.useOriginalRelayPort ?? false
 
         this.sctpRelay = new WaSctpRelay({
             logger: this.logger.child({ component: 'sctp' })
@@ -1158,19 +1162,24 @@ export class WaCallMediaSession implements AudioSender {
             }
         }
 
-        const WA_RELAY_PORT = 3478
+        // A relay answers only on the port it advertises, and the endpoints
+        // carry a mix. WhatsApp Web dials them all on the web client port and
+        // keeps the advertised one as `originalPort`, gating the alternative
+        // behind `shouldUseOriginalRelayPort`; this mirrors both sides of that.
+        const dialPort = (ep: RelayEndpoint) =>
+            this.useOriginalRelayPort ? ep.port : TRUE_WEB_CLIENT_RELAY_PORT
         const relays = uniqueEndpoints
             .filter((ep) => ep.key && ep.rawToken)
             .map((ep) => ({
                 ip: ep.ip,
-                port: WA_RELAY_PORT,
+                port: dialPort(ep),
                 token: ep.token,
                 authToken: ep.authToken,
                 rawAuthToken: ep.rawAuthToken,
                 rawToken: ep.rawToken,
                 key: ep.key,
                 relayId: ep.relayId,
-                name: ep.relayName || `${ep.ip}:${WA_RELAY_PORT}`,
+                name: ep.relayName || `${ep.ip}:${dialPort(ep)}`,
                 authTokenId: ep.authTokenId,
                 isFna: ep.isFna
             }))

--- a/packages/voip/src/call/__tests__/media-session-relays.test.ts
+++ b/packages/voip/src/call/__tests__/media-session-relays.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { createNoopLogger } from 'zapo-js'
+
+import { TRUE_WEB_CLIENT_RELAY_PORT } from '../../relay/WaSctpRelay.js'
+import { CallMediaType, type RelayEndpoint, type WaVoipDeps } from '../../types.js'
+import { CallInfo } from '../call-state.js'
+import { WaCallMediaSession, type WaCallMediaSessionDelegate } from '../WaCallMediaSession.js'
+
+const ID = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+
+interface ConfiguredRelay {
+    readonly ip: string
+    readonly port: number
+    readonly name?: string
+}
+
+/** A session whose relay configuration is captured instead of dialled. */
+function createSession(useOriginalRelayPort = false): {
+    session: WaCallMediaSession
+    configured: ConfiguredRelay[]
+} {
+    const call = CallInfo.newOutgoing(ID, 'peer@lid', 'me@lid', CallMediaType.Audio)
+    const session = new WaCallMediaSession({
+        deps: {} as unknown as WaVoipDeps,
+        logger: createNoopLogger(),
+        info: call,
+        useOriginalRelayPort,
+        delegate: {
+            emitState: () => {},
+            emitIncoming: () => {},
+            emitEnded: () => {},
+            emitInboundAudio: () => {},
+            emitOutboundAudioFinished: () => {}
+        } satisfies WaCallMediaSessionDelegate
+    })
+
+    const configured: ConfiguredRelay[] = []
+    ;(
+        session as unknown as {
+            sctpRelay: {
+                configureRelays: (relays: ConfiguredRelay[]) => Promise<void>
+                setSsrc: (ssrc: number) => void
+                setSubscriptionSsrc: (ssrc: number) => void
+                getConnectedCount: () => number
+            }
+        }
+    ).sctpRelay = {
+        configureRelays: async (relays) => {
+            configured.push(...relays)
+        },
+        setSsrc: () => {},
+        setSubscriptionSsrc: () => {},
+        getConnectedCount: () => 0
+    }
+
+    return { session, configured }
+}
+
+function connectRelays(session: WaCallMediaSession, endpoints: RelayEndpoint[]): Promise<void> {
+    return (
+        session as unknown as {
+            connectRelays: (endpoints: RelayEndpoint[]) => Promise<void>
+        }
+    ).connectRelays(endpoints)
+}
+
+function endpoint(overrides: Partial<RelayEndpoint> = {}): RelayEndpoint {
+    return {
+        ip: '192.168.1.1',
+        port: 3480,
+        token: 'TOKEN',
+        key: 'RELAYKEY',
+        relayId: 0,
+        rawToken: new Uint8Array([1, 2, 3]),
+        ...overrides
+    }
+}
+
+test('every relay is dialled on the web client port', async () => {
+    const { session, configured } = createSession()
+
+    await connectRelays(session, [endpoint({ ip: '10.0.0.1', port: 3480 })])
+
+    assert.equal(configured.length, 1)
+    assert.equal(configured[0].ip, '10.0.0.1')
+    assert.equal(configured[0].port, TRUE_WEB_CLIENT_RELAY_PORT)
+})
+
+test('an endpoint advertising the faux port is still dialled on the web client port', async () => {
+    const { session, configured } = createSession()
+
+    await connectRelays(session, [endpoint({ ip: '10.0.0.1', port: 3478 })])
+
+    assert.equal(configured[0].port, TRUE_WEB_CLIENT_RELAY_PORT)
+})
+
+test('a relay without a name is named for the address it dials', async () => {
+    const { session, configured } = createSession()
+
+    await connectRelays(session, [endpoint({ ip: '10.0.0.1', port: 3478 })])
+
+    assert.equal(configured[0].name, `10.0.0.1:${TRUE_WEB_CLIENT_RELAY_PORT}`)
+})
+
+test('the advertised port is dialled when the escape hatch is set', async () => {
+    const { session, configured } = createSession(true)
+
+    await connectRelays(session, [endpoint({ ip: '10.0.0.1', port: 47001 })])
+
+    assert.equal(configured[0].port, 47001)
+    assert.equal(configured[0].name, '10.0.0.1:47001')
+})
+
+test('endpoints of one host on different ports stay distinct under the escape hatch', async () => {
+    const { session, configured } = createSession(true)
+
+    await connectRelays(session, [
+        endpoint({ ip: '10.0.0.1', port: 3478, relayId: 0 }),
+        endpoint({ ip: '10.0.0.1', port: 3480, relayId: 1 })
+    ])
+
+    assert.deepEqual(
+        configured.map((relay) => relay.port),
+        [3478, 3480]
+    )
+})

--- a/packages/voip/src/relay/WaSctpRelay.ts
+++ b/packages/voip/src/relay/WaSctpRelay.ts
@@ -30,8 +30,20 @@ function closeQuietly(closeable: { close(): void } | null | undefined, logger: L
 type PeerConnectionClass = RTCPeerConnection
 type DataChannelClass = RTCDataChannel
 
+/**
+ * The port a web client's relay media rides on.
+ *
+ * A relay answers only on the port it advertises, and the `<te2>` blocks carry
+ * a mix. WhatsApp Web calls this one `TRUE_WEB_CLIENT_RELAY_PORT` and 3478
+ * `FAUX_WEB_CLIENT_RELAY_PORT`, and dials its candidates here rather than on
+ * the advertised port: a relay reached on 3478 completes the handshake and
+ * accepts the uplink, but never forwards the peer's stream back, so the call is
+ * silently one way.
+ */
+export const TRUE_WEB_CLIENT_RELAY_PORT = 3480
+
 const CONFIG = {
-    TRUE_WEB_CLIENT_RELAY_PORT: 3480,
+    TRUE_WEB_CLIENT_RELAY_PORT,
     CONNECTION_TIMEOUT: 20000,
     MAX_BUFFER_SIZE: 10 * 1024,
     KEEPALIVE_INTERVAL_MS: 1100,


### PR DESCRIPTION
## Why

`connectRelays` pins every relay connection to 3478. A relay answers only on the port it advertises, and reaching one on 3478 completes the handshake and carries the uplink without ever forwarding the peer's stream back, so the call is silently one way and nothing surfaces as an error.

WhatsApp Web names the two ports itself:

```js
var e = { CLOSE_OLD_CONNECTION_BEFORE_CALL_END: !1, FAUX_WEB_CLIENT_RELAY_PORT: 3478, TRUE_WEB_CLIENT_RELAY_PORT: 3480, USE_AUTH_TOKEN_FOR_ICE: !0 }
```

and builds its connection map with `portOverride: (port) => shouldUseOriginalRelayPort() ? port : TRUE_WEB_CLIENT_RELAY_PORT`, so by default it dials every candidate on 3480 and keeps the advertised port only as `originalPort`.

Overriding the advertised port is therefore right, which is why this is not a change of shape. The value was the faux one, and 3480 is already in the package as `CONFIG.TRUE_WEB_CLIENT_RELAY_PORT`, the fallback `configureRelays` applies to an endpoint that carries no port.

The gate is worth mirroring too. As it stands a relay is only ever reachable on one fixed port, however the `<te2>` block addresses it, and nothing outside the plugin can change that.

## What

`port: TRUE_WEB_CLIENT_RELAY_PORT`, and the generated name follows it. The constant moves next to the behaviour it explains and is exported, so `CONFIG` and the media session share one definition instead of two literals.

`useOriginalRelayPort`, default `false`, dials the port each endpoint advertises instead. It threads down the same path `maxConcurrentCalls` already takes, and the doc comment says plainly that it is the wrong choice against WhatsApp's own relays.

```ts
plugins: [voipPlugin({ useOriginalRelayPort: true })]
```

## Notes

The port policy could instead live in `WaSctpRelay`, whose `configureRelays` already applies `relay.port || CONFIG.TRUE_WEB_CLIENT_RELAY_PORT`, with the session passing `ep.port` through. That puts one place in charge of the dialled port. Happy to move it if you prefer that shape.

## Tests

Five in `packages/voip/src/call/__tests__/media-session-relays.test.ts`, on what reaches `configureRelays`: relays are dialled on the web client port, an endpoint advertising the faux port is dialled there too, an unnamed relay is named for the address it dials, the escape hatch dials the advertised port, and two ports on one host stay two relays under it. The first three fail on `master`.

`npm test` in `packages/voip` passes (77 tests); `tsc --noEmit`, ESLint and Prettier clean.
