### PR TITLE
fix(message): unwrap group status wrappers when resolving stanza attrs

### DIFF
--- a/src/message/encode/__tests__/content.test.ts
+++ b/src/message/encode/__tests__/content.test.ts
@@ -29,6 +29,37 @@ test('content helpers detect media payload and resolve message type', () => {
     assert.equal(resolveMessageTypeAttr({ pollCreationMessage: {} }), 'poll')
 })
 
+test('group status wrappers resolve the stanza attrs of the message they carry', () => {
+    // An opaque wrapper resolves to `media` with no `mediatype`, a pairing no
+    // client sends: the type has to come from the message inside the wrapper.
+    assert.equal(
+        resolveMessageTypeAttr({ groupStatusMessageV2: { message: { imageMessage: {} } } }),
+        'media'
+    )
+    assert.equal(
+        resolveEncMediaType({ groupStatusMessageV2: { message: { imageMessage: {} } } }),
+        'image'
+    )
+
+    assert.equal(
+        resolveMessageTypeAttr({ groupStatusMessageV2: { message: { conversation: 'hi' } } }),
+        'text'
+    )
+    assert.equal(
+        resolveEncMediaType({ groupStatusMessageV2: { message: { conversation: 'hi' } } }),
+        null
+    )
+
+    assert.equal(
+        resolveMessageTypeAttr({ groupStatusMessage: { message: { videoMessage: {} } } }),
+        'media'
+    )
+    assert.equal(
+        resolveEncMediaType({ groupStatusMessage: { message: { videoMessage: {} } } }),
+        'video'
+    )
+})
+
 test('getContentType picks the payload key, including the unsuffixed ones', () => {
     assert.equal(getContentType(undefined), undefined)
     assert.equal(getContentType({}), undefined)
@@ -168,7 +199,8 @@ test('resolveOutboundMessageAttrs matches the individual resolvers', () => {
         { ephemeralMessage: { message: { conversation: 'efemera' } } },
         { viewOnceMessage: { message: { imageMessage: { url: 'x' } } } },
         { ephemeralMessage: { message: { viewOnceMessageV2: { message: { videoMessage: {} } } } } },
-        { deviceSentMessage: { message: { extendedTextMessage: { text: 'ds' } } } }
+        { deviceSentMessage: { message: { extendedTextMessage: { text: 'ds' } } } },
+        { groupStatusMessageV2: { message: { imageMessage: { url: 'x' } } } }
     ]
     for (const message of corpus) {
         const combined = resolveOutboundMessageAttrs(message)

--- a/src/message/encode/content.ts
+++ b/src/message/encode/content.ts
@@ -212,7 +212,9 @@ export function unwrapMessage(message: Proto.IMessage): Proto.IMessage {
             msg.deviceSentMessage?.message ??
             msg.viewOnceMessage?.message ??
             msg.viewOnceMessageV2?.message ??
-            msg.documentWithCaptionMessage?.message
+            msg.documentWithCaptionMessage?.message ??
+            msg.groupStatusMessage?.message ??
+            msg.groupStatusMessageV2?.message
         if (!inner) return msg
         msg = inner
     }


### PR DESCRIPTION
`groupStatusMessageV2` is a wrapper carrying the real message in `.message`, like `deviceSentMessage`. `unwrapMessage` did not know it, so both resolvers read the empty outer wrapper: the type attr fell through to `media` and the media type resolved to null. The stanza went out declaring `type="media"` with no `mediatype`, a pairing no client sends.

wa-web resolves the send-side type attr through
`getUnwrappedProtobufMessage`, which unwraps any `{ message }` wrapper before computing the attrs, so a wrapped image status resolves to `type="media" mediatype="image"`. A whatsmeow capture of a working group status shows the other valid shape, `type="text"` with no `mediatype`. Ours matched neither.

Covers `groupStatusMessage` too, same shape. Every resolver routes through `unwrapMessage`, so the edit attr, meta attrs and media payload follow.

This closes the gap for group status only. Nineteen other `FutureProofMessage` wrappers stay opaque and resolve to the same invalid pair; `pollCreationMessageV4` is the notable one, since the poll branch never sees it. Making the unwrap generic needs the consumers that read wrapper fields off the unwrapped message to take the original alongside it, so it is left to its own change.

Refs #248

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/vinikjkkj/zapo/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message processing for group status messages and their nested content.
  * Nested image, video, and conversation content is now correctly identified, including encrypted media attributes.
  * Improved consistency when handling group-status images in outgoing messages.

* **Tests**
  * Added coverage to verify message type and media type resolution for supported group status message formats.
  * Added validation for nested media and conversation payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->